### PR TITLE
Fix createWalletType crash to display error instead

### DIFF
--- a/src/components/scenes/CreateWalletSelectCryptoScene.js
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.js
@@ -151,7 +151,7 @@ export class CreateWalletSelectCrypto extends Component<Props, State> {
     }
     if (unloadedWalletCount) {
       if (!errorShown) {
-        displayErrorAlert('Error missing wallet type. Unloaded plugins.')
+        displayErrorAlert(s.strings.create_wallet_selcet_crypto_unloaded_plugins_error)
         errorShown = true
       }
     }

--- a/src/connectors/scenes/CreateWalletSelectCryptoConnector.js
+++ b/src/connectors/scenes/CreateWalletSelectCryptoConnector.js
@@ -6,6 +6,7 @@ import { CreateWalletSelectCrypto as CreateWalletSelectCryptoComponent } from '.
 import type { CreateWalletSelectCryptoStateProps } from '../../components/scenes/CreateWalletSelectCryptoScene.js'
 import type { State } from '../../modules/ReduxTypes'
 import * as SETTINGS_SELECTORS from '../../modules/Settings/selectors.js'
+import { displayErrorAlert } from '../../modules/UI/components/ErrorAlert/actions'
 
 const mapStateToProps = (state: State): CreateWalletSelectCryptoStateProps => {
   const supportedWalletTypes = SETTINGS_SELECTORS.getSupportedWalletTypes(state)
@@ -22,7 +23,11 @@ const mapStateToProps = (state: State): CreateWalletSelectCryptoStateProps => {
     dimensions: state.ui.scenes.dimensions
   }
 }
-const mapDispatchToProps = () => ({})
+const mapDispatchToProps = (dispatch: Dispatch) => {
+  return {
+    displayErrorAlert: (message: string) => dispatch(displayErrorAlert(message))
+  }
+}
 export const CreateWalletSelectCrypto = connect(
   mapStateToProps,
   mapDispatchToProps

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -121,6 +121,7 @@ const strings = {
   wallet_list_add_token_modal_title: 'Ethereum Wallet Needed',
   wallet_list_add_token_modal_message: 'Please create an Ethereum wallet first to hold your tokens',
   create_wallet_select_valid_crypto: 'Please select a valid wallet type',
+  create_wallet_selcet_crypto_unloaded_plugins_error: 'Some wallet types unavailable. Please wait for account to fully load to access all wallet types.',
   create_wallet_invalid_input: 'Invalid input',
   create_wallet_select_valid_fiat: 'Please select a valid fiat currency',
   create_wallet_choose_crypto: 'Choose a wallet type',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -113,6 +113,7 @@
   "wallet_list_add_token_modal_title": "Ethereum Wallet Needed",
   "wallet_list_add_token_modal_message": "Please create an Ethereum wallet first to hold your tokens",
   "create_wallet_select_valid_crypto": "Please select a valid wallet type",
+  "create_wallet_selcet_crypto_unloaded_plugins_error": "Some wallet types unavailable. Please wait for account to fully load to access all wallet types.",
   "create_wallet_invalid_input": "Invalid input",
   "create_wallet_select_valid_fiat": "Please select a valid fiat currency",
   "create_wallet_choose_crypto": "Choose a wallet type",


### PR DESCRIPTION
The purpose of this task is to prevent the crashes occurring when a user **quickly** taps the "Create Wallet (+)" button immediately after login (before plugins have loaded). Instead of crashing with an error, I have modified the scene to just display a dropdown error alert.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/1112350860288128/f