### PR TITLE
Allow internationalized fiat amounts for txDetails (comma as decimal)

### DIFF
--- a/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
+++ b/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
@@ -7,6 +7,7 @@ import { Animated, Easing, Keyboard, ScrollView, TextInput, TouchableOpacity, Vi
 import slowlog from 'react-native-slowlog'
 import { sprintf } from 'sprintf-js'
 
+import { intl } from '../../../../locales/intl'
 import s from '../../../../locales/strings.js'
 import THEME from '../../../../theme/variables/airbitz'
 import { PLATFORM } from '../../../../theme/variables/platform.js'
@@ -111,7 +112,7 @@ export class TransactionDetails extends Component<TransactionDetailsProps, State
     let subCategory = ''
     let cat = ''
     let name = ''
-    let amountFiat = '0.00'
+    let amountFiat = intl.formatNumber('0.00')
     let notes = ''
     const direction = parseInt(props.edgeTransaction.nativeAmount) >= 0 ? 'receive' : 'send'
     if (props.edgeTransaction.wallet) {
@@ -127,8 +128,8 @@ export class TransactionDetails extends Component<TransactionDetailsProps, State
       notes = props.edgeTransaction.metadata.notes ? props.edgeTransaction.metadata.notes : ''
       if (props.edgeTransaction.metadata.amountFiat) {
         const initial = props.edgeTransaction.metadata.amountFiat.toFixed(2)
-        amountFiat = bns.abs(initial)
-        amountFiat = bns.toFixed(amountFiat, 2, 2)
+        const absoluteAmountFiat = bns.abs(initial)
+        amountFiat = intl.formatNumber(bns.toFixed(absoluteAmountFiat, 2, 2))
       }
     }
 
@@ -254,7 +255,7 @@ export class TransactionDetails extends Component<TransactionDetailsProps, State
       const absoluteAmountFiatOneDecimal = bns.abs(amountFiatOneDecimal)
       amountFiat = bns.toFixed(absoluteAmountFiatOneDecimal, 2, 2)
     } else {
-      amountFiat = '0.00'
+      amountFiat = intl.formatNumber('0.00')
     }
     this.setState({
       amountFiat
@@ -384,7 +385,8 @@ export class TransactionDetails extends Component<TransactionDetailsProps, State
   }
 
   onFocusFiatAmount = () => {
-    if (this.state.amountFiat === '0.00') {
+    const { amountFiat } = this.state
+    if (amountFiat === '0.00' || amountFiat === '0,00') {
       this.setState({
         amountFiat: ''
       })
@@ -418,7 +420,7 @@ export class TransactionDetails extends Component<TransactionDetailsProps, State
     const { name, notes, bizId, miscJson } = this.state
     const txid = this.props.edgeTransaction.txid
     const newAmountFiat = this.state.amountFiat
-    const amountFiat: number = !newAmountFiat ? 0.0 : Number.parseFloat(newAmountFiat)
+    const amountFiat: number = !newAmountFiat ? 0.0 : Number.parseFloat(newAmountFiat.replace(',', '.'))
     const edgeMetadata: EdgeMetadata = { name, category, notes, amountFiat, bizId, miscJson }
     this.props.setTransactionDetails(txid, this.props.edgeTransaction.currencyCode, edgeMetadata)
   }


### PR DESCRIPTION
The purpose of this task is to properly handle numbers with commas as decimals (international) within the fiat input in the txDetails scene.

Asana Task: https://app.asana.com/0/361770107085503/588715697078159/f