### PR TITLE
Insert Monero paymentID and receive address into outgoing Monero notes

### DIFF
--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -201,12 +201,17 @@ export const signBroadcastAndSave = () => async (dispatch: Dispatch, getState: G
       edgeMetadata.amountFiat = amountFiat
     }
     if (getSpecialCurrencyInfo(currencyCode).uniqueIdentifierToNotes) {
-      edgeMetadata.notes = sprintf(
+      const newNotesSyntax = sprintf(
         s.strings.tx_notes_metadata,
         s.strings.unique_identifier_payment_id,
         edgeSignedTransaction.otherParams.sendParams.paymentId,
         edgeSignedTransaction.otherParams.sendParams.targetAddress
       )
+      if (edgeMetadata.notes) {
+        edgeMetadata.notes += `\n${newNotesSyntax}`
+      } else {
+        edgeMetadata.notes = newNotesSyntax
+      }
     }
     await wallet.saveTxMetadata(edgeSignedTransaction.txid, edgeSignedTransaction.currencyCode, edgeMetadata)
     dispatch(updateSpendPending(false))

--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -7,6 +7,7 @@ import { Actions } from 'react-native-router-flux'
 import { sprintf } from 'sprintf-js'
 
 import { SEND_CONFIRMATION, TRANSACTION_DETAILS } from '../constants/indexConstants'
+import { getSpecialCurrencyInfo } from '../constants/WalletAndCurrencyConstants.js'
 import s from '../locales/strings.js'
 import { checkPin } from '../modules/Core/Account/api.js'
 import { getAccount, getWallet } from '../modules/Core/selectors.js'
@@ -198,6 +199,14 @@ export const signBroadcastAndSave = () => async (dispatch: Dispatch, getState: G
     }
     if (!edgeMetadata.amountFiat) {
       edgeMetadata.amountFiat = amountFiat
+    }
+    if (getSpecialCurrencyInfo(currencyCode).uniqueIdentifierToNotes) {
+      edgeMetadata.notes = sprintf(
+        s.strings.tx_notes_metadata,
+        s.strings.unique_identifier_payment_id,
+        edgeSignedTransaction.otherParams.sendParams.paymentId,
+        edgeSignedTransaction.otherParams.sendParams.targetAddress
+      )
     }
     await wallet.saveTxMetadata(edgeSignedTransaction.txid, edgeSignedTransaction.currencyCode, edgeMetadata)
     dispatch(updateSpendPending(false))

--- a/src/constants/WalletAndCurrencyConstants.js
+++ b/src/constants/WalletAndCurrencyConstants.js
@@ -129,7 +129,8 @@ export const SPECIAL_CURRENCY_INFO: SpecialCurrencyInfo = {
       addButtonText: s.strings.unique_identifier_dropdown_option_payment_id,
       identifierName: s.strings.unique_identifier_payment_id,
       identifierKeyboardType: 'default'
-    }
+    },
+    uniqueIdentifierToNotes: true
   },
   EOS: {
     dummyPublicAddress: 'edgecreator2',

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -283,6 +283,7 @@ const strings = {
   string_master_private_key: 'Master Private Key',
   string_split_wallet: 'Split %s',
   string_add_edit_tokens: 'Add / Edit Tokens',
+  tx_notes_metadata: '%s: %s\nRecipient Address: %s',
   exchange_notes_metadata_generic: 'Exchanged %1$s %2$s from %3$s to %4$s %5$s in %6$s to address %7$s \nOrder: %8$s. \nFor assistance, please contact %9$s.',
   exchange_notes_metadata_generic2:
     'Exchanged %1$s %2$s from %3$s to %4$s %5$s in %6$s to address %7$s \nOrder: %8$s. \nExchange payment address: %9$s. \nExchange unique identifier: %10$s \n\nFor assistance, please contact %11$s.',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -272,6 +272,7 @@
   "string_master_private_key": "Master Private Key",
   "string_split_wallet": "Split %s",
   "string_add_edit_tokens": "Add / Edit Tokens",
+  "tx_notes_metadata": "%s: %s\nRecipient Address: %s",
   "exchange_notes_metadata_generic": "Exchanged %1$s %2$s from %3$s to %4$s %5$s in %6$s to address %7$s \nOrder: %8$s. \nFor assistance, please contact %9$s.",
   "exchange_notes_metadata_generic2": "Exchanged %1$s %2$s from %3$s to %4$s %5$s in %6$s to address %7$s \nOrder: %8$s. \nExchange payment address: %9$s. \nExchange unique identifier: %10$s \n\nFor assistance, please contact %11$s.",
   "title_crypto_settings": "%s Settings",


### PR DESCRIPTION
The purpose of this task is to add the paymentID and receive address to Monero's outgoing transactions. This should help users and tech support debug issues more easily.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1109561748343713/f