### PR TITLE
Transaction List/Details screen: change the amount font same as the currency symbol

### DIFF
--- a/src/components/common/TransactionDetailAmountArea.js
+++ b/src/components/common/TransactionDetailAmountArea.js
@@ -116,8 +116,8 @@ class AmountArea extends Component {
           </View>
           <View style={[styles.amountAreaMiddle]}>
             <View style={[styles.amountAreaMiddleTop, { flexDirection: 'row' }]}>
-              <FormattedText style={[styles.amountAreaMiddleTopText]}>{symbolString}</FormattedText>
-              <FormattedText style={[styles.amountAreaMiddleTopText]}>{amountString}</FormattedText>
+              <FormattedText style={[styles.amountAreaMiddleTopText, styles.symbol]}>{symbolString}</FormattedText>
+              <FormattedText style={[styles.amountAreaMiddleTopText, styles.symbol]}>{amountString}</FormattedText>
             </View>
             <View style={[styles.amountAreaMiddleBottom]}>
               <FormattedText style={[styles.amountAreaMiddleBottomText]}>{feeSyntax}</FormattedText>

--- a/src/components/common/TransactionDetailAmountArea.js
+++ b/src/components/common/TransactionDetailAmountArea.js
@@ -116,7 +116,7 @@ class AmountArea extends Component {
           </View>
           <View style={[styles.amountAreaMiddle]}>
             <View style={[styles.amountAreaMiddleTop, { flexDirection: 'row' }]}>
-              <FormattedText style={[styles.amountAreaMiddleTopText, styles.symbol]}>{symbolString}</FormattedText>
+              <FormattedText style={[styles.amountAreaMiddleTopText]}>{symbolString}</FormattedText>
               <FormattedText style={[styles.amountAreaMiddleTopText]}>{amountString}</FormattedText>
             </View>
             <View style={[styles.amountAreaMiddleBottom]}>

--- a/src/components/scenes/TransactionListScene.js
+++ b/src/components/scenes/TransactionListScene.js
@@ -241,7 +241,7 @@ export class TransactionList extends Component<Props, State> {
                   <View style={{ flexDirection: 'row' }}>
                     {displayDenomination.symbol ? (
                       <View style={{ flexDirection: 'row' }}>
-                        <T numberOfLines={1} style={[styles.currentBalanceBoxBits, styles.symbol]}>
+                        <T numberOfLines={1} style={[styles.currentBalanceBoxBits]}>
                           {displayDenomination.symbol + ' '}
                         </T>
                         <T numberOfLines={1} style={[styles.currentBalanceBoxBits]}>

--- a/src/components/scenes/TransactionListScene.js
+++ b/src/components/scenes/TransactionListScene.js
@@ -241,10 +241,10 @@ export class TransactionList extends Component<Props, State> {
                   <View style={{ flexDirection: 'row' }}>
                     {displayDenomination.symbol ? (
                       <View style={{ flexDirection: 'row' }}>
-                        <T numberOfLines={1} style={[styles.currentBalanceBoxBits]}>
+                        <T numberOfLines={1} style={[styles.currentBalanceBoxBits, styles.symbol]}>
                           {displayDenomination.symbol + ' '}
                         </T>
-                        <T numberOfLines={1} style={[styles.currentBalanceBoxBits]}>
+                        <T numberOfLines={1} style={[styles.currentBalanceBoxBits, styles.symbol]}>
                           {cryptoAmountString}
                         </T>
                       </View>


### PR DESCRIPTION
… as the amount so it will be vertically centered

Task: Transaction List - amount isn't vertically centered with currency symbol
Note: Why do we need to have a separate font for the currency symbol? Check first before merging

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [x] n/a