### PR TITLE
Fix Smart Cash Currency Settings Crash

### DIFF
--- a/src/connectors/CurrencySettingsTitleConnector.js
+++ b/src/connectors/CurrencySettingsTitleConnector.js
@@ -4,11 +4,11 @@ import { connect } from 'react-redux'
 
 import { CurrencySettingsTitle } from '../components/common/CurrencySettingsTitle.js'
 import type { CurrencySettingsTitleOwnProps } from '../components/common/CurrencySettingsTitle.js'
+import { getCurrencyInfo } from '../modules/Core/selectors.js'
 import type { State } from '../modules/ReduxTypes.js'
-import { getPluginInfo } from '../modules/Settings/selectors.js'
 
 const mapStateToProps = (state: State, ownProps: CurrencySettingsTitleOwnProps) => {
-  const currencyInfo: EdgeCurrencyInfo = getPluginInfo(state, ownProps.pluginName)
+  const currencyInfo: EdgeCurrencyInfo = getCurrencyInfo(state, ownProps.pluginName.toLowerCase())
   return {
     logo: currencyInfo.symbolImage || ''
   }

--- a/src/connectors/scenes/CurrencySettingsConnector.js
+++ b/src/connectors/scenes/CurrencySettingsConnector.js
@@ -1,11 +1,12 @@
 // @flow
 
+import type { EdgeCurrencyInfo } from 'edge-core-js'
 import { connect } from 'react-redux'
 
 import { disableCustomNodes, enableCustomNodes, saveCustomNodesList, setDenominationKeyRequest } from '../../actions/SettingsActions'
 import CurrencySettings from '../../components/scenes/CurrencySettingsScene'
 import { CURRENCY_PLUGIN_NAMES } from '../../constants/indexConstants.js'
-import { getAccount } from '../../modules/Core/selectors.js'
+import { getAccount, getCurrencyInfo } from '../../modules/Core/selectors.js'
 import type { Dispatch, State } from '../../modules/ReduxTypes.js'
 import * as SETTINGS_SELECTORS from '../../modules/Settings/selectors'
 
@@ -18,8 +19,9 @@ const mapStateToProps = (state: State, ownProps) => {
   const userSettings = currencyPlugin.userSettings
   const electrumServers = userSettings ? userSettings.electrumServers : []
   const disableFetchingServers = userSettings ? userSettings.disableFetchingServers : false
+  const currencyInfo: EdgeCurrencyInfo = getCurrencyInfo(state, currencyPluginName)
   return {
-    logo: SETTINGS_SELECTORS.getPluginInfo(state, ownProps.pluginName).symbolImage,
+    logo: currencyInfo.symbolImage,
     denominations: SETTINGS_SELECTORS.getDenominations(state, ownProps.currencyCode),
     selectedDenominationKey: SETTINGS_SELECTORS.getDisplayDenominationKey(state, ownProps.currencyCode),
     electrumServers,

--- a/src/modules/Core/selectors.js
+++ b/src/modules/Core/selectors.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { EdgeCurrencyWallet } from 'edge-core-js'
+import type { EdgeCurrencyInfo, EdgeCurrencyWallet } from 'edge-core-js'
 
 import type { State } from '../ReduxTypes'
 import { getDefaultIsoFiat } from '../Settings/selectors.js'
@@ -38,6 +38,13 @@ export const getAccount = (state: State) => {
   const core = getCore(state)
   const account = core.account
   return account
+}
+
+export const getCurrencyInfo = (state: State, type: string): EdgeCurrencyInfo => {
+  const account = getAccount(state)
+  const currencyConfig = account.currencyConfig[type]
+  const currencyInfo = currencyConfig.currencyInfo
+  return currencyInfo
 }
 
 export const getUsername = (state: State) => {

--- a/src/modules/Settings/selectors.js
+++ b/src/modules/Settings/selectors.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { EdgeCurrencyInfo, EdgeDenomination } from 'edge-core-js'
+import type { EdgeDenomination } from 'edge-core-js'
 
 import { type CurrencySetting } from '../../reducers/scenes/SettingsReducer.js'
 import type { State } from '../ReduxTypes'
@@ -117,12 +117,6 @@ export const getPlugins = (state: State) => {
   const settings = getSettings(state)
   const plugins = settings.plugins
   return plugins
-}
-
-export const getPluginInfo = (state: State, type: string): EdgeCurrencyInfo => {
-  const plugins = getPlugins(state)
-  const currencyInfo: EdgeCurrencyInfo = plugins[type.toLowerCase()]
-  return currencyInfo
 }
 
 export const getSupportedWalletTypes = (state: State) => {


### PR DESCRIPTION
The purpose of this task is to prevent crashes in the Currency Settings area, caused by a missing currencyInfo in the settings Redux store.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/1102409942442732/f