### PR TITLE
Fix CSV export issue on empty wallets

### DIFF
--- a/src/components/scenes/TransactionsExportScene.js
+++ b/src/components/scenes/TransactionsExportScene.js
@@ -85,8 +85,8 @@ export class TransactionsExportSceneComponent extends Component<Props> {
     const transactionOptions: EdgeGetTransactionsOptions = {
       denomination: this.props.denomination
     }
-    const file = await this.props.sourceWallet.exportTransactionsToCSV(transactionOptions)
-
+    let file = await this.props.sourceWallet.exportTransactionsToCSV(transactionOptions)
+    if (typeof file !== 'string') file = ''
     const format = 'CSV'
 
     this.write(file, format)


### PR DESCRIPTION
The purpose of this task is to prevent crashing from occurring when someone attempts to export CSV on an empty wallet.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1116555037085238/f