### PR TITLE
Fix Settings Scenes Background Colors

### DIFF
--- a/src/modules/UI/scenes/PasswordRecovery/PasswordRecoveryComponent.ui.js
+++ b/src/modules/UI/scenes/PasswordRecovery/PasswordRecoveryComponent.ui.js
@@ -27,7 +27,7 @@ export default class PasswordRecovery extends Component<Props> {
             onCancel={this.props.onComplete}
             showHeader={this.props.showHeader}
           />
-          <View style={{ height: 320 }} />
+          <View style={[styles.bottomShim, { height: 320 }]} />
         </ScrollView>
       </SafeAreaView>
     )

--- a/src/modules/UI/scenes/Settings/__snapshots__/settingsOverview.test.js.snap
+++ b/src/modules/UI/scenes/Settings/__snapshots__/settingsOverview.test.js.snap
@@ -12,6 +12,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
   <ScrollView
     style={
       Object {
+        "backgroundColor": "#FFFFFF",
         "height": "100%",
         "position": "relative",
       }
@@ -421,6 +422,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
   <ScrollView
     style={
       Object {
+        "backgroundColor": "#FFFFFF",
         "height": "100%",
         "position": "relative",
       }

--- a/src/modules/UI/scenes/Settings/style.js
+++ b/src/modules/UI/scenes/Settings/style.js
@@ -12,11 +12,13 @@ export const styles = {
   },
   body: {
     paddingHorizontal: 20,
-    paddingVertical: 5
+    paddingVertical: 5,
+    backgroundColor: THEME.COLORS.WHITE
   },
   container: {
     position: 'relative',
-    height: '100%'
+    height: '100%',
+    backgroundColor: THEME.COLORS.WHITE
   },
   listStyle: {
     height: 100
@@ -178,7 +180,10 @@ export const styles = {
   },
   underlayColor: {
     color: THEME.COLORS.GRAY_4
-  }
+  },
   /// ////// end of default fiat area //////////
+  bottomShim: {
+    backgroundColor: THEME.COLORS.WHITE
+  }
 }
 export default StyleSheet.create(styles)

--- a/src/modules/UI/scenes/SpendingLimits/styles.js
+++ b/src/modules/UI/scenes/SpendingLimits/styles.js
@@ -10,7 +10,8 @@ const debug = {
 }
 export const rawStyles = {
   scene: {
-    padding: 24
+    padding: 24,
+    backgroundColor: THEME.COLORS.WHITE
   },
   spacer: {
     height: 28


### PR DESCRIPTION
The purpose of this task is to fix the footer background colors on a couple of the settings scenes (Password Recovery, Change Password, and Spending Limits). This bug appears to be a regression from the earlier task of adding extra space at the bottom of a few of the scenes so that the keyboard didn't cover the Save / Submit buttons.

Asana Task: https://app.asana.com/0/361770107085503/801891347444366/f