### PR TITLE
fix wallet spinner. tie to redux.

### DIFF
--- a/src/__tests__/__snapshots__/cryptoExchangeReducer.test.js.snap
+++ b/src/__tests__/__snapshots__/cryptoExchangeReducer.test.js.snap
@@ -4,6 +4,7 @@ exports[`initialState 1`] = `
 Object {
   "calculatingMax": false,
   "changeWallet": "none",
+  "creatingWallet": false,
   "fee": 0,
   "forceUpdateGuiCounter": 0,
   "fromBalanceMessage": "",

--- a/src/components/scenes/CryptoExchangeScene.js
+++ b/src/components/scenes/CryptoExchangeScene.js
@@ -59,7 +59,8 @@ export type CryptoExchangeSceneComponentStateProps = {
   wallets: { [string]: GuiWallet },
   totalWallets: number,
   supportedWalletTypes: Array<Object>,
-  state: State
+  state: State,
+  creatingWallet: boolean
 }
 
 export type CryptoExchangeSceneComponentDispatchProps = {
@@ -77,8 +78,7 @@ type LocalState = {
   whichWalletFocus: string, // Which wallet FlipInput was last focused and edited
   fromExchangeAmount: string,
   forceUpdateGuiCounter: number,
-  toExchangeAmount: string,
-  isCreatingWallet: boolean
+  toExchangeAmount: string
 }
 
 export class CryptoExchangeScene extends Component<Props, LocalState> {
@@ -93,8 +93,7 @@ export class CryptoExchangeScene extends Component<Props, LocalState> {
       whichWalletFocus: Constants.FROM,
       forceUpdateGuiCounter: 0,
       fromExchangeAmount: '',
-      toExchangeAmount: '',
-      isCreatingWallet: false
+      toExchangeAmount: ''
     }
     this.state = newState
     slowlog(this, /.*/, global.slowlogOptions)
@@ -113,11 +112,7 @@ export class CryptoExchangeScene extends Component<Props, LocalState> {
         console.log('nav: ', response)
       })
     }
-    if (nextProps.totalWallets > this.props.totalWallets) {
-      this.setState({
-        isCreatingWallet: false
-      })
-    }
+
     if (this.state.forceUpdateGuiCounter !== nextProps.forceUpdateGuiCounter) {
       this.setState({
         fromExchangeAmount: nextProps.fromExchangeAmount,
@@ -206,7 +201,7 @@ export class CryptoExchangeScene extends Component<Props, LocalState> {
               launchWalletSelector={this.launchToWalletSelector}
               onCryptoExchangeAmountChanged={this.toAmountChanged}
               isFocused={isToFocused}
-              isThinking={this.state.isCreatingWallet}
+              isThinking={this.props.creatingWallet}
               focusMe={this.focusToWallet}
             />
             <View style={style.shim} />
@@ -323,7 +318,7 @@ export class CryptoExchangeScene extends Component<Props, LocalState> {
     const allowedWallets = []
     for (const id in wallets) {
       const wallet = wallets[id]
-      if (excludedCurrencyCode !== wallet.currencyCode) {
+      if (excludedCurrencyCode !== wallet.currencyCode && wallet.currencyCode !== 'ETH') {
         walletCurrencyCodes.push(wallet.currencyCode)
         if (wallet.receiveAddress && wallet.receiveAddress.publicAddress) {
           allowedWallets.push(wallets[id])
@@ -351,9 +346,6 @@ export class CryptoExchangeScene extends Component<Props, LocalState> {
           onSelectWallet(response.id, response.currencyCode)
           return
         }
-        this.setState({
-          isCreatingWallet: true
-        })
         this.props.createCurrencyWallet(response.value, response.currencyCode)
       }
     })

--- a/src/components/scenes/CryptoExchangeScene.js
+++ b/src/components/scenes/CryptoExchangeScene.js
@@ -318,7 +318,7 @@ export class CryptoExchangeScene extends Component<Props, LocalState> {
     const allowedWallets = []
     for (const id in wallets) {
       const wallet = wallets[id]
-      if (excludedCurrencyCode !== wallet.currencyCode && wallet.currencyCode !== 'ETH') {
+      if (excludedCurrencyCode !== wallet.currencyCode) {
         walletCurrencyCodes.push(wallet.currencyCode)
         if (wallet.receiveAddress && wallet.receiveAddress.publicAddress) {
           allowedWallets.push(wallets[id])

--- a/src/connectors/scenes/CryptoExchangeSceneConnector.js
+++ b/src/connectors/scenes/CryptoExchangeSceneConnector.js
@@ -57,7 +57,7 @@ export const mapStateToProps = (state: State): CryptoExchangeSceneComponentState
   const showKYCAlert = state.cryptoExchange.showKYCAlert
   const wallets = state.ui.wallets.byId
   const totalWallets = Object.keys(wallets).length
-
+  const creatingWallet = state.cryptoExchange.creatingWallet
   return {
     fromWallet: fromWallet || emptyGuiWallet,
     fromExchangeAmount,
@@ -86,7 +86,8 @@ export const mapStateToProps = (state: State): CryptoExchangeSceneComponentState
     wallets,
     totalWallets,
     supportedWalletTypes,
-    state
+    state,
+    creatingWallet
   }
 }
 

--- a/src/reducers/CryptoExchangeReducer.js
+++ b/src/reducers/CryptoExchangeReducer.js
@@ -36,7 +36,8 @@ export type CryptoExchangeState = {
   quoteExpireDate: Date | null,
   quote: EdgeSwapQuote | null,
   showKYCAlert: boolean,
-  pluginCompleteKYC: string | null
+  pluginCompleteKYC: string | null,
+  creatingWallet: boolean
 }
 
 const dummyCurrencyInfo: GuiCurrencyInfo = {
@@ -82,12 +83,22 @@ const initialState = {
   quoteExpireDate: null,
   quote: null,
   showKYCAlert: false,
-  pluginCompleteKYC: null
+  pluginCompleteKYC: null,
+  creatingWallet: false
 }
 
 function cryptoExchangeInner (state = initialState, action: Action): CryptoExchangeState {
   let forceUpdateGuiCounter
   switch (action.type) {
+    case 'UI/WALLETS/CREATE_WALLET_START': {
+      return { ...state, creatingWallet: true }
+    }
+    case 'UI/WALLETS/CREATE_WALLET_SUCCESS': {
+      return { ...state, creatingWallet: false }
+    }
+    case 'UI/WALLETS/CREATE_WALLET_FAILURE': {
+      return { ...state, creatingWallet: false }
+    }
     case 'ON_KYC_TOKEN_SET': {
       return { ...state, showKYCAlert: false }
     }


### PR DESCRIPTION
Fixes P): Wallet Selector (exchange screen) - If a create wallet fails, the wallet selector button gets stuck spinning indefinitely
https://app.asana.com/0/361770107085503/1111016622465604

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a