### PR TITLE
Cause re-check of account handle if unfinished activation

### DIFF
--- a/src/components/scenes/CreateWalletAccountSetupScene.js
+++ b/src/components/scenes/CreateWalletAccountSetupScene.js
@@ -59,6 +59,9 @@ export class CreateWalletAccountSetup extends Component<Props, State> {
     this.state = {
       accountHandle: props.accountHandle || ''
     }
+    if (this.state.accountHandle) {
+      props.checkHandleAvailability(this.state.accountHandle)
+    }
   }
 
   componentDidMount () {
@@ -95,10 +98,11 @@ export class CreateWalletAccountSetup extends Component<Props, State> {
   }
 
   render () {
+    const { accountHandle } = this.state
     const { isCheckingHandleAvailability, handleAvailableStatus } = this.props
     const isHandleAvailable = handleAvailableStatus === 'AVAILABLE'
     const validityIcon = isHandleAvailable ? validIcon : invalidIcon
-    const showButton = isHandleAvailable && !isCheckingHandleAvailability
+    const showButton = accountHandle && isHandleAvailable && !isCheckingHandleAvailability
     let chooseHandleErrorMessage = ''
     if (handleAvailableStatus === 'INVALID') {
       chooseHandleErrorMessage = s.strings.create_wallet_account_invalid_account_name


### PR DESCRIPTION
The purpose of this task is to make sure that the account handle validation is accurate for unfinished EOS wallets.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/967521232573916/f