### PR TITLE
Bump wyre plugin to reduce logo size

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "body-parser": "^1.18.2",
     "detox": "^7.4.3",
     "edge-plugin-simplex": "https://github.com/Airbitz/edge-plugin-simplex.git#5155b5fa",
-    "edge-plugin-wyre": "https://github.com/EdgeApp/edge-plugin-wyre.git#31b260d",
+    "edge-plugin-wyre": "https://github.com/EdgeApp/edge-plugin-wyre.git#c6dca735",
     "edge-plugin-bitrefill": "https://github.com/EdgeApp/edge-plugin-bitrefill.git#3d9068d",
     "eslint": "^4.17.0",
     "eslint-config-standard": "^11.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,9 +3342,9 @@ edge-login-ui-rn@^0.5.16:
   dependencies:
     moment "^2.22.2"
 
-"edge-plugin-wyre@https://github.com/EdgeApp/edge-plugin-wyre.git#31b260d":
+"edge-plugin-wyre@https://github.com/EdgeApp/edge-plugin-wyre.git#c6dca735":
   version "0.0.3"
-  resolved "https://github.com/EdgeApp/edge-plugin-wyre.git#31b260d031aa72b23945e05b09499c3e0ad3f200"
+  resolved "https://github.com/EdgeApp/edge-plugin-wyre.git#c6dca735bb2703ec0fce5baaa36ff370db452fd5"
   dependencies:
     js-sha256 "^0.9.0"
     moment "^2.22.2"


### PR DESCRIPTION
The purpose of this task is to bump the Wyre plugin version number to include the new reference to smaller logo.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/998480980339861/f