### PR TITLE
Fix HelpModal iPad Pro width issue

### DIFF
--- a/src/modules/UI/components/HelpModal/HelpModal.ui.js
+++ b/src/modules/UI/components/HelpModal/HelpModal.ui.js
@@ -1,12 +1,14 @@
 // @flow
 
 import React, { Component } from 'react'
-import { Image, Linking, Platform, Text, View, WebView } from 'react-native'
+import { Dimensions, Image, Linking, Platform, Text, View, WebView } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 
 import helpImage from '../../../../assets/images/modal/help.png'
+import { isIphoneX } from '../../../../lib/isIphoneX.js'
 import s from '../../../../locales/strings.js'
 import THEME from '../../../../theme/variables/airbitz.js'
+import { PLATFORM } from '../../../../theme/variables/platform.js'
 import StylizedModal from '../Modal/index.js'
 import styles from './style.js'
 
@@ -27,6 +29,10 @@ export default class HelpModal extends Component<Props> {
   }
 
   render () {
+    const deviceWidth = Dimensions.get('window').width
+    const deviceHeight = Dimensions.get('window').height
+    const width = PLATFORM.platform === 'ios' ? deviceWidth - 20 : '100%'
+    const height = isIphoneX ? deviceHeight - 120 : deviceHeight - 80
     return (
       <StylizedModal
         visibilityBoolean={this.props.modal}
@@ -52,7 +58,7 @@ export default class HelpModal extends Component<Props> {
         style={styles.stylizedModal}
         modalHeaderIcon={styles.modalHeaderIcon}
         modalBodyStyle={styles.modalBodyStyle}
-        modalVisibleStyle={styles.modalVisibleStyle}
+        modalVisibleStyle={[styles.modalVisibleStyle, { height, width }]}
         modalBoxStyle={styles.modalBoxStyle}
         modalContentStyle={styles.modalContentStyle}
         modalMiddleStyle={styles.modalMiddleWebView}

--- a/src/modules/UI/components/HelpModal/style.js
+++ b/src/modules/UI/components/HelpModal/style.js
@@ -4,7 +4,6 @@ import { StyleSheet } from 'react-native'
 
 import { isIphoneX } from '../../../../lib/isIphoneX.js'
 import THEME from '../../../../theme/variables/airbitz.js'
-import { PLATFORM } from '../../../../theme/variables/platform.js'
 
 export default StyleSheet.create({
   stylizedModal: {
@@ -35,9 +34,7 @@ export default StyleSheet.create({
   },
   modalVisibleStyle: {
     flex: 1,
-    top: -27,
-    width: PLATFORM.platform === 'ios' ? PLATFORM.deviceWidth - 20 : '100%',
-    height: isIphoneX ? PLATFORM.deviceHeight - 120 : PLATFORM.deviceHeight - 80
+    top: -27
   },
   modalBoxStyle: {
     flex: 1


### PR DESCRIPTION
The purpose of this task is to prevent the width of the Help Modal from being too wide for the screen (as a result of device rotation).

Asana Task: https://app.asana.com/0/361770107085503/814809403791483/f