### PR TITLE
Make back arrow easier to press on Android

### DIFF
--- a/src/modules/UI/components/Header/Component/BackButton.ui.js
+++ b/src/modules/UI/components/Header/Component/BackButton.ui.js
@@ -27,7 +27,7 @@ export default class BackButton extends Component<Props> {
 
     return (
       <TouchableOpacity style={styles.backButton} onPress={this.props.onPress}>
-        {withArrow && <Icon size={22} name={icon} type={Constants.ION_ICONS} style={styles.backIconStyle} />}
+        {withArrow && <Icon size={22} name={icon} type={Constants.ION_ICONS} style={[styles.backIconStyle, !isIos && styles.backIconAndroid]} />}
         {withArrow && !isIos ? null : <T style={[styles.sideText]}>{this.props.label}</T>}
       </TouchableOpacity>
     )

--- a/src/modules/UI/components/Header/style.js
+++ b/src/modules/UI/components/Header/style.js
@@ -24,6 +24,12 @@ export default StyleSheet.create({
     paddingTop: 3,
     color: THEME.COLORS.WHITE
   },
+  backIconAndroid: {
+    paddingTop: 15,
+    paddingBottom: 15,
+    paddingLeft: 15,
+    paddingRight: 15
+  },
   sideText: {
     color: THEME.COLORS.WHITE,
     fontSize: 18


### PR DESCRIPTION
The purpose of this task is to make it easier for users on Android to be able to press the back button in the top-left part of the screen (navbar).

Asana Task: https://app.asana.com/0/361770107085503/821244593415412/f