### PR TITLE
Added a new SafeAreaView dependency to accomodate new iPhone devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "react-native-qrcode": "^0.2.3",
     "react-native-randombytes": "^3.5.0",
     "react-native-router-flux": "4.0.0-beta.31",
+    "react-native-safe-area-view": "^0.13.1",
     "react-native-share": "^1.1.3",
     "react-native-slider": "^0.11.0",
     "react-native-slowlog": "^1.0.2",
@@ -158,7 +159,7 @@
     "url-parse": "^1.4.4",
     "vm-browserify": "0.0.4",
     "why-did-you-update": "^0.1.1",
-    "yaob":"0.3.3"
+    "yaob": "0.3.3"
   },
   "devDependencies": {
     "babel-eslint": "^8.1.0",
@@ -193,7 +194,7 @@
     "prettier-eslint-cli": "^4.7.0",
     "rn-nodeify": "^7.0.1",
     "rollup": "^1.1.2",
-    "rollup-plugin-node-resolve":"4.0.0",
+    "rollup-plugin-node-resolve": "4.0.0",
     "updot": "^1.1.7"
   },
   "flow-coverage-report": {

--- a/src/modules/UI/components/SafeAreaView/SafeAreaView.ui.js
+++ b/src/modules/UI/components/SafeAreaView/SafeAreaView.ui.js
@@ -2,7 +2,8 @@
 
 import React from 'react'
 import type { Node } from 'react'
-import { SafeAreaView, StyleSheet } from 'react-native'
+import { StyleSheet } from 'react-native'
+import SafeAreaView from 'react-native-safe-area-view'
 
 import THEME from '../../../../theme/variables/airbitz.js'
 import Gradient from '../../components/Gradient/Gradient.ui'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8372,6 +8372,13 @@ react-native-router-flux@4.0.0-beta.31:
     prop-types "^15.6.0"
     react-navigation "1.5.8"
 
+react-native-safe-area-view@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.13.1.tgz#834bbb6d22f76a7ff07de56725ee5667ba1386b0"
+  integrity sha512-d/pu2866jApSwLtK/xWAvMXZkNTIQcFrjjbcTATBrmIfFNnu8TNFUcMRFpfJ+eOn5nmx7uGmDvs9B53Ft7JGpQ==
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+
 react-native-safe-area-view@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.7.0.tgz#38f5ab9368d6ef9e5d18ab64212938af3ec39421"


### PR DESCRIPTION
Task: Fix iPhone XS Max safe area

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [ ] Tested on small Android