### PR TITLE
Upgrade react-native-share to v1.1.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8792,9 +8792,9 @@ react-native-safe-area-view@^0.7.0:
     hoist-non-react-statics "^2.3.1"
 
 react-native-share@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-1.1.1.tgz#8c50c67c3fa519607f3352c03f56076c0481edeb"
-  integrity sha512-HCeCHWC0KsJQh2Y8LWqPbkI+H1gbjF2F844aMB1xlHqvnCzSsWPJERWEqzMVRSYprB0h1FFWg04KB7flSHggWw==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-1.1.3.tgz#513ea61075e2bb945d33cfda120e12592916299e"
+  integrity sha512-vKAJqgkEt7HjsF0HUwgom+E0FbmFNVZNncHwby1+O8/mXlKugh+Ym6rvv+A2ASHmD5TXKohJMYT2+jYofzPORA==
 
 react-native-slider@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
The command `react-native run-android` fails with the following error:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':react-native-share'.
> Could not resolve all files for configuration ':react-native-share:classpath'.
   > Could not find lint-gradle-api.jar (com.android.tools.lint:lint-gradle-api:26.1.2).
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle-api/26.1.2/lint-gradle-api-26.1.2.jar
```

Caused by an issue with react-native-share that was fixed in PR https://github.com/react-native-community/react-native-share/pull/387

This PR upgrades react-native-share to v1.1.3 to resolve this issue.

**Versions:**
- OSX 10.12.6
- Android Studio 3.1.3
- Android NDK r15c
- Yarn 1.12.3
- Node 8.9.4
- Npm 6.4.1
- Java 8u191
- CocoaPods 1.5.3