### PR TITLE
Fix spend error on slide-to-confirm

### DIFF
--- a/src/modules/UI/scenes/SendConfirmation/SendConfirmation.ui.js
+++ b/src/modules/UI/scenes/SendConfirmation/SendConfirmation.ui.js
@@ -16,7 +16,7 @@ import Gradient from '../../components/Gradient/Gradient.ui'
 
 import * as UTILS from '../../../utils.js'
 import type {GuiWallet, GuiCurrencyInfo} from '../../../../types'
-import type {AbcCurrencyWallet, AbcParsedUri} from 'airbitz-core-types'
+import type {AbcCurrencyWallet, AbcParsedUri, AbcTransaction} from 'airbitz-core-types'
 import type {SendConfirmationState} from './reducer'
 
 type Props = {
@@ -135,9 +135,9 @@ export default class SendConfirmation extends Component<any, any, any> {
   }
 
   signBroadcastAndSave = () => {
-    const {transaction} = this.props
+    const abcTransaction: AbcTransaction = this.props.sendConfirmation.transaction
     this.props.updateSpendPending(true)
-    this.props.signBroadcastAndSave(transaction)
+    this.props.signBroadcastAndSave(abcTransaction)
   }
 
   getTopSpacer = () => {

--- a/src/modules/UI/scenes/SendConfirmation/SendConfirmationConnector.js
+++ b/src/modules/UI/scenes/SendConfirmation/SendConfirmationConnector.js
@@ -8,7 +8,7 @@ import * as CORE_SELECTORS from '../../../Core/selectors.js'
 import * as UI_SELECTORS from '../../selectors.js'
 import * as SETTINGS_SELECTORS from '../../Settings/selectors.js'
 import type {GuiWallet, GuiCurrencyInfo, GuiDenomination} from '../../../../types'
-import type {AbcCurrencyWallet} from 'airbitz-core-types'
+import type {AbcCurrencyWallet, AbcTransaction} from 'airbitz-core-types'
 
 import {
   signBroadcastAndSave,
@@ -77,7 +77,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => ({
   processParsedUri: (parsedUri) => dispatch(processParsedUri(parsedUri)),
   updateSpendPending: (pendind) => dispatch(updateSpendPending(pendind)),
-  signBroadcastAndSave: (transaction) => dispatch(signBroadcastAndSave(transaction))
+  signBroadcastAndSave: (abcTransaction: AbcTransaction) => dispatch(signBroadcastAndSave(abcTransaction))
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(SendConfirmation)


### PR DESCRIPTION
Get `transaction` object from `props.sendConfirmation`, not `props` Flow would have found this bug.
Fixes bug "Unable to Send Wings via QR Code "