### PR TITLE
Fix detection and display of ShapeShift errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "dns.js": "^1.0.1",
     "domain-browser": "^1.1.7",
     "edge-components": "^0.0.12",
-    "edge-core-js": "0.12.17",
+    "edge-core-js": "0.12.18",
     "edge-currency-accountbased": "^0.0.12",
     "edge-currency-bitcoin": "3.6.1",
     "edge-currency-ethereum": "0.11.0",

--- a/src/actions/CryptoExchangeActions.js
+++ b/src/actions/CryptoExchangeActions.js
@@ -29,6 +29,11 @@ export type SetNativeAmountInfo = {
   toPrimaryInfo?: GuiCurrencyInfo
 }
 
+const pluginToName = {
+  shapeshift: 'ShapeShift',
+  changelly: 'Changelly'
+}
+
 function setFromWalletMax (amount: string) {
   return {
     type: 'SET_FROM_WALLET_MAX',
@@ -240,6 +245,7 @@ const getShiftTransaction = (fromWallet: GuiWallet, toWallet: GuiWallet, whichWa
   try {
     edgeCoinExchangeQuote = await account.fetchSwapQuote(quoteData)
   } catch (error) {
+    console.log(JSON.stringify(error))
     if (error.message === 'InsufficientFundsError') {
       dispatch(processMakeSpendError(error))
       return
@@ -288,7 +294,12 @@ const getShiftTransaction = (fromWallet: GuiWallet, toWallet: GuiWallet, whichWa
         return
       }
       if (error.message === 'noVerification') {
-        dispatch({ type: 'GENERIC_SHAPE_SHIFT_ERROR', data: s.strings.kyc_ss_finish })
+        let pluginName = ''
+        if (typeof error.pluginName === 'string') {
+          pluginName = pluginToName[error.pluginName]
+        }
+        const data = sprintf(s.strings.kyc_ss_finish, pluginName)
+        dispatch({ type: 'GENERIC_SHAPE_SHIFT_ERROR', data })
         Actions.popTo(Constants.EXCHANGE_SCENE)
         return
       }

--- a/src/connectors/components/SwapKYCModalConnector.js
+++ b/src/connectors/components/SwapKYCModalConnector.js
@@ -9,7 +9,7 @@ import type { Dispatch, State } from '../../modules/ReduxTypes'
 export const mapStateToProps = (state: State) => {
   return {
     showKYCAlert: state.cryptoExchange.showKYCAlert,
-    pluginName: 'shpaeshift'
+    pluginName: 'shapeshift'
   }
 }
 

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -412,8 +412,8 @@ const strings = {
   open_settings: 'Open Settings',
   kyc_something_wrong: 'Something went wrong',
   kyc_something_wrong_message: 'Please try again later',
-  kyc_ss_finish: 'Please complete id verification first”',
-  ss_geolock: 'Unable to complete based on location',
+  kyc_ss_finish: 'Please complete ID verification for %s',
+  ss_geolock: 'Location restricted. Unable to complete exchange.',
   ss_unable: 'No enabled exchanges support %1$s to %2$s.'
 }
 

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -385,7 +385,7 @@
   "open_settings": "Open Settings",
   "kyc_something_wrong": "Something went wrong",
   "kyc_something_wrong_message": "Please try again later",
-  "kyc_ss_finish": "Please complete id verification first”",
-  "ss_geolock": "Unable to complete based on location",
+  "kyc_ss_finish": "Please complete ID verification for %s",
+  "ss_geolock": "Location restricted. Unable to complete exchange.",
   "ss_unable": "No enabled exchanges support %1$s to %2$s."
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,10 +3347,10 @@ edge-components@^0.0.12:
   dependencies:
     react-native-linear-gradient "^2.4.0"
 
-edge-core-js@0.12.17:
-  version "0.12.17"
-  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-0.12.17.tgz#2d0641eb24ccd9ee23f78dfa82830d0865cb8ebc"
-  integrity sha512-bCTh7poZiXZqPDvPrFpe2dUjgJteiqs1ovmJf9K48M0D00Agdp6fM7DXAsUDqe2ZHjVwMjCbnZrgBwkdPa3Osg==
+edge-core-js@0.12.18:
+  version "0.12.18"
+  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-0.12.18.tgz#574c6bfb8949d6820352e65f7ad3c9607c390087"
+  integrity sha512-26bJSkWu5gJJUE19vRLKL0RmisjODbCAxwoCm8vSp1RRP1QVAxi1sx3HZB3b2LHrHdt5wv54p6MXP9owYU8XaQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     aes-js "^3.1.0"


### PR DESCRIPTION
* Bump edge-core-js to 0.12.18 which properly throws geoRestriction and noVerification errors
* Fix misspelling of 'shapeshift' as a plugin key. Fixes crash
* Change strings displayed due to noVerification and geoRestriction errors

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a