### PR TITLE
Fix fee denomination + amount for SendConf

### DIFF
--- a/src/components/scenes/SendConfirmationScene.js
+++ b/src/components/scenes/SendConfirmationScene.js
@@ -334,9 +334,15 @@ export class SendConfirmation extends Component<Props, State> {
 
     if (parentNetworkFee && bns.gt(parentNetworkFee, '0')) {
       const cryptoFeeSymbol = parentDisplayDenomination.symbol ? parentDisplayDenomination.symbol : ''
+      // multiplier for display denomination
+      const displayDenomMultiplier = parentDisplayDenomination.multiplier
+      // multiplier for exchange denomination
       const cryptoFeeMultiplier = this.props.parentExchangeDenomination.multiplier
-      const cryptoFeeAmount = parentNetworkFee ? convertNativeToDisplay(cryptoFeeMultiplier)(parentNetworkFee) : ''
-      const cryptoFeeString = `${cryptoFeeSymbol} ${cryptoFeeAmount}`
+      // fee amount in exchange denomination
+      const cryptoFeeExchangeDenomAmount = parentNetworkFee ? convertNativeToDisplay(cryptoFeeMultiplier)(parentNetworkFee) : ''
+      const exchangeToDisplayMultiplierRatio = bns.div(cryptoFeeMultiplier, displayDenomMultiplier, DIVIDE_PRECISION)
+      const cryptoFeeDisplayDenomAmount = bns.mul(cryptoFeeExchangeDenomAmount, exchangeToDisplayMultiplierRatio)
+      const cryptoFeeString = `${cryptoFeeSymbol} ${cryptoFeeDisplayDenomAmount}`
       const fiatFeeSymbol = secondaryInfo.displayDenomination.symbol ? secondaryInfo.displayDenomination.symbol : ''
       const exchangeConvertor = convertNativeToExchange(this.props.parentExchangeDenomination.multiplier)
       const cryptoFeeExchangeAmount = exchangeConvertor(parentNetworkFee)
@@ -354,11 +360,18 @@ export class SendConfirmation extends Component<Props, State> {
 
     if (networkFee && bns.gt(networkFee, '0')) {
       const cryptoFeeSymbol = primaryInfo.displayDenomination.symbol ? primaryInfo.displayDenomination.symbol : ''
+      // multiplier for display denomination
+      const displayDenomMultiplier = primaryInfo.displayDenomination.multiplier
+      // multiplier for EXCHANGE denomination
       const cryptoFeeMultiplier = this.props.primaryExchangeDenomination.multiplier
-      const cryptoFeeAmount = networkFee ? convertNativeToDisplay(cryptoFeeMultiplier)(networkFee) : ''
-      const cryptoFeeString = `${cryptoFeeSymbol} ${cryptoFeeAmount}`
+      // fee amount in exchange denomination
+      const cryptoFeeExchangeDenomAmount = networkFee ? convertNativeToDisplay(cryptoFeeMultiplier)(networkFee) : ''
+      const exchangeToDisplayMultiplierRatio = bns.div(cryptoFeeMultiplier, displayDenomMultiplier, DIVIDE_PRECISION)
+      const cryptoFeeDisplayDenomAmount = bns.mul(cryptoFeeExchangeDenomAmount, exchangeToDisplayMultiplierRatio)
+      const cryptoFeeString = `${cryptoFeeSymbol} ${cryptoFeeDisplayDenomAmount}`
       const fiatFeeSymbol = secondaryInfo.displayDenomination.symbol ? secondaryInfo.displayDenomination.symbol : ''
       const exchangeConvertor = convertNativeToExchange(primaryInfo.exchangeDenomination.multiplier)
+      // amount in EXCHANGE denomination
       const cryptoFeeExchangeAmount = exchangeConvertor(networkFee)
       const fiatFeeAmount = convertCurrencyFromExchangeRates(
         exchangeRates,


### PR DESCRIPTION
The purpose of this task is to fix the calculation of the Send Confirmation network fee to take exchange denomination vs display denomination (default crypto denom from user settings) into consideration.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/919742673029010/f