### PR TITLE
Adjust SendConf styling to keep ABSlider position static

### DIFF
--- a/src/modules/UI/scenes/SendConfirmation/SendConfirmation.ui.js
+++ b/src/modules/UI/scenes/SendConfirmation/SendConfirmation.ui.js
@@ -229,7 +229,7 @@ export class SendConfirmation extends Component<Props, State> {
               </Scene.Padding>
             </View>
 
-            <Scene.Row>{this.props.pending && <ActivityIndicator style={[{ flex: 1, alignSelf: 'center' }]} size={'small'} />}</Scene.Row>
+            <Scene.Row style={styles.activityIndicatorSpace}>{this.props.pending && <ActivityIndicator style={[{ flex: 1, alignSelf: 'center' }]} size={'small'} />}</Scene.Row>
 
             <Scene.Footer style={styles.footer}>
               <ABSlider

--- a/src/modules/UI/scenes/SendConfirmation/styles.js
+++ b/src/modules/UI/scenes/SendConfirmation/styles.js
@@ -110,8 +110,11 @@ export const rawStyles = {
   pinInputSpacer: {
     width: 10
   },
+  activityIndicatorSpace: {
+    height: 54,
+    paddingVertical: 18
+  },
   footer: {
-    paddingVertical: 24
   },
   debug
 }


### PR DESCRIPTION
The purpose of this task is to keep the ABSlider on the SendConfirmation scene static regardless of whether or not the ActivityIndicator is visible or not.

Asana Task: https://app.asana.com/0/361770107085503/774878206641550/f