### PR TITLE
Change fiatToggle to TouchableOpacity

### DIFF
--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -81,6 +81,7 @@
   "fragment_wallets_addwallet_name_hint": "New Wallet Name",
   "fragment_wallets_balance_text": "Total Balance",
   "fragment_wallets_fiat_toggle_title": "Fiat",
+  "fragment_wallets_crypto_toggle_title": "Crypto",
   "fragment_wallets_delete_wallet": "Delete Wallet",
   "fragment_wallets_set_custom_fees": "Set Custom Mining Fee",
   "fragment_wallets_resync_wallet": "Resync Wallet",

--- a/src/modules/UI/scenes/WalletList/WalletList.ui.js
+++ b/src/modules/UI/scenes/WalletList/WalletList.ui.js
@@ -2,7 +2,7 @@
 
 import slowlog from 'react-native-slowlog'
 import React, { Component } from 'react'
-import { Switch, ActivityIndicator, Animated, FlatList, Image, TouchableOpacity, View } from 'react-native'
+import { ActivityIndicator, Animated, FlatList, Image, TouchableOpacity, View } from 'react-native'
 import { Actions } from 'react-native-router-flux'
 import SortableListView from 'react-native-sortable-listview'
 import Ionicon from 'react-native-vector-icons/Ionicons'
@@ -207,10 +207,9 @@ export default class WalletList extends Component<Props, State> {
                         zIndex: this.state.fullListZIndex
                       }
                     ]}>
-                    <View style={styles.fiatToggleSwitchWrap}>
-                      <Switch onValueChange={this.onFiatSwitchToggle} value={this.props.isWalletFiatBalanceVisible} style={styles.fiatSwitchToggle} />
-                      <T style={styles.toggleFiatText}>{s.strings.fragment_wallets_fiat_toggle_title}</T>
-                    </View>
+                    <TouchableOpacity style={styles.fiatToggleWrap} onPress={this.onFiatSwitchToggle} >
+                      <T style={styles.toggleFiatText}>{this.props.isWalletFiatBalanceVisible ? s.strings.fragment_wallets_crypto_toggle_title : fiatSymbol}</T>
+                    </TouchableOpacity>
                     <TouchableOpacity style={[styles.walletsBoxHeaderAddWallet, { width: 41 }]} onPress={Actions[Constants.CREATE_WALLET_SELECT_CRYPTO]}>
                       <Ionicon name="md-add" style={[styles.dropdownIcon]} size={28} color="white" />
                     </TouchableOpacity>

--- a/src/modules/UI/scenes/WalletList/style.js
+++ b/src/modules/UI/scenes/WalletList/style.js
@@ -76,31 +76,37 @@ export const styles = {
     marginLeft: 16
   },
   donePlusContainer: {
-    minWidth: 160,
+    minWidth: 132,
     height: 50
   },
   plusContainer: {
     position: 'absolute',
-    justifyContent: 'space-around',
+    justifyContent: 'space-between',
     alignItems: 'center',
     height: 50,
     flexDirection: 'row'
   },
-  fiatToggleSwitchWrap: {
-    paddingRight: 40,
+  fiatToggleWrap: {
+    width: 92,
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    width: 160,
+    justifyContent: 'center',
     alignItems: 'center'
   },
-  fiatSwitchToggle: {
-
+  walletsBoxHeaderAddWallet: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    top: 0,
+    left: 0,
+    height: '100%',
+    paddingVertical: 12,
+    width: 82
   },
   toggleFiatText: {
     color: THEME.COLORS.WHITE,
     backgroundColor: THEME.COLORS.TRANSPARENT,
-    marginRight: 24,
-    fontSize: 18
+    fontSize: 18,
+    textAlign: 'center'
   },
   doneContainer: {
     position: 'absolute',
@@ -117,15 +123,6 @@ export const styles = {
     backgroundColor: THEME.COLORS.TRANSPARENT,
     top: 0,
     left: 0
-  },
-  walletsBoxHeaderAddWallet: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    top: 0,
-    left: 0,
-    height: '100%',
-    paddingVertical: 12
   },
   dropdownIcon: {
     textAlignVertical: 'center',


### PR DESCRIPTION
The purpose of this task is to remove the fiat toggle switch from the WalletList scene and replace it with a TouchableOpacity button.

Asana Task: https://app.asana.com/0/361770107085503/751504073180940/f