### PR TITLE
Wallet List: Remove paddings on the right side when sorting

### DIFF
--- a/src/components/common/SortableWalletListRow.js
+++ b/src/components/common/SortableWalletListRow.js
@@ -40,7 +40,7 @@ class SortableWalletListRow extends Component<Props, State> {
         {...this.props.sortHandlers}
       >
         {walletData.currencyCode ? (
-          <View style={[styles.rowContent, styles.sortableRowContent]}>
+          <View style={[styles.rowContent]}>
             <View style={[styles.rowDragArea]}>
               <Image source={sort} style={{ height: 15, width: 15 }} />
             </View>


### PR DESCRIPTION
Task: Sort wallet: looks to be excessive padding on the right hand side

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android