### PR TITLE
Limit cryptoExchange wallet names to one line

### DIFF
--- a/src/modules/UI/components/ExchangeQuote/ExchangeQuoteComponent.js
+++ b/src/modules/UI/components/ExchangeQuote/ExchangeQuoteComponent.js
@@ -57,7 +57,9 @@ class ExchangeQuoteComponent extends Component<Props, State> {
               <FormattedText style={styles.currencyNameText} isBold>
                 {this.props.currency}
               </FormattedText>
-              <FormattedText style={styles.walletNameText}>{this.props.walletName}</FormattedText>
+              <FormattedText style={styles.walletNameText} numberOfLines={1}>
+                {this.props.walletName}
+              </FormattedText>
             </View>
             <View style={styles.amountInfoContainer}>
               <FormattedText style={styles.cryptoAmountText} isBold>

--- a/src/styles/scenes/CryptoExchangeQuoteSceneStyles.js
+++ b/src/styles/scenes/CryptoExchangeQuoteSceneStyles.js
@@ -98,7 +98,7 @@ const CryptoExchangeQuoteSceneStyles = {
     walletNameText: {
       color: THEME.COLORS.WHITE,
       fontSize: scale(16),
-      paddingLeft: 10
+      paddingLeft: scale(10)
     },
     fiatAmountText: {
       color: THEME.COLORS.WHITE,


### PR DESCRIPTION
The purpose of this task is to prevent long wallet names from overflowing to a 2nd line in the crypto exchange quote scene.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/883037346365188/f