### PR TITLE
Fine tune various scaling parameters and styles

### DIFF
--- a/src/lib/scaling.js
+++ b/src/lib/scaling.js
@@ -17,12 +17,12 @@ const scaleHorizontal = size => {
   return out
 }
 
-export const scaleH = (size: number, factor: number = 0.4) => {
+export const scaleH = (size: number, factor: number = 0.3) => {
   const out = size + (scaleHorizontal(size) - size) * factor
   return out
 }
 
-export const scaleV = (size: number, factor: number = 0.4) => {
+export const scaleV = (size: number, factor: number = 0.3) => {
   const out = size + (scaleVertical(size) - size) * factor
   return out
 }

--- a/src/modules/UI/components/MenuDropDown/__snapshots__/MenuDropDown.test.js.snap
+++ b/src/modules/UI/components/MenuDropDown/__snapshots__/MenuDropDown.test.js.snap
@@ -7,7 +7,7 @@ exports[`MenuDropDown component should render with standard props 1`] = `
       "alignItems": "center",
       "flexDirection": "column",
       "justifyContent": "center",
-      "width": 70.81408450704225,
+      "width": 64.61056338028169,
     }
   }
 >
@@ -23,7 +23,7 @@ exports[`MenuDropDown component should render with standard props 1`] = `
         "alignItems": "center",
         "height": "100%",
         "justifyContent": "center",
-        "width": 70.81408450704225,
+        "width": 64.61056338028169,
       }
     }
   >
@@ -38,7 +38,7 @@ exports[`MenuDropDown component should render with standard props 1`] = `
               "alignSelf": "center",
               "height": "100%",
               "justifyContent": "center",
-              "width": 70.81408450704225,
+              "width": 64.61056338028169,
             },
             "underlayColor": "transparent",
           },
@@ -63,7 +63,7 @@ exports[`MenuDropDown component should render with standard props 1`] = `
           style={
             Object {
               "color": "#4A5157",
-              "fontSize": 30.788732394366196,
+              "fontSize": 28.091549295774648,
             }
           }
         >
@@ -91,7 +91,7 @@ exports[`MenuDropDown component should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -102,7 +102,7 @@ exports[`MenuDropDown component should render with standard props 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
           >

--- a/src/modules/UI/components/QRCode/__snapshots__/QRCode.test.js.snap
+++ b/src/modules/UI/components/QRCode/__snapshots__/QRCode.test.js.snap
@@ -5,8 +5,8 @@ exports[`QRCode should render 1`] = `
   style={
     Object {
       "backgroundColor": "#FFFFFF",
-      "borderRadius": 6.157746478873239,
-      "padding": 15.394366197183098,
+      "borderRadius": 5.618309859154929,
+      "padding": 14.045774647887324,
     }
   }
 >

--- a/src/modules/UI/components/WalletListRow/WalletListRow.ui.js
+++ b/src/modules/UI/components/WalletListRow/WalletListRow.ui.js
@@ -11,7 +11,6 @@ import { intl } from '../../../../locales/intl.js'
 import type { CustomTokenInfo, GuiDenomination, GuiWallet } from '../../../../types.js'
 import {
   DIVIDE_PRECISION,
-  cutOffText,
   decimalOrZero,
   getFiatSymbol,
   getSettingsCurrencyMultiplier,
@@ -121,7 +120,7 @@ export class WalletListRowComponent extends Component<WalletListRowProps, Wallet
           <View style={styles.rowInfo}>
             <View style={[styles.rowLeft]}>
               <Text style={[styles.rowNameText]} numberOfLines={1}>
-                {cutOffText(name, 34)}
+                {name}
               </Text>
             </View>
             <View style={[styles.rowRight]}>

--- a/src/modules/UI/scenes/ChangeMiningFee/__snapshots__/ChangeMiningFee.test.js.snap
+++ b/src/modules/UI/scenes/ChangeMiningFee/__snapshots__/ChangeMiningFee.test.js.snap
@@ -15,17 +15,17 @@ exports[`Change Mining Fees should render with custom props 1`] = `
     <Component
       style={
         Object {
-          "paddingHorizontal": 30.788732394366196,
-          "paddingVertical": 30.788732394366196,
+          "paddingHorizontal": 28.091549295774648,
+          "paddingVertical": 28.091549295774648,
           "position": "relative",
-          "top": 101.60281690140846,
+          "top": 92.70211267605633,
         }
       }
     >
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -39,7 +39,7 @@ exports[`Change Mining Fees should render with custom props 1`] = `
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -53,7 +53,7 @@ exports[`Change Mining Fees should render with custom props 1`] = `
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -88,17 +88,17 @@ exports[`Change Mining Fees should render with high props 1`] = `
     <Component
       style={
         Object {
-          "paddingHorizontal": 30.788732394366196,
-          "paddingVertical": 30.788732394366196,
+          "paddingHorizontal": 28.091549295774648,
+          "paddingVertical": 28.091549295774648,
           "position": "relative",
-          "top": 101.60281690140846,
+          "top": 92.70211267605633,
         }
       }
     >
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -112,7 +112,7 @@ exports[`Change Mining Fees should render with high props 1`] = `
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -126,7 +126,7 @@ exports[`Change Mining Fees should render with high props 1`] = `
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -161,17 +161,17 @@ exports[`Change Mining Fees should render with low props 1`] = `
     <Component
       style={
         Object {
-          "paddingHorizontal": 30.788732394366196,
-          "paddingVertical": 30.788732394366196,
+          "paddingHorizontal": 28.091549295774648,
+          "paddingVertical": 28.091549295774648,
           "position": "relative",
-          "top": 101.60281690140846,
+          "top": 92.70211267605633,
         }
       }
     >
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -185,7 +185,7 @@ exports[`Change Mining Fees should render with low props 1`] = `
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -199,7 +199,7 @@ exports[`Change Mining Fees should render with low props 1`] = `
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -234,17 +234,17 @@ exports[`Change Mining Fees should render with standard props 1`] = `
     <Component
       style={
         Object {
-          "paddingHorizontal": 30.788732394366196,
-          "paddingVertical": 30.788732394366196,
+          "paddingHorizontal": 28.091549295774648,
+          "paddingVertical": 28.091549295774648,
           "position": "relative",
-          "top": 101.60281690140846,
+          "top": 92.70211267605633,
         }
       }
     >
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -258,7 +258,7 @@ exports[`Change Mining Fees should render with standard props 1`] = `
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >
@@ -272,7 +272,7 @@ exports[`Change Mining Fees should render with standard props 1`] = `
       <Component
         style={
           Object {
-            "height": 67.73521126760564,
+            "height": 61.80140845070422,
           }
         }
       >

--- a/src/modules/UI/scenes/OnBoarding/__snapshots__/OnBoardingComponent.test.js.snap
+++ b/src/modules/UI/scenes/OnBoarding/__snapshots__/OnBoardingComponent.test.js.snap
@@ -149,7 +149,7 @@ Tap on a wallet name to send or receive funds for that wallet.",
           "container": Object {
             "alignItems": "center",
             "flexDirection": "row",
-            "height": 30.788732394366196,
+            "height": 28.091549295774648,
             "justifyContent": "center",
             "left": 0,
             "position": "absolute",
@@ -165,7 +165,7 @@ Tap on a wallet name to send or receive funds for that wallet.",
         Object {
           "alignItems": "center",
           "flexDirection": "column",
-          "height": 67.73521126760564,
+          "height": 61.80140845070422,
           "justifyContent": "space-around",
           "position": "absolute",
           "top": "82%",
@@ -185,8 +185,8 @@ Tap on a wallet name to send or receive funds for that wallet.",
           style={
             Object {
               "color": "#FFFFFF",
-              "fontSize": 24.630985915492957,
-              "lineHeight": 24.630985915492957,
+              "fontSize": 22.473239436619718,
+              "lineHeight": 22.473239436619718,
             }
           }
         >
@@ -199,7 +199,7 @@ Tap on a wallet name to send or receive funds for that wallet.",
         Object {
           "alignItems": "flex-end",
           "flexDirection": "column",
-          "height": 67.73521126760564,
+          "height": 61.80140845070422,
           "position": "absolute",
           "top": "3%",
           "width": "100%",
@@ -218,8 +218,8 @@ Tap on a wallet name to send or receive funds for that wallet.",
           style={
             Object {
               "color": "#FFFFFF",
-              "fontSize": 24.630985915492957,
-              "lineHeight": 24.630985915492957,
+              "fontSize": 22.473239436619718,
+              "lineHeight": 22.473239436619718,
             }
           }
         >

--- a/src/modules/UI/scenes/SendConfirmation/__snapshots__/sendConfirmation.test.js.snap
+++ b/src/modules/UI/scenes/SendConfirmation/__snapshots__/sendConfirmation.test.js.snap
@@ -34,12 +34,12 @@ exports[`SendConfirmation should render with destination 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "marginTop": 15.394366197183098,
+              "marginTop": 14.045774647887324,
             },
             Object {
               "backgroundColor": "transparent",
-              "height": 30.788732394366196,
-              "marginRight": 7.697183098591549,
+              "height": 28.091549295774648,
+              "marginRight": 7.022887323943662,
             },
           ]
         }
