### PR TITLE
Add keys to all Scene components

### DIFF
--- a/src/components/Main.ui.js
+++ b/src/components/Main.ui.js
@@ -362,7 +362,7 @@ export default class Main extends Component<Props> {
 
                 <Drawer key={Constants.EDGE} hideNavBar contentComponent={ControlPanel} hideDrawerButton={true} drawerPosition="right" drawerWidth={scale(280)}>
                   {/* Wrapper Scene needed to fix a bug where the tabs would reload as a modal ontop of itself */}
-                  <Scene hideNavBar>
+                  <Scene key={'AllMyTabs'} hideNavBar>
                     <Tabs
                       key={Constants.EDGE}
                       swipeEnabled={false}

--- a/src/components/scenes/SpendingLimitsScene.js
+++ b/src/components/scenes/SpendingLimitsScene.js
@@ -51,7 +51,7 @@ export class SpendingLimitsComponent extends Component<SpendingLimitsOwnProps, S
       <SafeAreaView style={{}}>
         <Gradient style={styles.gradient} />
 
-        <Scene style={styles.scene}>
+        <Scene key={'SpendingLimitsSceneKey'} style={styles.scene}>
           <KeyboardAwareScrollView>
             <Scene.Header>
               <PasswordInput label={ENTER_YOUR_PASSWORD} onChangeText={onPasswordChanged} />


### PR DESCRIPTION
This is claimed to be required react-native-router-flex to prevent crashes. Hopefully fixes reported crashes with signature:

"There is no route defined for key"

Reference: https://github.com/aksonov/react-native-router-flux/issues/2439

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a