### PR TITLE
Performance: Move calculateWalletFiatBalance out of connector (into component)

### DIFF
--- a/src/components/common/FullWalletListRow.js
+++ b/src/components/common/FullWalletListRow.js
@@ -16,7 +16,7 @@ import { SYNCED_ACCOUNT_DEFAULTS } from '../../modules/Core/Account/settings.js'
 import type { State } from '../../modules/ReduxTypes.js'
 import * as SETTINGS_SELECTORS from '../../modules/Settings/selectors'
 import T from '../../modules/UI/components/FormattedText/index'
-import { calculateSettingsFiatBalance } from '../../modules/UI/selectors.js'
+import { calculateSettingsFiatBalanceWithoutState } from '../../modules/UI/selectors.js'
 import styles, { styles as styleRaw } from '../../styles/scenes/WalletListStyle.js'
 import type { CustomTokenInfo, GuiDenomination } from '../../types'
 import { decimalOrZero, getFiatSymbol, getObjectDiff, truncateDecimals } from '../../util/utils.js'
@@ -53,7 +53,8 @@ export type FullWalletListRowLoadedStateProps = {
   customTokens: Array<CustomTokenInfo>,
   fiatSymbol: string,
   isWalletFiatBalanceVisible: boolean,
-  fiatBalance: string
+  settings: Object,
+  exchangeRates: { [string]: number }
 }
 
 export type FullWalletListRowLoadedOwnProps = {
@@ -91,7 +92,7 @@ class FullWalletListRowLoadedComponent extends Component<FullWalletListRowLoaded
   }
 
   render () {
-    const { data, fiatSymbol, fiatBalance } = this.props
+    const { data, fiatSymbol, settings, exchangeRates } = this.props
     const walletData = data.item
     const currencyCode = walletData.currencyCode
     const cryptocurrencyName = walletData.currencyNames[currencyCode]
@@ -128,7 +129,7 @@ class FullWalletListRowLoadedComponent extends Component<FullWalletListRowLoaded
         }
       }
     }
-
+    const fiatBalance = calculateSettingsFiatBalanceWithoutState(walletData, settings, exchangeRates)
     const fiatBalanceString = fiatSymbol + ' ' + fiatBalance
     return (
       <View style={[{ width: '100%' }]}>
@@ -202,16 +203,16 @@ const mapStateToProps = (state: State, ownProps: FullWalletListRowLoadedOwnProps
   const exchangeDenomination = SETTINGS_SELECTORS.getExchangeDenomination(state, ownProps.data.item.currencyCode)
   const settings = state.ui.settings
   const fiatSymbol = getFiatSymbol(settings.defaultFiat) || ''
-  const customTokens = state.ui.settings.customTokens
-  const isWalletFiatBalanceVisible = state.ui.settings.isWalletFiatBalanceVisible
-  const fiatBalance = calculateSettingsFiatBalance(ownProps.data.item, state)
+  const customTokens = settings.customTokens
+  const isWalletFiatBalanceVisible = settings.isWalletFiatBalanceVisible
   return {
     displayDenomination,
     exchangeDenomination,
     customTokens,
     fiatSymbol,
     isWalletFiatBalanceVisible,
-    fiatBalance
+    settings,
+    exchangeRates: state.exchangeRates
   }
 }
 const mapDispatchToProps = dispatch => ({

--- a/src/modules/UI/selectors.js
+++ b/src/modules/UI/selectors.js
@@ -142,6 +142,13 @@ export const convertCurrency = (state: State, fromCurrencyCode: string, toCurren
   return convertedAmount
 }
 
+export const convertCurrencyWithoutState = (exchangeRates: { [string]: number }, fromCurrencyCode: string, toCurrencyCode: string, amount: number = 1) => {
+  const rateKey = `${fromCurrencyCode}_${toCurrencyCode}`
+  const exchangeRate = exchangeRates[rateKey] ? exchangeRates[rateKey] : 0
+  const convertedAmount = amount * exchangeRate
+  return convertedAmount
+}
+
 export const convertCurrencyFromExchangeRates = (exchangeRates: { [string]: number }, fromCurrencyCode: string, toCurrencyCode: string, amount: number) => {
   if (!exchangeRates) return 0 // handle case of exchange rates not ready yet
   const rateKey = `${fromCurrencyCode}_${toCurrencyCode}`
@@ -163,6 +170,20 @@ export const calculateSettingsFiatBalance = (wallet: GuiWallet, state: State): s
   const nativeToExchangeRatio: string = exchangeDenomination.multiplier
   const cryptoAmount: number = parseFloat(convertNativeToExchange(nativeToExchangeRatio)(nativeBalance))
   fiatValue = convertCurrency(state, currencyCode, settings.defaultIsoFiat, cryptoAmount)
+  return intl.formatNumber(fiatValue, { toFixed: 2 }) || '0'
+}
+
+export const calculateSettingsFiatBalanceWithoutState = (wallet: GuiWallet, settings: Object, exchangeRates: { [string]: number }) => {
+  let fiatValue = 0 // default to zero if not calculable
+  const currencyCode = wallet.currencyCode
+  const nativeBalance = wallet.nativeBalances[currencyCode]
+  if (!nativeBalance || nativeBalance === '0') return '0'
+  const denominations = settings[currencyCode].denominations
+  const exchangeDenomination = denominations.find(denomination => denomination.name === currencyCode)
+  if (!exchangeDenomination) return '0'
+  const nativeToExchangeRatio: string = exchangeDenomination.multiplier
+  const cryptoAmount: number = parseFloat(convertNativeToExchange(nativeToExchangeRatio)(nativeBalance))
+  fiatValue = convertCurrencyWithoutState(exchangeRates, currencyCode, settings.defaultIsoFiat, cryptoAmount)
   return intl.formatNumber(fiatValue, { toFixed: 2 }) || '0'
 }
 


### PR DESCRIPTION
The purpose of this task is to move some of the heavy calculations of the WalletListRow out of the connector and into the component.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1114902118803440/f