### PR TITLE
Fix currencySettings header style (regression)

### DIFF
--- a/src/modules/UI/scenes/Settings/style.js
+++ b/src/modules/UI/scenes/Settings/style.js
@@ -21,6 +21,13 @@ export const styles = {
     height: '100%',
     backgroundColor: THEME.COLORS.WHITE
   },
+  titleStyle: {
+    alignSelf: 'center',
+    fontSize: 20,
+    color: THEME.COLORS.WHITE,
+    fontFamily: THEME.FONTS.DEFAULT,
+    marginLeft: 8
+  },
   listStyle: {
     height: scale(100)
   },


### PR DESCRIPTION
The purpose of this task is to re-add the currencySettings title style that was accidentally removed during a recent PR / commit.

Asana Task: https://app.asana.com/0/361770107085503/868855858279049/f