### PR TITLE
Return null if we don't have action.data passed into locale reducer

### DIFF
--- a/src/modules/UI/locale/reducer.js
+++ b/src/modules/UI/locale/reducer.js
@@ -4,7 +4,10 @@ import * as ACTION from './action'
 const localeInfo = (state = {}, action) => {
   switch (action.type) {
   case ACTION.SET_LOCALE_INFO:
-    return action.data
+    if (action.data)
+      return action.data
+    else
+      return null
   default:
     return state
   }


### PR DESCRIPTION
Returning undefined will cause redux to crash. Seems like we don't properly have a localeInfo on Android right now. That needs to also be debugged further