### PR TITLE
Fix EOS wallet creation crash (sendConf)

### DIFF
--- a/src/components/scenes/CreateWalletAccountSelectScene.js
+++ b/src/components/scenes/CreateWalletAccountSelectScene.js
@@ -171,7 +171,7 @@ export class CreateWalletAccountSelect extends Component<Props, State> {
       activationCost,
       paymentDenominationSymbol
     } = this.props
-    const { walletId } = this.state
+    const { walletId, createdWallet } = this.state
     const wallet = wallets[walletId]
     const { name, symbolImageDarkMono } = wallet
 
@@ -212,8 +212,13 @@ export class CreateWalletAccountSelect extends Component<Props, State> {
           <Text style={styles.accountReviewConfirmText}>{s.strings.create_wallet_account_confirm}</Text>
         </View>
         <View style={styles.confirmButtonArea}>
-          <PrimaryButton disabled={isCreatingWallet} style={[styles.confirmButton]} onPress={this.onPressSubmit}>
-            {isCreatingWallet ? <ActivityIndicator /> : <PrimaryButton.Text>{s.strings.legacy_address_modal_continue}</PrimaryButton.Text>}
+          <PrimaryButton disabled={isCreatingWallet || (createdWallet && !amount)} style={[styles.confirmButton]} onPress={this.onPressSubmit}>
+            {/* we want it disabled with activity indicator if creating wallet, or wallet is created and pending quote */}
+            {isCreatingWallet || (createdWallet && !amount) ? (
+              <ActivityIndicator />
+            ) : (
+              <PrimaryButton.Text>{s.strings.legacy_address_modal_continue}</PrimaryButton.Text>
+            )}
           </PrimaryButton>
         </View>
       </View>

--- a/src/components/scenes/CreateWalletAccountSelectScene.js
+++ b/src/components/scenes/CreateWalletAccountSelectScene.js
@@ -175,6 +175,8 @@ export class CreateWalletAccountSelect extends Component<Props, State> {
     const wallet = wallets[walletId]
     const { name, symbolImageDarkMono } = wallet
 
+    const isContinueButtonDisabled = isCreatingWallet || (createdWallet && !amount)
+
     return (
       <View>
         <View style={styles.selectPaymentLower}>
@@ -212,13 +214,9 @@ export class CreateWalletAccountSelect extends Component<Props, State> {
           <Text style={styles.accountReviewConfirmText}>{s.strings.create_wallet_account_confirm}</Text>
         </View>
         <View style={styles.confirmButtonArea}>
-          <PrimaryButton disabled={isCreatingWallet || (createdWallet && !amount)} style={[styles.confirmButton]} onPress={this.onPressSubmit}>
+          <PrimaryButton disabled={isContinueButtonDisabled} style={[styles.confirmButton]} onPress={this.onPressSubmit}>
             {/* we want it disabled with activity indicator if creating wallet, or wallet is created and pending quote */}
-            {isCreatingWallet || (createdWallet && !amount) ? (
-              <ActivityIndicator />
-            ) : (
-              <PrimaryButton.Text>{s.strings.legacy_address_modal_continue}</PrimaryButton.Text>
-            )}
+            {isContinueButtonDisabled ? <ActivityIndicator /> : <PrimaryButton.Text>{s.strings.legacy_address_modal_continue}</PrimaryButton.Text>}
           </PrimaryButton>
         </View>
       </View>


### PR DESCRIPTION
The purpose of this task is to prevent a crash by disabling the "Continue" button during EOS wallet creation when the wallet has been created *but* the price quote has not yet been received.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/968867613128367/f