### PR TITLE
added warning message to edge login if there is no appId

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -19,6 +19,8 @@ const strings = {
 
   dropdown_exchange_max_amount: 'Exchange Max Amount',
   edge_description: 'This application would like to create or access its wallet in your Edge account.\n\n It will not have access to any other wallets.',
+  edge_description_warning:
+    'WARNING: The following app %1$s is requesting full access to your account and all wallets. \n\nOnly accept this login request if you trust this application and where it was downloaded from.',
   exchange_failed: 'Exchange Failed',
   exchange_succeeded: 'Exchange Succeeded',
   exchanges_may_take_minutes: 'Exchanges may take several minutes to process. Please check your destination wallet after a few minutes',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -15,6 +15,7 @@
   "drawer_wallets": "Wallets",
   "dropdown_exchange_max_amount": "Exchange Max Amount",
   "edge_description": "This application would like to create or access its wallet in your Edge account.\n\n It will not have access to any other wallets.",
+  "edge_description_warning": "WARNING: The following app %1$s is requesting full access to your account and all wallets. \n\nOnly accept this login request if you trust this application and where it was downloaded from.",
   "exchange_failed": "Exchange Failed",
   "exchange_succeeded": "Exchange Succeeded",
   "exchanges_may_take_minutes": "Exchanges may take several minutes to process. Please check your destination wallet after a few minutes",

--- a/src/modules/UI/scenes/EdgeLogin/EdgeLoginSceneComponent.js
+++ b/src/modules/UI/scenes/EdgeLogin/EdgeLoginSceneComponent.js
@@ -26,6 +26,9 @@ export default class EdgeLoginScene extends Component<EdgeLoginSceneProps> {
     if (!this.props.error) {
       message = s.strings.edge_description
     }
+    if (!this.props.lobby && !this.props.error) {
+      throw new Error('Not normal expected behavior')
+    }
     if (this.props.lobby && this.props.lobby.loginRequest && this.props.lobby.loginRequest.appId === '') {
       textStyle = style.bodyTextWarning
       message = sprintf(s.strings.edge_description_warning, this.props.lobby.loginRequest.displayName)

--- a/src/modules/UI/scenes/EdgeLogin/EdgeLoginSceneComponent.js
+++ b/src/modules/UI/scenes/EdgeLogin/EdgeLoginSceneComponent.js
@@ -3,6 +3,7 @@
 import type { EdgeLobby } from 'edge-core-js'
 import React, { Component } from 'react'
 import { ActivityIndicator, Image, Text, View } from 'react-native'
+import { sprintf } from 'sprintf-js'
 
 import s from '../../../../locales/strings.js'
 import { PrimaryButton, SecondaryButton } from '../../components/Buttons/index'
@@ -21,12 +22,17 @@ type EdgeLoginSceneProps = {
 export default class EdgeLoginScene extends Component<EdgeLoginSceneProps> {
   renderBody (style: Object) {
     let message = this.props.error
+    let textStyle = style.bodyText
     if (!this.props.error) {
       message = s.strings.edge_description
     }
+    if (this.props.lobby && this.props.lobby.loginRequest && this.props.lobby.loginRequest.appId === '') {
+      textStyle = style.bodyTextWarning
+      message = sprintf(s.strings.edge_description_warning, this.props.lobby.loginRequest.displayName)
+    }
     return (
       <View style={style.body}>
-        <Text style={style.bodyText}>{message}</Text>
+        <Text style={textStyle}>{message}</Text>
       </View>
     )
   }

--- a/src/styles/scenes/EdgeLoginSceneStyle.js
+++ b/src/styles/scenes/EdgeLoginSceneStyle.js
@@ -76,6 +76,14 @@ const EdgeLoginScreen = {
     textAlign: 'center',
     fontFamily: THEME.FONTS.DEFAULT
   },
+  bodyTextWarning: {
+    marginRight: '5%',
+    marginLeft: '5%',
+    color: THEME.COLORS.ACCENT_RED,
+    fontSize: 18,
+    textAlign: 'center',
+    fontFamily: THEME.FONTS.DEFAULT
+  },
   cancel: {
     flex: 1,
     marginRight: '1.5%',


### PR DESCRIPTION
This pr adds a warning for edge login if an app does not pass an app id.
It fixes Asana task 
Edge Login: Add warning if user is logging into full access app
https://app.asana.com/0/361770107085503/770492945216288