### PR TITLE
Adjust primary currencyCode area to fit 5 characters (flipInput)

### DIFF
--- a/src/modules/UI/components/FlipInput/FlipInput.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput.ui.js
@@ -84,7 +84,7 @@ export default class FlipInput extends Component<Props, State> {
   bottomDisplayAmount = () => this.state.isToggled ? this.state.primaryDisplayAmount : this.state.secondaryDisplayAmount
 
   topRow = (denominationInfo: FlipInputFieldInfo, onChangeText: ((string) => void)) => <View style={top.row} key={'top'}>
-      <Text style={top.symbol}>
+      <Text style={[top.symbol]}>
         {denominationInfo.displayDenomination.symbol}
       </Text>
       <TextInput style={[top.amount]}
@@ -95,7 +95,8 @@ export default class FlipInput extends Component<Props, State> {
         autoCorrect={false}
         keyboardType='numeric'
         selectionColor='white'
-        returnKeyType='done' />
+        returnKeyType='done'
+      />
       <Text style={[top.currencyCode]}>
         {denominationInfo.displayDenomination.name}
       </Text>
@@ -139,7 +140,7 @@ export default class FlipInput extends Component<Props, State> {
     // console.log('this.state', this.state)
     return (
       <View style={[styles.container]}>
-        <View style={styles.flipButton}>
+        <View style={[styles.flipButton]}>
           <FAIcon style={[styles.flipIcon]} onPress={this.onToggleFlipInput} name='swap-vert' size={36} />
         </View>
         {this.renderRows(primaryInfo, secondaryInfo, isToggled)}

--- a/src/modules/UI/components/FlipInput/styles.js
+++ b/src/modules/UI/components/FlipInput/styles.js
@@ -11,7 +11,8 @@ export const styles = StyleSheet.create({
 
   container: {
     flex: 1,
-    margin: 20,
+    marginVertical: 20,
+    marginHorizontal: 14,
     alignSelf: 'stretch',
     backgroundColor: THEME.COLORS.TRANSPARENT,
     flexDirection: 'row'
@@ -49,25 +50,25 @@ export const top = StyleSheet.create({
     borderBottomWidth: 1
   },
   symbol: {
-    flex: 1,
+    flex: 3,
     fontSize: 17,
     color: THEME.COLORS.WHITE,
     textAlign: 'center',
     backgroundColor: THEME.COLORS.TRANSPARENT
   },
   amount: {
-    flex: 4,
+    flex: 6,
     fontSize: 40,
     color: THEME.COLORS.WHITE,
     textAlign: 'center',
     backgroundColor: THEME.COLORS.TRANSPARENT
   },
   currencyCode: {
-    flex: 1,
+    flex: 3,
     fontSize: 17,
+    lineHeight: 20,
     color: THEME.COLORS.WHITE,
     textAlign: 'right',
-    marginRight: 5,
     backgroundColor: THEME.COLORS.TRANSPARENT
   }
 })
@@ -96,7 +97,6 @@ export const bottom = StyleSheet.create({
     flex: 1,
     color: THEME.COLORS.WHITE,
     textAlign: 'right',
-    marginRight: 5,
     backgroundColor: THEME.COLORS.TRANSPARENT
   },
   alert: {

--- a/src/modules/UI/scenes/SendConfirmation/SendConfirmation.ui.js
+++ b/src/modules/UI/scenes/SendConfirmation/SendConfirmation.ui.js
@@ -96,7 +96,7 @@ export default class SendConfirmation extends Component<Props & DispatchProps, S
             }
           </View>
 
-          <View style={[styles.main, UTILS.border(), {flex: this.state.keyboardVisible ? 0 : 1}]}>
+          <View style={[styles.main, UTILS.border('yellow'), {flex: this.state.keyboardVisible ? 0 : 1}]}>
             <ExchangedFlipInput
               primaryInfo={{...primaryInfo, nativeAmount}}
               secondaryInfo={secondaryInfo}


### PR DESCRIPTION
The purpose of this task is to create enough room for the primary currency code in the FlipInput so that 4 and 5-character currency codes do not get cut-off nor pushed to a second line. This was accomplished primarily by squeezing a bit of room from the margins and also from the primary amount textInput.

Asana Task: https://app.asana.com/0/361770107085503/454846041677698/f