### PR TITLE
create more friendly error message

### DIFF
--- a/src/actions/EdgeLoginActions.js
+++ b/src/actions/EdgeLoginActions.js
@@ -32,6 +32,7 @@ export const lobbyLogin = () => async (dispatch: any, getState: any) => {
     }, 750)
   } catch (e) {
     dispatch({ type: 'EDGE_LOBBY_ACCEPT_FAILED' })
+    e.message = e.message.includes('Could not reach') ? s.strings.edge_login_fail_message : e.message
     showModal(errorModal(s.strings.edge_login_failed, e))
   }
 }

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -532,6 +532,7 @@ const strings = {
   error_creating_wallets:
     'Network timeout occurred trying to create and backup wallets. Please check your network connection and restart app to retry wallet creation.',
   edge_login_failed: 'Failed to Login',
+  edge_login_fail_message: 'Could not connect to network. Please check your network connection and try again.',
   edge_login_fetching: 'Fetching Edge Login info...',
   modal_addressexplorer_message: 'Show Address in Block Explorer?',
   modal_addressexplorer_null: 'This currency has no explorer site as of now'

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -495,7 +495,8 @@
   "choose_your_wallet": "Choose Your Wallet",
   "error_creating_wallets": "Network timeout occurred trying to create and backup wallets. Please check your network connection and restart app to retry wallet creation.",
   "edge_login_failed": "Failed to Login",
+  "edge_login_fail_message": "Could not connect to network. Please check your network connection and try again.",
   "edge_login_fetching": "Fetching Edge Login info...",
-  "modal_addressexplorer_message": "Show Address in Blockexplorer?",
+  "modal_addressexplorer_message": "Show Address in Block Explorer?",
   "modal_addressexplorer_null": "This currency has no explorer site as of now"
 }


### PR DESCRIPTION
This fixes Asana 
Edge Login spins forever in poor networks
https://app.asana.com/0/361770107085503/1113807296910175

This makes the error message more human friendly when there is a connection failure.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a