### PR TITLE
Add icons for exchange providers

### DIFF
--- a/src/components/common/TransactionRow.js
+++ b/src/components/common/TransactionRow.js
@@ -85,12 +85,15 @@ export class TransactionRowComponent extends Component<Props, State> {
 
     if (tx.metadata && tx.metadata.name) {
       if (this.props.contacts) {
-        const contact = this.props.contacts.find(element => {
+        let contact
+        for (const element of this.props.contacts) {
           const fullName = element.givenName && element.familyName ? element.givenName + ' ' + element.familyName : element.givenName
           const found = element.thumbnailPath && UTILS.unspacedLowercase(fullName) === UTILS.unspacedLowercase(tx.metadata.name)
-          // if (found) console.log('element is: ', element)
-          return found
-        })
+          if (found) {
+            contact = element
+            break
+          }
+        }
         if (contact) {
           thumbnailPath = contact.thumbnailPath
         }

--- a/src/modules/UI/components/ContactsLoader/ContactsLoader.ui.js
+++ b/src/modules/UI/components/ContactsLoader/ContactsLoader.ui.js
@@ -13,6 +13,45 @@ export type Props = {
   loadContactsFail: (error: Error) => void
 }
 
+const merchantPartners = [
+  {
+    givenName: 'ShapeShift',
+    hasThumbnail: true,
+    thumbnailPath: 'https://developer.edge.app/content/shapeshift.png',
+    emailAddresses: [],
+    postalAddresses: [],
+    middleName: '',
+    company: '',
+    jobTitle: '',
+    familyName: '',
+    recordID: ''
+  },
+  {
+    givenName: 'Changelly',
+    hasThumbnail: true,
+    thumbnailPath: 'https://developer.edge.app/content/changelly.png',
+    emailAddresses: [],
+    postalAddresses: [],
+    middleName: '',
+    company: '',
+    jobTitle: '',
+    familyName: '',
+    recordID: ''
+  },
+  {
+    givenName: 'Change NOW',
+    hasThumbnail: true,
+    thumbnailPath: 'https://developer.edge.app/content/changenow.png',
+    emailAddresses: [],
+    postalAddresses: [],
+    middleName: '',
+    company: '',
+    jobTitle: '',
+    familyName: '',
+    recordID: ''
+  }
+]
+
 export class ContactsLoader extends Component<Props> {
   UNSAFE_componentWillReceiveProps (nextProps: Props) {
     const { contactsPermission } = nextProps
@@ -32,7 +71,7 @@ export class ContactsLoader extends Component<Props> {
   }
 
   filterContacts = (contacts: Array<GuiContact>) => {
-    return contacts.filter(item => item.givenName)
+    return contacts.filter(item => item.givenName).concat(merchantPartners)
   }
 
   sortContacts = (contacts: Array<GuiContact>): Array<GuiContact> => {


### PR DESCRIPTION
Add exchange provider names and icons to contact list so they get matched with pretagged transactions and then show icons on the tx list and details.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a