### PR TITLE
Fix issue causing flow error on image files

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -40,8 +40,7 @@ experimental.strict_type_args=true
 
 munge_underscores=true
 
-module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
-
+module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> '<PROJECT_ROOT>/src/extension-resolver.js.flow'
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps

--- a/src/extension-resolver.js.flow
+++ b/src/extension-resolver.js.flow
@@ -1,0 +1,3 @@
+declare module ImageStub {
+  declare var exports: { [key: string]: string };
+}


### PR DESCRIPTION
This is a fix for a known bug where flow does not seem to be able to properly import non-JS files (PNG, etc):
https://github.com/facebook/flow/issues/1068
https://github.com/facebook/flow/issues/338

Right now it seems that any scene that gets flowed and imports image files (at least PNG's) is failing. So I made this fix.