### PR TITLE
Bump simplex plugin to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "babel-preset-react-native": "^1.9.0",
     "body-parser": "^1.18.2",
     "detox": "^7.4.3",
-    "edge-plugin-simplex": "https://github.com/Airbitz/edge-plugin-simplex.git#28c9385",
+    "edge-plugin-simplex": "https://github.com/Airbitz/edge-plugin-simplex.git#fb2eb83",
     "eslint": "^4.17.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-flowtype": "^2.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,9 +3442,9 @@ edge-login-ui-rn@^0.5.12:
     sprintf-js "^1.0.3"
     zxcvbn "^4.4.2"
 
-"edge-plugin-simplex@https://github.com/Airbitz/edge-plugin-simplex.git#28c9385":
+"edge-plugin-simplex@https://github.com/Airbitz/edge-plugin-simplex.git#fb2eb83":
   version "0.0.3"
-  resolved "https://github.com/Airbitz/edge-plugin-simplex.git#28c93851f6d2cb039623a07ea231129a705a3705"
+  resolved "https://github.com/Airbitz/edge-plugin-simplex.git#fb2eb83ad153f397fd71f94fa0e38fac4e06fca8"
   dependencies:
     moment "^2.22.2"
 


### PR DESCRIPTION
This version of the plugin uses the `publicAddress` rather than the
`legacyAddress` for BCH addresses. Simplex does not accept the
`legacyAddress`.