### PR TITLE
Push wallet name to new line for delete wallet (Spanish) modal

### DIFF
--- a/src/locales/strings/es.json
+++ b/src/locales/strings/es.json
@@ -101,7 +101,7 @@
   "fragment_wallets_resync_wallet_first_confirm_message_mobile": "¿Estás seguro de que quieres resincronizar?",
   "fragment_wallets_split_wallet_first_confirm_message_mobile": "¿Estás seguro de que quieres partir la cartera? (Wallet split)",
   "fragment_wallets_get_seed_wallet_first_confirm_message_mobile": "¿ Estás seguro de que quieres revelar la semilla privada de la siguiente cartera?",
-  "fragmet_wallets_delete_wallet_first_confirm_message_mobile": "¿Estás seguro de que quieres borrar la cartera?",
+  "fragmet_wallets_delete_wallet_first_confirm_message_mobile": "¿Estás seguro de que quieres borrar la cartera?\n",
   "fragmet_wallets_list_archive_title_capitalized": "Archivo",
   "fragment_wallets_syncing_wallet_txs": "Sincronizando las transacciones de la cartera...",
   "create_wallet_select_valid_crypto": "Seleccione un tipo de cartera válido por favor",


### PR DESCRIPTION
The purpose of this task is to push the wallet name to a new line for the Spanish version of the delete wallet modal.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/875186582391439/f