### PR TITLE
fix prop names in object causing crash

### DIFF
--- a/src/components/modals/KYCAlertModal.js
+++ b/src/components/modals/KYCAlertModal.js
@@ -77,10 +77,10 @@ export const createKYCAlertModal = (opts: Object) => (props: { +onDone: Function
       termsText={opts.termsText}
       privacyText={opts.privacyText}
       amlText={opts.amlText}
-      onAccept={opts.acceptKYCWarning}
-      termsClick={opts.viewTerms}
-      privacyClick={opts.viewPrivacy}
-      amlClick={opts.viewAML}
+      onAccept={opts.onAccept}
+      termsClick={opts.termsClick}
+      privacyClick={opts.privacyClick}
+      amlClick={opts.amlClick}
     />
   )
 }


### PR DESCRIPTION
Fixes both ASANA: 
URGENT: Swap crashes accepting KYC modal 
https://app.asana.com/0/361770107085503/964023458287410

KYC Swap modal. Can't tap any links at bottom
https://app.asana.com/0/361770107085503/964023458287412

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a