### PR TITLE
Fix non-persistent customFee (and metaData)

### DIFF
--- a/src/modules/UI/scenes/SendConfirmation/selectors.js
+++ b/src/modules/UI/scenes/SendConfirmation/selectors.js
@@ -133,8 +133,8 @@ export const getSpendInfoWithoutState = (newSpendInfo?: GuiMakeSpendInfo = {}, s
       }
     ]
   }
-  const metaData = sceneState.metadata || initialState.guiMakeSpendInfo.metadata
-  const customNetworkFee = sceneState.customNetworkFee || initialState.guiMakeSpendInfo.customNetworkFee
+  const metaData = sceneState.guiMakeSpendInfo.metadata || initialState.guiMakeSpendInfo.metadata
+  const customNetworkFee = sceneState.guiMakeSpendInfo.customNetworkFee || initialState.guiMakeSpendInfo.customNetworkFee
   return {
     currencyCode: newSpendInfo.currencyCode || selectedCurrencyCode,
     metadata: newSpendInfo.metadata ? { ...metaData, ...newSpendInfo.metadata } : metaData,


### PR DESCRIPTION
The purpose of this task is to ensure that customFees persist when the input field (FlipInput) has its text change.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1112060050249485/f