### PR TITLE
Fix the top offset of the dropdown alerts to line up with StatusBar

### DIFF
--- a/src/modules/UI/components/DropdownAlert/DropdownAlert.ui.js
+++ b/src/modules/UI/components/DropdownAlert/DropdownAlert.ui.js
@@ -25,8 +25,7 @@ export default class DropdownAlert extends Component<Props> {
       onPress={onPress}
       panResponderEnabled={false}
       updateStatusBar={false}
-      startDelta={-10}
-      endDelta={44}
+      endDelta={20}
       onClose={onClose}>
       {children}
     </RNDropdownAlert>


### PR DESCRIPTION
The previous value caused the top of the dropdowns to cut through the middle of text.