### PR TITLE
Fix crash on logout during EOS wallet-create process

### DIFF
--- a/src/components/scenes/CreateWalletAccountSelectScene.js
+++ b/src/components/scenes/CreateWalletAccountSelectScene.js
@@ -176,6 +176,7 @@ export class CreateWalletAccountSelect extends Component<Props, State> {
     } = this.props
     const { walletId, createdWallet } = this.state
     const wallet = wallets[walletId]
+    if (!wallet) return null
     const { name, symbolImageDarkMono } = wallet
 
     const isContinueButtonDisabled = isCreatingWallet || (createdWallet && !amount)


### PR DESCRIPTION
The purpose of this task to prevent the crash that occurs during the EOS Wallet Activation process when a user logs out via the sidebar. The crash was occurring because the logout dispatched action causes a change in the mapStateToProps returned value for CreateWalletAccountSelect (EOS) scene, triggering a render which tries to access the name property of an unreachable wallet.

A further investigation should be taken to look into how the logout mechanism works and if there is a way to prevent these types of errors from occurring during logout.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1109183476243106/f