### PR TITLE
fix transaction detail stack issue

### DIFF
--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -190,7 +190,6 @@ export const signBroadcastAndSave = () => async (dispatch: Dispatch, getState: G
     if (guiMakeSpendInfo.onSuccess) {
       guiMakeSpendInfo.onSuccess()
     } else {
-      // Actions.pop()
       Actions.replace(TRANSACTION_DETAILS, { edgeTransaction: edgeSignedTransaction })
     }
     const successInfo = {

--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -190,8 +190,8 @@ export const signBroadcastAndSave = () => async (dispatch: Dispatch, getState: G
     if (guiMakeSpendInfo.onSuccess) {
       guiMakeSpendInfo.onSuccess()
     } else {
-      Actions.pop()
-      Actions[TRANSACTION_DETAILS]({ edgeTransaction: edgeSignedTransaction })
+      // Actions.pop()
+      Actions.replace(TRANSACTION_DETAILS, { edgeTransaction: edgeSignedTransaction })
     }
     const successInfo = {
       success: true,


### PR DESCRIPTION
fix 
Asana 
Tapping Send shows the previously seen transaction instead of bringing up the camera
https://app.asana.com/0/361770107085503/946310230497918
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a