### PR TITLE
Wallet List: Re-add paddings to drop down item options

### DIFF
--- a/src/__tests__/__snapshots__/sendConfirmationOptions.test.js.snap
+++ b/src/__tests__/__snapshots__/sendConfirmationOptions.test.js.snap
@@ -58,6 +58,7 @@ exports[`SendConfirmation XMR 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -91,6 +92,7 @@ exports[`SendConfirmation XMR 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -126,6 +128,7 @@ exports[`SendConfirmation XMR 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -205,6 +208,7 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -238,6 +242,7 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -276,6 +281,7 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -311,6 +317,7 @@ exports[`SendConfirmation XRP 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -390,6 +397,7 @@ exports[`SendConfirmation not editable 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -469,6 +477,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -502,6 +511,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }
@@ -540,6 +550,7 @@ exports[`SendConfirmation should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }

--- a/src/modules/UI/components/MenuDropDown/__snapshots__/MenuDropDown.test.js.snap
+++ b/src/modules/UI/components/MenuDropDown/__snapshots__/MenuDropDown.test.js.snap
@@ -91,6 +91,7 @@ exports[`MenuDropDown component should render with standard props 1`] = `
           style={
             Object {
               "flexDirection": "row",
+              "paddingHorizontal": 8.427464788732394,
               "paddingVertical": 5.618309859154929,
             }
           }

--- a/src/styles/components/HeaderMenuDropDownStyles.js
+++ b/src/styles/components/HeaderMenuDropDownStyles.js
@@ -62,7 +62,8 @@ const MenuDropDownStyle = {
   menuOptions: {},
   menuOptionItem: {
     flexDirection: 'row',
-    paddingVertical: scale(4)
+    paddingVertical: scale(4),
+    paddingHorizontal: scale(6)
   },
   optionText: {
     color: THEME.COLORS.GRAY_1,


### PR DESCRIPTION
Task: Wallet options modal needs padding
Commit not verified. Have errors on flow not related to task.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android