### PR TITLE
remove custom mining fee from some currencies

### DIFF
--- a/src/components/scenes/ChangeMiningFeeScene.js
+++ b/src/components/scenes/ChangeMiningFeeScene.js
@@ -29,7 +29,8 @@ export type ChangeMiningFeeOwnProps = {
 export type ChangeMiningFeeStateProps = {
   feeSetting: string,
   customFeeSettings: Array<string>,
-  customNetworkFee: Object
+  customNetworkFee: Object,
+  hideCustomFeeOption?: boolean
 }
 
 export type ChangeMiningFeeDispatchProps = {}
@@ -72,6 +73,16 @@ export default class ChangeMiningFee extends Component<ChangeMiningFeeProps, Sta
       })
     }
   }
+  renderCustomFeeButton = () => {
+    if (!this.props.hideCustomFeeOption) {
+      return (
+        <PrimaryButton style={styles.customFeeButton} onPress={this.showCustomFeesModal}>
+          <PrimaryButton.Text>{s.strings.fragment_wallets_set_custom_fees}</PrimaryButton.Text>
+        </PrimaryButton>
+      )
+    }
+    return null
+  }
 
   render () {
     const { feeSetting } = this.state
@@ -93,11 +104,7 @@ export default class ChangeMiningFee extends Component<ChangeMiningFeeProps, Sta
             <View style={styles.row}>
               <RadioButton value={FEE.LOW_FEE} label={LOW_FEE_TEXT} onPress={this.handlePress} isSelected={FEE.LOW_FEE === feeSetting} />
             </View>
-            <View style={{ marginTop: 18 }}>
-              <PrimaryButton style={styles.customFeeButton} onPress={this.showCustomFeesModal}>
-                <PrimaryButton.Text>{s.strings.fragment_wallets_set_custom_fees}</PrimaryButton.Text>
-              </PrimaryButton>
-            </View>
+            <View style={{ marginTop: 18 }}>{this.renderCustomFeeButton()}</View>
           </View>
         </View>
       </SafeAreaView>

--- a/src/connectors/scenes/ChangeMiningFeeSendConfirmationConnector.ui.js
+++ b/src/connectors/scenes/ChangeMiningFeeSendConfirmationConnector.ui.js
@@ -18,12 +18,14 @@ export const mapStateToProps = (state: State, ownProps: ChangeMiningFeeOwnProps)
   if (_.has(wallet, 'currencyInfo.defaultSettings.customFeeSettings')) {
     customFeeSettings = wallet.currencyInfo.defaultSettings.customFeeSettings
   }
-
+  const noCustomFeeCurrencies = ['XRP', 'XMR', 'XLM']
+  const hideCustomFeeOption = noCustomFeeCurrencies.includes(wallet.currencyInfo.currencyCode)
   return {
     customNetworkFee: getCustomNetworkFee(state),
     customFeeSettings: customFeeSettings,
     // fee: state.ui.scenes.sendConfirmation.fee,
-    feeSetting: getNetworkFeeOption(state)
+    feeSetting: getNetworkFeeOption(state),
+    hideCustomFeeOption
   }
 }
 


### PR DESCRIPTION
Asana task: Send - XMR/XRP/XLM custom mining fee modal is empty
https://app.asana.com/0/361770107085503/909519185512813
Should have been titled, do not show option for custom fees on those currencies. 

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a