### PR TITLE
Fix `paste` button in Scan -> Address button

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -301,7 +301,7 @@ const strings = {
   fragment_send_incorrect_password_title: 'Incorrect Password',
   fragment_send_no_satoshi_title: 'Enter an amount',
   fragment_send_no_satoshi_message: 'Please enter an amount to send',
-  fragment_send_send_to_hint: 'Bitcoin Address or Private Key',
+  fragment_send_send_to_hint: 'Public Address or Private Key',
   fragment_send_failure_title: 'Send failure',
   fragment_send_send_bitcoin_invalid: 'Invalid bitcoin address',
   fragment_send_send_bitcoin_unscannable: 'Unable to scan QR code',

--- a/src/modules/UI/scenes/Scan/components/AddressInput.js
+++ b/src/modules/UI/scenes/Scan/components/AddressInput.js
@@ -5,6 +5,7 @@ import {
 } from 'react-native'
 import {TertiaryButton} from '../../../components/Buttons'
 import styles from '../style.js'
+import strings from '../../../../../locales/default'
 
 export class AddressInput extends Component { // this component is for the input area of the Recipient Address Modal
   render () {
@@ -16,7 +17,7 @@ export class AddressInput extends Component { // this component is for the input
             onChangeText={this.props.onChangeText}
             autoCapitalize={'none'}
             autoFocus
-            placeholder={this.props.copyMessage}
+            placeholder={strings.enUS.fragment_send_send_to_hint}
             returnKeyType={'done'}
             autoCorrect={false}
             onSubmitEditing={this.props.onSubmit}

--- a/src/modules/UI/scenes/Scan/components/AddressModal.js
+++ b/src/modules/UI/scenes/Scan/components/AddressModal.js
@@ -25,8 +25,8 @@ export default class AddressModal extends Component {
     }
   }
 
-  componentDidMount () {
-    const coreWallet = this.props.coreWallet
+  _setClipboard (props: Props) {
+    const coreWallet = props.coreWallet
     Clipboard.getString().then((uri) => {
       try {
         // Will throw in case uri is invalid
@@ -41,6 +41,14 @@ export default class AddressModal extends Component {
         // console.log(e)
       }
     })
+  }
+
+  componentDidMount () {
+    this._setClipboard(this.props)
+  }
+
+  componentWillReceiveProps (nextProps: Props) {
+    this._setClipboard(nextProps)
   }
 
   render () {


### PR DESCRIPTION
Code to grab clipboard was only happening in DidMount. Since switch to RNRF v4, DidMount only gets called once so if the clipboard was empty, it would never get clipboard content.

Fix is to also grab clipboard content at WillReceiveProps

Fixes bug " [Paste] is no longer an option when Sending via Address"