### PR TITLE
Fix duplicate transactions from core by holding a txid map

### DIFF
--- a/src/__tests__/scenesReducer.test.js
+++ b/src/__tests__/scenesReducer.test.js
@@ -88,6 +88,7 @@ test('initialState', () => {
     transactionList: {
       searchVisible: false,
       transactions: [],
+      transactionIdMap: {},
       currentCurrencyCode: '',
       currentEndIndex: 0,
       numTransactions: 0,

--- a/src/__tests__/transactionListReducer.test.js
+++ b/src/__tests__/transactionListReducer.test.js
@@ -8,6 +8,7 @@ test('initialState', () => {
   const expected = {
     searchVisible: false,
     transactions: [],
+    transactionIdMap: {},
     currentCurrencyCode: '',
     currentEndIndex: 0,
     numTransactions: 0,

--- a/src/reducers/scenes/TransactionListReducer.js
+++ b/src/reducers/scenes/TransactionListReducer.js
@@ -11,6 +11,7 @@ export type TransactionListState = {
   +currentWalletId: string,
   +numTransactions: number,
   +searchVisible: boolean,
+  +transactionIdMap: { [txid: string]: TransactionListTx },
   +transactions: Array<TransactionListTx>
 }
 
@@ -24,6 +25,23 @@ const transactions = (state = [], action: Action): Array<TransactionListTx> => {
 
     case 'UI/WALLETS/SELECT_WALLET': {
       return []
+    }
+
+    default:
+      return state
+  }
+}
+
+const transactionIdMap = (state = {}, action: Action): { [txid: string]: TransactionListTx } => {
+  if (!action.data) return state
+  switch (action.type) {
+    case 'UI/SCENES/TRANSACTION_LIST/UPDATE_TRANSACTIONS': {
+      // $FlowFixMe
+      return action.data.transactionIdMap
+    }
+
+    case 'UI/WALLETS/SELECT_WALLET': {
+      return {}
     }
 
     default:
@@ -104,5 +122,6 @@ export const transactionList: Reducer<TransactionListState, Action> = combineRed
   currentWalletId,
   numTransactions,
   searchVisible,
+  transactionIdMap,
   transactions
 })


### PR DESCRIPTION
Also make sure we get all transactions by setting startEntries to undefined if we are at the end of the tx list and trying to get all remaining transactions.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a