### PR TITLE
Move core management to its own component

### DIFF
--- a/src/components/core/EdgeAccountCallbackManager.js
+++ b/src/components/core/EdgeAccountCallbackManager.js
@@ -4,9 +4,9 @@ import type { EdgeAccount } from 'edge-core-js'
 import React from 'react'
 import { connect } from 'react-redux'
 
-import { updateExchangeRates } from '../../ExchangeRates/action'
-import type { Dispatch, State } from '../../ReduxTypes.js'
-import { updateWalletsRequest } from '../Wallets/action.js'
+import { updateWalletsRequest } from '../../modules/Core/Wallets/action.js'
+import { updateExchangeRates } from '../../modules/ExchangeRates/action.js'
+import type { Dispatch, State } from '../../modules/ReduxTypes.js'
 
 type EdgeAccountCallbackManagerStateProps = {
   account: EdgeAccount

--- a/src/components/core/EdgeContextCallbackManager.js
+++ b/src/components/core/EdgeContextCallbackManager.js
@@ -4,8 +4,8 @@ import type { EdgeContext } from 'edge-core-js'
 import React from 'react'
 import { connect } from 'react-redux'
 
-import type { Dispatch, State } from '../../ReduxTypes.js'
-import { displayErrorAlert } from '../../UI/components/ErrorAlert/actions'
+import type { Dispatch, State } from '../../modules/ReduxTypes.js'
+import { displayErrorAlert } from '../../modules/UI/components/ErrorAlert/actions'
 
 type EdgeContextCallbackManagerStateProps = {
   context: EdgeContext

--- a/src/components/core/EdgeCoreManager.js
+++ b/src/components/core/EdgeCoreManager.js
@@ -1,0 +1,84 @@
+// @flow
+
+import type { EdgeContext, EdgeCorePluginFactory } from 'edge-core-js'
+import { eosCurrencyPluginFactory, rippleCurrencyPluginFactory, stellarCurrencyPluginFactory } from 'edge-currency-accountbased'
+import {
+  bitcoinCurrencyPluginFactory,
+  bitcoincashCurrencyPluginFactory,
+  bitcoingoldCurrencyPluginFactory,
+  bitcoinsvCurrencyPluginFactory,
+  dashCurrencyPluginFactory,
+  digibyteCurrencyPluginFactory,
+  // eboostCurrencyPluginFactory,
+  feathercoinCurrencyPluginFactory,
+  groestlcoinCurrencyPluginFactory,
+  litecoinCurrencyPluginFactory,
+  qtumCurrencyPluginFactory,
+  smartcashCurrencyPluginFactory,
+  ufoCurrencyPluginFactory,
+  vertcoinCurrencyPluginFactory,
+  zcoinCurrencyPluginFactory
+} from 'edge-currency-bitcoin'
+import { ethereumCurrencyPluginFactory } from 'edge-currency-ethereum'
+import { moneroCurrencyPluginFactory } from 'edge-currency-monero'
+import { coinbasePlugin, coincapPlugin, currencyconverterapiPlugin, shapeshiftPlugin } from 'edge-exchange-plugins'
+import React, { PureComponent } from 'react'
+import { View } from 'react-native'
+
+import { makeCoreContext } from '../../util/makeContext.js'
+import EdgeAccountCallbackManager from './EdgeAccountCallbackManager.js'
+import EdgeContextCallbackManager from './EdgeContextCallbackManager.js'
+import EdgeWalletsCallbackManager from './EdgeWalletsCallbackManager.js'
+
+type Props = {
+  onLoad: (context: EdgeContext) => mixed,
+  onError: (error: any) => mixed
+}
+
+const pluginFactories: Array<EdgeCorePluginFactory> = [
+  // Exchanges:
+  coinbasePlugin,
+  shapeshiftPlugin,
+  coincapPlugin,
+  currencyconverterapiPlugin,
+  // Currencies:
+  bitcoincashCurrencyPluginFactory,
+  bitcoinCurrencyPluginFactory,
+  ethereumCurrencyPluginFactory,
+  eosCurrencyPluginFactory,
+  stellarCurrencyPluginFactory,
+  rippleCurrencyPluginFactory,
+  moneroCurrencyPluginFactory,
+  dashCurrencyPluginFactory,
+  litecoinCurrencyPluginFactory,
+  bitcoinsvCurrencyPluginFactory,
+  // eboostCurrencyPluginFactory,
+  // dogecoinCurrencyPluginFactory,
+  qtumCurrencyPluginFactory,
+  digibyteCurrencyPluginFactory,
+  zcoinCurrencyPluginFactory,
+  bitcoingoldCurrencyPluginFactory,
+  vertcoinCurrencyPluginFactory,
+  feathercoinCurrencyPluginFactory,
+  smartcashCurrencyPluginFactory,
+  groestlcoinCurrencyPluginFactory,
+  ufoCurrencyPluginFactory
+]
+
+export class EdgeCoreManager extends PureComponent<Props> {
+  componentDidMount () {
+    makeCoreContext(pluginFactories)
+      .then(this.props.onLoad)
+      .catch(this.props.onError)
+  }
+
+  render () {
+    return (
+      <View>
+        <EdgeContextCallbackManager />
+        <EdgeAccountCallbackManager />
+        <EdgeWalletsCallbackManager />
+      </View>
+    )
+  }
+}

--- a/src/components/core/EdgeWalletCallbackManager.js
+++ b/src/components/core/EdgeWalletCallbackManager.js
@@ -4,10 +4,10 @@ import type { EdgeCurrencyWallet, EdgeTransaction } from 'edge-core-js'
 import React from 'react'
 import { connect } from 'react-redux'
 
-import { newTransactionsRequest, refreshTransactionsRequest } from '../../../actions/TransactionListActions.js'
-import { refreshReceiveAddressRequest, refreshWallet, updateWalletLoadingProgress } from '../../../actions/WalletActions.js'
-import { isReceivedTransaction } from '../../../util/utils.js'
-import { checkPasswordRecovery } from '../../UI/components/PasswordRecoveryReminderModal/PasswordRecoveryReminderModalActions.js'
+import { newTransactionsRequest, refreshTransactionsRequest } from '../../actions/TransactionListActions.js'
+import { refreshReceiveAddressRequest, refreshWallet, updateWalletLoadingProgress } from '../../actions/WalletActions.js'
+import { checkPasswordRecovery } from '../../modules/UI/components/PasswordRecoveryReminderModal/PasswordRecoveryReminderModalActions.js'
+import { isReceivedTransaction } from '../../util/utils.js'
 
 type EdgeWalletCallbackManagerStateProps = {
   id: string,

--- a/src/components/core/EdgeWalletsCallbackManager.js
+++ b/src/components/core/EdgeWalletsCallbackManager.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-import type { State } from '../../ReduxTypes.js'
+import type { State } from '../../modules/ReduxTypes.js'
 import EdgeWalletCallbackManager from './EdgeWalletCallbackManager'
 
 type Props = {


### PR DESCRIPTION
This works towards our goal of having a coherent directory structure. It also lays the groundwork for moving the core into a webview, so it would be nice to get this in and tested while the rest of that project continues in parallel.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [*] Tested on small Android
- [*] n/a