### PR TITLE
Force txList to attempt to load transactions upon component mounting

### DIFF
--- a/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
+++ b/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
@@ -88,6 +88,13 @@ export class TransactionList extends Component<Props, State> {
     slowlog(this, /.*/, global.slowlogOptions)
   }
 
+  componentDidMount = () => {
+    this.props.fetchMoreTransactions(this.props.selectedWalletId, this.props.selectedCurrencyCode, this.state.reset)
+    if (this.state.reset) {
+      this.setState({ reset: false })
+    }
+  }
+
   componentWillReceiveProps (nextProps: Props) {
     if (nextProps.selectedWalletId !== this.props.selectedWalletId || nextProps.selectedCurrencyCode !== this.props.selectedCurrencyCode) {
       this.props.fetchMoreTransactions(nextProps.selectedWalletId, nextProps.selectedCurrencyCode, this.state.reset)


### PR DESCRIPTION
The purpose of this task is to get the TransactionList to load transactions upon first entry. The transactions were not being called because `handleScrollEnd` was not being called by the `FlatList` component because no list was being rendered (aka you can't be at the end of the list if there is no list), and instead the `ListEmptyComponent` was being rendered initially, and there isn't really an end to that component per se because it is a normal component and not a list.

Fix was to force the GUI to fetch transactions upon `componentDidMount`

Asana Task: https://app.asana.com/0/361770107085503/759658666093565/f