### PR TITLE
Fix EOS nativeAmount tx error

### DIFF
--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -119,8 +119,12 @@ export const sendConfirmationUpdateTx = (guiMakeSpendInfo: GuiMakeSpendInfo | Ed
   dispatch(newSpendInfo(spendInfo, authRequired))
 
   await makeSpend(edgeWallet, spendInfo)
-    .then(edgeTransaction => dispatch(updateTransaction(edgeTransaction, guiMakeSpendInfoClone, forceUpdateGui, null)))
-    .catch(e => dispatch(updateTransaction(null, guiMakeSpendInfoClone, forceUpdateGui, e)))
+    .then(edgeTransaction => {
+      return dispatch(updateTransaction(edgeTransaction, guiMakeSpendInfoClone, forceUpdateGui, null))
+    })
+    .catch(e => {
+      return dispatch(updateTransaction(null, guiMakeSpendInfoClone, forceUpdateGui, e))
+    })
 }
 
 export const updateMaxSpend = () => (dispatch: Dispatch, getState: GetState) => {

--- a/src/components/scenes/SendConfirmationScene.js
+++ b/src/components/scenes/SendConfirmationScene.js
@@ -327,7 +327,9 @@ export class SendConfirmation extends Component<Props, State> {
   }
 
   onSlideToConfirm = () => {
-    this.props.signBroadcastAndSave(this.state.nativeAmount, this.state.exchangeAmount, this.props.fiatPerCrypto.toString())
+    const { nativeAmount, signBroadcastAndSave, fiatPerCrypto } = this.props
+    const { exchangeAmount } = this.state
+    signBroadcastAndSave(nativeAmount, exchangeAmount, fiatPerCrypto.toString())
   }
 
   networkFeeSyntax = () => {


### PR DESCRIPTION
The purpose of this task is to fix the transaction error that occurs while paying for EOS activation. The fix was to fix a regression by passing the `props` (not `state`) version of `nativeAmount` to the `signBroadcastAndSave` action. We are able to keep `exchangeAmount` as-is because it is only used for updating the displayed fiat amount on SendConfirmation (which the app should route away from on success, anyway).

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/1111288373353711/f