### PR TITLE
Fix txDetails fiat amount thrown off by 1000

### DIFF
--- a/src/locales/intl.js
+++ b/src/locales/intl.js
@@ -15,7 +15,8 @@ let locale = EN_US_LOCALE
 
 type IntlLocaleType = any
 type IntlNumberFormatOptionsType = {
-  toFixed?: number
+  toFixed?: number,
+  noGrouping?: boolean
 }
 
 const intlHandler = {
@@ -57,10 +58,14 @@ const intlHandler = {
     }
     const [integers, decimals] = stringify.split(NATIVE_DECIMAL_SEPARATOR)
     const len = integers.length
-    i = len % NUMBER_GROUP_SIZE || NUMBER_GROUP_SIZE
-    intPart = integers.substr(0, i)
-    for (; i < len; i += NUMBER_GROUP_SIZE) {
-      intPart += locale.groupingSeparator + integers.substr(i, NUMBER_GROUP_SIZE)
+    if (!options || !options.noGrouping) {
+      i = len % NUMBER_GROUP_SIZE || NUMBER_GROUP_SIZE
+      intPart = integers.substr(0, i)
+      for (; i < len; i += NUMBER_GROUP_SIZE) {
+        intPart += locale.groupingSeparator + integers.substr(i, NUMBER_GROUP_SIZE)
+      }
+    } else {
+      intPart = integers.substr(0, len)
     }
     stringify = decimals ? intPart + locale.decimalSeparator + decimals : intPart
     return stringify

--- a/src/locales/intl.js
+++ b/src/locales/intl.js
@@ -65,7 +65,7 @@ const intlHandler = {
         intPart += locale.groupingSeparator + integers.substr(i, NUMBER_GROUP_SIZE)
       }
     } else {
-      intPart = integers.substr(0, len)
+      intPart = integers
     }
     stringify = decimals ? intPart + locale.decimalSeparator + decimals : intPart
     return stringify

--- a/src/locales/intl.test.js
+++ b/src/locales/intl.test.js
@@ -336,6 +336,34 @@ describe('formatNumber', function () {
       const actual = intl.formatNumber(input, options)
       expect(actual).toBe(expected)
     })
+    test('noGrouping toFixed=2 1234 => 1234.00', function () {
+      const input = '1234'
+      const options = { toFixed: 2, noGrouping: true }
+      const expected = '1234.00'
+      const actual = intl.formatNumber(input, options)
+      expect(actual).toBe(expected)
+    })
+    test('noGrouping toFixed=2 123456 => 123456.00', function () {
+      const input = '123456'
+      const options = { toFixed: 2, noGrouping: true }
+      const expected = '123456.00'
+      const actual = intl.formatNumber(input, options)
+      expect(actual).toBe(expected)
+    })
+    test('noGrouping toFixed=2 123456.12 => 123456.12', function () {
+      const input = '123456.12'
+      const options = { toFixed: 2, noGrouping: true }
+      const expected = '123456.12'
+      const actual = intl.formatNumber(input, options)
+      expect(actual).toBe(expected)
+    })
+    test('noGrouping 123456 => 123456', function () {
+      const input = '123456'
+      const options = { noGrouping: true }
+      const expected = '123456'
+      const actual = intl.formatNumber(input, options)
+      expect(actual).toBe(expected)
+    })
   })
 })
 
@@ -367,6 +395,34 @@ describe('formatNumber de_DE locale', function () {
       const input = '1234.56'
       const expected = '1.234,56'
       const actual = intl.formatNumber(input)
+      expect(actual).toBe(expected)
+    })
+    test('noGrouping toFixed=2 1234 => 1234,00', function () {
+      const input = '1234'
+      const options = { toFixed: 2, noGrouping: true }
+      const expected = '1234,00'
+      const actual = intl.formatNumber(input, options)
+      expect(actual).toBe(expected)
+    })
+    test('noGrouping toFixed=2 123456 => 123456,00', function () {
+      const input = '123456'
+      const options = { toFixed: 2, noGrouping: true }
+      const expected = '123456,00'
+      const actual = intl.formatNumber(input, options)
+      expect(actual).toBe(expected)
+    })
+    test('noGrouping toFixed=2 123456.12 => 123456,12', function () {
+      const input = '123456.12'
+      const options = { toFixed: 2, noGrouping: true }
+      const expected = '123456,12'
+      const actual = intl.formatNumber(input, options)
+      expect(actual).toBe(expected)
+    })
+    test('noGrouping 123456 => 123456', function () {
+      const input = '123456'
+      const options = { noGrouping: true }
+      const expected = '123456'
+      const actual = intl.formatNumber(input, options)
       expect(actual).toBe(expected)
     })
   })

--- a/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
+++ b/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
@@ -132,7 +132,7 @@ export class TransactionDetails extends Component<TransactionDetailsProps, State
       if (edgeTransaction.metadata.amountFiat) {
         const initial = edgeTransaction.metadata.amountFiat.toFixed(2)
         const absoluteAmountFiat = bns.abs(initial)
-        amountFiat = intl.formatNumber(bns.toFixed(absoluteAmountFiat, 2, 2))
+        amountFiat = intl.formatNumber(bns.toFixed(absoluteAmountFiat, 2, 2), { noGrouping: true })
       }
     }
 

--- a/src/modules/UI/scenes/TransactionDetails/__snapshots__/TransactionDetails.ui.test.js.snap
+++ b/src/modules/UI/scenes/TransactionDetails/__snapshots__/TransactionDetails.ui.test.js.snap
@@ -478,7 +478,7 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
                   },
                 }
               }
-              fiatAmount="6,392.93"
+              fiatAmount="6392.93"
               fiatCurrencyCode="iso:USD"
               fiatCurrencySymbol="$"
               guiWallet={


### PR DESCRIPTION
Do not add grouping separator when internationalizing fiat amount string. Parser when saving txdetails would think the group separator was a decimal separator and truncate the number.