### PR TITLE
Fix problem of fiatInput getting updated after entry

### DIFF
--- a/src/modules/UI/components/FlipInput/ExchangedFlipInput.js
+++ b/src/modules/UI/components/FlipInput/ExchangedFlipInput.js
@@ -67,23 +67,15 @@ export default class ExchangedFlipInput extends Component<Props, State> {
 
   componentWillReceiveProps (nextProps: Props) {
     if (nextProps.primaryInfo.nativeAmount) {
-      const nativeAmount:string = bns.abs(nextProps.primaryInfo.nativeAmount)
-      const primaryDisplayAmount:string = this.convertPrimaryNativeToDisplay(nativeAmount)
-      if (bns.eq(this.state.primaryDisplayAmount, primaryDisplayAmount)) {
-        // Display amount didn't change. Check if exchange rate did.
-        if (this.props.secondaryToPrimaryRatio !== nextProps.secondaryToPrimaryRatio) {
-          if (this.state.lastChanged === LC_PRIMARY) {
-            this.onPrimaryAmountChange(this.state.primaryDisplayAmount)
-          } else if (this.state.lastChanged === LC_SECONDARY) {
-            this.onSecondaryAmountChange(this.state.secondaryDisplayAmount)
-          }
-        }
-      } else {
-        if (this.state.lastChanged === LC_UNDEFINED || this.state.lastChanged === LC_PRIMARY) {
+      const primaryNativeAmount: string = bns.abs(nextProps.primaryInfo.nativeAmount)
+      const primaryDisplayAmount = this.convertPrimaryNativeToDisplay(primaryNativeAmount)
+      if (this.state.lastChanged === LC_UNDEFINED) {
+        this.onPrimaryAmountChange(primaryDisplayAmount)
+      } else if (this.state.lastChanged === LC_PRIMARY) {
+        if (!bns.eq(this.state.primaryDisplayAmount, primaryDisplayAmount)) {
           this.onPrimaryAmountChange(primaryDisplayAmount)
         }
       }
-      // console.log('componentWillReceiveProps')
     }
   }
 

--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -25,8 +25,6 @@ export default class Request extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      primaryNativeAmount: '',
-      secondaryNativeAmount: '',
       publicAddress: '',
       encodedURI: '',
       loading: props.loading
@@ -65,12 +63,9 @@ export default class Request extends Component {
     })
   }
 
-  onAmountsChange = ({primaryDisplayAmount, secondaryDisplayAmount}) => {
+  onAmountsChange = ({primaryDisplayAmount}) => {
     const primaryNativeToDenominationRatio = this.props.primaryInfo.displayDenomination.multiplier.toString()
-    const secondaryNativeToDenominationRatio = this.props.secondaryInfo.displayDenomination.multiplier.toString()
-
     const primaryNativeAmount = UTILS.convertDisplayToNative(primaryNativeToDenominationRatio)(primaryDisplayAmount)
-    const secondaryNativeAmount = UTILS.convertDisplayToNative(secondaryNativeToDenominationRatio)(secondaryDisplayAmount)
 
     const parsedURI = {
       publicAddress: this.state.publicAddress,
@@ -79,8 +74,6 @@ export default class Request extends Component {
     const encodedURI = this.props.abcWallet.encodeUri(parsedURI)
 
     this.setState({
-      primaryNativeAmount,
-      secondaryNativeAmount,
       encodedURI
     })
   }
@@ -96,7 +89,6 @@ export default class Request extends Component {
       primaryInfo,
       secondaryInfo
     } = this.props
-    const nativeAmount = this.state.primaryNativeAmount
     return (
       <Gradient style={styles.view}>
 
@@ -109,7 +101,7 @@ export default class Request extends Component {
 
         <View style={styles.main}>
           <ExchangedFlipInput
-            primaryInfo={{...primaryInfo, nativeAmount}}
+            primaryInfo={primaryInfo}
             secondaryInfo={secondaryInfo}
             secondaryToPrimaryRatio={secondaryToPrimaryRatio}
             onAmountsChange={this.onAmountsChange}


### PR DESCRIPTION
Prior to this change, an edit of the secondary amount (fiat) would update the primary amount which would then re-update the fiatamount cause a slight difference in the amount the user entered. (ie. $1 => $0.99). This change prevents the reupdate of the same field that the user edited.