### PR TITLE
Add period on transaction popup failure message

### DIFF
--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -4,6 +4,7 @@ import { bns } from 'biggystring'
 import type { EdgeMetadata, EdgeParsedUri, EdgeSpendInfo, EdgeTransaction } from 'edge-core-js'
 import { Alert } from 'react-native'
 import { Actions } from 'react-native-router-flux'
+import { sprintf } from 'sprintf-js'
 
 import { SEND_CONFIRMATION, TRANSACTION_DETAILS } from '../constants/indexConstants'
 import s from '../locales/strings.js'
@@ -206,7 +207,7 @@ export const signBroadcastAndSave = () => async (dispatch: Dispatch, getState: G
     const errorInfo = {
       success: false,
       title: s.strings.transaction_failure,
-      message: e.message
+      message: sprintf(s.strings.transaction_failure_message, e.message)
     }
     dispatch(updateTransaction(edgeSignedTransaction, null, true, new Error('broadcastError')))
     dispatch({ type: 'OPEN_AB_ALERT', data: errorInfo })

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -167,6 +167,7 @@ const strings = {
   send_confirmation_to: 'To: %s',
   send_confirmation_address: 'Address: %s',
   transaction_failure: 'Transaction Failure',
+  transaction_failure_message: '%s.',
   transaction_success: 'Transaction Success',
   transaction_success_message: 'Your transaction has been successfully sent.',
   incorrect_pin: 'Incorrect PIN',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -158,6 +158,7 @@
   "send_confirmation_to": "To: %s",
   "send_confirmation_address": "Address: %s",
   "transaction_failure": "Transaction Failure",
+  "transaction_failure_message": "%s.",
   "transaction_success": "Transaction Success",
   "transaction_success_message": "Your transaction has been successfully sent.",
   "incorrect_pin": "Incorrect PIN",


### PR DESCRIPTION
Task: Visual text - Add a period at the end of the fail transaction popup

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android