### PR TITLE
url to be blank for Android shares

### DIFF
--- a/src/components/scenes/RequestScene.js
+++ b/src/components/scenes/RequestScene.js
@@ -323,9 +323,9 @@ export class Request extends Component<Props, State> {
     const path = Platform.OS === Constants.IOS ? RNFS.DocumentDirectoryPath + '/' + title + '.txt' : RNFS.ExternalDirectoryPath + '/' + title + '.txt'
     RNFS.writeFile(path, message, 'utf8')
       .then(success => {
-        console.log('FILE WRITTEN!')
+        const url = Platform.OS === Constants.IOS ? 'file://' + path : ''
         const shareOptions = {
-          url: 'file://' + path,
+          url,
           title,
           message,
           subject: sprintf(s.strings.request_qr_email_title, s.strings.app_name, this.props.currencyCode) //  for email,


### PR DESCRIPTION
Fixes: Asana Android Request Email Share Address - Shows the file location of the device
https://app.asana.com/0/361770107085503/914173440500616

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a