### PR TITLE
adjustwed swap metadata to use sawp info and have destination address

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -240,7 +240,7 @@ const strings = {
   string_master_private_key: 'Master Private Key',
   string_split_wallet: 'Split %s',
   string_add_edit_tokens: 'Add / Edit Tokens',
-  exchange_notes_metadata_generic: 'Exchanged %1$s %2$s from %3$s to %4$s %5$s in %6$s. \nOrder: %7$s. \nFor assistance, please contact %8$s.',
+  exchange_notes_metadata_generic: 'Exchanged %1$s %2$s from %3$s to %4$s %5$s in %6$s to address %7$s \nOrder: %8$s. \nFor assistance, please contact %9$s.',
   title_crypto_settings: '%s Settings',
   title_add_tokens: 'Add Tokens',
   title_create_wallet_select_crypto: 'Select Type',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -231,7 +231,7 @@
   "string_master_private_key": "Master Private Key",
   "string_split_wallet": "Split %s",
   "string_add_edit_tokens": "Add / Edit Tokens",
-  "exchange_notes_metadata_generic": "Exchanged %1$s %2$s from %3$s to %4$s %5$s in %6$s. \nOrder: %7$s. \nFor assistance, please contact %8$s.",
+  "exchange_notes_metadata_generic": "Exchanged %1$s %2$s from %3$s to %4$s %5$s in %6$s to address %7$s \nOrder: %8$s. \nFor assistance, please contact %9$s.",
   "title_crypto_settings": "%s Settings",
   "title_add_tokens": "Add Tokens",
   "title_create_wallet_select_crypto": "Select Type",


### PR DESCRIPTION
fixes : Asana 
Swap - Show address sent to swap partners
https://app.asana.com/0/361770107085503/879668277792914

ChangeNow - Exchange transaction does not tag ChangeNow in the transactions history screen
https://app.asana.com/0/361770107085503/944350842551518

ChangeNow - Inside the Notes of an exchange transaction does not show contact ChangeNow support email
https://app.asana.com/0/361770107085503/944694185807966


#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a