### PR TITLE
Fix request side effect / constructor issue

### DIFF
--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -80,11 +80,7 @@ export class Request extends Component<Props, State> {
       isXRPMinimumModalVisible: false,
       hasXRPMinimumModalAlreadyShown: false
     }
-    try {
-      this.generateEncodedUri()
-    } catch (e) {
-      console.log('error generating encodedURI: ', e)
-    }
+
     if (props.currencyCode === 'XRP') {
       if (bns.lt(props.guiWallet.primaryNativeBalance, '20000000')) {
         this.state.isXRPMinimumModalVisible = true
@@ -92,6 +88,14 @@ export class Request extends Component<Props, State> {
       }
     }
     slowlog(this, /.*/, global.slowlogOptions)
+  }
+
+  UNSAFE_componentDidMount () {
+    try {
+      this.generateEncodedUri()
+    } catch (e) {
+      console.log('error generating encodedURI: ', e)
+    }
   }
 
   onCloseXRPMinimumModal = () => {

--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -90,7 +90,7 @@ export class Request extends Component<Props, State> {
     slowlog(this, /.*/, global.slowlogOptions)
   }
 
-  UNSAFE_componentDidMount () {
+  componentDidMount () {
     try {
       this.generateEncodedUri()
     } catch (e) {


### PR DESCRIPTION
The purpose of this task is to move the QR code generation of the request scene from the constructor to `componentDidMount`

Asana Task: https://app.asana.com/0/361770107085503/830239350791970/f