### PR TITLE
Fix EOS activation not detected

### DIFF
--- a/src/actions/WalletActions.js
+++ b/src/actions/WalletActions.js
@@ -11,6 +11,7 @@ import * as Constants from '../constants/indexConstants.js'
 import s from '../locales/strings.js'
 import * as SETTINGS_API from '../modules/Core/Account/settings.js'
 import * as CORE_SELECTORS from '../modules/Core/selectors.js'
+import { updateWalletsRequest } from '../modules/Core/Wallets/action.js'
 import * as WALLET_API from '../modules/Core/Wallets/api.js'
 import { updateExchangeRates } from '../modules/ExchangeRates/action.js'
 import type { Dispatch, GetState } from '../modules/ReduxTypes'
@@ -143,6 +144,12 @@ export const selectEOSWallet = (walletId: string, currencyCode: string, from?: s
   const guiWallet = UI_SELECTORS.getWallet(state, walletId)
   if (walletId !== currentWalletId || currencyCode !== currentWalletCurrencyCode || from === Constants.WALLET_LIST_SCENE) {
     const { publicAddress } = guiWallet.receiveAddress
+    if (!publicAddress) {
+      // Update all wallets' addresses. Hopefully gets the updated address for the next time
+      // We enter the EOS wallet
+      dispatch(updateWalletsRequest())
+    }
+
     if (publicAddress) {
       // already activated
       dispatch({


### PR DESCRIPTION
Refresh all wallet addresses if we enter an EOS wallet that is not activated. This makes sure we call getReceiveAddress on all wallets to refresh their addresses so at least the following time we enter the wallet, we'll have up to date addresses which we use to detect activation.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a