### PR TITLE
fix 2FA button status where button was always disabled

### DIFF
--- a/src/modules/UI/scenes/Otp/OtpSettingsSceneComponent.js
+++ b/src/modules/UI/scenes/Otp/OtpSettingsSceneComponent.js
@@ -89,7 +89,7 @@ export default class OtpSettingsScene extends Component<OtpSettingsSceneProps, S
     }
     return (
       <PrimaryButton onPress={this.onPress}>
-        <PrimaryButton.Text>{s.strings.otp_disable}</PrimaryButton.Text>
+        <PrimaryButton.Text>{s.strings.otp_enable}</PrimaryButton.Text>
       </PrimaryButton>
     )
   }


### PR DESCRIPTION
Fixes Asana task 
2FA - The button shows as "Disable 2FA" whether it is enabled or not. For example a brand new account shows as Disable instead of Enable
https://app.asana.com/0/361770107085503/814581022784612