### PR TITLE
Transaction List: Remove fixed height on transaction denomination and value row to not cut off monero denomination icon

### DIFF
--- a/src/styles/scenes/TransactionListStyle.js
+++ b/src/styles/scenes/TransactionListStyle.js
@@ -127,7 +127,6 @@ export const styles = {
   },
   currentBalanceBoxBitsWrap: {
     // two
-    height: scale(44),
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: THEME.COLORS.TRANSPARENT


### PR DESCRIPTION
Task: Monero is cut off on iOS/Android 

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a