### PR TITLE
Fix 20 XRP modal not showing up on first entry to Request

### DIFF
--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -135,7 +135,8 @@ export class Request extends Component<Props, State> {
       })
     }
     // old blank address to new
-    if (didWalletChange) {
+    if (didWalletChange || didAddressChange) {
+      // include 'didAddressChange' because didWalletChange returns false upon initial request scene load
       if (nextProps.currencyCode === 'XRP') {
         if (!this.state.hasXRPMinimumModalAlreadyShown) {
           if (bns.lt(nextProps.guiWallet.primaryNativeBalance, '20000000')) {


### PR DESCRIPTION
The purpose of this task is to ensure that the 20 XRP minimum is displayed on first access to an XRP wallet at the Request scene. It seems it was displaying on 2nd entrance to Request scene beforehand.

Asana Task: https://app.asana.com/0/361770107085503/816034397889780/f