### PR TITLE
Remove 'and Directory' from helpModal title

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -118,7 +118,7 @@ const strings = {
   create_wallet_crypto_type_label: 'Wallet Type:',
   create_wallet_fiat_type_label: 'Wallet Fiat:',
   help_build: 'Build',
-  help_modal_title: 'Crypto Wallet and Directory',
+  help_modal_title: 'Crypto Wallet',
   help_version: 'Version',
   loading: 'Loading…',
   mining_fee_high_label_choice: 'High',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -112,7 +112,7 @@
   "create_wallet_crypto_type_label": "Wallet Type:",
   "create_wallet_fiat_type_label": "Wallet Fiat:",
   "help_build": "Build",
-  "help_modal_title": "Crypto Wallet and Directory",
+  "help_modal_title": "Crypto Wallet",
   "help_version": "Version",
   "loading": "Loading…",
   "mining_fee_high_label_choice": "High",


### PR DESCRIPTION
The purpose of this task is to remove the 'And Directory' part of the helpModal title so that it only reads "Crypto Wallet".

Asana Task: https://app.asana.com/0/361770107085503/553467619718329/f