### PR TITLE
Give extra room for ChangePassword + Password Recovery 'DONE' button

### DIFF
--- a/src/modules/UI/scenes/ChangePinPassword/ChangePasswordComponent.ui.js
+++ b/src/modules/UI/scenes/ChangePinPassword/ChangePasswordComponent.ui.js
@@ -3,7 +3,7 @@
 import type { EdgeAccount, EdgeContext } from 'edge-core-js'
 import { ChangePasswordScreen } from 'edge-login-ui-rn'
 import React, { Component } from 'react'
-import { View } from 'react-native'
+import { ScrollView, View } from 'react-native'
 
 import Gradient from '../../components/Gradient/Gradient.ui'
 import SafeAreaView from '../../components/SafeAreaView'
@@ -36,7 +36,7 @@ export default class ChangePassword extends Component<ChangePasswordComponent> {
     return (
       <SafeAreaView>
         <Gradient style={styles.gradient} />
-        <View style={styles.container}>
+        <ScrollView style={styles.container}>
           <ChangePasswordScreen
             account={this.props.account}
             context={this.props.context}
@@ -44,7 +44,8 @@ export default class ChangePassword extends Component<ChangePasswordComponent> {
             onCancel={this.onComplete}
             showHeader={this.props.showHeader}
           />
-        </View>
+          <View style={[styles.bottomShim, { height: 360 }]} />
+        </ScrollView>
       </SafeAreaView>
     )
   }

--- a/src/modules/UI/scenes/PasswordRecovery/PasswordRecoveryComponent.ui.js
+++ b/src/modules/UI/scenes/PasswordRecovery/PasswordRecoveryComponent.ui.js
@@ -2,7 +2,7 @@
 
 import { PasswordRecoveryScreen } from 'edge-login-ui-rn'
 import React, { Component } from 'react'
-import { View } from 'react-native'
+import { ScrollView, View } from 'react-native'
 
 import Gradient from '../../components/Gradient/Gradient.ui'
 import SafeAreaView from '../../components/SafeAreaView'
@@ -19,7 +19,7 @@ export default class PasswordRecovery extends Component<Props> {
     return (
       <SafeAreaView>
         <Gradient style={styles.gradient} />
-        <View style={styles.container}>
+        <ScrollView style={styles.container}>
           <PasswordRecoveryScreen
             account={this.props.account}
             context={this.props.context}
@@ -27,7 +27,8 @@ export default class PasswordRecovery extends Component<Props> {
             onCancel={this.props.onComplete}
             showHeader={this.props.showHeader}
           />
-        </View>
+          <View style={{ height: 320 }} />
+        </ScrollView>
       </SafeAreaView>
     )
   }

--- a/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
+++ b/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
@@ -609,6 +609,7 @@ export class TransactionDetails extends Component<TransactionDetailsProps, State
                   />
                 </View>
               </View>
+              <View style={{ height: 300 }} />
             </ScrollView>
           </View>
         </View>


### PR DESCRIPTION
The purpose of this task is to give smaller devices more room on the Change Password, Password Recovery, and Transaction Details scenes to make sure that the keyboard does not cover the 'DONE' button(s)

Asana Task: https://app.asana.com/0/361770107085503/778189856161368/f
Asana Task: https://app.asana.com/0/361770107085503/778189856161365/f