### PR TITLE
Optimize settings reducer

### DIFF
--- a/src/modules/UI/Settings/reducer.js
+++ b/src/modules/UI/Settings/reducer.js
@@ -556,10 +556,20 @@ export const settingsLegacy = (state: SettingsState = initialState, action: Acti
 }
 
 export const settings = (state: SettingsState = initialState, action: Action) => {
+  let result = state
   const legacy = settingsLegacy(state, action)
-  const result = {
-    ...legacy,
-    spendingLimits: spendingLimits(state.spendingLimits, action)
+
+  if (legacy !== state) {
+    result = legacy
+  }
+
+  const spendingLimitsObj = spendingLimits(state.spendingLimits, action)
+
+  if (spendingLimitsObj !== state.spendingLimits) {
+    result = {
+      ...result,
+      spendingLimits: spendingLimitsObj
+    }
   }
 
   return result


### PR DESCRIPTION
Do not return a new object if settingsLegacy() or spendingLimits() functions do not change any state.
This prevents routines that pass `state.settings` through `mapStateToProps` from re-rendering