### PR TITLE
Work around missing wallets problem

### DIFF
--- a/src/modules/Core/Account/callbacks.js
+++ b/src/modules/Core/Account/callbacks.js
@@ -19,7 +19,7 @@ const makeAccountCallbacks = (dispatch: Dispatch): EdgeAccountCallbacks => {
 
     onKeyListChanged: () => {
       // $FlowFixMe
-      dispatch(updateWalletsRequest())
+      setTimeout(() => dispatch(updateWalletsRequest()), 0)
     },
 
     onAddressesChecked (walletId: string, transactionCount: number) {


### PR DESCRIPTION
Kevin might have a more elegant fix for this with `EdgeAccount.watch('currencyWallets', () => {})`, but this is the quick & dirty version.