### PR TITLE
Fix XRP 20 modal regression

### DIFF
--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -85,6 +85,12 @@ export class Request extends Component<Props, State> {
     } catch (e) {
       console.log('error generating encodedURI: ', e)
     }
+    if (props.currencyCode === 'XRP') {
+      if (bns.lt(props.guiWallet.primaryNativeBalance, '20000000')) {
+        this.state.isXRPMinimumModalVisible = true
+        this.state.hasXRPMinimumModalAlreadyShown = true
+      }
+    }
     slowlog(this, /.*/, global.slowlogOptions)
   }
 


### PR DESCRIPTION
The purpose of this task is to fix the issue of the 20 XRP minimum modal not showing because the Request scene starts off with a `publicAddress` now rather than having it produced later in the React lifecycle.

Asana Task: https://app.asana.com/0/361770107085503/816034397889780/f