### PR TITLE
Re-center navBar title area (header) after router upgrade (Android)

### DIFF
--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -20,7 +20,7 @@ import { moneroCurrencyPluginFactory } from 'edge-currency-monero'
 import { rippleCurrencyPluginFactory } from 'edge-currency-ripple'
 import { coinbasePlugin, coincapPlugin, shapeshiftPlugin } from 'edge-exchange-plugins'
 import React, { Component } from 'react'
-import { Image, Keyboard, Linking, StatusBar, TouchableWithoutFeedback } from 'react-native'
+import { Image, Keyboard, Linking, StatusBar, TouchableWithoutFeedback, View } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import Locale from 'react-native-locale'
 import { MenuProvider } from 'react-native-popup-menu'
@@ -679,7 +679,11 @@ export default class Main extends Component<Props, State> {
   }
 
   renderTitle = (title: string) => {
-    return <T style={styles.titleStyle}>{title}</T>
+    return (
+      <View style={styles.titleWrapper}>
+        <T style={styles.titleStyle}>{title}</T>
+      </View>
+    )
   }
 
   renderMenuButton = () => {

--- a/src/modules/style.js
+++ b/src/modules/style.js
@@ -14,6 +14,11 @@ export const stylesRaw = {
     color: THEME.COLORS.WHITE,
     fontFamily: THEME.FONTS.DEFAULT
   },
+  titleWrapper: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%'
+  },
   helpModal: {
     flex: 1
   },


### PR DESCRIPTION
The purpose of this task is to re-style the navBar title on Android to be centered again. The recent upgrade to RN55 included upgrades of react-native-router-flux and react-navigation, which interrupted some styles for the navBar.

Asana Task: https://app.asana.com/0/361770107085503/796290981203649/f