### PR TITLE
Log to local server

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,7 @@ if (!__DEV__) {
   console.log = log
 }
 
-if (ENV.LOCAL_SERVER) {
+if (ENV.LOG_SERVER) {
   let originalLog = console.log
   // $FlowFixMe: suppressing this error until we can find a workaround
   console.log = function () {

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -4,7 +4,7 @@ import RNFS from 'react-native-fs'
 import ENV from '../../env.json'
 
 const SAVE_TIMEOUT = 1000 * 10 // ms
-const LOCAL_SERVER_TIMEOUT = 1000 // ms
+const LOG_SERVER_TIMEOUT = 1000 // ms
 
 const path = RNFS.DocumentDirectoryPath + '/logs.txt'
 
@@ -73,7 +73,7 @@ export async function log (...info: Array<number | string | null | {}>) {
 }
 
 async function request (data: string) {
-  return global.fetch(`${ENV.LOCAL_SERVER.host}:${ENV.LOCAL_SERVER.port}/log`, {
+  return global.fetch(`${ENV.LOG_SERVER.host}:${ENV.LOG_SERVER.port}/log`, {
     method: 'POST',
     headers : {
       'Accept': 'application/json',
@@ -84,7 +84,7 @@ async function request (data: string) {
 }
 
 async function sendToServer (logs: string) {
-  if (Date.now() - lastSavingLocalServer < LOCAL_SERVER_TIMEOUT) {
+  if (Date.now() - lastSavingLocalServer < LOG_SERVER_TIMEOUT) {
     logs !== '' && saveToLocalServerBuffer(logs)
     setTimeout(() => sendToServer(''), Date.now() - lastSavingLocalServer)
     return


### PR DESCRIPTION
Adds the option to send logs to any http server through a POST request to /log.
This allows debugging for release version and not just in debug mode as we have now.

To setup the logger to send logs to a server you need to add the following to your local env.json file:

"LOG_SERVER": {
    "host": "what ever the ip/dns is with http/https",
    "port": "port number"
  }

And all the logs will be sent to host:port/log as a POST requests.

If you don't add "LOG_SERVER" to env.json then it will just ignore this option and won't send the logs and will continue to work as usual.