### PR TITLE
Prevent 'Siguiente' button from cutting off text (Exchange Scene)

### DIFF
--- a/src/styles/scenes/CryptoExchangeSceneStyles.js
+++ b/src/styles/scenes/CryptoExchangeSceneStyles.js
@@ -56,8 +56,7 @@ const CryptoExchangeSceneStyle = {
   },
   downArrowSize: scale(36),
   actionButtonContainer: {
-    width: '90%',
-    height: THEME.BUTTONS.HEIGHT
+    width: '90%'
   },
   flipWrapper: {
     container: {


### PR DESCRIPTION
The purpose of this task is to prevent the "Next" / "Siguiente" button on the exchange scene from cutting off text

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/875186582391430/f