### PR TITLE
Fix Android back button behavior to prevent app crashes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,7 +46,7 @@
       android:label="@string/app_name"
       android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
       android:windowSoftInputMode="adjustPan"
-      android:launchMode="singleTask">
+      android:launchMode="singleTop">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/android/app/src/main/java/co/edgesecure/app/MainActivity.java
+++ b/android/app/src/main/java/co/edgesecure/app/MainActivity.java
@@ -25,5 +25,8 @@ public class MainActivity extends ReactActivity {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         }
     }
-
+    @Override
+    public void invokeDefaultOnBackPressed() {
+        moveTaskToBack(true);
+    }
 }

--- a/src/components/Main.ui.js
+++ b/src/components/Main.ui.js
@@ -852,7 +852,8 @@ export default class Main extends Component<Props> {
       return HwBackButtonHandler()
     }
     if (this.isCurrentScene(Constants.EXCHANGE_QUOTE_SCENE)) {
-      return Actions.popTo(Constants.EXCHANGE_SCENE)
+      Actions.popTo(Constants.EXCHANGE_SCENE)
+      return true
     }
     Actions.pop()
     return true

--- a/src/components/common/HwBackButtonHandler.android.js
+++ b/src/components/common/HwBackButtonHandler.android.js
@@ -1,7 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 
 import { ToastAndroid } from 'react-native'
-import { Actions } from 'react-native-router-flux'
 
 import s from '../../locales/strings'
 
@@ -10,7 +9,6 @@ let BACK_BUTTON_PRESSED_ONCE_TO_EXIT = false
 
 const hwBackButtonHandler = () => {
   if (BACK_BUTTON_PRESSED_ONCE_TO_EXIT) {
-    Actions.pop()
     return false
   }
 


### PR DESCRIPTION
* Make default back button handler in Java only background app, not exit app
* Do not call Actions.pop() when at the WalletList screen. This will exit the app since we're at the top of the stack. Just return false which passes handling to Java to background the app.
* Return true when back button is hit from Exchange Quote scene. This will prevent app backgrounding and just go back to ExchangeScene

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a