### PR TITLE
Don't show loading bar when the transactions are already loaded

### DIFF
--- a/src/modules/UI/components/WiredProgressBar/WiredProgressBar.ui.js
+++ b/src/modules/UI/components/WiredProgressBar/WiredProgressBar.ui.js
@@ -24,13 +24,10 @@ export class ProgressBar extends PureComponent<ProgressBarProps, ProgressBarStat
 
   constructor (props: ProgressBarProps) {
     super(props)
+    this.animation = new Animated.Value(props.progress)
     this.state = {
-      isWalletProgressVisible: true
+      isWalletProgressVisible: props.progress !== 100
     }
-  }
-
-  UNSAFE_componentWillMount () {
-    this.animation = new Animated.Value(this.props.progress)
   }
 
   componentDidUpdate (prevProps: ProgressBarProps) {


### PR DESCRIPTION
Task: Add green loading bar to Tx list

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android