### PR TITLE
William/upgrade webview

### DIFF
--- a/android/app/src/main/java/co/edgesecure/app/MainApplication.java
+++ b/android/app/src/main/java/co/edgesecure/app/MainApplication.java
@@ -1,6 +1,7 @@
 package co.edgesecure.app;
 
 import android.app.Application;
+import android.webkit.WebView;
 
 import com.facebook.react.ReactApplication;
 import com.reactnativecommunity.webview.RNCWebViewPackage;
@@ -109,5 +110,7 @@ public class MainApplication extends Application implements ReactApplication {
 
     BugsnagReactNative.start(this);
     SoLoader.init(this, /* native exopackage */ false);
+
+    WebView.setWebContentsDebuggingEnabled(true);
   }
 }

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "react-native-tcp": "git://github.com/Airbitz/react-native-tcp.git#c6af8f728fcbbae23d20c0211fd5b6c322f7a446",
     "react-native-udp": "^2.0.0",
     "react-native-vector-icons": "^6.1.0",
-    "react-native-webview": "https://github.com/react-native-community/react-native-webview#1f11f10",
+    "react-native-webview": "^3.1.3",
     "react-redux": "^5.0.5",
     "react-test-renderer": "^16.4.1",
     "readable-stream": "^1.0.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8453,9 +8453,10 @@ react-native-vector-icons@^6.1.0:
     prop-types "^15.6.2"
     yargs "^8.0.2"
 
-"react-native-webview@https://github.com/react-native-community/react-native-webview#1f11f10":
-  version "2.14.0"
-  resolved "https://github.com/react-native-community/react-native-webview#1f11f10a6968f859d8ad84c5d9d46b1d6731a0a8"
+react-native-webview@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-3.2.1.tgz#a51843699f700c8c02a9c7fb33f9db96bc401237"
+  integrity sha512-pVLYK8zI2YD66FoMD90yFC2l/jhQjpknv6Bs0ezYrXmyWxhUdoCLMqAWjbrVbyR/w4P0pCE1YtVvMadozfGe0w==
   dependencies:
     escape-string-regexp "^1.0.5"
     fbjs "^0.8.17"


### PR DESCRIPTION
The upstream react-native-webview project has solved some of the build issues we were encountering, so we can switch to the official NPM version instead of some weird branch.

Also, enable Chrome debugging for webview contents.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [x] n/a