### PR TITLE
Prevent 'infinite loop' for new ETH wallet creation

### DIFF
--- a/src/components/scenes/CreateWalletChoiceScene.js
+++ b/src/components/scenes/CreateWalletChoiceScene.js
@@ -21,7 +21,7 @@ type CreateWalletChoiceProps = {
 export class CreateWalletChoiceComponent extends PureComponent<CreateWalletChoiceProps> {
   onSelectNew = () => {
     const { selectedWalletType } = this.props
-    Actions[Constants.CREATE_WALLET_SELECT_CRYPTO]({ selectedWalletType })
+    Actions[Constants.CREATE_WALLET_SELECT_FIAT]({ selectedWalletType })
   }
 
   onSelectRestore = () => {


### PR DESCRIPTION
The purpose of this task is to prevent an infinite loop for creating a new ETH wallet (rather than importing). This issue was most likely leftover from when the import wallet scene order was changed during development (Import vs. Create scene used to be before selectCryptoType).

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/838232040088964/f