### PR TITLE
Fix networkFee persistence issue

### DIFF
--- a/src/modules/UI/scenes/SendConfirmation/selectors.js
+++ b/src/modules/UI/scenes/SendConfirmation/selectors.js
@@ -139,7 +139,7 @@ export const getSpendInfoWithoutState = (newSpendInfo?: GuiMakeSpendInfo = {}, s
     currencyCode: newSpendInfo.currencyCode || selectedCurrencyCode,
     metadata: newSpendInfo.metadata ? { ...metaData, ...newSpendInfo.metadata } : metaData,
     spendTargets,
-    networkFeeOption: newSpendInfo.networkFeeOption || sceneState.networkFeeOption || initialState.guiMakeSpendInfo.networkFeeOption,
+    networkFeeOption: newSpendInfo.networkFeeOption || sceneState.guiMakeSpendInfo.networkFeeOption || initialState.guiMakeSpendInfo.networkFeeOption,
     customNetworkFee: newSpendInfo.customNetworkFee ? { ...customNetworkFee, ...newSpendInfo.customNetworkFee } : customNetworkFee,
     otherParams: newSpendInfo.otherParams || {}
   }


### PR DESCRIPTION
The purpose of this task is to ensure that choosing a networkFee option on the SendConfirmation scene actually "sticks" / persists once the user starts changing the amount in the FlipInput. The recently-changed code was trying to access the `networkFee` on the `sceneState` object instead of `sceneState.guiSpendInfo` object.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1112060050249485/f