### PR TITLE
Adjust 'Done' button positioning on WalletList when sorting

### DIFF
--- a/src/modules/UI/scenes/WalletList/WalletList.ui.js
+++ b/src/modules/UI/scenes/WalletList/WalletList.ui.js
@@ -182,7 +182,7 @@ export default class WalletList extends Component<Props, State> {
                 </View>
               </View>
 
-              <View style={[styles.donePlusContainer]}>
+              <View style={[styles.donePlusContainer, this.state.sortableListExists && styles.donePlusSortable]}>
                 {this.state.sortableListExists && (
                   <Animated.View
                     style={[

--- a/src/modules/UI/scenes/WalletList/style.js
+++ b/src/modules/UI/scenes/WalletList/style.js
@@ -79,6 +79,10 @@ export const styles = {
     minWidth: 132,
     height: 50
   },
+  donePlusSortable: {
+    alignItems: 'flex-end',
+    marginRight: 30
+  },  
   plusContainer: {
     position: 'absolute',
     justifyContent: 'space-between',


### PR DESCRIPTION
The purpose of this task is to make a minor adjustment to the positioning of the 'Done' button on the WalletList when the list is in "sortable" mode.

Asana Task: https://app.asana.com/0/361770107085503/764208704340684/f