### PR TITLE
Add NFC usage description for iOS

### DIFF
--- a/ios/edge/Info.plist
+++ b/ios/edge/Info.plist
@@ -50,6 +50,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NFCReaderUsageDescription</key>
+	<string>$(PRODUCT_NAME) does not use NFC.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$(PRODUCT_NAME) uses photos to retrieve QR Code images.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>


### PR DESCRIPTION
Edge Wallet does not use any NFC features, nor does it use any
information that may be available via NFC.