### PR TITLE
Add keyExtractor to fix React error that FlatList key is not a string

### DIFF
--- a/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
+++ b/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
@@ -166,6 +166,7 @@ export class TransactionList extends Component<Props, State> {
                   initialNumToRender={INITIAL_TRANSACTION_BATCH_NUMBER}
                   onEndReached={this.handleScrollEnd}
                   onEndReachedThreshold={SCROLL_THRESHOLD}
+                  keyExtractor={item => item.key.toString()}
                 />
               </View>
             </View>


### PR DESCRIPTION
Convert key from number to string to prevent RN redbox error