### PR TITLE
Allow immediate OTP disable, move reminder to Settings onEnter, onBackDropPress No Change

### DIFF
--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -188,7 +188,8 @@ type Props = {
   dispatchDisableScan: () => void,
   urlReceived: string => void,
   updateCurrentSceneKey: string => void,
-  contextCallbacks: EdgeContextCallbacks
+  contextCallbacks: EdgeContextCallbacks,
+  showReEnableOtpModal: () => void
 }
 type State = {
   context: ?EdgeContext
@@ -532,6 +533,7 @@ export default class Main extends Component<Props, State> {
                       <Scene
                         key={Constants.SETTINGS_OVERVIEW}
                         navTransparent={true}
+                        onEnter={() => this.props.showReEnableOtpModal()}
                         component={SettingsOverview}
                         renderTitle={this.renderTitle(SETTINGS)}
                         renderLeftButton={this.renderBackButton()}

--- a/src/modules/MainConnector.js
+++ b/src/modules/MainConnector.js
@@ -11,6 +11,7 @@ import type { Dispatch } from './ReduxTypes'
 import { setKeyboardHeight } from './UI/dimensions/action'
 import { updateCurrentSceneKey } from './UI/scenes/action.js'
 import { disableScan, enableScan } from './UI/scenes/Scan/action'
+import { showReEnableOtpModal } from './UI/scenes/Settings/action.js'
 import { addCurrencyPlugin } from './UI/Settings/action'
 import { selectWallet } from './UI/Wallets/action.js'
 
@@ -48,7 +49,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     return dispatch(actions.deepLinkLogout(backupKey))
   },
   contextCallbacks: makeContextCallbacks(dispatch),
-  onSelectWallet: (walletId, currencyCode) => dispatch(selectWallet(walletId, currencyCode))
+  onSelectWallet: (walletId, currencyCode) => dispatch(selectWallet(walletId, currencyCode)),
+  showReEnableOtpModal: () => dispatch(showReEnableOtpModal())
 })
 export default connect(
   mapStateToProps,

--- a/src/modules/UI/scenes/Settings/SettingsOverview.ui.js
+++ b/src/modules/UI/scenes/Settings/SettingsOverview.ui.js
@@ -109,13 +109,6 @@ export default class SettingsOverview extends Component<Props, State> {
     }
   }
 
-  componentDidMount = () => {
-    const { otpResetDate } = this.props
-    if (otpResetDate) {
-      this.props.showReEnableOtpModal()
-    }
-  }
-
   _onPressDummyRouting = () => {}
 
   unlockSettingsAlert = () => Alert.alert(null, s.strings.settings_alert_unlock, [{ text: s.strings.string_ok }])

--- a/src/modules/UI/scenes/Settings/SettingsOverviewConnector.js
+++ b/src/modules/UI/scenes/Settings/SettingsOverviewConnector.js
@@ -8,15 +8,7 @@ import type { Dispatch, State } from '../../../../modules/ReduxTypes'
 import * as CORE_SELECTORS from '../../../Core/selectors'
 import { resetSendLogsStatus, sendLogs } from '../../../Logs/action'
 import * as SETTINGS_SELECTORS from '../../Settings/selectors'
-import {
-  checkCurrentPassword,
-  lockSettings,
-  restoreWallets,
-  setAutoLogoutTimeInMinutesRequest,
-  showReEnableOtpModal,
-  togglePinLoginEnabled,
-  updateTouchIdEnabled
-} from './action'
+import { checkCurrentPassword, lockSettings, restoreWallets, setAutoLogoutTimeInMinutesRequest, togglePinLoginEnabled, updateTouchIdEnabled } from './action'
 import SettingsOverview from './SettingsOverview.ui'
 
 // settings_button_lock_settings, or //settings_button_unlock_settings
