### PR TITLE
createWallet fixes:

### DIFF
--- a/src/constants/WalletAndCurrencyConstants.js
+++ b/src/constants/WalletAndCurrencyConstants.js
@@ -1,4 +1,4 @@
-export const BITCOIN_44_WALLET = 'wallet:bitcoin-bip44'
+export const BITCOIN_44_WALLET = 'wallet:bitcoin44segwit'
 export const ETHEREUM_WALLET = 'wallet:ethereum'
 
 export const USD_FIAT = 'iso:USD'

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -838,8 +838,8 @@ const strings = {
   title_Exchange: 'Exchange',
   dropdown_exchange_max_amount: 'Exchange Max Amount',
 
-  string_first_ethereum_wallet_name: 'My Ethereum Wallet',
-  strings_first_bitcoin_44_wallet_name: 'My Bitcoin Wallet',
+  string_first_ethereum_wallet_name: 'My Ether',
+  strings_first_bitcoin_44_wallet_name: 'My Bitcoin',
 
   // help modal
   help_modal_title: 'Crypto Wallet and Directory',

--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -48,8 +48,8 @@ export const initializeAccount = (account: AbcAccount) => (dispatch: Dispatch, g
         return
       }
       // TODO: Allen - Turn on when Bitcoin is turned back on
-      //dispatch(actions.createCurrencyWallet(strings.enUS['strings_first_bitcoin_44_wallet_name'], Constants.BITCOIN_44_WALLET, Constants.USD_FIAT)) //name.. walletType, fiat currency. TODO: get fiat to react to device.
-      dispatch(actions.createCurrencyWallet(strings.enUS['string_first_ethereum_wallet_name'], Constants.ETHEREUM_WALLET, Constants.USD_FIAT))
+      dispatch(actions.createCurrencyWallet(strings.enUS['strings_first_bitcoin_44_wallet_name'], Constants.BITCOIN_44_WALLET, Constants.USD_FIAT, false)) //name.. walletType, fiat currency. TODO: get fiat to react to device.
+      dispatch(actions.createCurrencyWallet(strings.enUS['string_first_ethereum_wallet_name'], Constants.ETHEREUM_WALLET, Constants.USD_FIAT, false))
       dispatch(loadSettings())
     })
 }

--- a/src/modules/UI/scenes/CreateWallet/action.js
+++ b/src/modules/UI/scenes/CreateWallet/action.js
@@ -27,7 +27,8 @@ export const selectFiat = (fiat: string) => ({
 export const createCurrencyWallet = (
   walletName: string,
   walletType: string,
-  fiatCurrencyCode: string
+  fiatCurrencyCode: string,
+  popScene: boolean = true
 ) => (dispatch: any, getState: any) => {
   const state = getState()
   const account = CORE_SELECTORS.getAccount(state)
@@ -36,6 +37,8 @@ export const createCurrencyWallet = (
     name: walletName,
     fiatCurrencyCode
   }).then(() => {
-    Actions.pop()
+    if (popScene) {
+      Actions.pop()
+    }
   })
 }


### PR DESCRIPTION
* Change wallettype for bitcoin to `wallet:bitcoin44segwit`
* Shorten default wallet names so they don't collide with backbutton in header
* Enable creation of bitcoin wallet on login
* Change createCurrencyWallet to take popScene parameter. Use FALSE for when creating a wallet from login so we don't pop back to the login UI