### PR TITLE
Include blank txList footer on Android

### DIFF
--- a/src/components/scenes/TransactionListScene.js
+++ b/src/components/scenes/TransactionListScene.js
@@ -160,6 +160,7 @@ export class TransactionList extends Component<Props, State> {
                 <FlatList
                   ListEmptyComponent={this.renderBuyCrypto()}
                   ListHeaderComponent={this.currentRenderBalanceBox()}
+                  ListFooterComponent={<View style={{ height: isAndroid ? 50 : 0 }} />}
                   style={styles.transactionsScrollWrap}
                   data={txs}
                   renderItem={this.renderTx}


### PR DESCRIPTION
The purpose of this task is to fix the cut-off occurring on Android at the bottom of the txList.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/1110495445154459/f