### PR TITLE
Update logos to properly show on dark background.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dns.js": "^1.0.1",
     "domain-browser": "^1.1.7",
     "edge-currency-bitcoin": "^0.7.2",
-    "edge-currency-ethereum": "^0.3.4",
+    "edge-currency-ethereum": "^0.3.5",
     "edge-exchange-plugins": "^0.1.1",
     "https-browserify": "0.0.1",
     "lodash": "^4.17.2",

--- a/src/styles/scenes/CryptoExchangeSceneStyles.js
+++ b/src/styles/scenes/CryptoExchangeSceneStyles.js
@@ -72,7 +72,7 @@ const CryptoExchangeSceneStyle = {
       left:0,
       height:29,
       width:29,
-      backgroundColor: THEME.COLORS.WHITE,
+      backgroundColor: THEME.COLORS.TRANSPARENT,
       borderRadius: 15,
       alignItems:'center',
       justifyContent:'space-around'


### PR DESCRIPTION
- Bump ethereum dep to 0.3.5 which uses white on transparent icons
- Remove white background of CryptoExchange scene