### PR TITLE
Fix transaction list infinite spinner on empty wallets

### DIFF
--- a/src/actions/TransactionListActions.js
+++ b/src/actions/TransactionListActions.js
@@ -137,8 +137,11 @@ const getAndMergeTransactions = async (state: State, dispatch: Dispatch, walletI
       }
     }
     const transactionCount = transactionsWithKeys.length
-    // $FlowFixMe
-    const lastUnfilteredIndex = transactionsWithKeys[transactionCount - 1].otherParams.unfilteredIndex
+    let lastUnfilteredIndex = 0
+    if (transactionCount) {
+      // $FlowFixMe
+      lastUnfilteredIndex = transactionsWithKeys[transactionCount - 1].otherParams.unfilteredIndex
+    }
     dispatch(
       // $FlowFixMe
       updateTransactions({


### PR DESCRIPTION
* Set lastUnfilteredIndex to 0 if we have no transactions to prevent throw

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a