### PR TITLE
Fix menu dropdown width *again*

### DIFF
--- a/src/modules/UI/components/MenuDropDown/__snapshots__/MenuDropDown.test.js.snap
+++ b/src/modules/UI/components/MenuDropDown/__snapshots__/MenuDropDown.test.js.snap
@@ -91,7 +91,6 @@ exports[`MenuDropDown component should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }

--- a/src/modules/UI/scenes/SendConfirmation/__snapshots__/sendConfirmationOptions.test.js.snap
+++ b/src/modules/UI/scenes/SendConfirmation/__snapshots__/sendConfirmationOptions.test.js.snap
@@ -58,7 +58,6 @@ exports[`SendConfirmation XMR 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -92,7 +91,6 @@ exports[`SendConfirmation XMR 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -128,7 +126,6 @@ exports[`SendConfirmation XMR 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -208,7 +205,6 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -242,7 +238,6 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -281,7 +276,6 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -317,7 +311,6 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -397,7 +390,6 @@ exports[`SendConfirmation not editable 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -477,7 +469,6 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -511,7 +502,6 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -550,7 +540,6 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
-              "paddingHorizontal": 5.618309859154929,
               "paddingVertical": 5.618309859154929,
             }
           }

--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptions.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/WalletListRowOptions.ui.js
@@ -17,10 +17,6 @@ type Props = {
 const modifiedMenuDropDownStyle = {
   // manually overwrite width
   ...MenuDropDownStyle,
-  menuIconWrap: {
-    ...MenuDropDownStyle.menuIconWrap,
-    width: '100%'
-  },
   icon: {
     ...MenuDropDownStyle.icon,
     fontSize: scale(30),

--- a/src/styles/components/HeaderMenuDropDownStyles.js
+++ b/src/styles/components/HeaderMenuDropDownStyles.js
@@ -62,8 +62,7 @@ const MenuDropDownStyle = {
   menuOptions: {},
   menuOptionItem: {
     flexDirection: 'row',
-    paddingVertical: scale(4),
-    paddingHorizontal: scale(4)
+    paddingVertical: scale(4)
   },
   optionText: {
     color: THEME.COLORS.GRAY_1,


### PR DESCRIPTION
The purpose of this task is to fix the wallet dropdown menu (and header dropdown) again. It appears the fix was reverted from the `develop` branch at some point.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/889507941391832/f