### PR TITLE
Bump bitcoin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "domain-browser": "^1.1.7",
     "edge-components": "^0.0.5",
     "edge-core-js": "0.12.0",
-    "edge-currency-bitcoin": "3.3.2",
+    "edge-currency-bitcoin": "3.4.0",
     "edge-currency-ethereum": "0.11.0",
     "edge-currency-monero": "^0.0.9",
     "edge-currency-ripple": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3289,10 +3289,10 @@ edge-core-js@0.12.0:
     ws "^5.1.1"
     yaob "^0.3.0"
 
-edge-currency-bitcoin@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/edge-currency-bitcoin/-/edge-currency-bitcoin-3.3.2.tgz#6d5c60d0968a84e9bd7609c577255f0025c66a67"
-  integrity sha512-6imppcF29Tae31ghgrAzrOWrdcY1rm4NuuQplW5XosfgAGr/I9E3RaedgLEhAXI8vI4V3B90s+Bxj1gpm7jV3w==
+edge-currency-bitcoin@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/edge-currency-bitcoin/-/edge-currency-bitcoin-3.4.0.tgz#f1199f01863270c199d473cad9d365d03f75c97e"
+  integrity sha512-VnLnHti7mHfuHkpaWzYwTr/0rpaC2ZIz5TKniHzSwmvYmUL4mcqSQ6T0jwMY1Oy+kfQZub68cv7Fhk0vI1a6rw==
   dependencies:
     bcoin "git+https://github.com/Airbitz/bcoin.git#primitiveBuild"
     biggystring "3.0.2"


### PR DESCRIPTION
* Implements eboost
* Removes parsing of xpriv and mnemonic seed for sweeping (was not tested thoroughly)
* Update Digibyte P2SH address format
* Fix currency names "Bitcoin Cash" "Bitcoin Gold" "Digibyte"
* Properly implement `changeSettings`