### PR TITLE
Fix object iteration during initializeAccount

### DIFF
--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -153,8 +153,9 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
         accountInitObject.denominationKeys.push({ currencyCode: token.currencyCode, denominationKey: token.multiplier })
       })
     }
-
-    for (const key of accountInitObject) {
+    console.log('in between loops')
+    for (const key in accountInitObject) {
+      console.log('inside key of accountInitObject with key: ', key)
       if (accountInitObject[key]) {
         // avoid trying to look at property 'denomination' of undefined
         const typeofDenomination = typeof accountInitObject[key].denomination
@@ -163,7 +164,7 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
         }
       }
     }
-
+    console.log('past accountInitObject loop')
     const loadedLocalSettings = await getLocalSettings(account)
     const mergedLocalSettings = mergeSettings(loadedLocalSettings, LOCAL_ACCOUNT_DEFAULTS, LOCAL_ACCOUNT_TYPES)
     if (mergedLocalSettings.isOverWriteNeeded) {

--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -153,9 +153,7 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
         accountInitObject.denominationKeys.push({ currencyCode: token.currencyCode, denominationKey: token.multiplier })
       })
     }
-    console.log('in between loops')
     for (const key in accountInitObject) {
-      console.log('inside key of accountInitObject with key: ', key)
       if (accountInitObject[key]) {
         // avoid trying to look at property 'denomination' of undefined
         const typeofDenomination = typeof accountInitObject[key].denomination
@@ -164,7 +162,6 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: Object) => 
         }
       }
     }
-    console.log('past accountInitObject loop')
     const loadedLocalSettings = await getLocalSettings(account)
     const mergedLocalSettings = mergeSettings(loadedLocalSettings, LOCAL_ACCOUNT_DEFAULTS, LOCAL_ACCOUNT_TYPES)
     if (mergedLocalSettings.isOverWriteNeeded) {


### PR DESCRIPTION
Likely an error with one of my recent commits. Iterating over an object, not an array.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a