### PR TITLE
Patch RCTFont.mm to fix crash

### DIFF
--- a/patches/RCTFont.patch
+++ b/patches/RCTFont.patch
@@ -1,0 +1,26 @@
+--- RCTFont.mm	2018-11-09 01:14:13.000000000 -0800
++++ RCTFont.new.mm	2019-03-04 00:13:43.000000000 -0800
+@@ -145,12 +145,12 @@
+ static UIFont *cachedSystemFont(CGFloat size, RCTFontWeight weight)
+ {
+   static NSCache *fontCache;
+-  static std::mutex fontCacheMutex;
++  static std::mutex *fontCacheMutex = new std::mutex;
+ 
+   NSString *cacheKey = [NSString stringWithFormat:@"%.1f/%.2f", size, weight];
+   UIFont *font;
+   {
+-    std::lock_guard<std::mutex> lock(fontCacheMutex);
++    std::lock_guard<std::mutex> lock(*fontCacheMutex);
+     if (!fontCache) {
+       fontCache = [NSCache new];
+     }
+@@ -177,7 +177,7 @@
+     }
+ 
+     {
+-      std::lock_guard<std::mutex> lock(fontCacheMutex);
++      std::lock_guard<std::mutex> lock(*fontCacheMutex);
+       [fontCache setObject:font forKey:cacheKey];
+     }
+   }

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -94,4 +94,8 @@ unamestr=`uname`
 if [[ "$unamestr" == 'Darwin' ]]; then
     cd ios
     pod install
+    cd ..
 fi
+
+# Apply patches
+patch ./node_modules/react-native/React/Views/RCTFont.mm ./patches/RCTFont.patch


### PR DESCRIPTION
This commit implements the following PR as a patch to RCTFont.mm.
https://github.com/facebook/react-native/pull/22607

This is an attempt at fixing a high count Bugsnag reported crash which has a profile similar to
https://github.com/facebook/react-native/issues/13588

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a