### PR TITLE
Set parameter for number of Redux actions to show in RN Debugger

### DIFF
--- a/src/lib/configureStore.js
+++ b/src/lib/configureStore.js
@@ -16,7 +16,7 @@ const middleware = [errorAlert, loginStatusChecker, thunk, soundsMiddleware]
 if (ENV.ENABLE_REDUX_PERF_LOGGING) middleware.push(perfLogger)
 
 const composeEnhancers =
-  typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ name: 'ui' }) : compose
+  typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ name: 'ui', maxAge: 50 }) : compose
 
 export default function configureStore (initialState: Object) {
   // $FlowFixMe


### PR DESCRIPTION
The purpose of this task is to explicitly define the number of actions show in the React Native Debugger so that the `maxAge` parameter can be modified according to a developer's needs.

There is no associated Asana task for this.