### PR TITLE
Prevent animation of popped scene (causing freezing)

### DIFF
--- a/src/components/scenes/CreateWalletReviewScene.js
+++ b/src/components/scenes/CreateWalletReviewScene.js
@@ -66,7 +66,8 @@ export class CreateWalletReview extends Component<CreateWalletReviewProps, Creat
       false,
       cleanedPrivateKey
     )
-    if (createdWallet) {
+    // note that we will be using cleanedPrivateKey as a flag for an imported private key
+    if (createdWallet && cleanedPrivateKey) {
       this.setState({
         isAnimationVisible: true
       })


### PR DESCRIPTION
The purpose of this task is to prevent the app from freezing after a wallet is created. The solution was to prevent the GUI from attempting to use `setState` to start animating a scene that react-native-router-flux was in the process of removing (ie popping).

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/1114642775214512/f