### PR TITLE
Transaction list: Fiat Balance below 1e-6 is will be displayed as 0

### DIFF
--- a/src/components/scenes/TransactionListScene.js
+++ b/src/components/scenes/TransactionListScene.js
@@ -212,7 +212,7 @@ export class TransactionList extends Component<Props, State> {
     // beginning of fiat balance
     let fiatBalanceString
     const receivedFiatSymbol = fiatSymbol ? UTILS.getFiatSymbol(isoFiatCurrencyCode) : ''
-    const fiatBalanceFormat = `${intl.formatNumber(balanceInFiat && balanceInFiat > 0 ? balanceInFiat : 0, { toFixed: 2 })} ${fiatCurrencyCode}`
+    const fiatBalanceFormat = `${intl.formatNumber(balanceInFiat && balanceInFiat > 0.000001 ? balanceInFiat : 0, { toFixed: 2 })} ${fiatCurrencyCode}`
     if (receivedFiatSymbol.length !== 1) {
       fiatBalanceString = fiatBalanceFormat
     } else {

--- a/src/components/scenes/TransactionListScene.js
+++ b/src/components/scenes/TransactionListScene.js
@@ -212,10 +212,11 @@ export class TransactionList extends Component<Props, State> {
     // beginning of fiat balance
     let fiatBalanceString
     const receivedFiatSymbol = fiatSymbol ? UTILS.getFiatSymbol(isoFiatCurrencyCode) : ''
+    const fiatBalanceFormat = `${intl.formatNumber(balanceInFiat && balanceInFiat > 0 ? balanceInFiat : 0, { toFixed: 2 })} ${fiatCurrencyCode}`
     if (receivedFiatSymbol.length !== 1) {
-      fiatBalanceString = intl.formatNumber(balanceInFiat || 0, { toFixed: 2 }) + ' ' + fiatCurrencyCode
+      fiatBalanceString = fiatBalanceFormat
     } else {
-      fiatBalanceString = receivedFiatSymbol + ' ' + intl.formatNumber(balanceInFiat || 0, { toFixed: 2 }) + ' ' + fiatCurrencyCode
+      fiatBalanceString = receivedFiatSymbol + ' ' + fiatBalanceFormat
     }
     return (
       <TouchableOpacity onPress={this.props.toggleBalanceVisibility} style={styles.touchableBalanceBox} activeOpacity={BALANCE_BOX_OPACITY}>


### PR DESCRIPTION
Task: If DGB has a dust balance that is on the negative 5th decimal place or 0.00001 then it will show a negative balance $-5.37 in this case

Note: The function intl.formatNumber() seems to be having error when processing numbers below 0.000001. Fix only the display and not the function itself. Best fix on the bug is that someone qualified should refactor intl.formatNumber to consider very small numbers.

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android