### PR TITLE
Fix txDetails crash related to category colors

### DIFF
--- a/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
+++ b/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
@@ -17,7 +17,7 @@ import Contacts from 'react-native-contacts'
 import ContactSearchResults from './ContactSearchResults.ui.js'
 import FormattedText from '../../components/FormattedText/index'
 import Gradient from '../../components/Gradient/Gradient.ui'
-import styles from './style'
+import styles, {styles as styleRaw} from './style'
 import THEME from '../../../../theme/variables/airbitz'
 import * as UTILS from '../../../utils'
 import AmountArea from './AmountArea.ui.js'
@@ -400,22 +400,22 @@ export class TransactionDetails extends Component<Props & DispatchProps, State> 
 
     const types = {
       exchange: {
-        color: styles.typeExchange.color,
+        color: styleRaw.typeExchange.color,
         syntax: EXCHANGE_TEXT,
         key: 'exchange'
       },
       expense: {
-        color: styles.typeExpense.color,
+        color: styleRaw.typeExpense.color,
         syntax: EXPENSE_TEXT,
         key: 'expense'
       },
       transfer: {
-        color: styles.typeTransfer.color,
+        color: styleRaw.typeTransfer.color,
         syntax: TRANSFER_TEXT,
         key: 'transfer'
       },
       income: {
-        color: styles.typeIncome.color,
+        color: styleRaw.typeIncome.color,
         syntax: INCOME_TEXT,
         key: 'income'
       }

--- a/src/modules/UI/scenes/TransactionDetails/style.js
+++ b/src/modules/UI/scenes/TransactionDetails/style.js
@@ -1,8 +1,7 @@
 import {StyleSheet} from 'react-native'
 import THEME from '../../../../theme/variables/airbitz'
 
-export default StyleSheet.create({
-
+export const styles = {
   container: {
     flex: 1,
     alignItems: 'stretch',
@@ -355,4 +354,6 @@ export default StyleSheet.create({
   underlayColor: {
     color: THEME.COLORS.GRAY_4
   }
-})
+}
+
+export default StyleSheet.create(styles)


### PR DESCRIPTION
The purpose of this task is to fix the crash that occurs when accessing the txDetails scene that is the result of a `color` variable getting confused with the `color` property on a style.

Asana Task: https://app.asana.com/0/361770107085503/317312547827462/f