### PR TITLE
Check the float value of display amount to determine if it should change

### DIFF
--- a/src/modules/UI/components/FlipInput/ExchangedFlipInput.js
+++ b/src/modules/UI/components/FlipInput/ExchangedFlipInput.js
@@ -40,7 +40,7 @@ export default class ExchangedFlipInput extends Component {
     if (nextProps.primaryInfo.nativeAmount) {
       const nativeAmount = UTILS.absoluteValue(nextProps.primaryInfo.nativeAmount)
       const primaryDisplayAmount = this.convertPrimaryNativeToDisplay(nativeAmount)
-      if (this.state.primaryDisplayAmount === primaryDisplayAmount) { return }
+      if (parseFloat(this.state.primaryDisplayAmount) === parseFloat(primaryDisplayAmount)) { return }
       this.onPrimaryAmountChange(primaryDisplayAmount)
       // console.log('componentWillReceiveProps')
     }


### PR DESCRIPTION
This fixes issue where user cannot enter a value such as "0.001". As soon as the text field "0." is changed to "0.0", the expression edited in this commit will evaluate to false and call this.onPrimaryAmountChange with a new display amount of "0" deleting the last "0". By checking the float value instead of the string value, the === expression would return true so the display amount doesn't get overridden.