@@ -48,7 +48,7 @@ exports[`SendConfirmation should render with destination 1`] = `
           style={
             Object {
               "color": "#FFFFFF",
-              "fontSize": 24.630985915492957,
+              "fontSize": 22.473239436619718,
             }
           }
         >
@@ -69,12 +69,12 @@ exports[`SendConfirmation should render with destination 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "marginVertical": 18.473239436619718,
+              "marginVertical": 16.854929577464787,
             },
             Object {
               "backgroundColor": "transparent",
-              "height": 30.788732394366196,
-              "marginRight": 7.697183098591549,
+              "height": 28.091549295774648,
+              "marginRight": 7.022887323943662,
             },
           ]
         }
@@ -191,7 +191,7 @@ exports[`SendConfirmation should render with destination 1`] = `
                     Object {
                       "backgroundColor": "transparent",
                       "color": "#FFFFFF",
-                      "fontSize": 24.630985915492957,
+                      "fontSize": 22.473239436619718,
                     },
                   ]
                 }
@@ -235,8 +235,8 @@ exports[`SendConfirmation should render with destination 1`] = `
       <Row
         style={
           Object {
-            "height": 83.12957746478872,
-            "paddingVertical": 27.70985915492958,
+            "height": 75.84718309859154,
+            "paddingVertical": 25.28239436619718,
           }
         }
       />
@@ -247,7 +247,7 @@ exports[`SendConfirmation should render with destination 1`] = `
           forceUpdateGuiCounter={0}
           parentStyle={
             Object {
-              "width": 415.6478873239437,
+              "width": 379.2359154929577,
             }
           }
           resetSlider={false}
@@ -293,12 +293,12 @@ exports[`SendConfirmation should render with standard props 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "marginTop": 15.394366197183098,
+              "marginTop": 14.045774647887324,
             },
             Object {
               "backgroundColor": "transparent",
-              "height": 30.788732394366196,
-              "marginRight": 7.697183098591549,
+              "height": 28.091549295774648,
+              "marginRight": 7.022887323943662,
             },
           ]
         }
@@ -307,7 +307,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "color": "#FFFFFF",
-              "fontSize": 24.630985915492957,
+              "fontSize": 22.473239436619718,
             }
           }
         >
@@ -328,12 +328,12 @@ exports[`SendConfirmation should render with standard props 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "marginVertical": 18.473239436619718,
+              "marginVertical": 16.854929577464787,
             },
             Object {
               "backgroundColor": "transparent",
-              "height": 30.788732394366196,
-              "marginRight": 7.697183098591549,
+              "height": 28.091549295774648,
+              "marginRight": 7.022887323943662,
             },
           ]
         }
@@ -450,7 +450,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
                     Object {
                       "backgroundColor": "transparent",
                       "color": "#FFFFFF",
-                      "fontSize": 24.630985915492957,
+                      "fontSize": 22.473239436619718,
                     },
                   ]
                 }
@@ -479,8 +479,8 @@ exports[`SendConfirmation should render with standard props 1`] = `
       <Row
         style={
           Object {
-            "height": 83.12957746478872,
-            "paddingVertical": 27.70985915492958,
+            "height": 75.84718309859154,
+            "paddingVertical": 25.28239436619718,
           }
         }
       />
@@ -491,7 +491,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
           forceUpdateGuiCounter={0}
           parentStyle={
             Object {
-              "width": 415.6478873239437,
+              "width": 379.2359154929577,
             }
           }
           resetSlider={false}
@@ -537,12 +537,12 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
           Array [
             Object {
               "alignItems": "center",
-              "marginTop": 15.394366197183098,
+              "marginTop": 14.045774647887324,
             },
             Object {
               "backgroundColor": "transparent",
-              "height": 30.788732394366196,
-              "marginRight": 7.697183098591549,
+              "height": 28.091549295774648,
+              "marginRight": 7.022887323943662,
             },
           ]
         }
@@ -551,7 +551,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
           style={
             Object {
               "color": "#FFFFFF",
-              "fontSize": 24.630985915492957,
+              "fontSize": 22.473239436619718,
             }
           }
         >
@@ -572,12 +572,12 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
           Array [
             Object {
               "alignItems": "center",
-              "marginVertical": 18.473239436619718,
+              "marginVertical": 16.854929577464787,
             },
             Object {
               "backgroundColor": "transparent",
-              "height": 30.788732394366196,
-              "marginRight": 7.697183098591549,
+              "height": 28.091549295774648,
+              "marginRight": 7.022887323943662,
             },
           ]
         }
@@ -694,7 +694,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
                     Object {
                       "backgroundColor": "transparent",
                       "color": "#FFFFFF",
-                      "fontSize": 24.630985915492957,
+                      "fontSize": 22.473239436619718,
                     },
                   ]
                 }
@@ -716,7 +716,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
                     "alignItems": "center",
                     "backgroundColor": "transparent",
                     "justifyContent": "center",
-                    "padding": 21.552112676056336,
+                    "padding": 19.66408450704225,
                   }
                 }
               >
@@ -738,8 +738,8 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
       <Row
         style={
           Object {
-            "height": 83.12957746478872,
-            "paddingVertical": 27.70985915492958,
+            "height": 75.84718309859154,
+            "paddingVertical": 25.28239436619718,
           }
         }
       />
@@ -750,7 +750,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
           forceUpdateGuiCounter={0}
           parentStyle={
             Object {
-              "width": 415.6478873239437,
+              "width": 379.2359154929577,
             }
           }
           resetSlider={false}
@@ -799,12 +799,12 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
           Array [
             Object {
               "alignItems": "center",
-              "marginTop": 15.394366197183098,
+              "marginTop": 14.045774647887324,
             },
             Object {
               "backgroundColor": "transparent",
-              "height": 30.788732394366196,
-              "marginRight": 7.697183098591549,
+              "height": 28.091549295774648,
+              "marginRight": 7.022887323943662,
             },
           ]
         }
