### PR TITLE
Added android real window height to be used on device height. Specifi…

### DIFF
--- a/src/theme/variables/platform.js
+++ b/src/theme/variables/platform.js
@@ -5,11 +5,11 @@ import ExtraDimensions from 'react-native-extra-dimensions-android'
 
 import { isIphoneX } from '../../lib/isIphoneX.js'
 
-const ANDROID_REAL_WINDOW_HEIGHT = ExtraDimensions.get('REAL_WINDOW_HEIGHT')
-
 const platform = Platform.OS
 const deviceWidth = Dimensions.get('window').width
-const deviceHeight = platform === 'ios' ? Dimensions.get('window').height : ANDROID_REAL_WINDOW_HEIGHT
+const deviceHeight = platform === 'ios'
+  ? Dimensions.get('window').height
+  : ExtraDimensions.get('REAL_WINDOW_HEIGHT')
 
 const PLATFORM = {
   platform,

--- a/src/theme/variables/platform.js
+++ b/src/theme/variables/platform.js
@@ -1,12 +1,15 @@
 // @flow
 
 import { Dimensions, Platform } from 'react-native'
+import ExtraDimensions from 'react-native-extra-dimensions-android'
 
 import { isIphoneX } from '../../lib/isIphoneX.js'
 
-const deviceHeight = Dimensions.get('window').height
-const deviceWidth = Dimensions.get('window').width
+const ANDROID_REAL_WINDOW_HEIGHT = ExtraDimensions.get('REAL_WINDOW_HEIGHT')
+
 const platform = Platform.OS
+const deviceWidth = Dimensions.get('window').width
+const deviceHeight = platform === 'ios' ? Dimensions.get('window').height : ANDROID_REAL_WINDOW_HEIGHT
 
 const PLATFORM = {
   platform,


### PR DESCRIPTION
…cally for the drop down modal and disregarding the soft navigation bar on android devices, s8 and up

NOT TESTED, no physical samsung S8 device or highter.
Task: S8 Exchange drop down still has blue area that isn't covered at bottom

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android