### PR TITLE
Fix txDetails category crash and metadata persistence

### DIFF
--- a/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
+++ b/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
@@ -343,8 +343,8 @@ export class TransactionDetails extends Component<Props & DispatchProps, State> 
     })
   }
 
-  onSelectCategory = (itemValue: any) => {
-    this.setState({type: itemValue})
+  onSelectCategory = (item: any) => {
+    this.setState({type: item.itemValue})
     this.onExitCategories()
   }
 
@@ -358,7 +358,7 @@ export class TransactionDetails extends Component<Props & DispatchProps, State> 
 
   onSaveTxDetails = () => {
     let category
-    if (this.state.subCategory && this.state.type) {
+    if (this.state.type) {
       category = this.state.type.charAt(0).toUpperCase() + this.state.type.slice(1) + ':' + this.state.subCategory
     } else {
       category = undefined
@@ -431,7 +431,7 @@ export class TransactionDetails extends Component<Props & DispatchProps, State> 
       type = types[this.state.type]
     }
 
-    const color = type.color
+    const categoryColor = type.color
     let sortedSubcategories = this.props.subcategoriesList.length > 0 ? this.props.subcategoriesList.sort() : []
     const txExplorerLink = sprintf(this.props.currencyInfo.transactionExplorer, this.props.abcTransaction.txid)
     return (
@@ -480,8 +480,8 @@ export class TransactionDetails extends Component<Props & DispatchProps, State> 
           style={[{opacity: this.state.subcategoryOpacity, width: '100%', zIndex: this.state.subcatZIndex, backgroundColor: THEME.COLORS.WHITE, position: 'absolute', height: platform.usableHeight}]}
           >
           <View style={[styles.modalCategoryRow]}>
-            <TouchableOpacity style={[styles.categoryLeft, {borderColor: color}]} disabled>
-              <FormattedText style={[{color: color}, styles.categoryLeftText]}>{type.syntax}</FormattedText>
+            <TouchableOpacity style={[styles.categoryLeft, {borderColor: categoryColor}]} disabled>
+              <FormattedText style={[{color: categoryColor}, styles.categoryLeftText]}>{type.syntax}</FormattedText>
             </TouchableOpacity>
             <View style={[styles.modalCategoryInputArea]}>
               <TextInput
@@ -561,7 +561,7 @@ export class TransactionDetails extends Component<Props & DispatchProps, State> 
                 onFocusNotes={this.onFocusNotes}
                 onBlurNotes={this.onBlurNotes}
                 direction={this.state.direction}
-                color={color}
+                color={categoryColor}
                 types={types}
                 onFocusFiatAmount={this.onFocusFiatAmount}
                 walletDefaultDenomProps={this.state.walletDefaultDenomProps}


### PR DESCRIPTION
The purpose of this task was to fix a bug caused by changing the category (spin wheel) on the txDetails page. The issue seems to have stemmed from category + subcategory metadata not saving correctly (the `&&` conditional).

Asana Task: https://app.asana.com/0/361770107085503/454519999136882/f