### PR TITLE
Fix deleting wallets

### DIFF
--- a/src/modules/UI/scenes/WalletList/components/DeleteWalletButtonsConnector.js
+++ b/src/modules/UI/scenes/WalletList/components/DeleteWalletButtonsConnector.js
@@ -5,7 +5,7 @@ import {closeDeleteWalletModal, deleteWallet} from '../action'
 const mapStateToProps = () => ({})
 const mapDispatchToProps = (dispatch) => ({
   onNegative: () => {},
-  onPositive: () => dispatch(deleteWallet()),
+  onPositive: (walletId) => dispatch(deleteWallet(walletId)),
   onDone: () => dispatch(closeDeleteWalletModal())
 })
 

--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptionsConnector.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptionsConnector.js
@@ -1,6 +1,6 @@
 import {connect} from 'react-redux'
 import WalletListRowOptions from './WalletListRowOptions.ui'
-import {updateRenameWalletInput} from './action'
+import {updateRenameWalletInput} from '../../action'
 import UI_SELECTORS from '../../../../selectors'
 
 const mapStateToProps = (state) => ({

--- a/src/modules/UI/scenes/WalletList/reducer.js
+++ b/src/modules/UI/scenes/WalletList/reducer.js
@@ -40,8 +40,10 @@ const walletId = (state = '', action) => {
   const {type, data = {} } = action
   const {walletId} = data
   switch (type) {
+  case ACTION.OPEN_DELETE_WALLET_MODAL:
   case ACTION.OPEN_RENAME_WALLET_MODAL:
     return walletId
+  case ACTION.CLOSE_DELETE_WALLET_MODAL:
   case ACTION.CLOSE_RENAME_WALLET_MODAL:
     return ''
   default:


### PR DESCRIPTION
The GUI wasn't sending a proper walletId to the core, so it was always deleting a wallet with an id of `undefined`.