@@ -813,7 +813,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
           style={
             Object {
               "color": "#FFFFFF",
-              "fontSize": 24.630985915492957,
+              "fontSize": 22.473239436619718,
             }
           }
         >
@@ -834,12 +834,12 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
           Array [
             Object {
               "alignItems": "center",
-              "marginVertical": 18.473239436619718,
+              "marginVertical": 16.854929577464787,
             },
             Object {
               "backgroundColor": "transparent",
-              "height": 30.788732394366196,
-              "marginRight": 7.697183098591549,
+              "height": 28.091549295774648,
+              "marginRight": 7.022887323943662,
             },
           ]
         }
@@ -956,7 +956,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
                     Object {
                       "backgroundColor": "transparent",
                       "color": "#FFFFFF",
-                      "fontSize": 24.630985915492957,
+                      "fontSize": 22.473239436619718,
                     },
                   ]
                 }
@@ -978,7 +978,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
                     "alignItems": "center",
                     "backgroundColor": "transparent",
                     "justifyContent": "center",
-                    "padding": 21.552112676056336,
+                    "padding": 19.66408450704225,
                   }
                 }
               >
@@ -1000,8 +1000,8 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
       <Row
         style={
           Object {
-            "height": 83.12957746478872,
-            "paddingVertical": 27.70985915492958,
+            "height": 75.84718309859154,
+            "paddingVertical": 25.28239436619718,
           }
         }
       />
@@ -1012,7 +1012,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
           forceUpdateGuiCounter={0}
           parentStyle={
             Object {
-              "width": 415.6478873239437,
+              "width": 379.2359154929577,
             }
           }
           resetSlider={false}

--- a/src/modules/UI/scenes/SendConfirmation/__snapshots__/sendConfirmationOptions.test.js.snap
+++ b/src/modules/UI/scenes/SendConfirmation/__snapshots__/sendConfirmationOptions.test.js.snap
@@ -15,8 +15,8 @@ exports[`SendConfirmation XMR 1`] = `
       disabled={false}
       style={
         Object {
-          "paddingHorizontal": 12.315492957746478,
-          "paddingVertical": 6.157746478873239,
+          "paddingHorizontal": 11.236619718309859,
+          "paddingVertical": 5.618309859154929,
         }
       }
     >
@@ -24,9 +24,9 @@ exports[`SendConfirmation XMR 1`] = `
         style={
           Object {
             "color": "#FFFFFF",
-            "fontSize": 27.70985915492958,
+            "fontSize": 25.28239436619718,
             "fontWeight": "700",
-            "paddingHorizontal": 12.315492957746478,
+            "paddingHorizontal": 11.236619718309859,
           }
         }
       >
