### PR TITLE
Reduce Spinner Font Size (txDetails Category Area)

### DIFF
--- a/src/modules/UI/scenes/TransactionDetails/AmountArea.ui.js
+++ b/src/modules/UI/scenes/TransactionDetails/AmountArea.ui.js
@@ -189,7 +189,7 @@ class AmountArea extends Component<Props, State> {
               left: -20
             }
           ]}
-            itemStyle={{fontFamily: 'SourceSansPro-Black', color: THEME.COLORS.GRAY_1, fontSize: 30, paddingBottom: 14}}
+            itemStyle={{fontFamily: 'SourceSansPro-Black', color: THEME.COLORS.GRAY_1, fontSize: 22, paddingBottom: 14}}
             selectedValue={this.props.type.key}
             onValueChange={(itemValue) => this.props.selectCategory({itemValue})}>
             {categories.map((x) => (


### PR DESCRIPTION
The purpose of this task is to reduce the fontSize of the Picker elements on the txDetails page when a user is trying to change the category (Transfer, Exchange, Expense, Income).

Asana Task: https://app.asana.com/0/361770107085503/454386426649118/f