### PR TITLE
Bump simplex plugin to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "babel-preset-react-native": "^1.9.0",
     "body-parser": "^1.18.2",
     "detox": "^7.4.3",
-    "edge-plugin-simplex": "https://github.com/Airbitz/edge-plugin-simplex.git#ff34f3a",
+    "edge-plugin-simplex": "https://github.com/Airbitz/edge-plugin-simplex.git#c1b81e1",
     "eslint": "^4.17.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-flowtype": "^2.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2568,9 +2568,9 @@ edge-login-ui-rn@^0.4.0:
     sprintf-js "^1.0.3"
     zxcvbn "^4.4.2"
 
-"edge-plugin-simplex@https://github.com/Airbitz/edge-plugin-simplex.git#ff34f3a":
-  version "0.0.2"
-  resolved "https://github.com/Airbitz/edge-plugin-simplex.git#ff34f3a1c57b2b12fa0cee5e07d3bc0c3484b6e1"
+"edge-plugin-simplex@https://github.com/Airbitz/edge-plugin-simplex.git#c1b81e1":
+  version "0.0.3"
+  resolved "https://github.com/Airbitz/edge-plugin-simplex.git#c1b81e1c2e61339382edfb345a14435e356dd0c1"
   dependencies:
     moment "^2.22.2"
 


### PR DESCRIPTION
When fetching an address, this defaults to the legacyAddress, falling
back to the publicAddress if no legacyAddress exists. This was necessary
to support LTC because simplex doesn't support M addresses.