### PR TITLE
Fix vertical alignment of Wallet List icons

### DIFF
--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/FullWalletListRow.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/FullWalletListRow.ui.js
@@ -135,7 +135,7 @@ class FullWalletListRowLoadedComponent extends Component<FullWalletListRowLoaded
                   <View style={[styles.rowNameTextWrapIOS]}>
                     <T style={[styles.rowNameText]} numberOfLines={1}>
                       {symbolImageDarkMono && (
-                        <Image style={[styles.rowCurrencyLogoIOS]} transform={[{ translateY: 6 }]} source={{ uri: symbolImageDarkMono }} />
+                        <Image style={[styles.rowCurrencyLogoIOS]} transform={[{ translateY: 3 }]} source={{ uri: symbolImageDarkMono }} />
                       )}{' '}
                       {cutOffText(name, 34)}
                     </T>


### PR DESCRIPTION
The purpose of this task is to fix the alignment of the crypto icons on the Wallet List, which appear to have been displaced either via regression or React Native upgrade.

Asana Task: https://app.asana.com/0/361770107085503/799828850647961/f