### PR TITLE
Fix rename wallet crash

### DIFF
--- a/src/modules/UI/scenes/WalletList/WalletList.ui.js
+++ b/src/modules/UI/scenes/WalletList/WalletList.ui.js
@@ -402,7 +402,7 @@ export default class WalletList extends Component<any, {
     headerText='fragment_wallets_rename_wallet'
     headerSubtext={this.props.walletName}
     modalMiddle={<WalletNameInput />}
-    modalBottom={<RenameWalletButtons walletId={this.props.walletId} />}
+    modalBottom={<RenameWalletButtons walletName={this.props.walletName} walletId={this.props.walletId} />}
     visibilityBoolean={this.props.renameWalletModalVisible}
     onExitButtonFxn={this.props.closeRenameWalletModal}
     />

--- a/src/modules/UI/scenes/WalletList/components/RenameWalletButtons.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/RenameWalletButtons.ui.js
@@ -1,3 +1,5 @@
+// @flow
+
 import React, {Component} from 'react'
 import {TouchableHighlight, View} from 'react-native'
 import T from '../../../components/FormattedText'
@@ -8,14 +10,35 @@ import {sprintf} from 'sprintf-js'
 const NEGATIVE_TEXT = sprintf(strings.enUS['string_cancel_cap'])
 const POSITIVE_TEXT = sprintf(strings.enUS['calculator_done'])
 
-export default class RenameWalletButtons extends Component {
+export type JsxProps = {
+  walletName: string,
+}
+
+export type StateToProps = {
+  walletId: string,
+  renameWalletInput: string
+}
+
+export type DispatchProps = {
+  onPositive: (walletId: string, walletName: string) => any,
+  onNegative: () => any,
+  onDone: () => any
+}
+
+type Props = JsxProps & StateToProps & DispatchProps
+
+export default class RenameWalletButtons extends Component <Props> {
   onPositive = () => {
-    this.props.onPositive(this.props.walletId, this.props.renameWalletInput)
+    if (this.props.renameWalletInput) {
+      this.props.onPositive(this.props.walletId, this.props.renameWalletInput)
+    } else {
+      this.props.onPositive(this.props.walletId, this.props.walletName)
+    }
     this.props.onDone()
   }
 
   onNegative = () => {
-    this.props.onNegative('')
+    this.props.onNegative()
     this.props.onDone()
   }
 

--- a/src/modules/UI/scenes/WalletList/components/RenameWalletButtonsConnector.js
+++ b/src/modules/UI/scenes/WalletList/components/RenameWalletButtonsConnector.js
@@ -1,21 +1,20 @@
+// @flow
 import {connect} from 'react-redux'
-import RenameWalletButtons from './RenameWalletButtons.ui'
+import RenameWalletButtons, {type StateToProps, type DispatchProps} from './RenameWalletButtons.ui'
+import type {State, Dispatch} from '../../../../ReduxTypes'
 import {
-  updateRenameWalletInput,
   closeRenameWalletModal,
   renameWallet
 } from '../action'
 
-const mapStateToProps = (state) => ({
-  currentWalletBeingRenamed: state.ui.wallets.byId[state.ui.wallets.selectedWalletId],
+const mapStateToProps = (state: State): StateToProps => ({
   walletId: state.ui.scenes.walletList.walletId,
   renameWalletInput: state.ui.scenes.walletList.renameWalletInput
 })
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
   onNegative: () => {},
   onPositive: (walletId, walletName) => dispatch(renameWallet(walletId, walletName)),
   onDone: () => dispatch(closeRenameWalletModal()),
-  updateRenameWalletInput: (input) => updateRenameWalletInput(input)
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(RenameWalletButtons)

--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptions.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptions.ui.js
@@ -34,10 +34,7 @@ export default class WalletListRowOptions extends Component {
   }
 
   optionAction = (optionKey) => {
-    this.props.executeWalletRowOption(this.props.walletKey, optionKey, this.props.wallets, this.props.archives)
-    if (optionKey === Constants.RENAME_VALUE) {
-      this.props.updateRenameWalletInput(this.props.wallets[this.props.walletKey].name)
-    }
+    this.props.executeWalletRowOption(this.props.walletKey, optionKey)
   }
 
   render () {

--- a/src/modules/UI/scenes/WalletList/components/WalletNameInput.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletNameInput.ui.js
@@ -3,8 +3,14 @@ import React, {Component} from 'react'
 import {TextInput, View} from 'react-native'
 import styles from '../style'
 
-export default class WalletNameInput extends Component<$FlowFixMeProps> {
-  _onNameInputChange = (input) => {
+type Props = {
+  currentWalletBeingRenamed: string,
+  updateRenameWalletInput: (string) => any
+}
+
+export default class WalletNameInput extends Component<Props> {
+
+  _onNameInputChange = (input: string) => {
     // be aware that walletListRowOptions.ui.js also initially dispatches this action
     this.props.updateRenameWalletInput(input)
   }


### PR DESCRIPTION
Interesting bug was exposed due to merge of CryptoExchange branch.

Prior to the refactor of constants from CryptoExchange branch, there was a capitalization mismatch in optionAction() in WalletNameInput.ui.js causing (optionKey == Constants.RENAME_VALUE) to always be false. This allowed renames to still work but the default walletname would never get propogated causing a wallet to get renamed to "" if the user tapped OK without changing the textfield. With the Constants refactor, the (optionKey == Constants.RENAME_VALUE) would return true and throw an error due to this.props.wallets never being set.

Fixed by making the WalletNameInput component self sufficient and able to take in the default walletName itself.

Added sufficient Flow types to relevant files