### PR TITLE
Slight adjustment to positioning of Bitcoin currency symbol in WalletList

### DIFF
--- a/src/modules/UI/scenes/WalletList/style.js
+++ b/src/modules/UI/scenes/WalletList/style.js
@@ -252,6 +252,7 @@ export const styles = {
   },
   rowBalanceDenominationText: {
     fontSize: 14,
+    lineHeight: 18,
     color: THEME.COLORS.GRAY_1,
     textAlign: 'right'
   },


### PR DESCRIPTION
The purpose of this task is to fix the positioning of the Bitcoin symbol on the WalletList (right side), which was positioned too high within the parentheses.

Asana Task: https://app.asana.com/0/361770107085503/772821084680783/f