### PR TITLE
Fix payment protocol destination detection

### DIFF
--- a/src/components/common/TransactionRow.js
+++ b/src/components/common/TransactionRow.js
@@ -64,6 +64,12 @@ export class TransactionRowComponent extends Component<Props, State> {
     const completedTxList: Array<TransactionListTx> = this.props.transactions
     // $FlowFixMe
     const tx = this.props.transaction.item
+
+    // Work around corrupted metadata from another GUI bug:
+    if (tx.metadata != null && tx.metadata.name != null && typeof tx.metadata.name !== 'string') {
+      tx.metadata.name = ''
+    }
+
     let txColorStyle, lastOfDate, txImage, pendingTimeStyle, pendingTimeSyntax, transactionPartner
     let txName = ''
     let thumbnailPath = ''

--- a/src/modules/Core/Wallets/api.js
+++ b/src/modules/Core/Wallets/api.js
@@ -53,9 +53,9 @@ export const getReceiveAddress = (wallet: EdgeCurrencyWallet, currencyCode: stri
 }
 
 export const makeSpendInfo = (paymentProtocolInfo: EdgePaymentProtocolInfo): Promise<EdgeSpendInfo> => {
-  const { domain, memo, merchant, nativeAmount, spendTargets } = paymentProtocolInfo
+  const { domain, memo, nativeAmount, spendTargets } = paymentProtocolInfo
 
-  const name = domain === BITPAY.domain ? BITPAY.merchantName(memo) : merchant || domain
+  const name = domain === BITPAY.domain ? BITPAY.merchantName(memo) : domain
   const notes = memo
 
   return Promise.resolve({


### PR DESCRIPTION
The `merchant` field doesn't contain they payee name in the current implementation. Always use the domain name instead to avoid crashes.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a