### PR TITLE
Populate default denominations from currency plugins

### DIFF
--- a/src/modules/Core/Account/accountReducer.test.js
+++ b/src/modules/Core/Account/accountReducer.test.js
@@ -2,7 +2,7 @@
 
 /* globals describe test expect */
 
-import { account as accountReducer, initialState, loggedIn } from './reducer.js'
+import { account as accountReducer, initialState } from './reducer.js'
 
 describe('account', () => {
   test('initialState', () => {
@@ -14,7 +14,7 @@ describe('account', () => {
 
   test('LOGGED_IN', () => {
     const account = { id: '123123', activeWalletIds: ['1', '2', '3'] }
-    const action = loggedIn(account)
+    const action = { type: 'ACCOUNT/LOGGED_IN', data: { account } }
     const actual = accountReducer(initialState, action)
 
     expect(actual).toMatchSnapshot()

--- a/src/modules/Core/Account/reducer.js
+++ b/src/modules/Core/Account/reducer.js
@@ -9,11 +9,6 @@ export type AccountState = EdgeAccount | Object
 
 export const initialState: AccountState = {}
 
-export const loggedIn = (account: EdgeAccount) => ({
-  type: 'ACCOUNT/LOGGED_IN',
-  data: { account }
-})
-
 const accountReducer = (state = initialState, action: Action) => {
   switch (action.type) {
     case 'ACCOUNT/LOGGED_IN': {

--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -11,7 +11,6 @@ import { sprintf } from 'sprintf-js'
 import * as Constants from '../../constants/indexConstants'
 import s from '../../locales/strings.js'
 import * as ACCOUNT_API from '../Core/Account/api'
-import { loggedIn } from '../Core/Account/reducer.js'
 import * as SETTINGS_API from '../Core/Account/settings.js'
 // Login/action.js
 import * as CORE_SELECTORS from '../Core/selectors'
@@ -23,7 +22,18 @@ import { getReceiveAddresses } from '../utils.js'
 const localeInfo = Locale.constants() // should likely be moved to login system and inserted into Redux
 
 export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => async (dispatch: Dispatch, getState: GetState) => {
-  dispatch(loggedIn(account))
+  const currencyPlugins = []
+  const currencyCodes = {}
+
+  for (const pluginName in account.currencyConfig) {
+    const { currencyInfo } = account.currencyConfig[pluginName]
+    const { currencyCode } = currencyInfo
+    currencyInfo.walletTypes.forEach(type => {
+      currencyCodes[type] = currencyCode
+    })
+    currencyPlugins.push({ pluginName, currencyInfo })
+  }
+  dispatch({ type: 'ACCOUNT/LOGGED_IN', data: { account, currencyPlugins } })
 
   account.activeWalletIds.length < 1 ? Actions[Constants.ONBOARDING]() : Actions[Constants.EDGE]()
 
@@ -33,7 +43,6 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
 
   const state = getState()
   const context = CORE_SELECTORS.getContext(state)
-  const currencyCodes = {}
   if (Platform.OS === Constants.IOS) {
     PushNotification.configure({
       onNotification: notification => {
@@ -46,7 +55,7 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
     touchIdInfo: touchIdInfo,
     walletId: '',
     currencyCode: '',
-    currencyPlugins: [],
+    currencyPlugins,
     otpInfo: { enabled: account.otpKey != null, otpKey: account.otpKey, otpResetPending: false },
     autoLogoutTimeInSeconds: '',
     bluetoothMode: false,
@@ -68,14 +77,6 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
     passwordRecoveryRemindersShown: SETTINGS_API.PASSWORD_RECOVERY_REMINDERS_SHOWN
   }
   try {
-    for (const pluginName in account.currencyConfig) {
-      const { currencyInfo } = account.currencyConfig[pluginName]
-      const { currencyCode } = currencyInfo
-      currencyInfo.walletTypes.forEach(type => {
-        currencyCodes[type] = currencyCode
-      })
-      accountInitObject.currencyPlugins.push({ pluginName, currencyInfo })
-    }
     if (account.activeWalletIds.length < 1) {
       // we are going to assume that since there is no wallets, this is a first time user
       Actions[Constants.ONBOARDING]()

--- a/src/modules/UI/Settings/reducer.js
+++ b/src/modules/UI/Settings/reducer.js
@@ -159,6 +159,32 @@ const currencyPLuginUtil = (state, payloadData) => {
 
 export const settingsLegacy = (state: SettingsState = initialState, action: Action) => {
   switch (action.type) {
+    case 'ACCOUNT/LOGGED_IN': {
+      if (!action.data) throw new Error('Invalid Action')
+
+      // Setup default denominations for settings based on currencyInfo
+      if (!action.data.currencyPlugins) return state
+      const newState = { ...state }
+      for (const plugin of action.data.currencyPlugins) {
+        const currencyCode = plugin.currencyInfo.currencyCode
+        if (!newState[currencyCode]) newState[currencyCode] = {}
+        if (!newState[currencyCode].denomination) {
+          newState[currencyCode].denomination = plugin.currencyInfo.denominations[0].multiplier
+        }
+        if (!newState[currencyCode].denominations) {
+          newState[currencyCode].denominations = plugin.currencyInfo.denominations
+        }
+        for (const token of plugin.currencyInfo.metaTokens) {
+          const tokenCode = token.currencyCode
+          newState[tokenCode] = {
+            denomination: token.denominations[0].multiplier,
+            denominations: token.denominations
+          }
+        }
+      }
+      return newState
+    }
+
     case 'ACCOUNT_INIT_COMPLETE': {
       if (!action.data) throw new Error('Invalid action')
       const {


### PR DESCRIPTION
This fixes issue of not having denominations ready in time for rendering certain scenes which need it. This also removes the need to have default denominations for currencies that will just use the primary denomination of the currency.