### PR TITLE
Fix checking for supported tokens with slow networks PR2

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -254,6 +254,7 @@ const strings = {
   title_use_legacy_address: 'Use Legacy Address',
   title_use_regular_address: 'Use Regular Address',
   token_not_supported: 'Token is not supported by exchange',
+  loading_supported_currencies: 'Loading supported currencies',
   no_exchanges_available: 'No Exchanges Enabled',
   check_exchange_settings: 'Please enable them in your Exchange Settings.',
   amount_above_limit: 'Transaction amount is above the max limit of %1$s %2$s',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -247,6 +247,7 @@
   "title_use_legacy_address": "Use Legacy Address",
   "title_use_regular_address": "Use Regular Address",
   "token_not_supported": "Token is not supported by exchange",
+  "loading_supported_currencies": "Loading supported currencies",
   "no_exchanges_available": "No Exchanges Enabled",
   "check_exchange_settings": "Please enable them in your Exchange Settings.",
   "amount_above_limit": "Transaction amount is above the max limit of %1$s %2$s",


### PR DESCRIPTION
• added 3 or 15 second timer for getting exchange tokens.• added catch at beginning of function to harden against leaving scene
• tested by console logging when function is fired if it is we are no longer in exchange scene
• router considers opening side menu as leaving the scene
• no logout issues

fix Asana :
Exchange - refresh list of supported currencies every 15 seconds
https://app.asana.com/0/361770107085503/886135611556824

Exchange - Show "Loading supported currencies"
https://app.asana.com/0/361770107085503/886135611556826
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a