### PR TITLE
Disable editing of all native tokens

### DIFF
--- a/src/components/common/ManageTokenRow.js
+++ b/src/components/common/ManageTokenRow.js
@@ -1,15 +1,14 @@
 // @flow
 
 import type { EdgeMetaToken } from 'edge-core-js'
-import _ from 'lodash'
 import React, { Component } from 'react'
 import { TouchableHighlight, TouchableWithoutFeedback, View } from 'react-native'
 import Icon from 'react-native-vector-icons/SimpleLineIcons'
 
+import { SYNCED_ACCOUNT_DEFAULTS } from '../../modules/Core/Account/settings.js'
 import CheckBox from '../../modules/UI/components/CheckBox/index'
 import Text from '../../modules/UI/components/FormattedText/index'
 import styles, { styles as rawStyles } from '../../styles/scenes/ManageTokensStyle.js'
-import type { CustomTokenInfo } from '../../types.js'
 import * as UTILS from '../../util/utils.js'
 
 // import THEME from '../../../../theme/variables/airbitz'
@@ -26,8 +25,7 @@ export type Props = {
   },
   enabled?: boolean,
   enabledList: Array<string>,
-  goToEditTokenScene: string => void,
-  customTokensList: Array<CustomTokenInfo>
+  goToEditTokenScene: string => void
 }
 
 class ManageTokenRow extends Component<Props, State> {
@@ -40,19 +38,20 @@ class ManageTokenRow extends Component<Props, State> {
 
   render () {
     const { item } = this.props.metaToken
+    const { goToEditTokenScene, toggleToken, enabledList } = this.props
     let enabled = false
-    if (this.props.enabledList.indexOf(item.currencyCode) >= 0) {
+    if (enabledList.indexOf(item.currencyCode) >= 0) {
       enabled = true
     }
-
-    const isEditable: boolean = _.findIndex(this.props.customTokensList, token => token.currencyCode === item.currencyCode) !== -1
-    const onPress = isEditable ? this.props.goToEditTokenScene : UTILS.noOp
+    // disable editing if token is native to the app
+    const isEditable = !Object.keys(SYNCED_ACCOUNT_DEFAULTS).includes(item.currencyCode)
+    const onPress = isEditable ? goToEditTokenScene : UTILS.noOp
 
     return (
       <TouchableHighlight onPress={() => onPress(item.currencyCode)} underlayColor={rawStyles.underlay.color} style={[styles.manageTokenRow]}>
         <View style={[styles.manageTokenRowInterior]}>
           <View style={styles.rowLeftArea}>
-            <TouchableWithoutFeedback onPress={() => this.props.toggleToken(item.currencyCode)} isVisible={item.isVisible} enabled={enabled}>
+            <TouchableWithoutFeedback onPress={() => toggleToken(item.currencyCode)} isVisible={item.isVisible} enabled={enabled}>
               <View style={[styles.touchableCheckboxInterior]}>
                 <CheckBox style={styles.checkBox} enabled={enabled} />
               </View>

--- a/src/components/scenes/ManageTokensScene.js
+++ b/src/components/scenes/ManageTokensScene.js
@@ -112,7 +112,6 @@ export default class ManageTokens extends Component<ManageTokensProps, State> {
                       walletId={this.props.guiWallet.id}
                       toggleToken={this.toggleToken}
                       enabledList={this.state.enabledList}
-                      customTokensList={this.props.settingsCustomTokens}
                       metaTokens={this.props.guiWallet.metaTokens}
                     />
                   )}


### PR DESCRIPTION
The purpose of this task is to make it so that a user is **unable** to edit or delete native tokens. The native token info should take precedence over any custom token info.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1113720244890380/f