### PR TITLE
Fix Android EOS crash, variable not boolean

### DIFF
--- a/src/components/scenes/CreateWalletAccountSetupScene.js
+++ b/src/components/scenes/CreateWalletAccountSetupScene.js
@@ -119,7 +119,7 @@ export class CreateWalletAccountSetup extends Component<Props, State> {
       chooseHandleErrorMessage = s.strings.create_wallet_account_unknown_error
     }
     const { accountHandle } = this.state
-    const showButton = accountHandle && isHandleAvailable && !isCheckingHandleAvailability
+    const showButton = !!accountHandle && isHandleAvailable && !isCheckingHandleAvailability
     return (
       <SafeAreaView>
         <Gradient style={styles.scrollableGradient} />


### PR DESCRIPTION
This task is to fix a bug on Android where a string literal being evaluated within JSX (but not within a <Text> tag) was causing a crash. 

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1107487776558543/f