### PR TITLE
Use grey XRP logo into buy crypto

### DIFF
--- a/src/components/common/BuyCrypto.js
+++ b/src/components/common/BuyCrypto.js
@@ -17,8 +17,11 @@ export type Props = {
 export default class BuyCrypto extends Component<Props> {
   getLogo = () => {
     const { wallet } = this.props
+    console.log(wallet)
     switch (wallet.currencyCode) {
       case 'ETH':
+        return wallet.symbolImageDarkMono
+      case 'XRP':
         return wallet.symbolImageDarkMono
       default:
         return wallet.symbolImage


### PR DESCRIPTION
Todo: Add XRP Logo inside XRP Wallet if 0 Transactions - "Buy XRP with Credit Card"

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android