### PR TITLE
Reduce height of header gradient for txDetails

### DIFF
--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -253,8 +253,8 @@ export default class Main extends Component<Props, State> {
                           <Scene key={Constants.TRANSACTION_LIST} tintColor={styles.backButtonColor} navTransparent={true} icon={this.icon(Constants.TRANSACTION_LIST)}renderTitle={this.renderWalletListNavBar} component={TransactionListConnector} onRight={() => Actions.drawerOpen()} rightButtonImage={MenuIcon} tabBarLabel='Transactions' title='Transactions' animation={'fade'} duration={600} />
                         </Stack>
                         <Scene key={Constants.REQUEST} renderTitle={this.renderWalletListNavBar} navTransparent={true} icon={this.icon(Constants.REQUEST)} component={Request} tabBarLabel='Request' title='Request' renderLeftButton={() => <HelpButton/>} onRight={() => Actions.drawerOpen()} rightButtonImage={MenuIcon} animation={'fade'} duration={600} />
-                        <Stack key={Constants.SCAN} title='Send' icon={this.icon(Constants.SCAN)} navTransparent={true} tabBarLabel='Send' >
-                          <Scene key='scan_notused' renderTitle={this.renderWalletListNavBar} component={Scan} onRight={() => Actions.drawerOpen()} navTransparent={true} rightButtonImage={MenuIcon} onEnter={this.props.dispatchEnableScan} onExit={this.props.dispatchDisableScan} renderLeftButton={() => <HelpButton/>} tabBarLabel='Send' title='Send' animation={'fade'} duration={600} />
+                        <Stack key={Constants.SCAN} title='Send' navigationBarStyle={{backgroundColor: THEME.COLORS.PRIMARY}} icon={this.icon(Constants.SCAN)} tabBarLabel='Send' >
+                          <Scene key='scan_notused' renderTitle={this.renderWalletListNavBar} component={Scan} onRight={() => Actions.drawerOpen()} rightButtonImage={MenuIcon} onEnter={this.props.dispatchEnableScan} onExit={this.props.dispatchDisableScan} renderLeftButton={() => <HelpButton/>} tabBarLabel='Send' title='Send' animation={'fade'} duration={600} />
                           <Scene key={Constants.EDGE_LOGIN}
                             renderTitle={'Edge Login'}
                             component={EdgeLoginSceneConnector}

--- a/src/modules/UI/scenes/Scan/Scan.ui.js
+++ b/src/modules/UI/scenes/Scan/Scan.ui.js
@@ -73,7 +73,6 @@ export default class Scan extends Component<any, any> {
   render () {
     return (
       <View style={styles.container}>
-        <Gradient style={{height: 66, width: '100%'}} />
         {this.renderCamera()}
         <View style={[styles.overlay, UTILS.border()]}>
 
@@ -239,7 +238,7 @@ export default class Scan extends Component<any, any> {
     } else if (this.state.cameraPermission === false) {
       return (
         <View style={[styles.preview, {justifyContent: 'center', alignItems: 'center'}, UTILS.border()]}>
-          <Text style={[UTILS.border(), {alignSelf: 'center'}]}>
+          <Text>
             {DENIED_PERMISSION_TEXT}
           </Text>
         </View>

--- a/src/modules/UI/scenes/Scan/style.js
+++ b/src/modules/UI/scenes/Scan/style.js
@@ -26,9 +26,7 @@ export const styles = {
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: THEME.COLORS.GRAY_1,
-    opacity: 0.95,
-    position: 'relative',
-    top: 66
+    opacity: 0.95
   },
   overlayTopText: {
     color: THEME.COLORS.WHITE,


### PR DESCRIPTION
The purpose of this commit is to implement the linear gradient header appropriately on the txDetails page, specifically making sure that the height is not too tall. Also, this PR reverts the header to blue for the Scan scene since it was causing issues.

Asana Task: https://app.asana.com/0/361770107085503/459375388568102/f