### PR TITLE
Add support for deeping link more edge related URIs

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -61,6 +61,24 @@
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="airbitz"></data>
+      </intent-filter>
+      <intent-filter android:label="Edge">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="airbitz-ret"></data>
+      </intent-filter>
+      <intent-filter android:label="Edge">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="edge"></data>
+      </intent-filter>
+      <intent-filter android:label="Edge">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="edge-ret"></data>
       </intent-filter>
       <intent-filter android:label="Bitcoin">

--- a/ios/edge/Info.plist
+++ b/ios/edge/Info.plist
@@ -39,6 +39,8 @@
 			<array>
 				<string>edge</string>
 				<string>airbitz</string>
+				<string>edge-ret</string>
+				<string>airbitz-ret</string>
 			</array>
 		</dict>
 		<dict>

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -799,11 +799,26 @@ describe('getObjectDiff', () => {
 })
 
 describe('isEdgeLogin', () => {
-  test('Edge Login', () => {
-    expect(isEdgeLogin('airbitz://edge/')).toBe(true)
+  test('Edge Login airbitz:', () => {
+    expect(isEdgeLogin('airbitz://edge/1234567890a')).toBe(true)
   })
-  test('Non Edge Login', () => {
-    expect(isEdgeLogin('not an edge login')).toBe(false)
+  test('Edge Login airbitz-ret', () => {
+    expect(isEdgeLogin('airbitz-ret://edge/1234567890a')).toBe(true)
+  })
+  test('Edge Login edge', () => {
+    expect(isEdgeLogin('edge://edge/1234567890a')).toBe(true)
+  })
+  test('Edge Login edge-ret', () => {
+    expect(isEdgeLogin('edge-ret://edge/1234567890a')).toBe(true)
+  })
+  test('Non Edge Login bad protocol', () => {
+    expect(isEdgeLogin('edge-re://edge/1234567890a')).toBe(false)
+  })
+  test('Non Edge Login bad host', () => {
+    expect(isEdgeLogin('edge-ret://edgey/1234567890a')).toBe(false)
+  })
+  test('Non Edge Login bad path', () => {
+    expect(isEdgeLogin('edge-ret://edge/1234567890')).toBe(false)
   })
 })
 

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -567,10 +567,25 @@ export function snooze (ms: number): Promise<void> {
   return new Promise((resolve: any) => setTimeout(resolve, ms))
 }
 
-export const isEdgeLogin = (data: string) => {
-  const EDGE_LOGIN_REG_EXP = /^airbitz:\/\/edge\//
+const MyEdgeLoginProtocols = {
+  'edge:': true,
+  'edge-ret:': true,
+  'airbitz:': true,
+  'airbitz-ret:': true
+}
 
-  return EDGE_LOGIN_REG_EXP.test(data)
+export const isEdgeLogin = (data: string) => {
+  const parsedUrl = parse(data, {}, false)
+  if (MyEdgeLoginProtocols[parsedUrl.protocol]) {
+    if (parsedUrl.host === 'edge') {
+      if (typeof parsedUrl.pathname === 'string') {
+        if (parsedUrl.pathname.length > 11) {
+          return true
+        }
+      }
+    }
+  }
+  return false
 }
 
 const REQUEST_CURRENCIES = {


### PR DESCRIPTION
Support airbitz-ret, airbitz, edge, and edge-ret
Allows for broad support of edge login URIs

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a