### PR TITLE
Fix currencySettings Android crash

### DIFF
--- a/src/modules/UI/scenes/Settings/CurrencySettings.ui.js
+++ b/src/modules/UI/scenes/Settings/CurrencySettings.ui.js
@@ -136,9 +136,8 @@ export default class CurrencySettings extends Component<Props, State> {
                 const key = denomination.multiplier
                 const left = (
                   <View style={{ flexDirection: 'row' }}>
-                    <T style={styles.symbol}>
-                      {denomination.symbol} - {denomination.name}
-                    </T>
+                    <T style={styles.symbol}>{denomination.symbol}</T>
+                    <T> - {denomination.name}</T>
                   </View>
                 )
                 const isSelected = key === this.props.selectedDenominationKey

--- a/src/modules/UI/scenes/Settings/CurrencySettings.ui.js
+++ b/src/modules/UI/scenes/Settings/CurrencySettings.ui.js
@@ -119,7 +119,7 @@ export default class CurrencySettings extends Component<Props, State> {
         <View style={[styles.ethereumSettings]}>
           <Gradient style={styles.gradient} />
           <View style={styles.container}>
-            {this.props.defaultElectrumServer && (
+            {this.props.defaultElectrumServer.length !== 0 && (
               <SetCustomNodesModal
                 isActive={this.state.isSetCustomNodesModalVisible}
                 onExit={this.closeSetCustomNodesModal}
@@ -136,8 +136,9 @@ export default class CurrencySettings extends Component<Props, State> {
                 const key = denomination.multiplier
                 const left = (
                   <View style={{ flexDirection: 'row' }}>
-                    <T style={styles.symbol}>{denomination.symbol}</T>
-                    <T> - {denomination.name}</T>
+                    <T style={styles.symbol}>
+                      {denomination.symbol} - {denomination.name}
+                    </T>
                   </View>
                 )
                 const isSelected = key === this.props.selectedDenominationKey
@@ -145,7 +146,7 @@ export default class CurrencySettings extends Component<Props, State> {
                 return <Row key={denomination.multiplier} denomination={denomination} left={left} isSelected={isSelected} onPress={onPress} />
               })}
             </RadioRows>
-            {this.props.defaultElectrumServer && (
+            {this.props.defaultElectrumServer.length !== 0 && (
               <View>
                 {this.subHeader(CUSTOM_NODES_TEXT)}
                 <SwitchRow

--- a/src/modules/UI/scenes/Settings/__snapshots__/CurrencySettings.ui.test.js.snap
+++ b/src/modules/UI/scenes/Settings/__snapshots__/CurrencySettings.ui.test.js.snap
@@ -94,6 +94,8 @@ exports[`CurrencySettings should render 1`] = `
                 }
               >
                 ₿
+              </FormattedText>
+              <FormattedText>
                  - 
                 BTG
               </FormattedText>
@@ -126,6 +128,8 @@ exports[`CurrencySettings should render 1`] = `
                 }
               >
                 m₿
+              </FormattedText>
+              <FormattedText>
                  - 
                 mBTG
               </FormattedText>
@@ -158,6 +162,8 @@ exports[`CurrencySettings should render 1`] = `
                 }
               >
                 ƀ
+              </FormattedText>
+              <FormattedText>
                  - 
                 bits
               </FormattedText>

--- a/src/modules/UI/scenes/Settings/__snapshots__/CurrencySettings.ui.test.js.snap
+++ b/src/modules/UI/scenes/Settings/__snapshots__/CurrencySettings.ui.test.js.snap
@@ -25,7 +25,6 @@ exports[`CurrencySettings should render 1`] = `
         }
       }
     >
-      
       <Gradient
         style={
           Array [
@@ -95,8 +94,6 @@ exports[`CurrencySettings should render 1`] = `
                 }
               >
                 ₿
-              </FormattedText>
-              <FormattedText>
                  - 
                 BTG
               </FormattedText>
@@ -129,8 +126,6 @@ exports[`CurrencySettings should render 1`] = `
                 }
               >
                 m₿
-              </FormattedText>
-              <FormattedText>
                  - 
                 mBTG
               </FormattedText>
@@ -163,8 +158,6 @@ exports[`CurrencySettings should render 1`] = `
                 }
               >
                 ƀ
-              </FormattedText>
-              <FormattedText>
                  - 
                 bits
               </FormattedText>
@@ -173,7 +166,6 @@ exports[`CurrencySettings should render 1`] = `
           onPress={[Function]}
         />
       </RadioRows>
-      
     </Component>
   </Component>
 </SafeAreaViewComponent>


### PR DESCRIPTION
The purpose of this task is to prevent the currencySettings from crashing on Android for currencies that do **not** have custom nodes ability.

Asana Task: https://app.asana.com/0/361770107085503/868855858279050/f