### PR TITLE
Remove unactivated EOS from WalletListModal

### DIFF
--- a/src/__tests__/Request.test.js
+++ b/src/__tests__/Request.test.js
@@ -21,7 +21,8 @@ describe('Request', () => {
       receiveAddress: null,
       secondaryCurrencyInfo: null,
       showToWalletModal: null,
-      useLegacyAddress: null
+      useLegacyAddress: null,
+      wallets: {}
     }
     const actual = renderer.render(<Request {...props} />)
 
@@ -42,7 +43,8 @@ describe('Request', () => {
       secondaryCurrencyInfo: {},
       showToWalletModal: false,
       useLegacyAddress: false,
-      currentScene: 'request'
+      currentScene: 'request',
+      wallets: {}
     }
     const actual = renderer.render(<Request {...props} />)
 

--- a/src/__tests__/Scan.ui.test.js
+++ b/src/__tests__/Scan.ui.test.js
@@ -17,6 +17,7 @@ describe('Scan component', () => {
       showToWalletModal: false,
       deepLinkPending: false,
       deepLinkUri: null,
+      wallets: {},
       qrCodeScanned: jest.fn(),
       parseScannedUri: jest.fn(),
       markAddressDeepLinkDone: jest.fn(),
@@ -45,7 +46,8 @@ describe('Scan component', () => {
       toggleEnableTorch: jest.fn(),
       toggleAddressModal: jest.fn(),
       toggleScanToWalletListModal: jest.fn(),
-      onSelectWallet: jest.fn()
+      onSelectWallet: jest.fn(),
+      wallets: {}
     }
     const actual = renderer.render(<Scan {...props} />)
 

--- a/src/components/scenes/CryptoExchangeScene.js
+++ b/src/components/scenes/CryptoExchangeScene.js
@@ -300,11 +300,11 @@ export class CryptoExchangeScene extends Component<Props, State> {
       }
     }
 
-    const walletsCopy = { ...wallets }
-    for (const id in walletsCopy) {
-      const wallet = walletsCopy[id]
-      if (!wallet.receiveAddress || !wallet.receiveAddress.publicAddress) {
-        delete walletsCopy[id]
+    const allowedWallets = {}
+    for (const id in wallets) {
+      const wallet = wallets[id]
+      if (wallet.receiveAddress && wallet.receiveAddress.publicAddress) {
+        allowedWallets[id] = wallets[id]
       }
     }
     if (this.props.showWalletSelectModal) {
@@ -315,7 +315,7 @@ export class CryptoExchangeScene extends Component<Props, State> {
           type={Constants.CRYPTO_EXCHANGE}
           whichWallet={whichWallet}
           excludedCurrencyCode={excludedCurrencyCode}
-          wallets={walletsCopy}
+          wallets={allowedWallets}
         />
       )
     }

--- a/src/components/scenes/RequestScene.js
+++ b/src/components/scenes/RequestScene.js
@@ -40,7 +40,8 @@ export type RequestStateProps = {
   legacyAddress: string,
   secondaryCurrencyInfo: GuiCurrencyInfo,
   showToWalletModal: boolean,
-  useLegacyAddress: boolean
+  useLegacyAddress: boolean,
+  wallets: { [string]: GuiWallet }
 }
 export type RequestLoadingProps = {
   edgeWallet: null,
@@ -225,8 +226,15 @@ export class Request extends Component<Props, State> {
     }
 
     const color = 'white'
-    const { primaryCurrencyInfo, secondaryCurrencyInfo, exchangeSecondaryToPrimaryRatio, onSelectWallet } = this.props
+    const { primaryCurrencyInfo, secondaryCurrencyInfo, exchangeSecondaryToPrimaryRatio, onSelectWallet, wallets } = this.props
     const requestAddress = this.props.useLegacyAddress ? this.state.legacyAddress : this.state.publicAddress
+    const allowedWallets = {}
+    for (const id in wallets) {
+      const wallet = wallets[id]
+      if (wallet.receiveAddress && wallet.receiveAddress.publicAddress) {
+        allowedWallets[id] = wallets[id]
+      }
+    }
 
     return (
       <SafeAreaView>
@@ -266,7 +274,12 @@ export class Request extends Component<Props, State> {
           </View>
 
           {this.props.showToWalletModal && (
-            <WalletListModal topDisplacement={Constants.REQUEST_WALLET_DIALOG_TOP} type={Constants.TO} onSelectWallet={onSelectWallet} />
+            <WalletListModal
+              wallets={allowedWallets}
+              topDisplacement={Constants.REQUEST_WALLET_DIALOG_TOP}
+              type={Constants.TO}
+              onSelectWallet={onSelectWallet}
+            />
           )}
         </Gradient>
       </SafeAreaView>

--- a/src/components/scenes/ScanScene.js
+++ b/src/components/scenes/ScanScene.js
@@ -23,6 +23,7 @@ import Gradient from '../../modules/UI/components/Gradient/Gradient.ui'
 import SafeAreaView from '../../modules/UI/components/SafeAreaView/index'
 import WalletListModal from '../../modules/UI/components/WalletListModal/WalletListModalConnector'
 import styles, { styles as styleRaw } from '../../styles/scenes/ScaneStyle'
+import { type GuiWallet } from '../../types.js'
 
 type Props = {
   cameraPermission: PermissionStatus,
@@ -37,7 +38,8 @@ type Props = {
   toggleAddressModal: () => void,
   toggleScanToWalletListModal: () => void,
   onSelectWallet: (string, string) => void,
-  markAddressDeepLinkDone: () => any
+  markAddressDeepLinkDone: () => any,
+  wallets: { [string]: GuiWallet }
 }
 
 const HEADER_TEXT = s.strings.send_scan_header_text
@@ -70,8 +72,14 @@ export class Scan extends Component<Props> {
   }
 
   render () {
-    const { onSelectWallet } = this.props
-
+    const { onSelectWallet, wallets } = this.props
+    const allowedWallets = {}
+    for (const id in wallets) {
+      const wallet = wallets[id]
+      if (wallet.receiveAddress && wallet.receiveAddress.publicAddress) {
+        allowedWallets[id] = wallets[id]
+      }
+    }
     return (
       <SafeAreaView>
         <View style={{ flex: 1 }}>
@@ -116,7 +124,12 @@ export class Scan extends Component<Props> {
             <ABAlert />
           </View>
           {this.props.showToWalletModal && (
-            <WalletListModal topDisplacement={Constants.SCAN_WALLET_DIALOG_TOP} type={Constants.FROM} onSelectWallet={onSelectWallet} />
+            <WalletListModal
+              wallets={allowedWallets}
+              topDisplacement={Constants.SCAN_WALLET_DIALOG_TOP}
+              type={Constants.FROM}
+              onSelectWallet={onSelectWallet}
+            />
           )}
         </View>
         <SecondaryModal />

--- a/src/connectors/scenes/RequestConnector.js
+++ b/src/connectors/scenes/RequestConnector.js
@@ -16,6 +16,7 @@ import { getDenomFromIsoCode } from '../../util/utils'
 const mapStateToProps = (state: State): RequestStateProps | RequestLoadingProps => {
   const guiWallet: GuiWallet = UI_SELECTORS.getSelectedWallet(state)
   const currencyCode: string = UI_SELECTORS.getSelectedCurrencyCode(state)
+
   if (!guiWallet || !currencyCode) {
     return {
       currencyCode: null,
@@ -29,7 +30,8 @@ const mapStateToProps = (state: State): RequestStateProps | RequestLoadingProps 
       publicAddress: '',
       legacyAddress: '',
       useLegacyAddress: null,
-      currentScene: state.ui.scenes.currentScene
+      currentScene: state.ui.scenes.currentScene,
+      wallets: state.ui.wallets.byId
     }
   }
 
@@ -69,7 +71,8 @@ const mapStateToProps = (state: State): RequestStateProps | RequestLoadingProps 
     secondaryCurrencyInfo,
     showToWalletModal: state.ui.scenes.walletListModal.walletListModalVisible,
     useLegacyAddress: state.ui.scenes.requestType.useLegacyAddress,
-    currentScene: state.ui.scenes.currentScene
+    currentScene: state.ui.scenes.currentScene,
+    wallets: state.ui.wallets.byId
   }
 }
 const mapDispatchToProps = (dispatch: Dispatch): RequestDispatchProps => ({

--- a/src/connectors/scenes/ScanConnector.js
+++ b/src/connectors/scenes/ScanConnector.js
@@ -14,7 +14,8 @@ const mapStateToProps = (state: State) => ({
   scanEnabled: state.ui.scenes.scan.scanEnabled,
   showToWalletModal: state.ui.scenes.walletListModal.walletListModalVisible,
   deepLinkPending: state.core.deepLinking.deepLinkPending,
-  deepLinkUri: state.core.deepLinking.addressDeepLinkData.uri
+  deepLinkUri: state.core.deepLinking.addressDeepLinkData.uri,
+  wallets: state.ui.wallets.byId
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({


### PR DESCRIPTION
The purpose of this task is to omit unactivated wallets (EOS) from dropdowns for requesting and sending.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1108931850293728/f