@@ -37,7 +37,7 @@ exports[`SendConfirmation XMR 1`] = `
       customStyles={Object {}}
       optionsContainerStyle={
         Object {
-          "width": 254.00704225352115,
+          "width": 231.75528169014086,
         }
       }
     >
@@ -58,7 +58,7 @@ exports[`SendConfirmation XMR 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -66,7 +66,7 @@ exports[`SendConfirmation XMR 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
           >
@@ -91,7 +91,7 @@ exports[`SendConfirmation XMR 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -100,7 +100,7 @@ exports[`SendConfirmation XMR 1`] = `
               Array [
                 Object {
                   "color": "#4A5157",
-                  "fontSize": 27.70985915492958,
+                  "fontSize": 25.28239436619718,
                 },
               ]
             }
@@ -126,7 +126,7 @@ exports[`SendConfirmation XMR 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -134,7 +134,7 @@ exports[`SendConfirmation XMR 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
           >
@@ -162,8 +162,8 @@ exports[`SendConfirmation XRP 1`] = `
       disabled={false}
       style={
         Object {
-          "paddingHorizontal": 12.315492957746478,
-          "paddingVertical": 6.157746478873239,
+          "paddingHorizontal": 11.236619718309859,
+          "paddingVertical": 5.618309859154929,
         }
       }
     >
@@ -171,9 +171,9 @@ exports[`SendConfirmation XRP 1`] = `
         style={
           Object {
             "color": "#FFFFFF",
-            "fontSize": 27.70985915492958,
+            "fontSize": 25.28239436619718,
             "fontWeight": "700",
-            "paddingHorizontal": 12.315492957746478,
+            "paddingHorizontal": 11.236619718309859,
           }
         }
       >
@@ -184,7 +184,7 @@ exports[`SendConfirmation XRP 1`] = `
       customStyles={Object {}}
       optionsContainerStyle={
         Object {
-          "width": 254.00704225352115,
+          "width": 231.75528169014086,
         }
       }
     >
@@ -205,7 +205,7 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -213,7 +213,7 @@ exports[`SendConfirmation XRP 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
           >
@@ -238,7 +238,7 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -247,7 +247,7 @@ exports[`SendConfirmation XRP 1`] = `
               Array [
                 Object {
                   "color": "#4A5157",
-                  "fontSize": 27.70985915492958,
+                  "fontSize": 25.28239436619718,
                 },
                 Object {
                   "color": "#F1AA19",
@@ -276,7 +276,7 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -285,7 +285,7 @@ exports[`SendConfirmation XRP 1`] = `
               Array [
                 Object {
                   "color": "#4A5157",
-                  "fontSize": 27.70985915492958,
+                  "fontSize": 25.28239436619718,
                 },
               ]
             }
@@ -311,7 +311,7 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -319,7 +319,7 @@ exports[`SendConfirmation XRP 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
           >
@@ -347,8 +347,8 @@ exports[`SendConfirmation not editable 1`] = `
       disabled={false}
       style={
         Object {
-          "paddingHorizontal": 12.315492957746478,
-          "paddingVertical": 6.157746478873239,
+          "paddingHorizontal": 11.236619718309859,
+          "paddingVertical": 5.618309859154929,
         }
       }
     >
@@ -356,9 +356,9 @@ exports[`SendConfirmation not editable 1`] = `
         style={
           Object {
             "color": "#FFFFFF",
-            "fontSize": 27.70985915492958,
+            "fontSize": 25.28239436619718,
             "fontWeight": "700",
-            "paddingHorizontal": 12.315492957746478,
+            "paddingHorizontal": 11.236619718309859,
           }
         }
       >
@@ -369,7 +369,7 @@ exports[`SendConfirmation not editable 1`] = `
       customStyles={Object {}}
       optionsContainerStyle={
         Object {
-          "width": 254.00704225352115,
+          "width": 231.75528169014086,
         }
       }
     >
@@ -390,7 +390,7 @@ exports[`SendConfirmation not editable 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -398,7 +398,7 @@ exports[`SendConfirmation not editable 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
           >
@@ -426,8 +426,8 @@ exports[`SendConfirmation should render with standard props 1`] = `
       disabled={false}
       style={
         Object {
-          "paddingHorizontal": 12.315492957746478,
-          "paddingVertical": 6.157746478873239,
+          "paddingHorizontal": 11.236619718309859,
+          "paddingVertical": 5.618309859154929,
         }
       }
     >
@@ -435,9 +435,9 @@ exports[`SendConfirmation should render with standard props 1`] = `
         style={
           Object {
             "color": "#FFFFFF",
-            "fontSize": 27.70985915492958,
+            "fontSize": 25.28239436619718,
             "fontWeight": "700",
-            "paddingHorizontal": 12.315492957746478,
+            "paddingHorizontal": 11.236619718309859,
           }
         }
       >
@@ -448,7 +448,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
       customStyles={Object {}}
       optionsContainerStyle={
         Object {
-          "width": 254.00704225352115,
+          "width": 231.75528169014086,
         }
       }
     >
@@ -469,7 +469,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -477,7 +477,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
           >
@@ -502,7 +502,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -511,7 +511,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
               Array [
                 Object {
                   "color": "#4A5157",
-                  "fontSize": 27.70985915492958,
+                  "fontSize": 25.28239436619718,
                 },
                 Object {
                   "color": "#F1AA19",
@@ -540,7 +540,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingVertical": 6.157746478873239,
+              "paddingVertical": 5.618309859154929,
             }
           }
         >
@@ -548,7 +548,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
           >

--- a/src/modules/UI/scenes/Settings/__snapshots__/CurrencySettings.ui.test.js.snap
+++ b/src/modules/UI/scenes/Settings/__snapshots__/CurrencySettings.ui.test.js.snap
@@ -31,9 +31,9 @@ exports[`CurrencySettings should render 1`] = `
           Array [
             Object {
               "flexDirection": "row",
-              "height": 76.97183098591549,
+              "height": 70.22887323943661,
               "justifyContent": "space-between",
-              "padding": 18.473239436619718,
+              "padding": 16.854929577464787,
             },
           ]
         }
@@ -57,8 +57,8 @@ exports[`CurrencySettings should render 1`] = `
                 Object {
                   "backgroundColor": "transparent",
                   "color": "#FFFFFF",
-                  "fontSize": 27.70985915492958,
-                  "marginLeft": 24.630985915492957,
+                  "fontSize": 25.28239436619718,
+                  "marginLeft": 22.473239436619718,
                 }
               }
             >

--- a/src/modules/UI/scenes/Settings/__snapshots__/settingsOverview.test.js.snap
+++ b/src/modules/UI/scenes/Settings/__snapshots__/settingsOverview.test.js.snap
@@ -23,9 +23,9 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
         Array [
           Object {
             "flexDirection": "row",
-            "height": 76.97183098591549,
+            "height": 70.22887323943661,
             "justifyContent": "space-between",
-            "padding": 18.473239436619718,
+            "padding": 16.854929577464787,
           },
         ]
       }
@@ -51,7 +51,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
                 Object {
                   "backgroundColor": "transparent",
                   "color": "#FFFFFF",
-                  "fontSize": 33.86760563380282,
+                  "fontSize": 30.90070422535211,
                 },
               ]
             }
@@ -62,8 +62,8 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               Object {
                 "backgroundColor": "transparent",
                 "color": "#FFFFFF",
-                "fontSize": 27.70985915492958,
-                "marginLeft": 24.630985915492957,
+                "fontSize": 25.28239436619718,
+                "marginLeft": 22.473239436619718,
               }
             }
           >
@@ -99,7 +99,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
           style={
             Object {
               "color": "#4A5157",
-              "fontSize": 27.70985915492958,
+              "fontSize": 25.28239436619718,
             }
           }
           type="simpleIcons"
@@ -116,7 +116,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
           style={
             Object {
               "color": "#4A5157",
-              "fontSize": 27.70985915492958,
+              "fontSize": 25.28239436619718,
             }
           }
           type="simpleIcons"
@@ -133,7 +133,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
           style={
             Object {
               "color": "#4A5157",
-              "fontSize": 27.70985915492958,
+              "fontSize": 25.28239436619718,
             }
           }
           type="simpleIcons"
@@ -150,7 +150,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
           style={
             Object {
               "color": "#4A5157",
-              "fontSize": 27.70985915492958,
+              "fontSize": 25.28239436619718,
             }
           }
           type="simpleIcons"
@@ -163,9 +163,9 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
         Array [
           Object {
             "flexDirection": "row",
-            "height": 76.97183098591549,
+            "height": 70.22887323943661,
             "justifyContent": "space-between",
-            "padding": 18.473239436619718,
+            "padding": 16.854929577464787,
           },
         ]
       }
@@ -191,7 +191,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
                 Object {
                   "backgroundColor": "transparent",
                   "color": "#FFFFFF",
-                  "fontSize": 33.86760563380282,
+                  "fontSize": 30.90070422535211,
                 },
               ]
             }
@@ -202,8 +202,8 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               Object {
                 "backgroundColor": "transparent",
                 "color": "#FFFFFF",
-                "fontSize": 27.70985915492958,
-                "marginLeft": 24.630985915492957,
+                "fontSize": 25.28239436619718,
+                "marginLeft": 22.473239436619718,
               }
             }
           >
@@ -222,7 +222,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
             type="simpleIcons"
@@ -323,7 +323,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
             Object {
               "backgroundColor": "#F4F5F6",
               "flex": 1,
-              "padding": 30.788732394366196,
+              "padding": 28.091549295774648,
             },
           ]
         }
@@ -340,7 +340,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
         style={
           Object {
             "flex": 1,
-            "height": 78.5112676056338,
+            "height": 71.63345070422535,
           }
         }
       />
@@ -451,9 +451,9 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
         Array [
           Object {
             "flexDirection": "row",
-            "height": 76.97183098591549,
+            "height": 70.22887323943661,
             "justifyContent": "space-between",
-            "padding": 18.473239436619718,
+            "padding": 16.854929577464787,
           },
         ]
       }
@@ -479,7 +479,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
                 Object {
                   "backgroundColor": "transparent",
                   "color": "#FFFFFF",
-                  "fontSize": 33.86760563380282,
+                  "fontSize": 30.90070422535211,
                 },
               ]
             }
@@ -490,8 +490,8 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               Object {
                 "backgroundColor": "transparent",
                 "color": "#FFFFFF",
-                "fontSize": 27.70985915492958,
-                "marginLeft": 24.630985915492957,
+                "fontSize": 25.28239436619718,
+                "marginLeft": 22.473239436619718,
               }
             }
           >
@@ -527,7 +527,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
           style={
             Object {
               "color": "#4A5157",
-              "fontSize": 27.70985915492958,
+              "fontSize": 25.28239436619718,
             }
           }
           type="simpleIcons"
@@ -544,7 +544,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
           style={
             Object {
               "color": "#4A5157",
-              "fontSize": 27.70985915492958,
+              "fontSize": 25.28239436619718,
             }
           }
           type="simpleIcons"
@@ -561,7 +561,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
           style={
             Object {
               "color": "#4A5157",
-              "fontSize": 27.70985915492958,
+              "fontSize": 25.28239436619718,
             }
           }
           type="simpleIcons"
@@ -578,7 +578,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
           style={
             Object {
               "color": "#4A5157",
-              "fontSize": 27.70985915492958,
+              "fontSize": 25.28239436619718,
             }
           }
           type="simpleIcons"
@@ -591,9 +591,9 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
         Array [
           Object {
             "flexDirection": "row",
-            "height": 76.97183098591549,
+            "height": 70.22887323943661,
             "justifyContent": "space-between",
-            "padding": 18.473239436619718,
+            "padding": 16.854929577464787,
           },
         ]
       }
@@ -619,7 +619,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
                 Object {
                   "backgroundColor": "transparent",
                   "color": "#FFFFFF",
-                  "fontSize": 33.86760563380282,
+                  "fontSize": 30.90070422535211,
                 },
               ]
             }
@@ -630,8 +630,8 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               Object {
                 "backgroundColor": "transparent",
                 "color": "#FFFFFF",
-                "fontSize": 27.70985915492958,
-                "marginLeft": 24.630985915492957,
+                "fontSize": 25.28239436619718,
+                "marginLeft": 22.473239436619718,
               }
             }
           >
@@ -650,7 +650,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
             style={
               Object {
                 "color": "#4A5157",
-                "fontSize": 27.70985915492958,
+                "fontSize": 25.28239436619718,
               }
             }
             type="simpleIcons"
@@ -751,7 +751,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
             Object {
               "backgroundColor": "#F4F5F6",
               "flex": 1,
-              "padding": 30.788732394366196,
+              "padding": 28.091549295774648,
             },
           ]
         }
@@ -768,7 +768,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
         style={
           Object {
             "flex": 1,
-            "height": 78.5112676056338,
+            "height": 71.63345070422535,
           }
         }
       />

--- a/src/modules/UI/scenes/TransactionDetails/__snapshots__/TransactionDetails.ui.test.js.snap
+++ b/src/modules/UI/scenes/TransactionDetails/__snapshots__/TransactionDetails.ui.test.js.snap
@@ -15,7 +15,7 @@ exports[`TransactionDetails.ui should render 1`] = `
     <Gradient
       style={
         Object {
-          "height": 101.60281690140846,
+          "height": 92.70211267605633,
           "position": "absolute",
           "width": "100%",
         }
@@ -25,7 +25,7 @@ exports[`TransactionDetails.ui should render 1`] = `
       style={
         Object {
           "position": "relative",
-          "top": 101.60281690140846,
+          "top": 92.70211267605633,
         }
       }
     >
@@ -59,7 +59,7 @@ exports[`TransactionDetails.ui should render 1`] = `
                 Array [
                   Object {
                     "flexDirection": "row",
-                    "height": 49.261971830985914,
+                    "height": 44.946478873239435,
                     "justifyContent": "center",
                   },
                 ]
@@ -77,7 +77,7 @@ exports[`TransactionDetails.ui should render 1`] = `
                 Object {
                   "flexDirection": "column",
                   "position": "relative",
-                  "top": 30.788732394366196,
+                  "top": 28.091549295774648,
                 },
               ]
             }
@@ -97,7 +97,7 @@ exports[`TransactionDetails.ui should render 1`] = `
                   Array [
                     Object {
                       "alignItems": "center",
-                      "padding": 6.157746478873239,
+                      "padding": 5.618309859154929,
                       "width": "80%",
                     },
                   ]
@@ -116,8 +116,8 @@ exports[`TransactionDetails.ui should render 1`] = `
                       Object {
                         "color": "#4A5157",
                         "fontFamily": "SourceSansPro-Black",
-                        "fontSize": 26.170422535211266,
-                        "height": 36.946478873239435,
+                        "fontSize": 23.87781690140845,
+                        "height": 33.709859154929575,
                         "textAlign": "center",
                         "width": "100%",
                       },
@@ -134,7 +134,7 @@ exports[`TransactionDetails.ui should render 1`] = `
                   "alignSelf": "center",
                   "borderBottomColor": "#CCCCCC",
                   "borderBottomWidth": 1,
-                  "height": 1.5394366197183098,
+                  "height": 1.4045774647887324,
                   "width": "38%",
                 }
               }
@@ -145,7 +145,7 @@ exports[`TransactionDetails.ui should render 1`] = `
                   Object {
                     "alignItems": "center",
                     "flexDirection": "column",
-                    "padding": 6.157746478873239,
+                    "padding": 5.618309859154929,
                   },
                 ]
               }
@@ -155,7 +155,7 @@ exports[`TransactionDetails.ui should render 1`] = `
                   Array [
                     Object {
                       "color": "#87939E",
-                      "fontSize": 21.552112676056336,
+                      "fontSize": 19.66408450704225,
                     },
                   ]
                 }
@@ -293,7 +293,7 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
     <Gradient
       style={
         Object {
-          "height": 101.60281690140846,
+          "height": 92.70211267605633,
           "position": "absolute",
           "width": "100%",
         }
@@ -303,7 +303,7 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
       style={
         Object {
           "position": "relative",
-          "top": 101.60281690140846,
+          "top": 92.70211267605633,
         }
       }
     >
@@ -337,7 +337,7 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
                 Array [
                   Object {
                     "flexDirection": "row",
-                    "height": 49.261971830985914,
+                    "height": 44.946478873239435,
                     "justifyContent": "center",
                   },
                 ]
@@ -355,7 +355,7 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
                 Object {
                   "flexDirection": "column",
                   "position": "relative",
-                  "top": 30.788732394366196,
+                  "top": 28.091549295774648,
                 },
               ]
             }
@@ -375,7 +375,7 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
                   Array [
                     Object {
                       "alignItems": "center",
-                      "padding": 6.157746478873239,
+                      "padding": 5.618309859154929,
                       "width": "80%",
                     },
                   ]
@@ -394,8 +394,8 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
                       Object {
                         "color": "#4A5157",
                         "fontFamily": "SourceSansPro-Black",
-                        "fontSize": 26.170422535211266,
-                        "height": 36.946478873239435,
+                        "fontSize": 23.87781690140845,
+                        "height": 33.709859154929575,
                         "textAlign": "center",
                         "width": "100%",
                       },
@@ -412,7 +412,7 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
                   "alignSelf": "center",
                   "borderBottomColor": "#CCCCCC",
                   "borderBottomWidth": 1,
-                  "height": 1.5394366197183098,
+                  "height": 1.4045774647887324,
                   "width": "38%",
                 }
               }
