### PR TITLE
fix no custom fees for specific currencies

### DIFF
--- a/src/connectors/scenes/ChangeMiningFeeSendConfirmationConnector.ui.js
+++ b/src/connectors/scenes/ChangeMiningFeeSendConfirmationConnector.ui.js
@@ -18,7 +18,7 @@ export const mapStateToProps = (state: State, ownProps: ChangeMiningFeeOwnProps)
   if (_.has(wallet, 'currencyInfo.defaultSettings.customFeeSettings')) {
     customFeeSettings = wallet.currencyInfo.defaultSettings.customFeeSettings
   }
-  const hideCustomFeeOption = !!Constants.getSpecialCurrencyInfo(wallet.currencyInfo.currencyCode).noChangeMiningFee
+  const hideCustomFeeOption = !!Constants.getSpecialCurrencyInfo(wallet.currencyInfo.currencyCode).noCustomMiningFee
   return {
     customNetworkFee: getCustomNetworkFee(state),
     customFeeSettings: customFeeSettings,

--- a/src/constants/indexConstants.js
+++ b/src/constants/indexConstants.js
@@ -26,6 +26,7 @@ export const LOCAL_STORAGE_BACKGROUND_PUSH_KEY = 'EdgeWalletLastPushNotification
 
 export const SPECIAL_CURRENCY_INFO = {
   XLM: {
+    noCustomMiningFee: true,
     uniqueIdentifier: {
       addButtonText: s.strings.unique_identifier_dropdown_option_memo_id,
       identifierName: s.strings.unique_identifier_memo_id,
@@ -37,6 +38,7 @@ export const SPECIAL_CURRENCY_INFO = {
     }
   },
   XRP: {
+    noCustomMiningFee: true,
     uniqueIdentifier: {
       addButtonText: s.strings.unique_identifier_dropdown_option_destination_tag,
       identifierName: s.strings.unique_identifier_destination_tag,
@@ -48,6 +50,7 @@ export const SPECIAL_CURRENCY_INFO = {
     }
   },
   XMR: {
+    noCustomMiningFee: true,
     noMaxSpend: true,
     uniqueIdentifier: {
       addButtonText: s.strings.unique_identifier_dropdown_option_payment_id,


### PR DESCRIPTION
Re-fixing Send - XMR/XRP/XLM custom mining fee modal is empty
https://app.asana.com/0/361770107085503/909519185512813
Was broken by EOS implementation. changes. 
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a