### PR TITLE
Fix Sweep Private Key 'Cancel' not re-enabling scan

### DIFF
--- a/src/modules/UI/scenes/Scan/reducers/scanEnabled.js
+++ b/src/modules/UI/scenes/Scan/reducers/scanEnabled.js
@@ -3,12 +3,15 @@
 import type { Action } from '../../../../ReduxTypes.js'
 
 import * as ACTION from '../action'
+import { DEACTIVATED as PRIMARY_MODAL_DEACTIVATED } from '../PrivateKeyModal/PrimaryModal/PrimaryModalActions.js'
 
 export const initialState = false
 export type State = boolean
 export const scanEnabled = (state: State = initialState, action: Action) => {
   switch (action.type) {
     case ACTION.ENABLE_SCAN:
+      return true
+    case PRIMARY_MODAL_DEACTIVATED:
       return true
     case ACTION.DISABLE_SCAN:
       return false


### PR DESCRIPTION
The purpose of this task is to re-enable scanning functionality after a user presses "Cancel" on the Sweep Private Key modal window. Before the scan scene would no longer scan anything after you pressed the "Cancel" button, which is not the desired behavior.

Asana Task: https://app.asana.com/0/361770107085503/716460273877813/f