### PR TITLE
Fix crash when entering txDetails from shapeshift transaction

### DIFF
--- a/src/actions/CryptoExchangeActions.js
+++ b/src/actions/CryptoExchangeActions.js
@@ -133,8 +133,7 @@ export const shiftCryptoCurrency = () => async (dispatch: Dispatch, getState: Ge
       await WALLET_API.saveTransaction(srcWallet, broadcastedTransaction)
 
       const category = sprintf(
-        '%s:%s %s %s',
-        s.strings.fragment_transaction_exchange,
+        'exchange:%s %s %s',
         state.cryptoExchange.fromCurrencyCode,
         s.strings.word_to_in_convert_from_to_string,
         state.cryptoExchange.toCurrencyCode

--- a/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
+++ b/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
@@ -147,7 +147,7 @@ export class TransactionDetails extends Component<TransactionDetailsProps, State
     }
 
     // if type is still not defined then figure out if send or receive (expense vs income)
-    if (!type) {
+    if (!type || !types[type]) {
       if (direction === 'receive') {
         type = types.income.key
       } else {


### PR DESCRIPTION
Crash only occurs if shapeshift transaction was done on non-english phone. The "exchange:" part of the category was being translated when it is being used as a key to lookup into translations.

Fixed exchange scene to use "exchange:" as the category string always
Fixed TransactionDetails to handle an invalid category and fallback