### PR TITLE
Settings - Default Fiat: Extend form width to 100%

### DIFF
--- a/src/components/scenes/DefaultFiatSettingScene.js
+++ b/src/components/scenes/DefaultFiatSettingScene.js
@@ -61,7 +61,7 @@ export default class DefaultFiatSetting extends Component<Props, State> {
             onChangeText={this.handleSearchTermChange}
             value={this.state.searchTerm}
             label={DEFAULT_FIAT_PICKER_PLACEHOLDER}
-            style={MaterialInputOnWhite}
+            style={[MaterialInputOnWhite, { width: '100%' }]}
           />
           <SearchResults
             renderRegularResultFxn={this.renderFiatTypeResult}


### PR DESCRIPTION
Task: Settings Default Currency - The Underline in Select a currency needs to be longer

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android