### PR TITLE
Add keyboardType props on payment Id modal

### DIFF
--- a/src/__tests__/__snapshots__/sendConfirmation.test.js.snap
+++ b/src/__tests__/__snapshots__/sendConfirmation.test.js.snap
@@ -757,6 +757,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
   </Gradient>
   <Connect(UniqueIdentifierModal)
     currencyCode="XMR"
+    keyboardType="default"
   />
 </SafeAreaViewComponent>
 `;
@@ -1019,6 +1020,7 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
   </Gradient>
   <Connect(UniqueIdentifierModal)
     currencyCode="XRP"
+    keyboardType="numeric"
   />
 </SafeAreaViewComponent>
 `;

--- a/src/components/modals/UniqueIdentifierModal.js
+++ b/src/components/modals/UniqueIdentifierModal.js
@@ -41,7 +41,6 @@ export class UniqueIdentifierModal extends Component<Props> {
     const confirm = s.strings.unique_identifier_modal_confirm
     const cancel = s.strings.unique_identifier_modal_cancel
     const icon = { type: 'ionIcons', name: 'ios-key' }
-    console.log(keyboardType)
 
     return (
       <InteractiveModal legacy isActive={isActive} onBackdropPress={onBackdropPress} onBackButtonPress={onBackButtonPress} onModalHide={onModalHide}>

--- a/src/components/modals/UniqueIdentifierModal.js
+++ b/src/components/modals/UniqueIdentifierModal.js
@@ -18,11 +18,22 @@ export type Props = {
   onCancel: () => any,
   currencyCode: string,
   uniqueIdentifier: string,
-  uniqueIdentifierChanged: (uniqueIdentifier: string) => void
+  uniqueIdentifierChanged: (uniqueIdentifier: string) => void,
+  keyboardType: ?string
 }
 export class UniqueIdentifierModal extends Component<Props> {
   render () {
-    const { currencyCode, isActive, onBackButtonPress, onBackdropPress, onCancel, onModalHide, uniqueIdentifier, uniqueIdentifierChanged } = this.props
+    const {
+      currencyCode,
+      isActive,
+      onBackButtonPress,
+      onBackdropPress,
+      onCancel,
+      onModalHide,
+      uniqueIdentifier,
+      uniqueIdentifierChanged,
+      keyboardType
+    } = this.props
     const type = getUniqueIdentifierType(currencyCode)
     const description = getUniqueIdentifierDescription(type)
     const title = type
@@ -30,7 +41,7 @@ export class UniqueIdentifierModal extends Component<Props> {
     const confirm = s.strings.unique_identifier_modal_confirm
     const cancel = s.strings.unique_identifier_modal_cancel
     const icon = { type: 'ionIcons', name: 'ios-key' }
-    const keyboardType = 'numeric'
+    console.log(keyboardType)
 
     return (
       <InteractiveModal legacy isActive={isActive} onBackdropPress={onBackdropPress} onBackButtonPress={onBackButtonPress} onModalHide={onModalHide}>

--- a/src/components/scenes/SendConfirmationScene.js
+++ b/src/components/scenes/SendConfirmationScene.js
@@ -285,7 +285,13 @@ export class SendConfirmation extends Component<Props, State> {
           </View>
         </Gradient>
 
-        {isTaggableCurrency && <UniqueIdentifierModal onConfirm={this.props.sendConfirmationUpdateTx} currencyCode={currencyCode} />}
+        {isTaggableCurrency && (
+          <UniqueIdentifierModal
+            onConfirm={this.props.sendConfirmationUpdateTx}
+            currencyCode={currencyCode}
+            keyboardType={this.keyboardTypeOnPaymentId(currencyCode)}
+          />
+        )}
       </SafeAreaView>
     )
   }
@@ -294,6 +300,19 @@ export class SendConfirmation extends Component<Props, State> {
     this.props.onChangePin(pin)
     if (pin.length >= 4) {
       this.pinInput.blur()
+    }
+  }
+
+  keyboardTypeOnPaymentId = (currencyCode: string) => {
+    switch (currencyCode) {
+      case 'XRP':
+        return 'numeric'
+      case 'XLM':
+        return 'numeric'
+      case 'XMR':
+        return 'default'
+      default:
+        return 'numeric'
     }
   }
 


### PR DESCRIPTION
Add check of what keyboard type on currency code, currently monero has the full keyboard

Task: Enable full keyboard when entering payment id Monero

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android