@@ -423,7 +423,7 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
                   Object {
                     "alignItems": "center",
                     "flexDirection": "column",
-                    "padding": 6.157746478873239,
+                    "padding": 5.618309859154929,
                   },
                 ]
               }
@@ -433,7 +433,7 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
                   Array [
                     Object {
                       "color": "#87939E",
-                      "fontSize": 21.552112676056336,
+                      "fontSize": 19.66408450704225,
                     },
                   ]
                 }
@@ -574,7 +574,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
     <Gradient
       style={
         Object {
-          "height": 101.60281690140846,
+          "height": 92.70211267605633,
           "position": "absolute",
           "width": "100%",
         }
@@ -584,7 +584,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
       style={
         Object {
           "position": "relative",
-          "top": 101.60281690140846,
+          "top": 92.70211267605633,
         }
       }
     >
@@ -618,7 +618,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
                 Array [
                   Object {
                     "flexDirection": "row",
-                    "height": 49.261971830985914,
+                    "height": 44.946478873239435,
                     "justifyContent": "center",
                   },
                 ]
@@ -636,7 +636,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
                 Object {
                   "flexDirection": "column",
                   "position": "relative",
-                  "top": 30.788732394366196,
+                  "top": 28.091549295774648,
                 },
               ]
             }
@@ -656,7 +656,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
                   Array [
                     Object {
                       "alignItems": "center",
-                      "padding": 6.157746478873239,
+                      "padding": 5.618309859154929,
                       "width": "80%",
                     },
                   ]
@@ -675,8 +675,8 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
                       Object {
                         "color": "#4A5157",
                         "fontFamily": "SourceSansPro-Black",
-                        "fontSize": 26.170422535211266,
-                        "height": 36.946478873239435,
+                        "fontSize": 23.87781690140845,
+                        "height": 33.709859154929575,
                         "textAlign": "center",
                         "width": "100%",
                       },
@@ -693,7 +693,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
                   "alignSelf": "center",
                   "borderBottomColor": "#CCCCCC",
                   "borderBottomWidth": 1,
-                  "height": 1.5394366197183098,
+                  "height": 1.4045774647887324,
                   "width": "38%",
                 }
               }
