### PR TITLE
Fix issue with plugin routing back to GUI

### DIFF
--- a/src/components/Main.ui.js
+++ b/src/components/Main.ui.js
@@ -740,16 +740,14 @@ export default class Main extends Component<Props, State> {
                         renderRightButton={this.renderEmptyButton()}
                         onLeft={Actions.pop}
                       />
-                      {/*
-                        <Scene
-                          key={Constants.PLUGIN}
-                          navTransparent={true}
-                          component={PluginView}
-                          renderTitle={this.renderTitle(PLUGIN_SPEND)}
-                          renderLeftButton={this.renderBackButton(BACK)}
-                          renderRightButton={this.renderEmptyButton()}
-                        />
-                      ) */}
+                      <Scene
+                        key={Constants.PLUGIN}
+                        navTransparent={true}
+                        component={PluginView}
+                        renderTitle={this.renderTitle(PLUGIN_SPEND)}
+                        renderLeftButton={this.renderBackButton(BACK)}
+                        renderRightButton={this.renderEmptyButton()}
+                      />
                     </Stack>
                     <Stack key={Constants.TERMS_OF_SERVICE}>
                       <Scene

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -279,7 +279,7 @@ const strings = {
   title_edit_token: 'Edit Token',
   title_add_token: 'Add Token',
   title_password_recovery: 'Password Recovery',
-  title_plugin_buysell: 'Buy Cryptocurrency',
+  title_plugin_buysell: 'Buy and Sell',
   title_plugin_spend_cryptocurrency: 'Spend Cryptocurrency',
   title_plugin_spend: 'Spend',
   title_otp: '2FA',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -268,7 +268,7 @@
   "title_edit_token": "Edit Token",
   "title_add_token": "Add Token",
   "title_password_recovery": "Password Recovery",
-  "title_plugin_buysell": "Buy Cryptocurrency",
+  "title_plugin_buysell": "Buy and Sell",
   "title_plugin_spend_cryptocurrency": "Spend Cryptocurrency",
   "title_plugin_spend": "Spend",
   "title_otp": "2FA",


### PR DESCRIPTION
The purpose of this task is to ensure that the plugins route back to the GUI correctly, specifically so that the "Spend" plugins (ie BitRefill) do not route back to the "Buy and Sell" plugins scene.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/979724374279429/f