### PR TITLE
Kylan/missing tx list balance fiat

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "edge-currency-bitcoin": "3.0.1",
     "edge-currency-ethereum": "0.10.3",
     "edge-currency-monero": "^0.0.8",
-    "edge-currency-ripple": "^0.0.7",
+    "edge-currency-ripple": "^0.0.8",
     "edge-exchange-plugins": "^0.2.0",
     "edge-login-ui-rn": "^0.3.3",
     "https-browserify": "0.0.1",

--- a/src/modules/UI/scenes/TransactionList/style.js
+++ b/src/modules/UI/scenes/TransactionList/style.js
@@ -134,7 +134,7 @@ export const styles = {
   },
   currentBalanceBoxDollarsWrap: {
     justifyContent: 'flex-start',
-    flex: 4,
+    height: 26,
     paddingTop: 4,
     backgroundColor: THEME.COLORS.TRANSPARENT
   },


### PR DESCRIPTION
The purpose of this task is to fix the styling for the balance box of the Transaction List to make the fiat amount show up again on all devices. The line of text's style got screwed up when working on the 'Hide Balance' persistency.

Asana Task: https://app.asana.com/0/361770107085503/671722582350692