### PR TITLE
Handle EOS account payment timeouts better

### DIFF
--- a/src/__tests__/createWalletReducer.test.js
+++ b/src/__tests__/createWalletReducer.test.js
@@ -21,7 +21,8 @@ test('initialState', () => {
     handleActivationInfo: {
       supportedCurrencies: {},
       activationCost: ''
-    }
+    },
+    walletAccountActivationQuoteError: ''
   }
   const actual = createWalletReducer(undefined, dummyAction)
 

--- a/src/__tests__/scenesReducer.test.js
+++ b/src/__tests__/scenesReducer.test.js
@@ -36,7 +36,8 @@ test('initialState', () => {
       handleActivationInfo: {
         supportedCurrencies: {},
         activationCost: ''
-      }
+      },
+      walletAccountActivationQuoteError: ''
     },
     dimensions: {
       keyboardHeight: 0

--- a/src/actions/WalletActions.js
+++ b/src/actions/WalletActions.js
@@ -110,10 +110,10 @@ export const refreshReceiveAddressRequest = (walletId: string) => (dispatch: Dis
   }
 }
 
-export const selectWallet = (walletId: string, currencyCode: string) => (dispatch: Dispatch, getState: GetState) => {
+export const selectWallet = (walletId: string, currencyCode: string, from?: string) => (dispatch: Dispatch, getState: GetState) => {
   if (currencyCode === 'EOS') {
     // EOS needs different path in case not activated yet
-    dispatch(selectEOSWallet(walletId, currencyCode))
+    dispatch(selectEOSWallet(walletId, currencyCode, from))
     return
   }
   const state = getState()
@@ -136,12 +136,12 @@ export const selectWallet = (walletId: string, currencyCode: string) => (dispatc
 }
 
 // check if the EOS wallet is activated (via public address blank string check) and route to activation scene(s)
-export const selectEOSWallet = (walletId: string, currencyCode: string) => (dispatch: Dispatch, getState: GetState) => {
+export const selectEOSWallet = (walletId: string, currencyCode: string, from?: string) => (dispatch: Dispatch, getState: GetState) => {
   const state = getState()
   const currentWalletId = state.ui.wallets.selectedWalletId
   const currentWalletCurrencyCode = state.ui.wallets.selectedCurrencyCode
   const guiWallet = UI_SELECTORS.getWallet(state, walletId)
-  if (walletId !== currentWalletId || currencyCode !== currentWalletCurrencyCode) {
+  if (walletId !== currentWalletId || currencyCode !== currentWalletCurrencyCode || from === Constants.WALLET_LIST_SCENE) {
     const { publicAddress } = guiWallet.receiveAddress
     if (publicAddress) {
       // already activated

--- a/src/components/common/FullWalletListRow.js
+++ b/src/components/common/FullWalletListRow.js
@@ -210,7 +210,7 @@ const mapStateToProps = (state: State, ownProps: FullWalletListRowLoadedOwnProps
   }
 }
 const mapDispatchToProps = dispatch => ({
-  selectWallet: (walletId: string, currencyCode): string => dispatch(selectWallet(walletId, currencyCode)),
+  selectWallet: (walletId: string, currencyCode): string => dispatch(selectWallet(walletId, currencyCode, Constants.WALLET_LIST_SCENE)),
   getEnabledTokensList: (walletId: string) => dispatch(getEnabledTokens(walletId))
 })
 

--- a/src/components/scenes/CreateWalletAccountSelectScene.js
+++ b/src/components/scenes/CreateWalletAccountSelectScene.js
@@ -41,7 +41,8 @@ export type CreateWalletAccountSelectStateProps = {
   activationCost: string,
   isCreatingWallet: boolean,
   paymentDenominationSymbol: string,
-  existingCoreWallet: EdgeCurrencyWallet
+  existingCoreWallet: EdgeCurrencyWallet,
+  walletAccountActivationQuoteError: string
 }
 
 export type CreateWalletAccountSelectOwnProps = {
@@ -56,7 +57,8 @@ export type CreateWalletAccountSelectDispatchProps = {
   createAccountBasedWallet: (string, string, string, boolean, boolean) => any,
   fetchAccountActivationInfo: string => void,
   createAccountTransaction: (string, string, string) => void,
-  fetchWalletAccountActivationPaymentInfo: (AccountPaymentParams, EdgeCurrencyWallet) => void
+  fetchWalletAccountActivationPaymentInfo: (AccountPaymentParams, EdgeCurrencyWallet) => void,
+  setWalletAccountActivationQuoteError: string => void
 }
 
 type Props = CreateWalletAccountSelectOwnProps & CreateWalletAccountSelectDispatchProps & CreateWalletAccountSelectStateProps
@@ -120,7 +122,8 @@ export class CreateWalletAccountSelect extends Component<Props, State> {
   }
 
   onSelectWallet = async (walletId: string, paymentCurrencyCode: string) => {
-    const { wallets, accountName, fetchWalletAccountActivationPaymentInfo } = this.props
+    const { wallets, accountName, fetchWalletAccountActivationPaymentInfo, setWalletAccountActivationQuoteError } = this.props
+    setWalletAccountActivationQuoteError('') // reset fetching quote error to falsy
     const paymentWallet = wallets[walletId]
     const walletName = paymentWallet.name
     this.setState({
@@ -224,7 +227,8 @@ export class CreateWalletAccountSelect extends Component<Props, State> {
   }
 
   render () {
-    const { supportedCurrencies, selectedWalletType, activationCost, wallets } = this.props
+    const { supportedCurrencies, selectedWalletType, activationCost, wallets, walletAccountActivationQuoteError } = this.props
+    const { walletId } = this.state
     const instructionSyntax = sprintf(
       s.strings.create_wallet_account_select_instructions_with_cost,
       selectedWalletType.currencyCode,
@@ -250,25 +254,27 @@ export class CreateWalletAccountSelect extends Component<Props, State> {
 
     return (
       <SafeAreaView>
-        <Gradient style={styles.scrollableGradient} />
-        <ScrollView>
-          <View style={styles.scrollableView}>
-            <Image source={logos['eos']} style={styles.currencyLogo} resizeMode={'cover'} />
-            <View style={styles.createWalletPromptArea}>
-              <Text style={styles.instructionalText}>{this.state.walletId ? confirmMessageSyntax : instructionSyntax}</Text>
+        <View style={styles.scene}>
+          <Gradient style={styles.scrollableGradient} />
+          <ScrollView>
+            <View style={styles.scrollableView}>
+              <Image source={logos['eos']} style={styles.currencyLogo} resizeMode={'cover'} />
+              <View style={styles.createWalletPromptArea}>
+                <Text style={styles.instructionalText}>{!walletId || walletAccountActivationQuoteError ? instructionSyntax : confirmMessageSyntax}</Text>
+              </View>
+              {!walletId || walletAccountActivationQuoteError ? this.renderSelectWallet() : this.renderPaymentReview()}
             </View>
-            {this.state.walletId ? this.renderPaymentReview() : this.renderSelectWallet()}
-          </View>
-          <View style={{ paddingBottom: 200 }} />
-        </ScrollView>
-        {this.state.isModalVisible && (
-          <WalletListModal
-            topDisplacement={Constants.TRANSACTIONLIST_WALLET_DIALOG_TOP}
-            type={Constants.FROM}
-            onSelectWallet={this.onSelectWallet}
-            wallets={walletsCopy}
-          />
-        )}
+            <View style={{ paddingBottom: 200 }} />
+          </ScrollView>
+          {this.state.isModalVisible && (
+            <WalletListModal
+              topDisplacement={Constants.TRANSACTIONLIST_WALLET_DIALOG_TOP}
+              type={Constants.FROM}
+              onSelectWallet={this.onSelectWallet}
+              wallets={walletsCopy}
+            />
+          )}
+        </View>
       </SafeAreaView>
     )
   }

--- a/src/connectors/scenes/CreateWalletAccountSelectConnector.js
+++ b/src/connectors/scenes/CreateWalletAccountSelectConnector.js
@@ -32,7 +32,7 @@ const mapStateToProps = (state: State, ownProps: CreateWalletAccountSelectOwnPro
   } else {
     paymentDenominationSymbol = ''
   }
-
+  const walletAccountActivationQuoteError = state.ui.scenes.createWallet.walletAccountActivationQuoteError
   return {
     paymentCurrencyCode: currencyCode,
     paymentAddress,
@@ -43,7 +43,8 @@ const mapStateToProps = (state: State, ownProps: CreateWalletAccountSelectOwnPro
     wallets: state.ui.wallets.byId,
     isCreatingWallet,
     paymentDenominationSymbol,
-    existingCoreWallet
+    existingCoreWallet,
+    walletAccountActivationQuoteError
   }
 }
 
@@ -54,7 +55,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   fetchWalletAccountActivationPaymentInfo: (paymentInfo: AccountPaymentParams, createdCoreWallet: EdgeCurrencyWallet) =>
     dispatch(fetchWalletAccountActivationPaymentInfo(paymentInfo, createdCoreWallet)),
   createAccountBasedWallet: (walletName: string, walletType: string, fiatCurrencyCode: string, popScene: boolean, selectWallet: boolean) =>
-    dispatch(createCurrencyWallet(walletName, walletType, fiatCurrencyCode, popScene, selectWallet))
+    dispatch(createCurrencyWallet(walletName, walletType, fiatCurrencyCode, popScene, selectWallet)),
+  setWalletAccountActivationQuoteError: message => dispatch({ type: 'WALLET_ACCOUNT_ACTIVATION_ESTIMATE_ERROR', data: message })
 })
 
 export const CreateWalletAccountSelectConnector = connect(

--- a/src/modules/Action.js
+++ b/src/modules/Action.js
@@ -245,3 +245,4 @@ export type Action =
         fee: string
       }
     }
+  | { type: 'WALLET_ACCOUNT_ACTIVATION_ESTIMATE_ERROR', data: string }

--- a/src/reducers/scenes/CreateWalletReducer.js
+++ b/src/reducers/scenes/CreateWalletReducer.js
@@ -24,7 +24,8 @@ export type CreateWalletState = {
   isCheckingHandleAvailability: boolean,
   handleAvailableStatus: HandleAvailableStatus,
   handleActivationInfo: HandleActivationInfo,
-  walletAccountActivationPaymentInfo: AccountActivationPaymentInfo
+  walletAccountActivationPaymentInfo: AccountActivationPaymentInfo,
+  walletAccountActivationQuoteError: string
 }
 
 const isCreatingWallet = (state = false, action: Action): boolean => {
@@ -101,10 +102,20 @@ const walletAccountActivationPaymentInfo = (state = initialActivationPaymentStat
   }
 }
 
+const walletAccountActivationQuoteError = (state: string = '', action: Action): string => {
+  switch (action.type) {
+    case 'WALLET_ACCOUNT_ACTIVATION_ESTIMATE_ERROR':
+      return action.data
+    default:
+      return state
+  }
+}
+
 export const createWallet: Reducer<CreateWalletState, Action> = combineReducers({
   isCreatingWallet,
   isCheckingHandleAvailability,
   handleAvailableStatus,
   handleActivationInfo,
-  walletAccountActivationPaymentInfo
+  walletAccountActivationPaymentInfo,
+  walletAccountActivationQuoteError
 })


### PR DESCRIPTION
The purpose of this task is to get the EOS activation quote fetch network timeout duration reduced and properly handle the case in the UI (ie convey the issue to user and let them re-pick a wallet).

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1107900607511580/f