### PR TITLE
Do not init wallets in initializeAccount

### DIFF
--- a/src/modules/Core/Wallets/reducer.js
+++ b/src/modules/Core/Wallets/reducer.js
@@ -15,7 +15,6 @@ export const initialState = {}
 
 const byId = (state = initialState, action: Action): $PropertyType<WalletsState, 'byId'> => {
   switch (action.type) {
-    case 'ACCOUNT_INIT_COMPLETE':
     case 'CORE/WALLETS/UPDATE_WALLETS':
       if (!action.data) throw new Error('Invalid action')
       const currencyWallets = action.data.currencyWallets

--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type { EdgeAccount, EdgeCurrencyWallet } from 'edge-core-js'
-import _ from 'lodash'
+import type { EdgeAccount } from 'edge-core-js'
 import { Platform } from 'react-native'
 import Locale from 'react-native-locale'
 import PushNotification from 'react-native-push-notification'
@@ -11,7 +10,6 @@ import { sprintf } from 'sprintf-js'
 import { insertWalletIdsForProgress } from '../../actions/WalletActions.js'
 import * as Constants from '../../constants/indexConstants'
 import s from '../../locales/strings.js'
-import { getReceiveAddresses } from '../../util/utils.js'
 import * as ACCOUNT_API from '../Core/Account/api'
 import * as SETTINGS_API from '../Core/Account/settings.js'
 // Login/action.js
@@ -70,7 +68,6 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
     customTokensSettings: [],
     activeWalletIds: [],
     archivedWalletIds: [],
-    currencyWallets: {},
     passwordReminder: {},
     isAccountBalanceVisible: false,
     isWalletFiatBalanceVisible: false,
@@ -125,29 +122,9 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
     const activeWalletIds = account.activeWalletIds
     dispatch(insertWalletIdsForProgress(activeWalletIds))
     const archivedWalletIds = account.archivedWalletIds
-    const currencyWallets = account.currencyWallets
 
     accountInitObject.activeWalletIds = activeWalletIds
     accountInitObject.archivedWalletIds = archivedWalletIds
-    accountInitObject.currencyWallets = currencyWallets
-
-    for (const walletId of Object.keys(currencyWallets)) {
-      const edgeWallet: EdgeCurrencyWallet = currencyWallets[walletId]
-      if (edgeWallet.type === 'wallet:ethereum') {
-        if (state.ui.wallets && state.ui.wallets.byId && state.ui.wallets.byId[walletId]) {
-          const enabledTokens = state.ui.wallets.byId[walletId].enabledTokens
-          const customTokens = state.ui.settings.customTokens
-          const enabledNotHiddenTokens = enabledTokens.filter(token => {
-            let isVisible = true // assume we will enable token
-            const tokenIndex = _.findIndex(customTokens, item => item.currencyCode === token)
-            // if token is not supposed to be visible, not point in enabling it
-            if (tokenIndex > -1 && customTokens[tokenIndex].isVisible === false) isVisible = false
-            return isVisible
-          })
-          edgeWallet.enableTokens(enabledNotHiddenTokens)
-        }
-      }
-    }
     const settings = await SETTINGS_API.getSyncedSettings(account)
     const syncDefaults = SETTINGS_API.SYNCED_ACCOUNT_DEFAULTS
     const syncFinal = { ...syncDefaults, ...settings }
@@ -186,10 +163,9 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
     accountInitObject.pinMode = coreFinal.pinMode
     accountInitObject.otpMode = coreFinal.otpMode
 
-    const receiveAddresses = await getReceiveAddresses(currencyWallets)
     dispatch({
       type: 'ACCOUNT_INIT_COMPLETE',
-      data: { ...accountInitObject, receiveAddresses }
+      data: { ...accountInitObject }
     })
     // $FlowFixMe
     dispatch(updateWalletsRequest())

--- a/src/reducers/scenes/WalletsReducer.js
+++ b/src/reducers/scenes/WalletsReducer.js
@@ -22,26 +22,6 @@ const byId = (state = {}, action: Action): $PropertyType<WalletsState, 'byId'> =
   if (!action.data) return state
 
   switch (action.type) {
-    case 'ACCOUNT_INIT_COMPLETE': {
-      // $FlowFixMe
-      const wallets = action.data.currencyWallets
-      const out = {}
-
-      for (const walletId of Object.keys(wallets)) {
-        // $FlowFixMe
-        const tempWallet = schema(wallets[walletId], action.data.receiveAddresses[walletId])
-        if (state[walletId]) {
-          const enabledTokensOnWallet = state[walletId].enabledTokens
-          tempWallet.enabledTokens = enabledTokensOnWallet
-          enabledTokensOnWallet.forEach(customToken => {
-            tempWallet.nativeBalances[customToken] = wallets[walletId].getBalance({ currencyCode: customToken })
-          })
-        }
-        out[walletId] = tempWallet
-      }
-
-      return out
-    }
     case 'CORE/WALLETS/UPDATE_WALLETS': {
       // $FlowFixMe
       const wallets = action.data.currencyWallets


### PR DESCRIPTION
initializeAccount runs asynchronously and wallets might get initialized while it is running due to a callback from Core. initializeAccount even calls requestRefreshWallets at the end guaranteeing that wallets get updated at the end.

This fix prevents initializeAccount from wiping out already initialized wallets and possibly crashing the app at startup if a deep link tries to access an already initialized wallet in redux.

This nicely removes a lot of duplicate code that existed in both account initialization and wallet updates

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a