### PR TITLE
Adjust addressModal style on small devices

### DIFF
--- a/src/modules/UI/scenes/Scan/components/AddressInput.js
+++ b/src/modules/UI/scenes/Scan/components/AddressInput.js
@@ -26,27 +26,29 @@ export class AddressInput extends Component<Props> {
   render () {
     return (
       <View>
-        <View style={[styles.addressInputWrap]}>
-          <FormField
-            style={[styles.addressInput]}
-            value={this.props.uri}
-            onChangeText={this.props.onChangeText}
-            autoCapitalize={'none'}
-            autoFocus
-            label={s.strings.fragment_send_send_to_hint}
-            returnKeyType={'done'}
-            autoCorrect={false}
-            onSubmitEditing={this.props.onSubmit}
-          />
-        </View>
+        <InteractiveModal.Row>
+          <InteractiveModal.Item>
+            <FormField
+              style={[styles.addressInput]}
+              value={this.props.uri}
+              onChangeText={this.props.onChangeText}
+              autoCapitalize={'none'}
+              autoFocus
+              label={s.strings.fragment_send_send_to_hint}
+              returnKeyType={'done'}
+              autoCorrect={false}
+              onSubmitEditing={this.props.onSubmit}
+            />
+          </InteractiveModal.Item>
+        </InteractiveModal.Row>
         {this.props.copyMessage && (
-          <View style={styles.pasteButtonRow}>
+          <InteractiveModal.Row>
             <InteractiveModal.Item>
               <TertiaryButton ellipsizeMode={'middle'} onPress={this.props.onPaste} numberOfLines={1} style={styles.addressInputButton}>
                 <TertiaryButton.Text>{this.props.copyMessage}</TertiaryButton.Text>
               </TertiaryButton>
             </InteractiveModal.Item>
-          </View>
+          </InteractiveModal.Row>
         )}
       </View>
     )

--- a/src/modules/UI/scenes/Scan/components/AddressInputButtons.js
+++ b/src/modules/UI/scenes/Scan/components/AddressInputButtons.js
@@ -1,12 +1,10 @@
 // @flow
 
 import React, { Component } from 'react'
-import { View } from 'react-native'
 import slowlog from 'react-native-slowlog'
 
 import s from '../../../../../locales/strings.js'
 import { PrimaryButton, SecondaryButton } from '../../../components/Buttons'
-import ModalStyle from '../../../components/Modal/style'
 import { InteractiveModal } from '../../../components/Modals'
 
 const CANCEL_TEXT = s.strings.string_cancel_cap
@@ -24,7 +22,7 @@ export class AddressInputButtons extends Component<Props> {
 
   render () {
     return (
-      <View style={ModalStyle.buttonsWrap}>
+      <InteractiveModal.Row>
         <InteractiveModal.Item>
           <SecondaryButton onPress={this.props.onCancel}>
             <SecondaryButton.Text>{CANCEL_TEXT}</SecondaryButton.Text>
@@ -36,7 +34,7 @@ export class AddressInputButtons extends Component<Props> {
             <PrimaryButton.Text>{DONE_TEXT}</PrimaryButton.Text>
           </PrimaryButton>
         </InteractiveModal.Item>
-      </View>
+      </InteractiveModal.Row>
     )
   }
 }

--- a/src/modules/UI/scenes/Scan/components/AddressModal.js
+++ b/src/modules/UI/scenes/Scan/components/AddressModal.js
@@ -103,6 +103,7 @@ export default class AddressModal extends Component<Props, State> {
         visibilityBoolean={this.props.addressModalVisible}
         onExitButtonFxn={this.props.onExitButtonFxn}
         style={copyMessage && styles.withAddressCopied}
+        modalBottomStyle={{ marginTop: 0 }}
       />
     )
   }


### PR DESCRIPTION
The purpose of this task is to make sure the buttons on the addressModal (Scan scene) do not get covered by the keyboard on small iOS devices.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/874227037418031/f