### PR TITLE
Fix slow QR scanning speed on Android

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -16,6 +16,7 @@
 .*/Libraries/react-native/ReactNative.js
 
 .*/node_modules/react-native/.*
+.*/node_modules/react-native-camera/.*
 .*/node_modules/react-native-device-info/.*
 .*/node_modules/react-native-dropdown/.*
 .*/node_modules/react-native-dropdownalert/.*

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-animatable": "^1.1.0",
     "react-native-app-settings": "^2.0.0",
     "react-native-background-fetch": "^2.4.3",
-    "react-native-camera": "git://github.com/EdgeApp/react-native-camera.git#97e0b9a",
+    "react-native-camera": "git://github.com/EdgeApp/react-native-camera.git#a31ea429d77",
     "react-native-contacts": "git://github.com/EdgeApp/react-native-contacts.git",
     "react-native-contacts-wrapper": "git://github.com/EdgeApp/react-native-contacts-wrapper.git",
     "react-native-cookies": "3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8173,12 +8173,11 @@ react-native-background-fetch@^2.4.3:
     plist "^2.0.1"
     xcode "^0.9.1"
 
-"react-native-camera@git://github.com/EdgeApp/react-native-camera.git#97e0b9a":
-  version "1.2.0"
-  resolved "git://github.com/EdgeApp/react-native-camera.git#97e0b9a2adfee27a9485ac0a698a75015a425323"
+"react-native-camera@git://github.com/EdgeApp/react-native-camera.git#a31ea429d77":
+  version "1.6.4"
+  resolved "git://github.com/EdgeApp/react-native-camera.git#a31ea429d7790c02ce78138e56141dc854360b33"
   dependencies:
-    lodash "^4.17.4"
-    prop-types "^15.5.10"
+    prop-types "^15.6.2"
 
 "react-native-contacts-wrapper@git://github.com/EdgeApp/react-native-contacts-wrapper.git":
   version "0.2.4"


### PR DESCRIPTION
Upgrade react-native-camera to forked Edge version which limits scan preview size to 720p

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a