### PR TITLE
Fix broken exchange max for accountbased currencies

### DIFF
--- a/src/actions/CryptoExchangeActions.js
+++ b/src/actions/CryptoExchangeActions.js
@@ -63,17 +63,15 @@ export const exchangeMax = () => async (dispatch: Dispatch, getState: GetState) 
     return
   }
   const wallet: EdgeCurrencyWallet = CORE_SELECTORS.getWallet(state, fromWallet.id)
-  const receiveAddress = await wallet.getReceiveAddress()
   const currencyCode = state.cryptoExchange.fromCurrencyCode ? state.cryptoExchange.fromCurrencyCode : undefined
+  const parentCurrencyCode = wallet.currencyInfo.currencyCode
+  const dummyPublicAddress = Constants.getSpecialCurrencyInfo(parentCurrencyCode).dummyPublicAddress
 
+  const publicAddress = dummyPublicAddress || (await wallet.getReceiveAddress()).publicAddress
   const edgeSpendInfo: EdgeSpendInfo = {
     networkFeeOption: Constants.STANDARD_FEE,
     currencyCode,
-    spendTargets: [
-      {
-        publicAddress: receiveAddress.publicAddress
-      }
-    ]
+    spendTargets: [{ publicAddress }]
   }
   const primaryNativeAmount = await wallet.getMaxSpendable(edgeSpendInfo)
   dispatch({ type: 'SET_FROM_WALLET_MAX', data: primaryNativeAmount })

--- a/src/constants/indexConstants.js
+++ b/src/constants/indexConstants.js
@@ -30,6 +30,7 @@ type SpecialCurrencyInfo = {
     needsAccountNameSetup?: boolean,
     noChangeMiningFee?: boolean,
     allowZeroTx?: boolean,
+    dummyPublicAddress?: string,
     uniqueIdentifier?: {
       addButtonText: string,
       identifierName: string,
@@ -44,6 +45,7 @@ type SpecialCurrencyInfo = {
 
 export const SPECIAL_CURRENCY_INFO: SpecialCurrencyInfo = {
   XLM: {
+    dummyPublicAddress: 'GBEVGJYAUKJ2TVPMC3GEPI2GGZQLMWZDRWJCVNBXCJ3ELYTDPHVQQM74',
     noCustomMiningFee: true,
     uniqueIdentifier: {
       addButtonText: s.strings.unique_identifier_dropdown_option_memo_id,
@@ -56,6 +58,7 @@ export const SPECIAL_CURRENCY_INFO: SpecialCurrencyInfo = {
     }
   },
   XRP: {
+    dummyPublicAddress: 'rfuESo7eHUnvebxgaFjfYxfwXhM2uBPAj3',
     noCustomMiningFee: true,
     uniqueIdentifier: {
       addButtonText: s.strings.unique_identifier_dropdown_option_destination_tag,
@@ -68,6 +71,7 @@ export const SPECIAL_CURRENCY_INFO: SpecialCurrencyInfo = {
     }
   },
   XMR: {
+    dummyPublicAddress: '46qxvuS78CNBoiiKmDjvjd5pMAZrTBbDNNHDoP52jKj9j5mk6m4R5nU6BDrWQURiWV9a2n5Sy8Qo4aJskKa92FX1GpZFiYA',
     noCustomMiningFee: true,
     noMaxSpend: true,
     uniqueIdentifier: {
@@ -77,6 +81,7 @@ export const SPECIAL_CURRENCY_INFO: SpecialCurrencyInfo = {
     }
   },
   EOS: {
+    dummyPublicAddress: 'edgecreator2',
     needsAccountNameSetup: true,
     noChangeMiningFee: true,
     uniqueIdentifier: {
@@ -86,6 +91,7 @@ export const SPECIAL_CURRENCY_INFO: SpecialCurrencyInfo = {
     }
   },
   ETH: {
+    dummyPublicAddress: '0x0d73358506663d484945ba85d0cd435ad610b0a0',
     allowZeroTx: true
   }
 }


### PR DESCRIPTION
Account based currencies will an throw error if user tries to spend to themselves. With the exchange scene, this is exactly what's done since the exchanger grabs an address from the same wallet for getMaxSpendable.

Fix by adding dummy addresses to specialCurrencyInfo for these currencies

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a