### PR TITLE
Disable slider on SendConfirmation until ready to send

### DIFF
--- a/src/__tests__/__snapshots__/sendConfirmation.test.js.snap
+++ b/src/__tests__/__snapshots__/sendConfirmation.test.js.snap
@@ -251,6 +251,7 @@ exports[`SendConfirmation should render with destination 1`] = `
             }
           }
           resetSlider={false}
+          showSpinner={false}
           sliderDisabled={true}
         />
       </Footer>
@@ -495,6 +496,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
             }
           }
           resetSlider={false}
+          showSpinner={false}
           sliderDisabled={true}
         />
       </Footer>
@@ -754,6 +756,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
             }
           }
           resetSlider={false}
+          showSpinner={false}
           sliderDisabled={true}
         />
       </Footer>
@@ -1016,6 +1019,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
             }
           }
           resetSlider={false}
+          showSpinner={false}
           sliderDisabled={true}
         />
       </Footer>

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -25,6 +25,7 @@ const strings = {
   exchange_succeeded: 'Exchange Succeeded',
   no_exchange_amount: 'No Amount Selected',
   select_exchange_amount: 'Please enter an amount to exchange',
+  select_exchange_amount_short: 'Enter an Amount',
   exchanges_may_take_minutes: 'Exchanges may take several minutes to process. Please check your destination wallet after a few minutes',
   fragment_wallets_addwallet_blockchain_hint: 'Choose a blockchain',
   fragment_wallets_addwallet_fiat_hint: 'Choose a fiat currency',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -20,6 +20,7 @@
   "exchange_succeeded": "Exchange Succeeded",
   "no_exchange_amount": "No Amount Selected",
   "select_exchange_amount": "Please enter an amount to exchange",
+  "select_exchange_amount_short": "Enter an Amount",
   "exchanges_may_take_minutes": "Exchanges may take several minutes to process. Please check your destination wallet after a few minutes",
   "fragment_wallets_addwallet_blockchain_hint": "Choose a blockchain",
   "fragment_wallets_addwallet_fiat_hint": "Choose a fiat currency",

--- a/src/modules/UI/components/Slider/Slider.ui.js
+++ b/src/modules/UI/components/Slider/Slider.ui.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { Component } from 'react'
-import { Text, View } from 'react-native'
+import { ActivityIndicator, Text, View } from 'react-native'
 import Slider from 'react-native-slider'
 import slowlog from 'react-native-slowlog'
 
@@ -11,13 +11,15 @@ import s from '../../../../locales/strings.js'
 import styles from './styles.js'
 
 const SLIDE_TO_COMPLETE_TEXT = s.strings.send_confirmation_slide_to_confirm
+const ENTER_AN_AMOUNT_TEXT = s.strings.select_exchange_amount_short
 
 type Props = {
   resetSlider?: boolean,
   sliderDisabled: boolean,
   forceUpdateGuiCounter: number,
   onSlidingComplete: () => {},
-  parentStyle: any
+  parentStyle: any,
+  showSpinner: boolean
 }
 
 type State = {
@@ -62,6 +64,9 @@ export default class ABSlider extends Component<Props, State> {
   }
 
   render () {
+    const thumbStyle = !this.props.sliderDisabled ? styles.thumb : styles.disabledThumb
+    const sliderText = !this.props.sliderDisabled ? SLIDE_TO_COMPLETE_TEXT : ENTER_AN_AMOUNT_TEXT
+
     return (
       <View style={[styles.container, this.props.parentStyle]}>
         <Slider
@@ -73,13 +78,14 @@ export default class ABSlider extends Component<Props, State> {
           value={this.state.value}
           style={styles.slider}
           trackStyle={styles.track}
-          thumbStyle={styles.thumb}
+          thumbStyle={thumbStyle}
           thumbImage={leftArrowImg}
           minimumTrackTintColor="transparent"
           maximumTrackTintColor="transparent"
           thumbTouchSize={{ width: scale(160), height: scale(160) }}
         />
-        <Text style={styles.textOverlay}>{SLIDE_TO_COMPLETE_TEXT}</Text>
+
+        {this.props.showSpinner ? <ActivityIndicator style={styles.activityIndicator} /> : <Text style={styles.textOverlay}>{sliderText}</Text>}
       </View>
     )
   }

--- a/src/modules/UI/components/Slider/styles.js
+++ b/src/modules/UI/components/Slider/styles.js
@@ -27,11 +27,25 @@ export const rawStyles = {
     backgroundColor: THEME.COLORS.ACCENT_MINT,
     borderRadius: 52
   },
+  disabledThumb: {
+    width: 52,
+    height: 52,
+    position: 'absolute',
+    backgroundColor: THEME.COLORS.GRAY_2,
+    borderRadius: 52
+  },
   textOverlay: {
     backgroundColor: THEME.COLORS.TRANSPARENT,
     fontSize: PLATFORM.deviceWidth >= 320 ? 13 : 16,
     position: 'absolute',
     color: THEME.COLORS.WHITE,
+    alignSelf: 'center',
+    top: 17,
+    zIndex: 1
+  },
+  activityIndicator: {
+    backgroundColor: THEME.COLORS.TRANSPARENT,
+    position: 'absolute',
     alignSelf: 'center',
     top: 17,
     zIndex: 1


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a

https://app.asana.com/0/361770107085503/905291401659450/f

Disable slider on SendConfirmation until ready (fee returned and valid amount entered), Show activity indicator while waiting on fee return.

This prevents the user from attempting to send a transaction before makeSpend returns the fee and other info. You should see a grayed our slider button and "Enter an Amount" until you enter an amount, at which point a spinner will show until the fee info is loaded and the slider enables.