### PR TITLE
Add footer as padding for SearchResults

### DIFF
--- a/src/modules/UI/components/SearchResults/SearchResults.ui.js
+++ b/src/modules/UI/components/SearchResults/SearchResults.ui.js
@@ -67,6 +67,7 @@ export default class SearchResults extends Component<Props, State> {
           keyExtractor={this.props.keyExtractor}
           overScrollMode="never"
           keyboardShouldPersistTaps="handled"
+          ListFooterComponent={<View style={{ height: 50 }} />}
         />
       </View>
     )


### PR DESCRIPTION
This is to prevent situations where the search results dropdowns result in the last item being covered by the footer.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana: https://app.asana.com/0/361770107085503/918691428554538/f