### PR TITLE
Fix wallet list menu dropdown and implement snapshot

### DIFF
--- a/src/modules/UI/components/MenuDropDown/MenuDropDown.test.js
+++ b/src/modules/UI/components/MenuDropDown/MenuDropDown.test.js
@@ -1,0 +1,29 @@
+/* globals describe it expect */
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+import React from 'react'
+import ShallowRenderer from 'react-test-renderer/shallow'
+
+import { MenuDropDownStyle } from '../../../../styles/components/HeaderMenuDropDownStyles.js'
+import { MenuDropDown } from './MenuDropDown.ui.js'
+
+describe('MenuDropDown component', () => {
+  it('should render with standard props', () => {
+    const renderer = new ShallowRenderer()
+    const props = {
+      data: [
+        {
+          key: 'Key1',
+          value: 'Value1',
+          label: 'Label1'
+        }
+      ],
+      style: {
+        ...MenuDropDownStyle
+      }
+    }
+    const actual = renderer.render(<MenuDropDown {...props} />)
+
+    expect(actual).toMatchSnapshot()
+  })
+})

--- a/src/modules/UI/components/MenuDropDown/MenuDropDown.ui.js
+++ b/src/modules/UI/components/MenuDropDown/MenuDropDown.ui.js
@@ -5,7 +5,6 @@ import { StyleSheet, Text, View } from 'react-native'
 import Menu, { MenuOption, MenuOptions, MenuTrigger } from 'react-native-popup-menu'
 import slowlog from 'react-native-slowlog'
 
-import * as Constants from '../../../../constants/indexConstants'
 import { getObjectDiff } from '../../../utils'
 
 export type StateProps = {
@@ -25,11 +24,6 @@ type State = {
 }
 
 class MenuDropDown extends Component<Props, State> {
-  static defaultProps = {
-    iconType: Constants.ENTYPO,
-    icon: Constants.THREE_DOT_MENU
-  }
-
   constructor (props: Props) {
     super(props)
     this.state = {
@@ -73,11 +67,14 @@ class MenuDropDown extends Component<Props, State> {
 
   render () {
     const style = this.props.style
-
     return (
       <View style={style.container}>
         <Menu style={style.menuButton} onSelect={this.props.onSelect}>
-          <MenuTrigger customStyles={style.menuTrigger} />
+          <MenuTrigger customStyles={style.menuTrigger}>
+            <View style={style.menuIconWrap}>
+              <Text style={style.icon}>&#8942;</Text>
+            </View>
+          </MenuTrigger>
           <MenuOptions customStyles={style.menuOptions}>{this.renderMenuOptions(style)}</MenuOptions>
         </Menu>
       </View>

--- a/src/modules/UI/components/MenuDropDown/__snapshots__/MenuDropDown.test.js.snap
+++ b/src/modules/UI/components/MenuDropDown/__snapshots__/MenuDropDown.test.js.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MenuDropDown component should render with standard props 1`] = `
+<Component
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "column",
+      "justifyContent": "center",
+      "width": 70.81408450704225,
+    }
+  }
+>
+  <ForwardRef(enhanceContext-Context.Consumer(Menu))
+    onBackdropPress={[Function]}
+    onClose={[Function]}
+    onOpen={[Function]}
+    onSelect={[Function]}
+    renderer={[Function]}
+    rendererProps={Object {}}
+    style={
+      Object {
+        "alignItems": "center",
+        "height": "100%",
+        "justifyContent": "center",
+        "width": 70.81408450704225,
+      }
+    }
+  >
+    <ForwardRef(enhanceContext-Context.Consumer(MenuTrigger))
+      customStyles={
+        Object {
+          "menuTriggerUnderlay": Object {},
+          "triggerTouchable": Object {
+            "activeOpacity": 1,
+            "style": Object {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "height": "100%",
+              "justifyContent": "center",
+              "width": 70.81408450704225,
+            },
+            "underlayColor": "transparent",
+          },
+        }
+      }
+      disabled={false}
+    >
+      <Component
+        style={
+          Object {
+            "alignItems": "center",
+            "height": "100%",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "color": "#4A5157",
+              "fontSize": 30.788732394366196,
+            }
+          }
+        >
+          ⋮
+        </Text>
+      </Component>
+    </ForwardRef(enhanceContext-Context.Consumer(MenuTrigger))>
+    <ForwardRef(enhanceContext-Context.Consumer(MenuOptions))
+      customStyles={Object {}}
+    >
+      <ForwardRef(enhanceContext-Context.Consumer(MenuOption))
+        customStyles={Object {}}
+        disableTouchable={false}
+        disabled={false}
+        style={
+          Object {
+            "borderBottomColor": "#D9E3ED",
+            "borderBottomWidth": 1,
+            "justifyContent": "center",
+          }
+        }
+        value="Value1"
+      >
+        <Component
+          style={
+            Object {
+              "flexDirection": "row",
+              "paddingVertical": 6.157746478873239,
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "color": "#4A5157",
+                "fontSize": 27.70985915492958,
+              }
+            }
+          >
+            Label1
+          </Text>
+        </Component>
+      </ForwardRef(enhanceContext-Context.Consumer(MenuOption))>
+    </ForwardRef(enhanceContext-Context.Consumer(MenuOptions))>
+  </ForwardRef(enhanceContext-Context.Consumer(Menu))>
+</Component>
+`;

--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptions.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptions.ui.js
@@ -20,6 +20,12 @@ const modifiedMenuDropDownStyle = {
   menuIconWrap: {
     ...MenuDropDownStyle.menuIconWrap,
     width: scale(46)
+  },
+  icon: {
+    ...MenuDropDownStyle.icon,
+    fontSize: scale(26),
+    position: 'relative',
+    top: 2
   }
 }
 


### PR DESCRIPTION
The purpose of this task is to re-implement the menu dropdown icons (three dots) on the wallet list. I have also added a snapshot to help defend against future regressions.

Asana Task: https://app.asana.com/0/361770107085503/871467099103199/f