### PR TITLE
Fix 'Copy' string to clipboard from Request scene

### DIFF
--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -122,7 +122,8 @@ export default class Request extends Component {
   }
 
   copyToClipboard = () => {
-    Clipboard.setString(this.state.encodedURI)
+    let splitEncodedUriAddress = this.state.encodedURI.split(':')[1].replace('?', '')
+    Clipboard.setString(splitEncodedUriAddress)
     Alert.alert('Request copied to clipboard')
   }
 


### PR DESCRIPTION
Asana task: https://app.asana.com/0/361770107085503/317312547827438/f
Commit: d050e66f

Purpose of this task was to remove the '[walletType]:' part of the encodedUri string that is copied to the clipboard.