@@ -704,7 +704,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
                   Object {
                     "alignItems": "center",
                     "flexDirection": "column",
-                    "padding": 6.157746478873239,
+                    "padding": 5.618309859154929,
                   },
                 ]
               }
@@ -714,7 +714,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
                   Array [
                     Object {
                       "color": "#87939E",
-                      "fontSize": 21.552112676056336,
+                      "fontSize": 19.66408450704225,
                     },
                   ]
                 }
@@ -852,7 +852,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
     <Gradient
       style={
         Object {
-          "height": 101.60281690140846,
+          "height": 92.70211267605633,
           "position": "absolute",
           "width": "100%",
         }
@@ -862,7 +862,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
       style={
         Object {
           "position": "relative",
-          "top": 101.60281690140846,
+          "top": 92.70211267605633,
         }
       }
     >
@@ -896,7 +896,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
                 Array [
                   Object {
                     "flexDirection": "row",
-                    "height": 49.261971830985914,
+                    "height": 44.946478873239435,
                     "justifyContent": "center",
                   },
                 ]
@@ -914,7 +914,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
                 Object {
                   "flexDirection": "column",
                   "position": "relative",
-                  "top": 30.788732394366196,
+                  "top": 28.091549295774648,
                 },
               ]
             }
@@ -934,7 +934,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
                   Array [
                     Object {
                       "alignItems": "center",
-                      "padding": 6.157746478873239,
+                      "padding": 5.618309859154929,
                       "width": "80%",
                     },
                   ]
@@ -953,8 +953,8 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
                       Object {
                         "color": "#4A5157",
                         "fontFamily": "SourceSansPro-Black",
-                        "fontSize": 26.170422535211266,
-                        "height": 36.946478873239435,
+                        "fontSize": 23.87781690140845,
+                        "height": 33.709859154929575,
                         "textAlign": "center",
                         "width": "100%",
                       },
@@ -971,7 +971,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
                   "alignSelf": "center",
                   "borderBottomColor": "#CCCCCC",
                   "borderBottomWidth": 1,
-                  "height": 1.5394366197183098,
+                  "height": 1.4045774647887324,
                   "width": "38%",
                 }
               }
@@ -982,7 +982,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
                   Object {
                     "alignItems": "center",
                     "flexDirection": "column",
-                    "padding": 6.157746478873239,
+                    "padding": 5.618309859154929,
                   },
                 ]
               }
@@ -992,7 +992,7 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
                   Array [
                     Object {
                       "color": "#87939E",
-                      "fontSize": 21.552112676056336,
+                      "fontSize": 19.66408450704225,
                     },
                   ]
                 }

--- a/src/modules/UI/scenes/TransactionList/components/TransactionRow.test.js
+++ b/src/modules/UI/scenes/TransactionList/components/TransactionRow.test.js
@@ -1,0 +1,75 @@
+/* globals global describe it expect */
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+import React from 'react'
+import ShallowRenderer from 'react-test-renderer/shallow'
+
+import { style } from '../style.js'
+import { TransactionRowComponent } from './TransactionRow.ui.js'
+
+describe('MenuDropDown component', () => {
+  it('should render without props', () => {
+    const renderer = new ShallowRenderer()
+    const uiWallet = {
+      id: 'SXq1f3x21H2e/h5A4ANvrMoK5xs+sQcDoFWHtCG25BA=',
+      type: 'wallet:monero',
+      name: 'Monero',
+      primaryNativeBalance: '1492780012',
+      nativeBalances: { XMR: '1492780012' },
+      currencyNames: { XMR: 'Monero' },
+      currencyCode: 'XMR',
+      isoFiatCurrencyCode: 'iso:USD',
+      fiatCurrencyCode: 'USD',
+      denominations: [{}],
+      allDenominations: { XMR: {} },
+      metaTokens: [],
+      enabledTokens: [],
+      receiveAddress: { metadata: {}, nativeAmount: '0', publicAddress: '432hJPUp2C...' },
+      blockHeight: 1688551,
+      symbolImage: 'https://developer.airbitz.co/content/monero-symbol-orange-64.png',
+      symbolImageDarkMono: 'https://developer.airbitz.co/content/monero-symbol-64-87939D.png',
+      key: 'SXq1f3x21H2e/h5A4ANvrMoK5xs+sQcDoFWHtCG25BA='
+    }
+    const transaction = {
+      blockHeight: 1683022,
+      date: 1539555412.068,
+      ourReceiveAddresses: [],
+      signedTx: 'no_signature',
+      txid: '4e92d23cff1714d52d48c0c5246adf4f6871d6d8d52d774b1b60cc4b28f8f296',
+      amountSatoshi: -32295514330000,
+      nativeAmount: '-32295514330000',
+      networkFee: '0',
+      currencyCode: 'XMR',
+      wallet: { id: 'SXq1f3x21H…', type: 'wallet:monero' },
+      otherParams: {},
+      SVGMetadataElement: { name: 'ShapeShift', category: '', notes: 'Exchanged …' },
+      dateString: 'Oct 14, 2018',
+      time: '3:16 PM',
+      key: 0
+    }
+    const props = {
+      style,
+      uiWallet,
+      transactions: [{ ...transaction }],
+      selectedCurrencyCode: 'XMR',
+      contacts: [],
+      isoFiatCurrencyCode: 'iso:USD',
+      fiatCurrencyCode: 'USD',
+      fiatSymbol: '$',
+      requiredConfirmations: 1,
+      transaction: {
+        item: {
+          ...transaction
+        }
+      },
+      displayDenomination: {
+        multiplier: '1000000000000',
+        name: 'XMR',
+        symbol: '‎ɱ'
+      }
+    }
+    const actual = renderer.render(<TransactionRowComponent {...props} />)
+
+    expect(actual).toMatchSnapshot()
+  })
+})

