### PR TITLE
Slightly reduce size of ShapeShift logo in exchange scene

### DIFF
--- a/src/styles/scenes/CryptoExchangeQuoteSceneStyles.js
+++ b/src/styles/scenes/CryptoExchangeQuoteSceneStyles.js
@@ -10,16 +10,16 @@ const CryptoExchangeQuoteSceneStyles = {
     height: THEME.SPACER.HEADER
   },
   topRow: {
-    flex: 1,
+    flex: 2,
     alignItems: 'center',
     justifyContent: 'space-around'
   },
   centerRow: {
-    flex: 2,
+    flex: 6,
     alignItems: 'center'
   },
   bottomRow: {
-    flex: 1,
+    flex: 3,
     padding: '5%',
     alignItems: 'center'
   },


### PR DESCRIPTION
The purpose of this task is to fix the text overlap in the crypto exchange "quote" scene.

Asana Task: https://app.asana.com/0/361770107085503/867580585829925/f