### PR TITLE
Refactor payee icon on transaction details

### DIFF
--- a/src/__tests__/__snapshots__/TransactionDetails.ui.test.js.snap
+++ b/src/__tests__/__snapshots__/TransactionDetails.ui.test.js.snap
@@ -64,12 +64,22 @@ exports[`TransactionDetails.ui should render 1`] = `
                   },
                 ]
               }
+            />
+            <Component
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "height": 0,
+                  "justifyContent": "center",
+                  "position": "relative",
+                }
+              }
             >
               <PayeeIcon
                 direction="receive"
                 thumbnailPath="thumb/nail/path"
               />
-            </Gradient>
+            </Component>
           </Component>
           <Component
             style={
@@ -341,12 +351,22 @@ exports[`TransactionDetails.ui should render with negative nativeAmount and fiat
                   },
                 ]
               }
+            />
+            <Component
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "height": 0,
+                  "justifyContent": "center",
+                  "position": "relative",
+                }
+              }
             >
               <PayeeIcon
                 direction="send"
                 thumbnailPath="thumb/nail/path"
               />
-            </Gradient>
+            </Component>
           </Component>
           <Component
             style={
@@ -621,12 +641,22 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in future
                   },
                 ]
               }
+            />
+            <Component
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "height": 0,
+                  "justifyContent": "center",
+                  "position": "relative",
+                }
+              }
             >
               <PayeeIcon
                 direction="receive"
                 thumbnailPath="thumb/nail/path"
               />
-            </Gradient>
+            </Component>
           </Component>
           <Component
             style={
@@ -898,12 +928,22 @@ exports[`TransactionDetails.ui should render with tx date off by 1000x in past 1
                   },
                 ]
               }
+            />
+            <Component
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "height": 0,
+                  "justifyContent": "center",
+                  "position": "relative",
+                }
+              }
             >
               <PayeeIcon
                 direction="receive"
                 thumbnailPath="thumb/nail/path"
               />
-            </Gradient>
+            </Component>
           </Component>
           <Component
             style={

--- a/src/components/scenes/TransactionDetailsScene.js
+++ b/src/components/scenes/TransactionDetailsScene.js
@@ -553,9 +553,10 @@ export class TransactionDetails extends Component<TransactionDetailsProps, State
             <ScrollView keyboardShouldPersistTaps="handled" ref="_scrollView" scrollEnabled={!this.state.subCategorySelectVisibility} overScrollMode="never">
               <View style={[styles.container]}>
                 <View>
-                  <Gradient style={[styles.expandedHeader]}>
+                  <Gradient style={[styles.expandedHeader]} />
+                  <View style={styles.PayeeIconWrapper}>
                     <PayeeIcon direction={this.state.direction} thumbnailPath={this.state.thumbnailPath} />
-                  </Gradient>
+                  </View>
                 </View>
                 <View style={[styles.dataArea]}>
                   <View style={[styles.payeeNameArea]}>

--- a/src/modules/UI/components/PayeeIcon/style.js
+++ b/src/modules/UI/components/PayeeIcon/style.js
@@ -11,6 +11,6 @@ export default StyleSheet.create({
     height: scale(48),
     borderRadius: 24,
     backgroundColor: THEME.COLORS.TRANSPARENT,
-    position: 'relative'
+    top: scale(-32)
   }
 })

--- a/src/styles/scenes/TransactionDetailsStyle.js
+++ b/src/styles/scenes/TransactionDetailsStyle.js
@@ -380,6 +380,12 @@ export const styles = {
     fontSize: scale(18),
     color: THEME.COLORS.ACCENT_BLUE,
     alignSelf: 'center'
+  },
+  PayeeIconWrapper: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    position: 'relative',
+    height: 0
   }
 }
 


### PR DESCRIPTION
Task: Transaction details - Arrow icon is cut off - iOS only

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a