### PR TITLE
Exchange Flip fixes

### DIFF
--- a/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
+++ b/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
@@ -56,21 +56,6 @@ export default class CryptoExchangeFlipInputWrapperComponent extends Component<P
 
   }
 
-  getLogo = () => {
-    const wallet = this.props.uiWallet ? this.props.uiWallet : null
-    if (!wallet) return null
-
-    if (this.props.currencyCode === wallet.currencyCode) return wallet.symbolImage
-
-    for (let i =0; i< wallet.metaTokens.length; i++) {
-      const obj = wallet.metaTokens[i]
-      if (obj.symbolImage && obj.currencyCode === this.props.currencyCode) {
-        return obj.symbolImage
-      }
-    }
-    return null
-  }
-
   renderLogo = (style: any, logo: string) => {
     if (logo) {
       return <View style={style.iconContainer}>
@@ -83,7 +68,6 @@ export default class CryptoExchangeFlipInputWrapperComponent extends Component<P
   }
 
   render () {
-    const logo = this.getLogo()
     const style = this.props.style
     if (!this.props.uiWallet) {
       return <View style={style.container} />

--- a/src/reducers/CryptoExchangeReducer.js
+++ b/src/reducers/CryptoExchangeReducer.js
@@ -46,9 +46,31 @@ function getLogo (wallet, currencyCode) {
   }
   return null
 } */
+function deepCopyState (state) {
+  const deepCopy = JSON.parse(JSON.stringify(state))
+  deepCopy.toWallet = state.fromWallet
+  deepCopy.toCurrencyCode = state.fromCurrencyCode
+  deepCopy.toNativeAmount = state.fromNativeAmount
+  deepCopy.toDisplayAmount = state.fromDisplayAmount
+  deepCopy.toWalletPrimaryInfo = state.fromWalletPrimaryInfo
+  deepCopy.toCurrencyIcon = state.fromCurrencyIcon
+  deepCopy.fromWallet = state.toWallet
+  deepCopy.fromCurrencyCode = state.toCurrencyCode
+  deepCopy.fromNativeAmount = state.toNativeAmount
+  deepCopy.fromDisplayAmount = state.toDisplayAmount
+  deepCopy.fromWalletPrimaryInfo = state.toWalletPrimaryInfo
+  deepCopy.fromCurrencyIcon = state.toCurrencyIcon
+  deepCopy.exchangeRate = state.reverseExchange
+  deepCopy.reverseExchange = state.exchangeRate
+  deepCopy.insufficientError = false
+  return deepCopy
+}
 
 export default function (state = initialState, action) {
+
   switch (action.type) {
+  case Constants.SWAP_FROM_TO_CRYPTO_WALLETS:
+    return deepCopyState(state)
   case Constants.SELECT_FROM_WALLET_CRYPTO_EXCHANGE:
     return {...state,
       fromWallet: action.data.wallet,
@@ -72,15 +94,6 @@ export default function (state = initialState, action) {
       toNativeAmount:'0',
       fromDisplayAmount: '0',
       toDisplayAmount: '0'
-    }
-  case Constants.SWAP_FROM_TO_CRYPTO_WALLETS:
-    return {...state,
-      toWallet: state.fromWallet,
-      fromWallet: state.toWallet,
-      toCurrencyCode: state.toCurrencyCode,
-      fromCurrencyCode: state.fromCurrencyCode,
-      toNativeAmount: state.toNativeAmount,
-      fromNativeAmount: state.fromNativeAmount
     }
   case Constants.DISABLE_WALLET_LIST_MODAL_VISIBILITY:
     return {...state, walletListModalVisible: false}


### PR DESCRIPTION
1. The center flip arrows doesn’t flip icons
7. Tapping center flip icon doesn’t zero out or update the amounts.
also removed dead code in CryptoExchangeFlipINputWrapperComponent.js
The numbers are not accurate, that is a known issue still pending , and will be in another PR