### PR TITLE
Fix EOS crash on logout

### DIFF
--- a/src/actions/CreateWalletActions.js
+++ b/src/actions/CreateWalletActions.js
@@ -185,7 +185,7 @@ export const createAccountTransaction = (createdWalletId: string, accountName: s
             notes: sprintf(s.strings.create_wallet_account_metadata_notes, createdWalletCurrencyCode, createdWalletCurrencyCode, 'support@edge.app')
           }
           paymentWallet.saveTxMetadata(edgeTransaction.txid, currencyCode, edgeMetadata).then(() => {
-            Actions[Constants.WALLET_LIST_SCENE]()
+            Actions.popTo(Constants.WALLET_LIST_SCENE)
             setTimeout(() => {
               Alert.alert(s.strings.create_wallet_account_payment_sent_title, s.strings.create_wallet_account_payment_sent_message)
             }, 750)


### PR DESCRIPTION
The purpose of this task is to fix the crash that happens during logout after completing an EOS activation payment. This was due to the scene not being unmounted after a successful payment.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1107487776558543/f