### PR TITLE
Adjust getSpendInfo to consider otherParams

### DIFF
--- a/src/modules/UI/scenes/SendConfirmation/selectors.js
+++ b/src/modules/UI/scenes/SendConfirmation/selectors.js
@@ -112,7 +112,8 @@ export const getSpendInfo = (state: State, newSpendInfo?: GuiMakeSpendInfo = {})
     metadata: newSpendInfo.metadata ? { ...getMetadata(state), ...newSpendInfo.metadata } : getMetadata(state),
     spendTargets,
     networkFeeOption: newSpendInfo.networkFeeOption || getNetworkFeeOption(state),
-    customNetworkFee: newSpendInfo.customNetworkFee ? { ...getCustomNetworkFee(state), ...newSpendInfo.customNetworkFee } : getCustomNetworkFee(state)
+    customNetworkFee: newSpendInfo.customNetworkFee ? { ...getCustomNetworkFee(state), ...newSpendInfo.customNetworkFee } : getCustomNetworkFee(state),
+    otherParams: newSpendInfo.otherParams || {}
   }
 }
 

--- a/src/reducers/scenes/SendConfirmationReducer.js
+++ b/src/reducers/scenes/SendConfirmationReducer.js
@@ -18,6 +18,7 @@ export type GuiMakeSpendInfo = {
   spendTargets?: Array<EdgeSpendTarget>,
   lockInputs?: boolean,
   uniqueIdentifier?: string,
+  otherParams?: Object,
   onDone?: (error: Error | null, edgeTransaction?: EdgeTransaction) => void,
   onSuccess?: () => any
 }


### PR DESCRIPTION
Fix `otherParams` issue for BIP 70

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a