--- a/src/modules/UI/scenes/TransactionList/components/TransactionRow.ui.js
+++ b/src/modules/UI/scenes/TransactionList/components/TransactionRow.ui.js
@@ -60,7 +60,7 @@ export class TransactionRowComponent extends Component<Props, State> {
   }
 
   render () {
-    global.pcount('TransactionRow:render')
+    global.pcount && global.pcount('TransactionRow:render')
     const completedTxList: Array<TransactionListTx> = this.props.transactions
     // $FlowFixMe
     const tx = this.props.transaction.item
@@ -138,7 +138,6 @@ export class TransactionRowComponent extends Component<Props, State> {
     } else {
       transactionPartner = txName
     }
-
     const out = (
       <View style={[styles.singleTransactionWrap]}>
         {(tx.key === 0 || tx.dateString !== completedTxList[tx.key - 1].dateString) && (
@@ -155,14 +154,18 @@ export class TransactionRowComponent extends Component<Props, State> {
         >
           <View style={[styles.transactionInfoWrap]}>
             <View style={styles.transactionLeft}>
-              {thumbnailPath ? (
-                <Image style={[styles.transactionLogo]} source={{ uri: thumbnailPath }} />
-              ) : (
-                <Image style={styles.transactionLogo} source={txImage} />
-              )}
+              <View style={[styles.transactionLeftLogoWrap]}>
+                {thumbnailPath ? (
+                  <Image style={[styles.transactionLogo]} source={{ uri: thumbnailPath }} />
+                ) : (
+                  <Image style={styles.transactionLogo} source={txImage} />
+                )}
+              </View>
 
               <View style={[styles.transactionLeftTextWrap]}>
-                <T style={[styles.transactionPartner]}>{transactionPartner}</T>
+                <T style={[styles.transactionPartner]} adjustsFontSizeToFit={true} minimumFontScale={0.6}>
+                  {transactionPartner}
+                </T>
                 <T style={[styles.transactionTimePendingArea, pendingTimeStyle]}>{pendingTimeSyntax}</T>
               </View>
             </View>

--- a/src/modules/UI/scenes/TransactionList/components/__snapshots__/TransactionRow.test.js.snap
+++ b/src/modules/UI/scenes/TransactionList/components/__snapshots__/TransactionRow.test.js.snap
@@ -1,0 +1,209 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MenuDropDown component should render without props 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "flex": 1,
+        "flexDirection": "column",
+      },
+    ]
+  }
+>
+  <Component
+    style={
+      Object {
+        "backgroundColor": "#F4F5F6",
+        "flex": 3,
+        "flexDirection": "row",
+        "padding": 4.213732394366197,
+        "paddingLeft": 21.068661971830984,
+        "paddingRight": 33.709859154929575,
+      }
+    }
+  >
+    <Component
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <FormattedText
+        style={
+          Object {
+            "color": "#87939E",
+            "fontSize": 19.66408450704225,
+          }
+        }
+      >
+        Oct 14, 2018
+      </FormattedText>
+    </Component>
+  </Component>
+  <TouchableHighlight
+    activeOpacity={0.85}
+    delayPressOut={100}
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "borderBottomColor": "#D9E3ED",
+          "borderBottomWidth": 1,
+          "height": 112.36619718309859,
+          "padding": 21.068661971830984,
+          "paddingLeft": 21.068661971830984,
+          "paddingRight": 21.068661971830984,
+        },
+        Object {
+          "borderBottomWidth": 1,
+        },
+      ]
+    }
+    underlayColor="#D9E3ED"
+  >
+    <Component
+      style={
+        Array [
+          Object {
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 56.183098591549296,
+            "justifyContent": "space-between",
+          },
+        ]
+      }
+    >
+      <Component
+        style={
+          Object {
+            "flex": 25,
+            "flexDirection": "row",
+          }
+        }
+      >
+        <Component
+          style={
+            Array [
+              Object {
+                "justifyContent": "center",
+              },
+            ]
+          }
+        >
+          <Image
+            source={
+              Object {
+                "testUri": "../../../src/assets/images/transactions/transaction-type-sent.png",
+              }
+            }
+            style={
+              Object {
+                "borderRadius": 28.091549295774648,
+                "height": 56.183098591549296,
+                "marginRight": 14.045774647887324,
+                "width": 56.183098591549296,
+              }
+            }
+          />
+        </Component>
+        <Component
+          style={
+            Array [
+              Object {
+                "flex": 10,
+                "justifyContent": "center",
+              },
+            ]
+          }
+        >
+          <FormattedText
+            adjustsFontSizeToFit={true}
+            minimumFontScale={0.6}
+            style={
+              Array [
+                Object {
+                  "color": "#4A5157",
+                  "fontSize": 22.473239436619718,
+                  "textAlignVertical": "center",
+                },
+              ]
+            }
+          >
+            Sent Monero
+          </FormattedText>
+          <FormattedText
+            style={
+              Array [
+                Object {
+                  "fontSize": 16.854929577464787,
+                  "position": "relative",
+                  "textAlignVertical": "bottom",
+                  "top": 5.618309859154929,
+                },
+                Object {
+                  "color": "#4A5157",
+                },
+              ]
+            }
+          >
+            3:16 PM
+          </FormattedText>
+        </Component>
+      </Component>
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-end",
+              "flex": 10,
+              "justifyContent": "center",
+            },
+          ]
+        }
+      >
+        <FormattedText
+          style={
+            Array [
+              Object {
+                "fontSize": 22.473239436619718,
+                "textAlignVertical": "center",
+              },
+              Object {
+                "color": "#E85466",
+              },
+              Object {
+                "fontFamily": "SourceSansPro-Black",
+              },
+            ]
+          }
+        >
+          ‎ɱ
+           
+          32.295514
+        </FormattedText>
+        <FormattedText
+          style={
+            Array [
+              Object {
+                "color": "#87939E",
+                "fontSize": 16.854929577464787,
+                "position": "relative",
+                "textAlignVertical": "center",
+                "top": 5.618309859154929,
+              },
+              Object {
+                "color": "#E85466",
+              },
+            ]
+          }
+        >
+          $ 0.00
+        </FormattedText>
+      </Component>
+    </Component>
+  </TouchableHighlight>
+</Component>
+`;

--- a/src/modules/UI/scenes/TransactionList/style.js
+++ b/src/modules/UI/scenes/TransactionList/style.js
@@ -237,11 +237,11 @@ export const styles = {
     backgroundColor: THEME.COLORS.OFF_WHITE
   },
   singleTransaction: {
-    height: scale(60),
+    height: scale(80),
     borderBottomWidth: 1,
     borderBottomColor: THEME.COLORS.GRAY_3,
-    padding: scale(10),
-    paddingRight: scale(30),
+    padding: scale(15),
+    paddingRight: scale(15),
     paddingLeft: scale(15)
   },
   singleTransactionWrap: {
@@ -252,7 +252,7 @@ export const styles = {
   singleDateArea: {
     backgroundColor: THEME.COLORS.GRAY_4,
     flex: 3,
-    padding: scale(8),
+    padding: scale(3),
     paddingLeft: scale(15),
     flexDirection: 'row',
     paddingRight: scale(24)
@@ -275,7 +275,8 @@ export const styles = {
     justifyContent: 'space-between'
   },
   transactionLeft: {
-    flexDirection: 'row'
+    flexDirection: 'row',
+    flex: 25
   },
   transactionLogo: {
     width: scale(40),
@@ -283,7 +284,11 @@ export const styles = {
     borderRadius: scale(20),
     marginRight: scale(10)
   },
+  transactionLeftLogoWrap: {
+    justifyContent: 'center'
+  },
   transactionLeftTextWrap: {
+    flex: 10,
     justifyContent: 'center'
   },
   transactionPartner: {
@@ -296,6 +301,7 @@ export const styles = {
     textAlignVertical: 'center'
   },
   transactionRight: {
+    flex: 10,
     alignItems: 'flex-end',
     justifyContent: 'center'
   },

--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/FullWalletListRow.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/FullWalletListRow.ui.js
@@ -130,25 +130,13 @@ class FullWalletListRowLoadedComponent extends Component<FullWalletListRowLoaded
             onPress={() => this._onPressSelectWallet(id, currencyCode)}
           >
             <View style={[styles.rowContent]}>
-              <View style={[styles.rowNameTextWrap]}>
-                {Platform.OS === 'ios' && (
-                  <View style={[styles.rowNameTextWrapIOS]}>
-                    <T style={[styles.rowNameText]} numberOfLines={1}>
-                      {symbolImageDarkMono && (
-                        <Image style={[styles.rowCurrencyLogoIOS]} transform={[{ translateY: 3 }]} source={{ uri: symbolImageDarkMono }} />
-                      )}{' '}
-                      {cutOffText(name, 34)}
-                    </T>
-                  </View>
-                )}
-                {Platform.OS === 'android' && (
-                  <View style={[styles.rowNameTextWrapAndroid]}>
-                    {symbolImageDarkMono && <Image style={[styles.rowCurrencyLogoAndroid]} source={{ uri: symbolImageDarkMono }} resizeMode="cover" />}
-                    <T style={[styles.rowNameText]} numberOfLines={1}>
-                      {cutOffText(name, 34)}
-                    </T>
-                  </View>
-                )}
+              <View style={styles.rowIconWrap}>
+                {symbolImageDarkMono && <Image style={[styles.rowCurrencyLogoAndroid]} source={{ uri: symbolImageDarkMono }} resizeMode="cover" />}
+              </View>
+              <View style={[styles.rowNameTextWrapAndroidIos]}>
+                <T style={[styles.rowNameText]} numberOfLines={2} adjustsFontSizeToFit={true} minimumFontScale={0.6}>
+                  {Platform.OS === 'ios' ? name : cutOffText(name, 34)}
+                </T>
               </View>
               {this.props.isWalletFiatBalanceVisible ? (
                 <View style={[styles.rowBalanceTextWrap]}>
@@ -169,7 +157,9 @@ class FullWalletListRowLoadedComponent extends Component<FullWalletListRowLoaded
                   </View>
                 </View>
               )}
-              <WalletListRowOptions currencyCode={walletData.currencyCode} executeWalletRowOption={walletData.executeWalletRowOption} walletKey={id} />
+              <View style={styles.rowOptionsWrap}>
+                <WalletListRowOptions currencyCode={walletData.currencyCode} executeWalletRowOption={walletData.executeWalletRowOption} walletKey={id} />
+              </View>
             </View>
           </TouchableHighlight>
           {this.renderTokenRow(id, enabledNativeBalances)}

--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptions.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptions.ui.js
@@ -19,11 +19,11 @@ const modifiedMenuDropDownStyle = {
   ...MenuDropDownStyle,
   menuIconWrap: {
     ...MenuDropDownStyle.menuIconWrap,
-    width: scale(46)
+    width: '100%'
   },
   icon: {
     ...MenuDropDownStyle.icon,
-    fontSize: scale(26),
+    fontSize: scale(30),
     position: 'relative',
     top: 2
   }

--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListTokenRow.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListTokenRow.ui.js
@@ -46,20 +46,24 @@ export class WalletListTokenRow extends PureComponent<Props> {
         onPress={this.selectWallet}
         {...this.props.sortHandlers}
       >
-        <View style={[styles.tokenRowContent]}>
-          <View style={[styles.tokenRowNameTextWrap]}>
+        <View style={[styles.rowContent]}>
+          <View style={styles.rowIconWrap} />
+          <View style={[styles.rowNameTextWrapAndroidIos]}>
             <T style={[styles.tokenRowText]}>{this.props.currencyCode}</T>
           </View>
 
-          <View style={[styles.tokenRowBalanceTextWrap]}>
-            {this.props.isWalletFiatBalanceVisible ? (
-              <T style={[styles.tokenRowText]}>{this.props.fiatSymbol + ' ' + this.props.fiatBalance}</T>
-            ) : (
-              <T style={[styles.tokenRowText]}>
-                {intl.formatNumber(UTILS.convertNativeToDisplay(this.props.displayDenomination.multiplier)(this.props.balance) || '0')}
-              </T>
-            )}
+          <View style={[styles.rowBalanceTextWrap]}>
+            <View style={styles.rowBalanceText}>
+              {this.props.isWalletFiatBalanceVisible ? (
+                <T style={[styles.rowBalanceAmountText]}>{this.props.fiatSymbol + ' ' + this.props.fiatBalance}</T>
+              ) : (
+                <T style={[styles.rowBalanceAmountText]}>
+                  {intl.formatNumber(UTILS.convertNativeToDisplay(this.props.displayDenomination.multiplier)(this.props.balance) || '0')}
+                </T>
+              )}
+            </View>
           </View>
+          <View style={styles.rowOptionsWrap} />
         </View>
       </TouchableHighlight>
     )

--- a/src/modules/UI/scenes/WalletList/style.js
+++ b/src/modules/UI/scenes/WalletList/style.js
@@ -2,7 +2,7 @@
 
 import { Platform, StyleSheet } from 'react-native'
 
-import { scale } from '../../../../lib/scaling.js'
+import { scale, scaleH } from '../../../../lib/scaling.js'
 import THEME from '../../../../theme/variables/airbitz'
 import { PLATFORM } from '../../../../theme/variables/platform.js'
 
@@ -143,7 +143,7 @@ export const styles = {
   },
   sortableWalletListRow: {
     width: PLATFORM.deviceWidth,
-    height: scale(50),
+    height: scale(70),
     backgroundColor: THEME.COLORS.WHITE,
     paddingVertical: scale(6),
     paddingHorizontal: scale(20),
@@ -158,8 +158,8 @@ export const styles = {
   },
   rowContainer: {
     padding: scale(6),
-    paddingLeft: scale(16),
-    flexDirection: 'column',
+    paddingLeft: scale(8),
+    height: scale(60),
     backgroundColor: THEME.COLORS.WHITE,
     borderBottomWidth: scale(1),
     borderBottomColor: THEME.COLORS.GRAY_3
@@ -171,17 +171,16 @@ export const styles = {
   sortableRowContent: {
     paddingRight: scale(32)
   },
+  rowIconWrap: {
+    justifyContent: 'center',
+    width: scale(36)
+  },
   rowNameTextWrap: {
     flex: 1,
     justifyContent: 'center',
     marginRight: scale(5)
   },
-  rowNameTextWrapIOS: {
-    flex: 1,
-    justifyContent: 'center',
-    marginRight: scale(5)
-  },
-  rowNameTextWrapAndroid: {
+  rowNameTextWrapAndroidIos: {
     flex: 1,
     justifyContent: 'flex-start',
     alignItems: 'center',
@@ -191,7 +190,8 @@ export const styles = {
   rowCurrencyLogoAndroid: {
     height: scale(22),
     width: scale(22),
-    marginRight: scale(5),
+    marginRight: scale(10),
+    marginLeft: scale(5),
     resizeMode: 'contain',
     alignSelf: 'center'
   },
@@ -206,8 +206,8 @@ export const styles = {
     color: THEME.COLORS.GRAY_1
   },
   rowBalanceTextWrap: {
-    justifyContent: 'center',
-    height: scale(38)
+    flex: 1,
+    justifyContent: 'center'
   },
   rowBalanceText: {
     flexDirection: 'row',
@@ -218,13 +218,15 @@ export const styles = {
     color: THEME.COLORS.GRAY_1,
     textAlign: 'right'
   },
+  rowOptionsWrap: {
+    width: scaleH(37)
+  },
   rowBalanceDenominationText: {
     fontSize: scale(14),
     lineHeight: scale(18),
     color: THEME.COLORS.GRAY_1,
     textAlign: 'right'
   },
-
   rowDragArea: {
     justifyContent: 'center',
     marginRight: scale(20),
@@ -315,9 +317,9 @@ export const styles = {
   },
   // beginning of token rows //
   tokenRowContainer: {
-    padding: scale(16),
-    paddingLeft: scale(30),
-    paddingRight: scale(44),
+    padding: scale(6),
+    paddingLeft: scale(8),
+    height: scale(50),
     backgroundColor: THEME.COLORS.GRAY_4,
     borderBottomWidth: 1,
     borderColor: THEME.COLORS.GRAY_3


### PR DESCRIPTION
* Change global scaling from .4 to .3
* Increase height of wallet list and transaction row
* Use same walletlist row component and style for iOS and Android
* Make transaction name and wallet name 2 rows if needed
* Add auto text sizing for iOS for Wallet name
* Decrease padding/margin to right of 3 dot options icon on wallet list
* Shrink height of date in tx list
* Make the wallet list token row formatted with the same alignment as regular wallets so that names and amounts line up