### PR TITLE
Adjust load-ahead factor for txList Lazy Load

### DIFF
--- a/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
+++ b/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
@@ -27,7 +27,7 @@ import styles, { styles as styleRaw } from './style'
 // import SearchBar from './components/SearchBar.ui'
 const INITIAL_TRANSACTION_BATCH_NUMBER = 10
 const SUBSEQUENT_TRANSACTION_BATCH_NUMBER = 30
-const SCROLL_THRESHOLD = 0.5
+const SCROLL_THRESHOLD = 2
 
 type Props = {
   getTransactions: (walletId: string, currencyCode: string) => void, // getting transactions from Redux


### PR DESCRIPTION
The purpose of this task is to cause the app to start loading more transactions once it gets to 2x the screen height from the bottom, rather than 0.5x. This should make for a smoother scroll.