### PR TITLE
Fix logout error popup

### DIFF
--- a/src/modules/UI/Wallets/reducer.js
+++ b/src/modules/UI/Wallets/reducer.js
@@ -143,6 +143,9 @@ export const byId = (state: WalletByIdState = {}, action: Action) => {
       const wallets = data.wallets
       const out = { ...state }
       for (const wallet of wallets) {
+        if (!state || !state[wallet.id]) {
+          continue
+        }
         const guiWallet = schema(wallet, state[wallet.id].receiveAddress)
         const enabledTokensOnWallet = state[wallet.id].enabledTokens
         guiWallet.enabledTokens = enabledTokensOnWallet


### PR DESCRIPTION
Check for a cleared redux state before dereferencing state properties.
Fixes the occasional `undefined is not an object e[a.id].receiveAddress` error popup after logout.