### PR TITLE
Fix Public Address Not Showing Immediately in Request Scene

### DIFF
--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -11,7 +11,7 @@ import { sprintf } from 'sprintf-js'
 
 import * as Constants from '../../../../constants/indexConstants'
 import s from '../../../../locales/strings.js'
-import type { GuiCurrencyInfo, GuiReceiveAddress, GuiWallet } from '../../../../types.js'
+import type { GuiCurrencyInfo, GuiWallet } from '../../../../types.js'
 import WalletListModal from '../../../UI/components/WalletListModal/WalletListModalConnector'
 import { getObjectDiff } from '../../../utils'
 import ExchangeRate from '../../components/ExchangeRate/index.js'
@@ -34,7 +34,8 @@ export type RequestStateProps = {
   guiWallet: GuiWallet,
   loading: false,
   primaryCurrencyInfo: GuiCurrencyInfo,
-  receiveAddress: GuiReceiveAddress,
+  publicAddress: string,
+  legacyAddress: string,
   secondaryCurrencyInfo: GuiCurrencyInfo,
   showToWalletModal: boolean,
   useLegacyAddress: boolean
@@ -46,7 +47,8 @@ export type RequestLoadingProps = {
   guiWallet: null,
   loading: true,
   primaryCurrencyInfo: null,
-  receiveAddress: null,
+  publicAddress: string,
+  legacyAddress: string,
   secondaryCurrencyInfo: null,
   showToWalletModal: null,
   useLegacyAddress: null
@@ -71,15 +73,9 @@ export type State = {
 export class Request extends Component<Props, State> {
   constructor (props: Props) {
     super(props)
-    let publicAddress = ''
-    let legacyAddress = ''
-    if (props.guiWallet && props.guiWallet.receiveAddress) {
-      publicAddress = props.guiWallet.receiveAddress.publicAddress ? props.guiWallet.receiveAddress.publicAddress : ''
-      legacyAddress = props.guiWallet.receiveAddress.legacyAddress ? props.guiWallet.receiveAddress.legacyAddress : ''
-    }    
     this.state = {
-      publicAddress,
-      legacyAddress,
+      publicAddress: props.publicAddress,
+      legacyAddress: props.legacyAddress,
       encodedURI: '',
       isXRPMinimumModalVisible: false,
       hasXRPMinimumModalAlreadyShown: false
@@ -114,8 +110,8 @@ export class Request extends Component<Props, State> {
 
   async generateEncodedUri () {
     const { edgeWallet, useLegacyAddress } = this.props
-    let publicAddress = this.props.guiWallet.receiveAddress.publicAddress
-    let legacyAddress = this.props.guiWallet.receiveAddress.legacyAddress
+    let publicAddress = this.props.publicAddress
+    let legacyAddress = this.props.legacyAddress
     const abcEncodeUri = useLegacyAddress ? { publicAddress, legacyAddress } : { publicAddress }
     let encodedURI = s.strings.loading
     try {
@@ -136,7 +132,7 @@ export class Request extends Component<Props, State> {
           this.props.refreshReceiveAddressRequest(edgeWallet.id)
         }
       }, PUBLIC_ADDRESS_REFRESH_MS)
-    }    
+    }
   }
 
   async UNSAFE_componentWillReceiveProps (nextProps: Props) {

--- a/src/modules/UI/scenes/Request/RequestConnector.js
+++ b/src/modules/UI/scenes/Request/RequestConnector.js
@@ -24,9 +24,10 @@ const mapStateToProps = (state: State): RequestStateProps | RequestLoadingProps 
       guiWallet: null,
       loading: true,
       primaryCurrencyInfo: null,
-      receiveAddress: null,
       secondaryCurrencyInfo: null,
       showToWalletModal: null,
+      publicAddress: '',
+      legacyAddress: '',
       useLegacyAddress: null,
       currentScene: state.ui.scenes.currentScene
     }
@@ -61,9 +62,10 @@ const mapStateToProps = (state: State): RequestStateProps | RequestLoadingProps 
     edgeWallet,
     exchangeSecondaryToPrimaryRatio,
     guiWallet,
+    publicAddress: guiWallet.receiveAddress.publicAddress || '',
+    legacyAddress: guiWallet.receiveAddress.legacyAddress || '',
     loading: false,
     primaryCurrencyInfo,
-    receiveAddress: state.ui.scenes.request.receiveAddress,
     secondaryCurrencyInfo,
     showToWalletModal: state.ui.scenes.walletListModal.walletListModalVisible,
     useLegacyAddress: state.ui.scenes.requestType.useLegacyAddress,

--- a/src/modules/UI/scenes/Request/__snapshots__/Request.test.js.snap
+++ b/src/modules/UI/scenes/Request/__snapshots__/Request.test.js.snap
@@ -63,7 +63,6 @@ exports[`Request should render with loaded props 1`] = `
       <RequestStatus
         amountReceivedInCrypto={0}
         amountRequestedInCrypto={0}
-        requestAddress=""
       />
     </Component>
     <Component


### PR DESCRIPTION
The purpose of this task is to show the public address immediately on the Request scene, making sure that the QR code generation does not delay the public address displaying. Once the new / real QR code has been generated then the QR barcode display will re-render.

Asana Task: https://app.asana.com/0/361770107085503/817257728515162/f