### PR TITLE
Fix SendConf 'Help' modal error

### DIFF
--- a/src/modules/UI/components/Header/Component/Right.js
+++ b/src/modules/UI/components/Header/Component/Right.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react'
-import SendConfirmationOptions from '../../../scenes/SendConfirmation/SendConfirmationOptions.js'
+import SendConfirmationOptions from '../../../scenes/SendConfirmation/SendConfirmationOptionsConnector.js'
 import HelpButton from './HelpButton.ui'
 import * as Constants from '../../../../../constants'
 

--- a/src/modules/UI/scenes/SendConfirmation/SendConfirmationOptions.js
+++ b/src/modules/UI/scenes/SendConfirmation/SendConfirmationOptions.js
@@ -27,6 +27,7 @@ const styles = StyleSheet.create({
 })
 
 export default class SendConfirmationOptions extends Component {
+
   _handleMenuOptions (key) {
     switch (key) {
     case 'help':


### PR DESCRIPTION
Commit: 388a8d89
Asana Task: https://app.asana.com/0/361770107085503/441612353481668/f

Purpose of this PR / task was to fix the error (crash) that was occurring when pressing the 'Help' option from the dropdown menu on the SendConfirmation page. The solution was to make sure that the Header was loading in the *connected* version of the component.

**Note**: the dropdown menu is a bit difficult to press because of its small size, also the fontSize on the help modal is too small. I have created respective Asana tasks for both of those smaller issues.