### PR TITLE
Add BSV and EBST to list of XPUB currencies

### DIFF
--- a/src/constants/DropDownValueConstants.js
+++ b/src/constants/DropDownValueConstants.js
@@ -70,7 +70,7 @@ export const WALLET_OPTIONS = {
   },
   VIEW_XPUB: {
     value: VIEW_XPUB_VALUE,
-    currencyCode: ['BTC', 'BCH', 'DASH', 'FTC', 'XZC', 'LTC', 'UFO', 'QTUM', 'VTC', 'BTG', 'DGB', 'SMART', 'GRS'],
+    currencyCode: ['BTC', 'BCH', 'DASH', 'FTC', 'XZC', 'LTC', 'UFO', 'QTUM', 'VTC', 'BTG', 'DGB', 'SMART', 'GRS', 'BSV', 'EBST'],
     label: s.strings.fragment_wallets_view_xpub,
     modalVisible: true
   }


### PR DESCRIPTION
The purpose of this task is to make the "XPub" Wallet List Option show up for E-Boost and Bitcoin Cash SV

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/944776949971559/f