### PR TITLE
Fix Payment ID text Cutoff on SendConfirmation

### DIFF
--- a/src/modules/UI/scenes/SendConfirmation/SendConfirmation.ui.js
+++ b/src/modules/UI/scenes/SendConfirmation/SendConfirmation.ui.js
@@ -219,7 +219,7 @@ export class SendConfirmation extends Component<Props, State> {
 
                   {(currencyCode === 'XMR' || currencyCode === 'XRP') && (
                     <Scene.Row style={{ paddingVertical: 10 }}>
-                      <PrimaryButton style={{ height: 40 }} onPress={this.props.uniqueIdentifierButtonPressed}>
+                      <PrimaryButton onPress={this.props.uniqueIdentifierButtonPressed}>
                         <PrimaryButton.Text ellipsizeMode={'tail'}>{uniqueIdentifierText(currencyCode, uniqueIdentifier)}</PrimaryButton.Text>
                       </PrimaryButton>
                     </Scene.Row>

--- a/src/modules/UI/scenes/SendConfirmation/__snapshots__/sendConfirmation.test.js.snap
+++ b/src/modules/UI/scenes/SendConfirmation/__snapshots__/sendConfirmation.test.js.snap
@@ -706,13 +706,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
                 }
               }
             >
-              <PrimaryButton
-                style={
-                  Object {
-                    "height": 40,
-                  }
-                }
-              >
+              <PrimaryButton>
                 <Text
                   ellipsizeMode="tail"
                 >
@@ -958,13 +952,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
                 }
               }
             >
-              <PrimaryButton
-                style={
-                  Object {
-                    "height": 40,
-                  }
-                }
-              >
+              <PrimaryButton>
                 <Text
                   ellipsizeMode="tail"
                 >


### PR DESCRIPTION
The purpose of this task is to fix the text being cut off on the Payment ID button on the Send Confirmation scene.

Asana Task: https://app.asana.com/0/361770107085503/812701187673600/f