### PR TITLE
Don't show Wallet Empty modal when user taps Sweep Private Key from side menu

### DIFF
--- a/src/components/Main.ui.js
+++ b/src/components/Main.ui.js
@@ -167,7 +167,7 @@ type Props = {
   openDrawer: () => void,
   dispatchAddressDeepLinkReceived: (addressDeepLinkData: Object) => any,
   deepLinkPending: boolean,
-  checkAndShowGetCryptoModal: () => void
+  checkAndShowGetCryptoModal: (?string) => void
 }
 
 async function queryUtilServer (context: EdgeContext, folder: DiskletFolder, usernames: Array<string>) {
@@ -529,10 +529,10 @@ export default class Main extends Component<Props> {
                         <Scene
                           key={Constants.SCAN_NOT_USED}
                           navTransparent={true}
-                          onEnter={() => {
+                          onEnter={props => {
                             this.props.requestPermission(PermissionStrings.CAMERA)
                             this.props.dispatchEnableScan()
-                            this.props.checkAndShowGetCryptoModal()
+                            this.props.checkAndShowGetCryptoModal(props.data)
                           }}
                           onExit={this.props.dispatchDisableScan}
                           component={Scan}

--- a/src/connectors/MainConnector.js
+++ b/src/connectors/MainConnector.js
@@ -55,7 +55,12 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       type: 'ADDRESS_DEEP_LINK_RECEIVED',
       data: addressDeepLinkData
     }),
-  checkAndShowGetCryptoModal: () => dispatch(checkAndShowGetCryptoModal())
+  checkAndShowGetCryptoModal: (routeData: string) => {
+    if (routeData === 'sweepPrivateKey') {
+      return null
+    }
+    dispatch(checkAndShowGetCryptoModal())
+  }
 })
 export default connect(
   mapStateToProps,

--- a/src/modules/UI/components/ControlPanel/Component/Main.js
+++ b/src/modules/UI/components/ControlPanel/Component/Main.js
@@ -163,8 +163,11 @@ const ScanButton = () => {
 }
 
 const SweepPrivateKeyButton = () => {
+  /* eslint-disable no-unused-vars */
+  const routeWithData = () => Actions.scan('sweepPrivateKey')
+  /* eslint-disable no-unused-vars */
   return (
-    <Button onPress={Actions.scan}>
+    <Button onPress={routeWithData}>
       <Button.Row>
         <Button.Left>
           <Image source={sweepIcon} style={styles.iconImage} />


### PR DESCRIPTION
Task: Title

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android