### PR TITLE
Remove 'From' and 'To' from Exchange Scene wallet dropdowns

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -19,8 +19,6 @@ const strings = {
   edge_description: 'This application would like to create or access its wallet in your Edge account.\n\n It will not have access to any other wallets.',
   exchange_failed: 'Exchange Failed',
   exchange_succeeded: 'Exchange Succeeded',
-  fragment_exchange_from: 'From:',
-  fragment_exchange_to: 'To:',
   exchanges_may_take_minutes: 'Exchanges may take several minutes to process. Please check your destination wallet after a few minutes',
   fragment_wallets_addwallet_blockchain_hint: 'Choose a blockchain',
   fragment_wallets_addwallet_fiat_hint: 'Choose a fiat currency',

--- a/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
+++ b/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
@@ -12,7 +12,6 @@ import type { ExchangedFlipInputAmounts } from './ExchangedFlipInput2.js'
 type State = {}
 
 export type Props = {
-  walletDirectionString: string,
   style: StyleSheet.Styles,
   guiWallet: GuiWallet,
   fee: string | null,
@@ -64,7 +63,7 @@ export class CryptoExchangeFlipInputWrapperComponent extends Component<Props, St
 
   render () {
     const style: StyleSheet.Styles = this.props.style
-    const { primaryCurrencyInfo, secondaryCurrencyInfo, fiatPerCrypto, forceUpdateGuiCounter, overridePrimaryExchangeAmount, walletDirectionString } = this.props
+    const { primaryCurrencyInfo, secondaryCurrencyInfo, fiatPerCrypto, forceUpdateGuiCounter, overridePrimaryExchangeAmount } = this.props
 
     if (!this.props.guiWallet || this.props.guiWallet.id === '' || !primaryCurrencyInfo || !secondaryCurrencyInfo) {
       return (
@@ -83,7 +82,7 @@ export class CryptoExchangeFlipInputWrapperComponent extends Component<Props, St
     const guiWalletName = this.props.guiWallet.name
     const displayDenomination = this.props.primaryCurrencyInfo.displayCurrencyCode
     const titleComp = function (styles) {
-      return <WalletNameHeader walletDirectionString={walletDirectionString} name={guiWalletName} denomination={displayDenomination} styles={styles} />
+      return <WalletNameHeader name={guiWalletName} denomination={displayDenomination} styles={styles} />
     }
 
     return (

--- a/src/modules/UI/components/Header/Component/WalletNameHeader.ui.js
+++ b/src/modules/UI/components/Header/Component/WalletNameHeader.ui.js
@@ -9,8 +9,7 @@ type Props = {
     textStyles: Array<{}>
   },
   name: string,
-  denomination: string,
-  walletDirectionString?: string
+  denomination: string
 }
 
 class WalletNameHeader extends React.Component<Props> {
@@ -19,13 +18,12 @@ class WalletNameHeader extends React.Component<Props> {
     const textStyles = styles.textStyles || []
     const name = this.props.name
     const denomination = this.props.denomination
-    const directionPrefix = this.props.walletDirectionString ? this.props.walletDirectionString : ''
 
     return (
       <View style={style.headerNameContainer}>
         <Text style={textStyles} ellipsizeMode={'middle'} numberOfLines={1}>
-          {directionPrefix + ' ' + name}
-          <Text style={[style.cCode, ...textStyles]}> ({denomination})</Text>
+          {name}:
+          <Text style={[style.cCode, ...textStyles]}>{denomination}</Text>
         </Text>
       </View>
     )

--- a/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
+++ b/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
@@ -158,7 +158,6 @@ export class CryptoExchangeSceneComponent extends Component<Props, State> {
             <CryptoExchangeConnector style={style.exchangeRateBanner} />
             <View style={style.shim} />
             <CryptoExchangeFlipInputWrapperComponent
-              walletDirectionString={s.strings.fragment_exchange_from}
               style={style.flipWrapper}
               guiWallet={this.props.fromWallet}
               fee={this.props.fee}
@@ -177,7 +176,6 @@ export class CryptoExchangeSceneComponent extends Component<Props, State> {
             <View style={style.shim} />
             <CryptoExchangeFlipInputWrapperComponent
               style={style.flipWrapper}
-              walletDirectionString={s.strings.fragment_exchange_to}
               guiWallet={this.props.toWallet}
               fee={null}
               buttonText={this.props.toButtonText}


### PR DESCRIPTION
The purpose is to revert the appearance of the Exchange scene wallet dropdowns to remove the "From:" and "To:" in order to save space.

Asana Task: https://app.asana.com/0/361770107085503/475629743533054/f