### PR TITLE
Change CreateWalletSelectCrypto back button to say 'Back'

### DIFF
--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -338,19 +338,19 @@ export default class Main extends Component<Props, State> {
                         />
 
                         <Scene
-                          key={Constants.CREATE_WALLET_NAME}
+                          key={Constants.CREATE_WALLET_SELECT_CRYPTO}
                           navTransparent={true}
-                          component={CreateWalletName}
-                          renderTitle={this.renderTitle(CREATE_WALLET)}
+                          component={CreateWalletSelectCrypto}
+                          renderTitle={this.renderTitle(CREATE_WALLET_SELECT_CRYPTO)}
                           renderLeftButton={this.renderBackButton(WALLETS)}
                           renderRightButton={this.renderEmptyButton()}
                         />
 
                         <Scene
-                          key={Constants.CREATE_WALLET_SELECT_CRYPTO}
+                          key={Constants.CREATE_WALLET_NAME}
                           navTransparent={true}
-                          component={CreateWalletSelectCrypto}
-                          renderTitle={this.renderTitle(CREATE_WALLET_SELECT_CRYPTO)}
+                          component={CreateWalletName}
+                          renderTitle={this.renderTitle(CREATE_WALLET)}
                           renderLeftButton={this.renderBackButton()}
                           renderRightButton={this.renderEmptyButton()}
                         />


### PR DESCRIPTION
The purpose of this task is to make sure that the "Create Wallet" scenes show the correct 'Back' button syntax.

Asana Task: https://app.asana.com/0/361770107085503/795095712879313/f