### PR TITLE
Make Wallet List Progress Bar Own Connected Component

### DIFF
--- a/src/modules/UI/scenes/WalletList/WalletList.ui.js
+++ b/src/modules/UI/scenes/WalletList/WalletList.ui.js
@@ -18,8 +18,8 @@ import { TwoButtonModalStyle } from '../../../../styles/indexStyles.js'
 import * as UTILS from '../../../utils'
 import T from '../../components/FormattedText'
 import Gradient from '../../components/Gradient/Gradient.ui'
-import ProgressBar from '../../components/ProgressBar/ProgressBar.ui.js'
 import SafeAreaView from '../../components/SafeAreaView/index.js'
+import { WalletListProgressBarConnector } from './components/WalletListProgressBar/WalletListProgressBarConnector'
 import FullWalletListRow from './components/WalletListRow/FullWalletListRow.ui.js'
 import SortableWalletListRow from './components/WalletListRow/SortableWalletListRow.ui.js'
 import WalletOptions from './components/WalletOptions/WalletOptionsConnector.ui.js'
@@ -170,7 +170,7 @@ export default class WalletList extends Component<Props, State> {
         <View style={styles.container} testID={'edge: wallet-list-scene'}>
           <WalletOptions />
           <Gradient style={styles.gradient} />
-          {this.state.isWalletProgressVisible && this.renderWalletListProgressDropdown()}
+          <WalletListProgressBarConnector />
           <TouchableOpacity onPress={this.handleOnBalanceBoxPress}>
             {this.props.isAccountBalanceVisible ? this.balanceBox(fiatBalanceString) : this.hiddenBalanceBox()}
           </TouchableOpacity>
@@ -525,16 +525,5 @@ export default class WalletList extends Component<Props, State> {
         </View>
       </View>
     )
-  }
-
-  renderWalletListProgressDropdown = () => {
-    if (this.props.progressPercentage === 100) {
-      setTimeout(() => {
-        this.setState({
-          isWalletProgressVisible: false
-        })
-      }, 2000)
-    }
-    return <ProgressBar progress={this.props.progressPercentage} />
   }
 }

--- a/src/modules/UI/scenes/WalletList/WalletListConnector.js
+++ b/src/modules/UI/scenes/WalletList/WalletListConnector.js
@@ -26,7 +26,6 @@ const mapStateToProps = (state: State) => {
   const dimensions = state.ui.scenes.dimensions
   const customTokens = state.ui.settings.customTokens
   const otpResetPending = SETTINGS_SELECTORS.getOtpResetPending(state)
-  const progressPercentage = UI_SELECTORS.getWalletLoadingPercent(state)
   const showOnBoarding = SETTINGS_SELECTORS.runOnBoarding(state)
   const isAccountBalanceVisible = state.ui.settings.isAccountBalanceVisible
   const isWalletFiatBalanceVisible = state.ui.settings.isWalletFiatBalanceVisible
@@ -46,7 +45,6 @@ const mapStateToProps = (state: State) => {
     dimensions,
     customTokens,
     otpResetPending,
-    progressPercentage,
     showOnBoarding,
     isAccountBalanceVisible,
     isWalletFiatBalanceVisible,

--- a/src/modules/UI/scenes/WalletList/components/WalletListProgressBar/WalletListProgressBar.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListProgressBar/WalletListProgressBar.ui.js
@@ -1,0 +1,42 @@
+// @flow
+
+import React, { Component } from 'react'
+
+import ProgressBar from '../../../../components/ProgressBar/ProgressBar.ui.js'
+
+export type WalletListProgressBarOwnProps = {}
+
+export type WalletListProgressBarStateProps = {
+  progressPercentage: number
+}
+
+export type WalletListProgressBarDispatchProps = {}
+
+export type WalletListProgressBarProps = WalletListProgressBarOwnProps & WalletListProgressBarStateProps & WalletListProgressBarDispatchProps
+
+export type WalletListProgressBarState = {
+  isWalletProgressVisible: boolean
+}
+
+export class WalletListProgressBarComponent extends Component<WalletListProgressBarProps, WalletListProgressBarState> {
+  constructor (props: WalletListProgressBarProps) {
+    super(props)
+    this.state = {
+      isWalletProgressVisible: true
+    }
+  }
+
+  render () {
+    if (this.props.progressPercentage === 100) {
+      setTimeout(() => {
+        this.setState({
+          isWalletProgressVisible: false
+        })
+      }, 2000)
+    }
+    if (this.state.isWalletProgressVisible) {
+      return <ProgressBar progress={this.props.progressPercentage} />
+    }
+    return null
+  }
+}

--- a/src/modules/UI/scenes/WalletList/components/WalletListProgressBar/WalletListProgressBarConnector.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListProgressBar/WalletListProgressBarConnector.js
@@ -1,0 +1,20 @@
+// @flow
+
+import { connect } from 'react-redux'
+
+import type { Dispatch, State } from '../../../../../ReduxTypes'
+import { getWalletLoadingPercent } from '../../../../selectors.js'
+import type { WalletListProgressBarDispatchProps, WalletListProgressBarStateProps } from './WalletListProgressBar.ui.js'
+import { WalletListProgressBarComponent } from './WalletListProgressBar.ui.js'
+
+const mapStateToProps = (state: State): WalletListProgressBarStateProps => {
+  const progressPercentage = getWalletLoadingPercent(state)
+  return {
+    progressPercentage
+  }
+}
+const mapDispatchToProps = (dispatch: Dispatch): WalletListProgressBarDispatchProps => {
+  return {}
+}
+
+export const WalletListProgressBarConnector = connect(mapStateToProps, mapDispatchToProps)(WalletListProgressBarComponent)


### PR DESCRIPTION
The purpose of this task is to have the Wallet List Progress Bar component be connected directly to Redux rather than receive the progress % property from the parent scene (Wallet List).

Asana Task: https://app.asana.com/0/361770107085503/749204124304339/f