### PR TITLE
Get both defaultFiat and isoDefaultFiat to both change on settings change

### DIFF
--- a/src/modules/Core/Account/settings.js
+++ b/src/modules/Core/Account/settings.js
@@ -178,7 +178,7 @@ export const setAutoLogoutTimeInSecondsRequest = (account: EdgeAccount, autoLogo
 
 export const setDefaultFiatRequest = (account: EdgeAccount, defaultFiat: string) =>
   getSyncedSettings(account).then(settings => {
-    const updatedSettings = updateSettings(settings, { defaultFiat })
+    const updatedSettings = updateSettings(settings, { defaultFiat, defaultIsoFiat: `iso:${defaultFiat}` })
     return setSyncedSettings(account, updatedSettings)
   })
 

--- a/src/modules/Settings/selectors.js
+++ b/src/modules/Settings/selectors.js
@@ -178,7 +178,7 @@ export const getAutoLogoutTimeInMinutes = (state: State) => {
 export const getDefaultFiat = (state: State) => {
   const settings = getSettings(state)
   const defaultFiat: string = settings.defaultFiat
-  return defaultFiat
+  return `iso:${defaultFiat}`
 }
 
 export const getDefaultIsoFiat = (state: State) => {

--- a/src/modules/Settings/selectors.js
+++ b/src/modules/Settings/selectors.js
@@ -177,8 +177,9 @@ export const getAutoLogoutTimeInMinutes = (state: State) => {
 
 export const getDefaultFiat = (state: State) => {
   const settings = getSettings(state)
-  const defaultFiat: string = settings.defaultFiat
-  return `iso:${defaultFiat}`
+  const defaultIsoFiat: string = settings.defaultIsoFiat
+  const defaultFiat = defaultIsoFiat.replace('iso:', '')
+  return defaultFiat
 }
 
 export const getDefaultIsoFiat = (state: State) => {


### PR DESCRIPTION
The purpose of this task is to fix the non-persistence of defaultFiat setting

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1108902637749922/f