### PR TITLE
Disable RTL on android/various devices

### DIFF
--- a/android/app/src/main/java/co/edgesecure/app/MainApplication.java
+++ b/android/app/src/main/java/co/edgesecure/app/MainApplication.java
@@ -37,6 +37,7 @@ import com.rt2zz.reactnativecontacts.ReactNativeContacts;
 import io.fixd.rctlocale.RCTLocalePackage;
 import com.oblongmana.webviewfileuploadandroid.AndroidWebViewPackage;
 import ca.jaysoo.extradimensions.ExtraDimensionsPackage;
+import com.facebook.react.modules.i18nmanager.I18nUtil;
 
 import java.util.Arrays;
 import java.util.List;
@@ -99,6 +100,11 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
+
+    //Disable RTL
+    I18nUtil sharedI18nUtilInstance = I18nUtil.getInstance();
+    sharedI18nUtilInstance.allowRTL(getApplicationContext(), false);
+
     BugsnagReactNative.start(this);
     SoLoader.init(this, /* native exopackage */ false);
   }


### PR DESCRIPTION
Task: Slide to Confirm Missing - If Developer Options - Force RTL is enabled (screen is in reverse) - Disable Right to Left completely hard coded

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android