@@ -31,7 +23,6 @@ const mapStateToProps = (state: State) => {
   const confirmPasswordError = SETTINGS_SELECTORS.getConfirmPasswordErrorMessage(state)
   const sendLogsStatus = SETTINGS_SELECTORS.getSendLogsStatus(state)
   const pinLoginEnabled = SETTINGS_SELECTORS.getPinLoginEnabled(state)
-  const otpResetDate = account.otpResetDate
   return {
     defaultFiat: SETTINGS_SELECTORS.getDefaultFiat(state),
     autoLogoutTimeInMinutes: SETTINGS_SELECTORS.getAutoLogoutTimeInMinutes(state),
@@ -44,8 +35,7 @@ const mapStateToProps = (state: State) => {
     isLocked,
     confirmPasswordError,
     sendLogsStatus,
-    pinLoginEnabled,
-    otpResetDate
+    pinLoginEnabled
   }
 }
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -57,8 +47,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   resetConfirmPasswordError: (arg: Object) => dispatch({ type: 'SET_CONFIRM_PASSWORD_ERROR', data: arg }),
   resetSendLogsStatus: () => dispatch(resetSendLogsStatus()),
   onTogglePinLoginEnabled: (enableLogin: boolean) => dispatch(togglePinLoginEnabled(enableLogin)),
-  onConfirmRestoreWallets: () => dispatch(restoreWallets()),
-  showReEnableOtpModal: () => dispatch(showReEnableOtpModal())
+  onConfirmRestoreWallets: () => dispatch(restoreWallets())
 })
 
 export default connect(

--- a/src/modules/UI/scenes/Settings/action.js
+++ b/src/modules/UI/scenes/Settings/action.js
@@ -8,7 +8,7 @@ import { Image } from 'react-native'
 import { Actions } from 'react-native-router-flux'
 
 import type { Dispatch, GetState, State } from '../../../../../src/modules/ReduxTypes.js'
-import { keepOtp } from '../../../../actions/OtpActions.js'
+import { disableOtp, keepOtp } from '../../../../actions/OtpActions.js'
 import iconImage from '../../../../assets/images/otp/OTP-badge_sm.png'
 import { CURRENCY_PLUGIN_NAMES } from '../../../../constants/indexConstants.js'
 import s from '../../../../locales/strings.js'
@@ -215,7 +215,11 @@ export function togglePinLoginEnabled (pinLoginEnabled: boolean) {
   }
 }
 
-export const showReEnableOtpModal = () => async (dispatch: Dispatch) => {
+export const showReEnableOtpModal = () => async (dispatch: Dispatch, getState: GetState) => {
+  const state = getState()
+  const account = CORE_SELECTORS.getAccount(state)
+  const otpResetDate = account.otpResetDate
+  if (!otpResetDate) return
   // Use `showModal` to put the modal component on screen:
   const modal = createYesNoModal({
     title: s.strings.title_otp_keep_modal,
@@ -229,6 +233,8 @@ export const showReEnableOtpModal = () => async (dispatch: Dispatch) => {
     // true on positive, false on negative
     // let 2FA expire
     dispatch(keepOtp())
+  } else {
+    dispatch(disableOtp())
   }
 }
 

--- a/src/modules/UI/scenes/Settings/action.js
+++ b/src/modules/UI/scenes/Settings/action.js
@@ -229,13 +229,13 @@ export const showReEnableOtpModal = () => async (dispatch: Dispatch, getState: G
     noButtonText: s.strings.otp_disable
   })
   const resolveValue = await showModal(modal)
-  if (resolveValue) {
+  if (resolveValue === true) {
     // true on positive, false on negative
     // let 2FA expire
     dispatch(keepOtp())
-  } else {
+  } else if (resolveValue === false) {
     dispatch(disableOtp())
-  }
+  } // if default of null (press backdrop) do not change anything and keep reminding
 }
 
 export const enableCustomNodes = (currencyCode: string) => async (dispatch: Dispatch, getState: GetState) => {


### PR DESCRIPTION
The purpose of this task is three-fold:
* Bind "Disable 2FA" to immediately disable 2FA rather than just keep OTP reset in place
* Move modal reminder to *every* entrance of Settings Overview scene
* Make modal backdrop press keep OTP / 2FA unchanged

Asana Task: https://app.asana.com/0/361770107085503/848466472814189/f