### PR TITLE
Fix SendConf Make Spend Issue

### DIFF
--- a/src/__tests__/__snapshots__/sendConfirmation.test.js.snap
+++ b/src/__tests__/__snapshots__/sendConfirmation.test.js.snap
@@ -244,7 +244,6 @@ exports[`SendConfirmation should render with destination 1`] = `
       >
         <ABSlider
           forceUpdateGuiCounter={0}
-          onSlidingComplete={[Function]}
           parentStyle={
             Object {
               "width": 379.2359154929577,
@@ -489,7 +488,6 @@ exports[`SendConfirmation should render with standard props 1`] = `
       >
         <ABSlider
           forceUpdateGuiCounter={0}
-          onSlidingComplete={[Function]}
           parentStyle={
             Object {
               "width": 379.2359154929577,
@@ -751,7 +749,6 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
       >
         <ABSlider
           forceUpdateGuiCounter={0}
-          onSlidingComplete={[Function]}
           parentStyle={
             Object {
               "width": 379.2359154929577,
@@ -1017,7 +1014,6 @@ exports[`SendConfirmation should render with unique identifier button with "ADD"
       >
         <ABSlider
           forceUpdateGuiCounter={0}
-          onSlidingComplete={[Function]}
           parentStyle={
             Object {
               "width": 379.2359154929577,

--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -105,7 +105,7 @@ export const paymentProtocolUriReceived = ({ paymentProtocolURL }: EdgePaymentPr
     })
 }
 
-export const sendConfirmationUpdateTx = (guiMakeSpendInfo: GuiMakeSpendInfo | EdgeParsedUri, forceUpdateGui?: boolean = true) => (
+export const sendConfirmationUpdateTx = (guiMakeSpendInfo: GuiMakeSpendInfo | EdgeParsedUri, forceUpdateGui?: boolean = true) => async (
   dispatch: Dispatch,
   getState: GetState
 ) => {

--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -58,14 +58,14 @@ export const newPin = (pin: string) => ({
   data: { pin }
 })
 
-export const updateAmount = (nativeAmount: string, exchangeAmount: string, fiatPerCrypto: string, forceUpdateGui?: boolean = false) => async (
+export const updateAmount = (nativeAmount: string, exchangeAmount: string, fiatPerCrypto: string, forceUpdateGui?: boolean = false) => (
   dispatch: Dispatch,
   getState: GetState
 ) => {
   const amountFiatString: string = bns.mul(exchangeAmount, fiatPerCrypto)
   const amountFiat: number = parseFloat(amountFiatString)
   const metadata: EdgeMetadata = { amountFiat }
-  await dispatch(sendConfirmationUpdateTx({ nativeAmount, metadata }, forceUpdateGui))
+  dispatch(sendConfirmationUpdateTx({ nativeAmount, metadata }, forceUpdateGui))
 }
 
 type EdgePaymentProtocolUri = EdgeParsedUri & { paymentProtocolURL: string }
@@ -105,7 +105,7 @@ export const paymentProtocolUriReceived = ({ paymentProtocolURL }: EdgePaymentPr
     })
 }
 
-export const sendConfirmationUpdateTx = (guiMakeSpendInfo: GuiMakeSpendInfo | EdgeParsedUri, forceUpdateGui?: boolean = true) => async (
+export const sendConfirmationUpdateTx = (guiMakeSpendInfo: GuiMakeSpendInfo | EdgeParsedUri, forceUpdateGui?: boolean = true) => (
   dispatch: Dispatch,
   getState: GetState
 ) => {
@@ -156,11 +156,7 @@ export const updateMaxSpend = () => (dispatch: Dispatch, getState: GetState) => 
     .catch(e => console.log(e))
 }
 
-export const signBroadcastAndSave = (nativeAmount: string, exchangeAmountArg: string, fiatPerCryptoArg: string) => async (
-  dispatch: Dispatch,
-  getState: GetState
-) => {
-  await dispatch(updateAmount(nativeAmount, exchangeAmountArg, fiatPerCryptoArg))
+export const signBroadcastAndSave = () => async (dispatch: Dispatch, getState: GetState) => {
   const state = getState()
   const account = getAccount(state)
   const selectedWalletId = getSelectedWalletId(state)

--- a/src/components/scenes/PluginViewScene.js
+++ b/src/components/scenes/PluginViewScene.js
@@ -34,7 +34,7 @@ import { THEME, colors } from '../../theme/variables/airbitz.js'
 const BACK = s.strings.title_back
 
 type PluginListProps = {
-  developerModeOn: boolean,
+  developerModeOn: boolean
 }
 
 type PluginListState = {

--- a/src/components/scenes/SendConfirmationScene.js
+++ b/src/components/scenes/SendConfirmationScene.js
@@ -2,7 +2,7 @@
 
 import { bns } from 'biggystring'
 import { Scene } from 'edge-components'
-import type { EdgeDenomination, EdgeMetadata } from 'edge-core-js'
+import type { EdgeCurrencyWallet, EdgeDenomination, EdgeMetadata, EdgeSpendInfo, EdgeTransaction } from 'edge-core-js'
 import React, { Component } from 'react'
 import { TouchableOpacity, View } from 'react-native'
 import slowlog from 'react-native-slowlog'
@@ -12,6 +12,7 @@ import { UniqueIdentifierModalConnect as UniqueIdentifierModal } from '../../con
 import { getSpecialCurrencyInfo } from '../../constants/indexConstants.js'
 import { intl } from '../../locales/intl'
 import s from '../../locales/strings.js'
+import { makeSpend } from '../../modules/Core/Wallets/api.js'
 import ExchangeRate from '../../modules/UI/components/ExchangeRate/index.js'
 import { ExchangedFlipInput } from '../../modules/UI/components/FlipInput/ExchangedFlipInput2.js'
 import type { ExchangedFlipInputAmounts } from '../../modules/UI/components/FlipInput/ExchangedFlipInput2.js'
@@ -21,8 +22,9 @@ import { PinInput } from '../../modules/UI/components/PinInput/PinInput.ui.js'
 import Recipient from '../../modules/UI/components/Recipient/index.js'
 import SafeAreaView from '../../modules/UI/components/SafeAreaView/index'
 import ABSlider from '../../modules/UI/components/Slider/index.js'
+import { type AuthType, getSpendInfoWithoutState } from '../../modules/UI/scenes/SendConfirmation/selectors'
 import { convertCurrencyFromExchangeRates } from '../../modules/UI/selectors.js'
-import { type GuiMakeSpendInfo } from '../../reducers/scenes/SendConfirmationReducer.js'
+import { type GuiMakeSpendInfo, type SendConfirmationState } from '../../reducers/scenes/SendConfirmationReducer.js'
 import styles, { rawStyles } from '../../styles/scenes/SendConfirmationStyle.js'
 import type { GuiCurrencyInfo, GuiDenomination } from '../../types'
 import { convertNativeToDisplay, convertNativeToExchange, decimalOrZero, getDenomFromIsoCode } from '../../util/utils.js'
@@ -54,7 +56,10 @@ export type SendConfirmationStateProps = {
   isEditable: boolean,
   authRequired: 'pin' | 'none',
   address: string,
-  exchangeRates: { [string]: number }
+  exchangeRates: { [string]: number },
+  coreWallet: EdgeCurrencyWallet,
+  sceneState: SendConfirmationState,
+  isLimitExceeded: AuthType
 }
 
 export type SendConfirmationDispatchProps = {
@@ -64,7 +69,9 @@ export type SendConfirmationDispatchProps = {
   updateAmount: (nativeAmount: string, exchangeAmount: string, fiatPerCrypto: string) => any,
   sendConfirmationUpdateTx: (guiMakeSpendInfo: GuiMakeSpendInfo) => any,
   onChangePin: (pin: string) => mixed,
-  uniqueIdentifierButtonPressed: () => void
+  uniqueIdentifierButtonPressed: () => void,
+  newSpendInfo: (EdgeSpendInfo, AuthType) => mixed,
+  updateTransaction: (?EdgeTransaction, ?GuiMakeSpendInfo, ?boolean, ?Error) => void
 }
 
 type SendConfirmationRouterParams = {
@@ -87,7 +94,8 @@ type State = {|
 
 export class SendConfirmation extends Component<Props, State> {
   pinInput: any
-
+  count: number
+  lastSeenCount: number
   constructor (props: Props) {
     super(props)
     slowlog(this, /.*/, global.slowlogOptions)
@@ -106,6 +114,8 @@ export class SendConfirmation extends Component<Props, State> {
       isFiatOnTop: !!(props.guiMakeSpendInfo && props.guiMakeSpendInfo.nativeAmount && bns.eq(props.guiMakeSpendInfo.nativeAmount, '0')),
       isFocus: !!(props.guiMakeSpendInfo && props.guiMakeSpendInfo.nativeAmount && bns.eq(props.guiMakeSpendInfo.nativeAmount, '0'))
     }
+    this.count = 0
+    this.lastSeenCount = 0
   }
 
   componentDidMount () {
@@ -316,14 +326,35 @@ export class SendConfirmation extends Component<Props, State> {
     }
   }
 
-  onExchangeAmountChanged = ({ nativeAmount, exchangeAmount }: ExchangedFlipInputAmounts) => {
+  onExchangeAmountChanged = async ({ nativeAmount, exchangeAmount }: ExchangedFlipInputAmounts) => {
+    const { fiatPerCrypto, coreWallet, sceneState, currencyCode, isLimitExceeded, newSpendInfo, updateTransaction } = this.props
     this.setState({
       showSpinner: true,
       nativeAmount,
       exchangeAmount
     })
+    const count = ++this.count
+    const amountFiatString: string = bns.mul(exchangeAmount, fiatPerCrypto.toString())
+    const amountFiat: number = parseFloat(amountFiatString)
+    const metadata: EdgeMetadata = { amountFiat }
+    const guiMakeSpendInfo = { nativeAmount, metadata }
 
-    this.props.updateAmount(nativeAmount, exchangeAmount, this.props.fiatPerCrypto.toString())
+    const guiMakeSpendInfoClone = { ...guiMakeSpendInfo }
+    const spendInfo = getSpendInfoWithoutState(guiMakeSpendInfoClone, sceneState, currencyCode)
+
+    try {
+      newSpendInfo(spendInfo, isLimitExceeded)
+      const edgeTransaction = await makeSpend(coreWallet, spendInfo)
+      if (count === this.count) {
+        this.lastSeenCount = count
+        updateTransaction(edgeTransaction, guiMakeSpendInfoClone, false, null)
+        this.setState({ showSpinner: false })
+      } else if (count > this.lastSeenCount) {
+        this.lastSeenCount = count
+      }
+    } catch (e) {
+      updateTransaction(null, guiMakeSpendInfoClone, false, e)
+    }
   }
 
   onSlideToConfirm = () => {

--- a/src/connectors/scenes/SendConfirmationConnector.js
+++ b/src/connectors/scenes/SendConfirmationConnector.js
@@ -77,7 +77,13 @@ const mapStateToProps = (state: State): SendConfirmationStateProps => {
   const nativeToExchangeRatio = getExchangeDenomination(state, currencyCode).multiplier
   const exchangeAmount = convertNativeToExchange(nativeToExchangeRatio)(nativeAmount)
   const fiatAmount = convertCurrency(state, currencyCode, defaultIsoFiatCurrencyCode, parseFloat(exchangeAmount))
-  const exceedsLimit = fiatAmount >= spendingLimits.transaction.amount
+
+  let authType
+  if (spendingLimits.transaction.isEnabled) {
+    authType = fiatAmount >= spendingLimits.transaction.amount ? 'pin' : 'none'
+  } else {
+    authType = 'none'
+  }
 
   const out = {
     balanceInCrypto,
@@ -106,7 +112,7 @@ const mapStateToProps = (state: State): SendConfirmationStateProps => {
     uniqueIdentifier,
     authRequired: state.ui.scenes.sendConfirmation.authRequired,
     address: state.ui.scenes.sendConfirmation.address,
-    isLimitExceeded: exceedsLimit ? 'pin' : 'none',
+    authType,
     sceneState,
     coreWallet
   }
@@ -120,8 +126,7 @@ const mapDispatchToProps = (dispatch: Dispatch): SendConfirmationDispatchProps =
   sendConfirmationUpdateTx: guiMakeSpendInfo => dispatch(sendConfirmationUpdateTx(guiMakeSpendInfo)),
   reset: () => dispatch(reset()),
   updateSpendPending: (pending: boolean): any => dispatch(updateSpendPending(pending)),
-  signBroadcastAndSave: (nativeAmount: string, exchangeAmount: string, fiatPerCrypto: string): any =>
-    dispatch(signBroadcastAndSave(nativeAmount, exchangeAmount, fiatPerCrypto)),
+  signBroadcastAndSave: (): any => dispatch(signBroadcastAndSave()),
   onChangePin: (pin: string) => dispatch(newPin(pin)),
   uniqueIdentifierButtonPressed: () => {
     dispatch(uniqueIdentifierModalActivated())

--- a/src/modules/UI/scenes/SendConfirmation/selectors.js
+++ b/src/modules/UI/scenes/SendConfirmation/selectors.js
@@ -60,8 +60,8 @@ export const getError = (state: State): Error => getScene(state).error
 export const getKeyboardIsVisible = (state: State): boolean => getScene(state).keyboardIsVisible
 
 export const getTransaction = (state: State): EdgeTransaction => getScene(state).transaction || initialState.transaction
-export const getGuiMakeSpendInfo = (state: State): GuiMakeSpendInfo => getScene(state).guiMakeSpendInfo || initialState.guiMakeSpendInfo
-export const getForceUpdateGuiCounter = (state: State): number => getScene(state).forceUpdateGuiCounter
+export const getGuiMakeSpendInfo = (state: State): GuiMakeSpendInfo => state.ui.scenes.sendConfirmation.guiMakeSpendInfo || initialState.guiMakeSpendInfo
+export const getForceUpdateGuiCounter = (state: State): number => state.ui.scenes.sendConfirmation.forceUpdateGuiCounter
 
 export const getNetworkFeeOption = (state: State): string => getGuiMakeSpendInfo(state).networkFeeOption || initialState.guiMakeSpendInfo.networkFeeOption || ''
 export const getCustomNetworkFee = (state: State): any => getGuiMakeSpendInfo(state).customNetworkFee || initialState.guiMakeSpendInfo.customNetworkFee || {}
@@ -82,8 +82,8 @@ export const getPublicAddress = (state: State): string => {
 export const getNativeAmount = (state: State): string | void => state.ui.scenes.sendConfirmation.nativeAmount
 
 export const getUniqueIdentifier = (state: State): string => {
-  const guiMakeSpendInfo = getGuiMakeSpendInfo(state)
-  const uniqueIdentifier = guiMakeSpendInfo.uniqueIdentifier
+  const guiMakeSpendInfo = state.ui.scenes.sendConfirmation.guiMakeSpendInfo || initialState.guiMakeSpendInfo
+  const uniqueIdentifier = guiMakeSpendInfo.uniqueIdentifier || ''
   return uniqueIdentifier || ''
 }
 
@@ -113,6 +113,34 @@ export const getSpendInfo = (state: State, newSpendInfo?: GuiMakeSpendInfo = {})
     spendTargets,
     networkFeeOption: newSpendInfo.networkFeeOption || getNetworkFeeOption(state),
     customNetworkFee: newSpendInfo.customNetworkFee ? { ...getCustomNetworkFee(state), ...newSpendInfo.customNetworkFee } : getCustomNetworkFee(state),
+    otherParams: newSpendInfo.otherParams || {}
+  }
+}
+
+export const getSpendInfoWithoutState = (newSpendInfo?: GuiMakeSpendInfo = {}, sceneState: Object, selectedCurrencyCode: string): EdgeSpendInfo => {
+  const uniqueIdentifier = newSpendInfo.uniqueIdentifier || sceneState.guiMakeSpendInfo.uniqueIdentifier || ''
+  let spendTargets = []
+  if (newSpendInfo.spendTargets) {
+    spendTargets = newSpendInfo.spendTargets
+  } else {
+    spendTargets = [
+      {
+        nativeAmount: newSpendInfo.nativeAmount || sceneState.nativeAmount,
+        publicAddress: newSpendInfo.publicAddress || initialState.guiMakeSpendInfo.publicAddress || sceneState.spendInfo.spendTargets[0].publicAddress,
+        otherParams: {
+          uniqueIdentifier
+        }
+      }
+    ]
+  }
+  const metaData = sceneState.metadata || initialState.guiMakeSpendInfo.metadata
+  const customNetworkFee = sceneState.customNetworkFee || initialState.guiMakeSpendInfo.customNetworkFee
+  return {
+    currencyCode: newSpendInfo.currencyCode || selectedCurrencyCode,
+    metadata: newSpendInfo.metadata ? { ...metaData, ...newSpendInfo.metadata } : metaData,
+    spendTargets,
+    networkFeeOption: newSpendInfo.networkFeeOption || sceneState.networkFeeOption || initialState.guiMakeSpendInfo.networkFeeOption,
+    customNetworkFee: newSpendInfo.customNetworkFee ? { ...customNetworkFee, ...newSpendInfo.customNetworkFee } : customNetworkFee,
     otherParams: newSpendInfo.otherParams || {}
   }
 }


### PR DESCRIPTION
The purpose of this task is to fix the Send Confirmation bug whereby the order of makeSpend's requested differ from the order of the transactions returned (and therefore result in the user sending a tx other than the latest). Solution was to move some redux action functionality to the scene component.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a