### PR TITLE
CocoaPods

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -192,7 +192,6 @@ dependencies {
     compile project(':react-native-fast-crypto')
     compile project(':react-native-locale')
     compile project(':react-native-vector-icons')
-    compile project(':react-native-udp')
     compile project(':react-native-tcp')
     compile project(':react-native-material-kit')
     compile project(':react-native-linear-gradient')

--- a/android/app/src/main/java/co/edgesecure/app/MainApplication.java
+++ b/android/app/src/main/java/co/edgesecure/app/MainApplication.java
@@ -28,7 +28,6 @@ import com.zmxv.RNSound.RNSoundPackage;
 import cl.json.RNSharePackage;
 import co.airbitz.fastcrypto.RNFastCryptoPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
-import com.tradle.react.UdpSocketsModule;
 import com.peel.react.TcpSocketsModule;
 import com.bitgo.randombytes.RandomBytesPackage;
 import com.github.xinthink.rnmk.ReactMaterialKitPackage;
@@ -76,7 +75,6 @@ public class MainApplication extends Application implements ReactApplication {
             new RandomBytesPackage(),
             new RNFastCryptoPackage(),
             new VectorIconsPackage(),
-            new UdpSocketsModule(),
             new TcpSocketsModule(),
             new ReactMaterialKitPackage(),
             new LinearGradientPackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -38,8 +38,6 @@ include ':react-native-locale'
 project(':react-native-locale').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-locale/android')
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
-include ':react-native-udp'
-project(':react-native-udp').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-udp/android')
 include ':react-native-tcp'
 project(':react-native-tcp').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-tcp/android')
 include ':react-native-material-kit'

--- a/copy-login-ui.sh
+++ b/copy-login-ui.sh
@@ -10,3 +10,4 @@ cp    $src/package.json $dest/package.json
 cp -r $src/src/ $dest/src/
 cp -r $src/android/ $dest/android/
 cp -r $src/ios/ $dest/ios/
+cp -r $src/edge-login-ui-rn.podspec $dest/edge-login-ui-rn.podspec

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,12 +1,57 @@
-# Uncomment the next line to define a global platform for your project
 platform :ios, '9.0'
 
-target 'edge' do
-  # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
-  # use_frameworks!
+source 'https://github.com/CocoaPods/Specs.git'
 
-  # Pods for edge
+target 'edge' do
+  # React Native
+  pod 'React', :path => '../node_modules/react-native', :subspecs => [
+    'Core',
+    'CxxBridge',
+    'DevSupport',
+    'RCTAnimation',
+    'RCTImage',
+    'RCTLinkingIOS',
+    'RCTNetwork',
+    'RCTPushNotification',
+    'RCTSettings',
+    'RCTText',
+    'RCTWebSocket',
+  ]
+  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
+  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
+  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
+  pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+
+  # Other dependencies
   pod 'Firebase/Core', '~> 5.3.0'
 
-end
+  # React Native linked dependencies
+  pod 'BugsnagReactNative', :path => '../node_modules/bugsnag-react-native'
+  pod 'BVLinearGradient', :path => '../node_modules/react-native-linear-gradient'
+  pod 'disklet', :path => '../node_modules/disklet'
+  pod 'edge-login-ui-rn', :path => '../node_modules/edge-login-ui-rn'
+  pod 'Picker', :path => '../node_modules/react-native-picker'
+  pod 'react-native-camera', :path => '../node_modules/react-native-camera'
+  pod 'react-native-contacts-wrapper', :path => '../node_modules/react-native-contacts-wrapper'
+  pod 'react-native-contacts', :path => '../node_modules/react-native-contacts'
+  pod 'react-native-cookies', :path => '../node_modules/react-native-cookies'
+  pod 'react-native-fast-crypto', :path => '../node_modules/react-native-fast-crypto'
+  pod 'react-native-firebase', :path => '../node_modules/react-native-firebase'
+  pod 'react-native-image-picker', :path => '../node_modules/react-native-image-picker'
+  pod 'react-native-locale', :path => '../node_modules/react-native-locale'
+  pod 'react-native-mail', :path => '../node_modules/react-native-mail'
+  pod 'react-native-material-kit', :path => '../node_modules/react-native-material-kit'
+  pod 'react-native-randombytes', :path => '../node_modules/react-native-randombytes'
+  pod 'react-native-smart-splash-screen', :path => '../node_modules/react-native-smart-splash-screen'
+  pod 'react-native-tcp', :path => '../node_modules/react-native-tcp'
+  pod 'react-native-webview', :path => '../node_modules/react-native-webview'
+  pod 'ReactNativePermissions', :path => '../node_modules/react-native-permissions'
+  pod 'RNBackgroundFetch', :path => '../node_modules/react-native-background-fetch'
+  pod 'RNDeviceInfo', :path => '../node_modules/react-native-device-info'
+  pod 'RNFS', :path => '../node_modules/react-native-fs'
+  pod 'RNOpenAppSettings', :path => '../node_modules/react-native-app-settings'
+  pod 'RNShare', :path => '../node_modules/react-native-share'
+  pod 'RNSound', :path => '../node_modules/react-native-sound'
+  pod 'RNVectorIcons', :path => '../node_modules/react-native-vector-icons'
 
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,17 @@
 PODS:
+  - boost-for-react-native (1.63.0)
+  - BugsnagReactNative (2.12.6):
+    - BugsnagReactNative/Core (= 2.12.6)
+    - React
+  - BugsnagReactNative/Core (2.12.6):
+    - React
+  - BVLinearGradient (2.5.3):
+    - React
+  - disklet (0.4.1):
+    - React
+  - DoubleConversion (1.1.5)
+  - edge-login-ui-rn (0.5.18):
+    - React
   - Firebase/Core (5.3.0):
     - Firebase/CoreOnly
     - FirebaseAnalytics (= 5.0.1)
@@ -13,20 +26,170 @@ PODS:
     - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
   - FirebaseInstanceID (3.1.1):
     - FirebaseCore (~> 5.0)
-  - GoogleToolboxForMac/Defines (2.1.4)
-  - "GoogleToolboxForMac/NSData+zlib (2.1.4)":
-    - GoogleToolboxForMac/Defines (= 2.1.4)
+  - Folly (2016.09.26.00):
+    - boost-for-react-native
+    - DoubleConversion
+    - glog
+  - glog (0.3.4)
+  - GoogleToolboxForMac/Defines (2.1.0)
+  - "GoogleToolboxForMac/NSData+zlib (2.1.0)":
+    - GoogleToolboxForMac/Defines (= 2.1.0)
   - nanopb (0.3.8):
     - nanopb/decode (= 0.3.8)
     - nanopb/encode (= 0.3.8)
   - nanopb/decode (0.3.8)
   - nanopb/encode (0.3.8)
+  - Picker (4.3.7):
+    - Picker/Core (= 4.3.7)
+  - Picker/Core (4.3.7):
+    - React
+  - React (0.55.3):
+    - React/Core (= 0.55.3)
+  - react-native-camera (1.6.4):
+    - React
+    - react-native-camera/RCT (= 1.6.4)
+    - react-native-camera/RN (= 1.6.4)
+  - react-native-camera/RCT (1.6.4):
+    - React
+  - react-native-camera/RN (1.6.4):
+    - React
+  - react-native-contacts (2.2.2):
+    - React
+  - react-native-contacts-wrapper (0.2.4):
+    - React
+  - react-native-cookies (3.3.0):
+    - React
+  - react-native-fast-crypto (1.8.0):
+    - React
+  - react-native-firebase (4.3.8):
+    - Firebase/Core
+    - React
+  - react-native-image-picker (0.14.3):
+    - React
+  - react-native-locale (0.0.17):
+    - React
+  - react-native-mail (3.0.6):
+    - React
+  - react-native-material-kit (0.3.4):
+    - React
+  - react-native-randombytes (3.5.1):
+    - React
+  - react-native-smart-splash-screen (2.3.5):
+    - React
+  - react-native-tcp (3.2.2):
+    - React
+  - react-native-webview (3.2.1):
+    - React
+  - React/Core (0.55.3):
+    - yoga (= 0.55.3.React)
+  - React/CxxBridge (0.55.3):
+    - Folly (= 2016.09.26.00)
+    - React/Core
+    - React/cxxreact
+  - React/cxxreact (0.55.3):
+    - boost-for-react-native (= 1.63.0)
+    - Folly (= 2016.09.26.00)
+    - React/jschelpers
+    - React/jsinspector
+  - React/DevSupport (0.55.3):
+    - React/Core
+    - React/RCTWebSocket
+  - React/fishhook (0.55.3)
+  - React/jschelpers (0.55.3):
+    - Folly (= 2016.09.26.00)
+    - React/PrivateDatabase
+  - React/jsinspector (0.55.3)
+  - React/PrivateDatabase (0.55.3)
+  - React/RCTAnimation (0.55.3):
+    - React/Core
+  - React/RCTBlob (0.55.3):
+    - React/Core
+  - React/RCTImage (0.55.3):
+    - React/Core
+    - React/RCTNetwork
+  - React/RCTLinkingIOS (0.55.3):
+    - React/Core
+  - React/RCTNetwork (0.55.3):
+    - React/Core
+  - React/RCTPushNotification (0.55.3):
+    - React/Core
+  - React/RCTSettings (0.55.3):
+    - React/Core
+  - React/RCTText (0.55.3):
+    - React/Core
+  - React/RCTWebSocket (0.55.3):
+    - React/Core
+    - React/fishhook
+    - React/RCTBlob
+  - ReactNativePermissions (1.0.6):
+    - React
+  - RNBackgroundFetch (2.4.5):
+    - React
+  - RNDeviceInfo (0.21.5):
+    - React
+  - RNFS (2.13.3):
+    - React
+  - RNOpenAppSettings (1.0.0):
+    - React
+  - RNShare (1.1.3):
+    - React
+  - RNSound (0.10.9):
+    - React/Core
+    - RNSound/Core (= 0.10.9)
+  - RNSound/Core (0.10.9):
+    - React/Core
+  - RNVectorIcons (6.1.0):
+    - React
+  - yoga (0.55.3.React)
 
 DEPENDENCIES:
+  - BugsnagReactNative (from `../node_modules/bugsnag-react-native`)
+  - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
+  - disklet (from `../node_modules/disklet`)
+  - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
+  - edge-login-ui-rn (from `../node_modules/edge-login-ui-rn`)
   - Firebase/Core (~> 5.3.0)
+  - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
+  - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - Picker (from `../node_modules/react-native-picker`)
+  - react-native-camera (from `../node_modules/react-native-camera`)
+  - react-native-contacts (from `../node_modules/react-native-contacts`)
+  - react-native-contacts-wrapper (from `../node_modules/react-native-contacts-wrapper`)
+  - react-native-cookies (from `../node_modules/react-native-cookies`)
+  - react-native-fast-crypto (from `../node_modules/react-native-fast-crypto`)
+  - react-native-firebase (from `../node_modules/react-native-firebase`)
+  - react-native-image-picker (from `../node_modules/react-native-image-picker`)
+  - react-native-locale (from `../node_modules/react-native-locale`)
+  - react-native-mail (from `../node_modules/react-native-mail`)
+  - react-native-material-kit (from `../node_modules/react-native-material-kit`)
+  - react-native-randombytes (from `../node_modules/react-native-randombytes`)
+  - react-native-smart-splash-screen (from `../node_modules/react-native-smart-splash-screen`)
+  - react-native-tcp (from `../node_modules/react-native-tcp`)
+  - react-native-webview (from `../node_modules/react-native-webview`)
+  - React/Core (from `../node_modules/react-native`)
+  - React/CxxBridge (from `../node_modules/react-native`)
+  - React/DevSupport (from `../node_modules/react-native`)
+  - React/RCTAnimation (from `../node_modules/react-native`)
+  - React/RCTImage (from `../node_modules/react-native`)
+  - React/RCTLinkingIOS (from `../node_modules/react-native`)
+  - React/RCTNetwork (from `../node_modules/react-native`)
+  - React/RCTPushNotification (from `../node_modules/react-native`)
+  - React/RCTSettings (from `../node_modules/react-native`)
+  - React/RCTText (from `../node_modules/react-native`)
+  - React/RCTWebSocket (from `../node_modules/react-native`)
+  - ReactNativePermissions (from `../node_modules/react-native-permissions`)
+  - RNBackgroundFetch (from `../node_modules/react-native-background-fetch`)
+  - RNDeviceInfo (from `../node_modules/react-native-device-info`)
+  - RNFS (from `../node_modules/react-native-fs`)
+  - RNOpenAppSettings (from `../node_modules/react-native-app-settings`)
+  - RNShare (from `../node_modules/react-native-share`)
+  - RNSound (from `../node_modules/react-native-sound`)
+  - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
+  - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
+    - boost-for-react-native
     - Firebase
     - FirebaseAnalytics
     - FirebaseCore
@@ -34,14 +197,113 @@ SPEC REPOS:
     - GoogleToolboxForMac
     - nanopb
 
+EXTERNAL SOURCES:
+  BugsnagReactNative:
+    :path: "../node_modules/bugsnag-react-native"
+  BVLinearGradient:
+    :path: "../node_modules/react-native-linear-gradient"
+  disklet:
+    :path: "../node_modules/disklet"
+  DoubleConversion:
+    :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
+  edge-login-ui-rn:
+    :path: "../node_modules/edge-login-ui-rn"
+  Folly:
+    :podspec: "../node_modules/react-native/third-party-podspecs/Folly.podspec"
+  glog:
+    :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
+  Picker:
+    :path: "../node_modules/react-native-picker"
+  React:
+    :path: "../node_modules/react-native"
+  react-native-camera:
+    :path: "../node_modules/react-native-camera"
+  react-native-contacts:
+    :path: "../node_modules/react-native-contacts"
+  react-native-contacts-wrapper:
+    :path: "../node_modules/react-native-contacts-wrapper"
+  react-native-cookies:
+    :path: "../node_modules/react-native-cookies"
+  react-native-fast-crypto:
+    :path: "../node_modules/react-native-fast-crypto"
+  react-native-firebase:
+    :path: "../node_modules/react-native-firebase"
+  react-native-image-picker:
+    :path: "../node_modules/react-native-image-picker"
+  react-native-locale:
+    :path: "../node_modules/react-native-locale"
+  react-native-mail:
+    :path: "../node_modules/react-native-mail"
+  react-native-material-kit:
+    :path: "../node_modules/react-native-material-kit"
+  react-native-randombytes:
+    :path: "../node_modules/react-native-randombytes"
+  react-native-smart-splash-screen:
+    :path: "../node_modules/react-native-smart-splash-screen"
+  react-native-tcp:
+    :path: "../node_modules/react-native-tcp"
+  react-native-webview:
+    :path: "../node_modules/react-native-webview"
+  ReactNativePermissions:
+    :path: "../node_modules/react-native-permissions"
+  RNBackgroundFetch:
+    :path: "../node_modules/react-native-background-fetch"
+  RNDeviceInfo:
+    :path: "../node_modules/react-native-device-info"
+  RNFS:
+    :path: "../node_modules/react-native-fs"
+  RNOpenAppSettings:
+    :path: "../node_modules/react-native-app-settings"
+  RNShare:
+    :path: "../node_modules/react-native-share"
+  RNSound:
+    :path: "../node_modules/react-native-sound"
+  RNVectorIcons:
+    :path: "../node_modules/react-native-vector-icons"
+  yoga:
+    :path: "../node_modules/react-native/ReactCommon/yoga"
+
 SPEC CHECKSUMS:
+  boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
+  BugsnagReactNative: 7ba00c17a3dedfeea4dd011919962d415a231c49
+  BVLinearGradient: 0d985ec461359c82bc254f26d11008bdae50d17a
+  disklet: 0aca5091512a734c94cdfe2bd575794b38717d9e
+  DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
+  edge-login-ui-rn: 731ccf21f5fbda6fe2c562e3e92b57a09de9596f
   Firebase: 68afeeb05461db02d7c9e3215cda28068670f4aa
   FirebaseAnalytics: b3628aea54c50464c32c393fb2ea032566e7ecc2
   FirebaseCore: 62f1b792a49bb9e8b4073f24606d2c93ffc352f0
   FirebaseInstanceID: f3f0657372592ecdfdfe2cac604a5a75758376a6
-  GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
+  Folly: 211775e49d8da0ca658aebc8eab89d642935755c
+  glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
+  GoogleToolboxForMac: 2b2596cbb7186865e98cadf2b1e262d851c2b168
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  Picker: 37554355aef82a532ea95b71b6eeba66bc86182b
+  React: 573d89cf10312b17920df6328eaf9ab8059283bf
+  react-native-camera: 9547ea9ab91ef13476a4ad79ec329b1fe634df8c
+  react-native-contacts: 72b9cda8a19f8b585fa73dbd801232c3eb50685c
+  react-native-contacts-wrapper: a423605f89dba6b83edf481940736646f97cd25a
+  react-native-cookies: 48615324004b541be94e9424f81224f0ba1ff68d
+  react-native-fast-crypto: 750f36a496f0d5c8f6586dc1f0b7e210e86267bf
+  react-native-firebase: c20ee01585998768935fc2cff74ff8e9740f1a73
+  react-native-image-picker: 3693786b3d5958c8f71deed66ec068b323565e0d
+  react-native-locale: 4a82bd5e629130ff135d8090c05cf22115cd5b2f
+  react-native-mail: 7ab61c6522cb955af4c5b9cebfefa070f96548c3
+  react-native-material-kit: e779e910356c15278dcd2d2153b8656d24084c05
+  react-native-randombytes: 1b6091800f62c6c393c6bc850ac089ebf63d4c0a
+  react-native-smart-splash-screen: a961513689f11d63e8496684c2fa4be2d24fe23b
+  react-native-tcp: ec39d0ce136873220a2895a0e89dc33804fe0def
+  react-native-webview: 9a84bb3d5a10bc66924d25b0efda7d1376db28a1
+  ReactNativePermissions: bf462424ca7823d1b8e6cb463184d6e7f151971b
+  RNBackgroundFetch: 8098db4fee60e99afd8bcefa950e8d1760d733ba
+  RNDeviceInfo: e7c5fcde13d40e161d8a27f6c5dc69c638936002
+  RNFS: c9bbde46b0d59619f8e7b735991c60e0f73d22c1
+  RNOpenAppSettings: 1169b90a275e9e18c5973e1608949f97d426e7f3
+  RNShare: 4f206fa36e384e95a0cbf79f2a92490647e93127
+  RNSound: 24fa73ccfa6236a0b493e3f4bf3c952028dc3ce2
+  RNVectorIcons: ac7bf6bfeafaf3ad34552cdc6eed6fb8c4b7c940
+  yoga: 9403c2451c1b47d8cee3e4f1b6fd0ececc63839c
 
-PODFILE CHECKSUM: 8da40ca8d52df737cfb333d4311ec5524cd28a60
+PODFILE CHECKSUM: b39fe0413b216fc82c3295555b341263251dc082
 
 COCOAPODS: 1.5.3

--- a/ios/edge.xcodeproj/project.pbxproj
+++ b/ios/edge.xcodeproj/project.pbxproj
@@ -5,91 +5,50 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
-		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
-		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
-		00C302E81ABCBA2D00DB3ED1 /* libRCTImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302C01ABCB91800DB3ED1 /* libRCTImage.a */; };
-		00C302E91ABCBA2D00DB3ED1 /* libRCTNetwork.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302DC1ABCB9D200DB3ED1 /* libRCTNetwork.a */; };
-		00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302E41ABCB9EE00DB3ED1 /* libRCTVibration.a */; };
 		049D53B0E7A04E8E9FB81225 /* Roboto.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9A4EAE0CED4F4DBE9099BE5B /* Roboto.ttf */; };
-		0A9941B39E5E4145BD2C54E8 /* libRNCookieManagerIOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F1A6ED124A949CD8FD272E7 /* libRNCookieManagerIOS.a */; };
-		133E29F31AD74F7200F7D852 /* libRCTLinking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C398B91ACF4ADC00677621 /* libRCTLinking.a */; };
-		139105C61AF99C1200B5F7CC /* libRCTSettings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139105C11AF99BAD00B5F7CC /* libRCTSettings.a */; };
-		139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139FDEF41B06529B00C62182 /* libRCTWebSocket.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
-		15FCD3C75DEF4703ABEED695 /* libRNCWebView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C946DE90C10A4211A8B15054 /* libRNCWebView.a */; };
-		182BD69D20D94D4BAEB40D43 /* SourceSansPro-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 55A86B1EC39A4267BB7BE53A /* SourceSansPro-LightItalic.ttf */; };
-		1DADC5E648C2487D9786E11A /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 04FF4D5C75964703B2A48184 /* Zocial.ttf */; };
-		2425AB9EBD224B2CB72EB5A9 /* SourceSansPro-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6A599ED42678408CB213F9CB /* SourceSansPro-Semibold.ttf */; };
-		319D7141C5F34FAFAB916A0D /* FontAwesome5_Solid.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 87B423B0EE3B49EBA8F2D0CC /* FontAwesome5_Solid.ttf */; };
-		349FD63F8F054B2AAA775162 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 622C7E72CA724FB2B1F8DCD8 /* MaterialIcons.ttf */; };
-		357C0DB2C7AC476D8CE815FF /* SourceSansPro-ExtraLightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A3DA0EB68E294A3591B2AEEB /* SourceSansPro-ExtraLightItalic.ttf */; };
+		224A82278CB1465E9E84DC30 /* SourceSansPro-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8D378044B6F0404F992F36CD /* SourceSansPro-Bold.ttf */; };
+		237AB7A9983F4B67B540A565 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 70AF6ADFA804412A874E948C /* MaterialIcons.ttf */; };
+		26B52E61E77947A1A4E07707 /* FontAwesome5_Solid.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FD256E3EDE9A4D5CA794D8AD /* FontAwesome5_Solid.ttf */; };
+		31BE19EEE2CA4692A7873F5F /* SourceSansPro-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 27D9F41192F8419DA0531DFF /* SourceSansPro-BoldItalic.ttf */; };
 		3D1368BD21DD76BB00DC8CE4 /* edge-core in Resources */ = {isa = PBXBuildFile; fileRef = 3D1368BC21DD76BB00DC8CE4 /* edge-core */; };
-		409217C1E0564E669BF105DF /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 532AA7D1068248558C022CEF /* Octicons.ttf */; };
-		4739EE2C3B5B44ED8FFE1DBC /* Foundation.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4E23DFF92A0149B1816FA4F2 /* Foundation.ttf */; };
-		492BBE74AA384E29A8AB2F44 /* FontAwesome5_Brands.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D4734E70511C4A4EA9A26574 /* FontAwesome5_Brands.ttf */; };
-		4E198631156B46B4B3639242 /* libRNOpenAppSettings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FE827F7FBEC849DABA8C4BB5 /* libRNOpenAppSettings.a */; };
-		4F81D22B9DB543B0AE7F2FFD /* SourceSansPro-BlackItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5DB5F067BAB54454803A6B66 /* SourceSansPro-BlackItalic.ttf */; };
-		52C52276F2F94D9BB9320EBA /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BC960AB014EF4BF1AA8168B3 /* MaterialCommunityIcons.ttf */; };
+		50FDCD65EBE045E282509085 /* SourceSansPro-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AA0A843F10D9480786517FEF /* SourceSansPro-Italic.ttf */; };
 		5753E201C6234F3D898201B7 /* rubicon-icon-font.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CB5F84A172E9414BB03C915D /* rubicon-icon-font.ttf */; };
-		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
+		5872448FDFE840DEBB46A6BA /* SourceSansPro-ExtraLightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 38A5524778E84A41B960E513 /* SourceSansPro-ExtraLightItalic.ttf */; };
+		5BAD66699331448D82B24104 /* FontAwesome5_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3F94957529C4939AD4E8BD9 /* FontAwesome5_Regular.ttf */; };
+		5F0AA175FFCB452283063917 /* AntDesign.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BC9BE38812E748DE91169D0A /* AntDesign.ttf */; };
 		6ED8C12021BB685C00CC03C7 /* splash.png in Resources */ = {isa = PBXBuildFile; fileRef = 6ED8C11F21BB685C00CC03C7 /* splash.png */; };
-		715ACAB2685D48069807A4D5 /* SourceSansPro-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3B43774D8E1D41F0A625BA1B /* SourceSansPro-Italic.ttf */; };
-		72F8DA229BCB44F6905F658B /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6F375984341A4E6F997CF0A2 /* Zocial.ttf */; };
-		79D627E0AF47498FB03B5D40 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 581BD78CAE5D4A1ABFD0B441 /* Octicons.ttf */; };
-		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
-		85B89D30F0DB45F7B93DB2C1 /* SourceSansPro-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 21B066BA09454AA2818C01A2 /* SourceSansPro-Black.ttf */; };
-		8E503D0B1DA74158AA730B37 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B33C2D198A6D43A589A90307 /* MaterialIcons.ttf */; };
-		9054AE0B96DA43BE8F84812E /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 182DA17E6C5B447AB76E288E /* SimpleLineIcons.ttf */; };
-		93D657C1D1194E61B95E8E49 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5E33C434CF774FE18A0B35D4 /* Entypo.ttf */; };
-		98A28FD8CA854DA0A8B7578E /* SourceSansPro-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5D0C6583E96C41568C4277CE /* SourceSansPro-Bold.ttf */; };
+		6FCB4F1AA1904A75B01966D6 /* TSBackgroundFetch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49D445F8FCA448348B61F284 /* TSBackgroundFetch.framework */; };
+		72FEADA163204A53BB83DDB1 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6BD0166F832945D4A07ABA82 /* EvilIcons.ttf */; };
+		77105E1044684D61B6B0B1EA /* SourceSansPro-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6315893BA6CF465CB1E166CF /* SourceSansPro-Black.ttf */; };
+		772873537EE6422F8F8E8CD3 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 067E24B3F6924143A3E3D7CA /* FontAwesome.ttf */; };
+		7C52DF4E7F844CC48347C9B4 /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DF62D00B1BE94D6E8890A424 /* Zocial.ttf */; };
+		8CBFB9E2496842FC8F06CE3C /* SourceSansPro-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5374C609A9164C53819F3FDD /* SourceSansPro-Semibold.ttf */; };
+		8E1B3057B68149CCA355FDBF /* FontAwesome5_Brands.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F7C7D268E2FC4EF68EACC927 /* FontAwesome5_Brands.ttf */; };
+		96C02F0519DD4F08B16B79C9 /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1DFA24CFCCD34ED081EE86CB /* SimpleLineIcons.ttf */; };
 		98AF3B3B1F99F7D20083E087 /* audio_sent.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 98AF3B031F99F7D10083E087 /* audio_sent.mp3 */; };
 		98AF3B3C1F99F7D20083E087 /* audio_received.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 98AF3B3A1F99F7D10083E087 /* audio_received.mp3 */; };
-		98C72D521F99E7AC00A92AE0 /* libRNSound.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 980AF5C91F9907460014FACB /* libRNSound.a */; };
-		9958B956282245938D6C6898 /* AntDesign.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E8F5DE7F82BD4582985D7792 /* AntDesign.ttf */; };
-		A453881724A5452A8A0333FB /* libDisklet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 739B863F6D8546BBBC8DBF00 /* libDisklet.a */; };
-		AB99B56D46BE4362B90C6E93 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1291273B8A2A4EAD88219964 /* EvilIcons.ttf */; };
+		9C77109EF9C7495E83B65835 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E22452AEA7F9422FA609E7B4 /* Octicons.ttf */; };
+		A32373B436A54BE09CB501C5 /* font.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1FA75A7FCCEA4AACBBC97934 /* font.ttf */; };
+		A88329F9AD044FEB8B7D2AA1 /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 497F4AA15A3F4601A2F7027F /* MaterialCommunityIcons.ttf */; };
+		ABAD41DADC5F4A96990A421E /* Feather.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F7BCB7447264484B9199BD43 /* Feather.ttf */; };
 		AC40390740E9458CBD92E01B /* SF-UI-Text-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 0F91EE15341B486DB1AD6756 /* SF-UI-Text-Regular.otf */; };
-		AF0E365272B24E1C89BB7452 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1C28B9E06CE740B69BDF8C55 /* EvilIcons.ttf */; };
-		B1E9C434242946E08D4599B2 /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0750F8B0567B4CBBADEFD8F6 /* SimpleLineIcons.ttf */; };
-		B316E8323117440B901AE33D /* Foundation.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 98A4A26A585B4A0993EB30FE /* Foundation.ttf */; };
+		AF471FA30819438C9BA580DD /* SourceSansPro-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9EAB0D55879A45ADA4669286 /* SourceSansPro-LightItalic.ttf */; };
+		B0EBAEF96518483CAAC1AE18 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5ECF5E5D3F9F4DF78B80C565 /* Entypo.ttf */; };
+		B1804E036A3340F9AB0CD987 /* Foundation.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 813EA91F40DF41ECAB6C8C83 /* Foundation.ttf */; };
 		B524052E4B614E5DB1524555 /* Roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 2FA801C9862A4F139CE441F6 /* Roboto_medium.ttf */; };
-		C0B8DCFF972C447AA62321BF /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BDFF01E9980F4B789F21E1E1 /* Ionicons.ttf */; };
-		C598D213BA5B4A13B2C02A44 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4C82058B371B46CD92A82298 /* Entypo.ttf */; };
-		C87C995B7DD04A7184195CAA /* SourceSansPro-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BE8F675658884B9F9B064110 /* SourceSansPro-Light.ttf */; };
-		CFC169ACDFF24F3B8D8A38D6 /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8AE61E1C4DDF4FFD823E9883 /* Ionicons.ttf */; };
-		D2ABB4584F0842688F83A019 /* FontAwesome5_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 31683FA3EE4F462EA116F298 /* FontAwesome5_Regular.ttf */; };
+		BBF0CDD08FB044868A4B510C /* SourceSansPro-SemiboldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7F94D33AFE62415995DED277 /* SourceSansPro-SemiboldItalic.ttf */; };
+		D4AFF217F0F5431F869AC7C6 /* SourceSansPro-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 974007B695574483B608D669 /* SourceSansPro-Light.ttf */; };
 		D6181FED10025926C9F176BD /* libPods-edge.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DCFC9E062F0D18DD4E39B5C5 /* libPods-edge.a */; };
-		DA22C55F2124FB1600B2F007 /* libBugsnagReactNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA22C55E2124F82E00B2F007 /* libBugsnagReactNative.a */; };
-		DA22C68E2125003C00B2F007 /* libRNFirebase.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA89DDF620F2CF670012B4BD /* libRNFirebase.a */; };
-		DA22C6F8212501B100B2F007 /* libRNFS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E1091461EB0512200947A0B /* libRNFS.a */; };
-		DA22C739212501CE00B2F007 /* libRNRandomBytes.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A815B621F84B4AA003D8190 /* libRNRandomBytes.a */; };
-		DA22C7432125021A00B2F007 /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA22C7402125021100B2F007 /* libRNDeviceInfo.a */; };
-		DA22C7442125023800B2F007 /* libRNShare.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A815B6B1F84B4AA003D8190 /* libRNShare.a */; };
-		DA22C746212504C200B2F007 /* libRCTLocale.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 65A317F81F01B95B009F4207 /* libRCTLocale.a */; };
-		DA22C747212504FD00B2F007 /* libRNFastCrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA6569521F17436100226952 /* libRNFastCrypto.a */; };
-		DA22C7482125050600B2F007 /* libBVLinearGradient.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E10912D1EB0512100947A0B /* libBVLinearGradient.a */; };
-		DA22C7492125055C00B2F007 /* libTcpSockets.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E1091371EB0512200947A0B /* libTcpSockets.a */; };
-		DA22C74A212505AD00B2F007 /* libReactNativePermissions.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA297D111FF790080075E037 /* libReactNativePermissions.a */; };
-		DA22C74B212505E500B2F007 /* libRCTContacts.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E1090FD1EB0512100947A0B /* libRCTContacts.a */; };
-		DA22C74C212505E500B2F007 /* libRCTContactsWrapper.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E10914B1EB0512200947A0B /* libRCTContactsWrapper.a */; };
-		DA22C74D2125068300B2F007 /* libRCTBEEPickerManager.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B3478FBE1FC60E0000FDA94E /* libRCTBEEPickerManager.a */; };
-		DA22C74E2125068300B2F007 /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E1091221EB0512100947A0B /* libRNImagePicker.a */; };
 		DA285EAC2203BF3000F79CE6 /* exchange_logo_faast@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = DA285EA92203BF2F00F79CE6 /* exchange_logo_faast@3x.png */; };
 		DA285EAD2203BF3000F79CE6 /* exchange_logo_faast.png in Resources */ = {isa = PBXBuildFile; fileRef = DA285EAA2203BF2F00F79CE6 /* exchange_logo_faast.png */; };
 		DA285EAE2203BF3000F79CE6 /* exchange_logo_faast@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DA285EAB2203BF2F00F79CE6 /* exchange_logo_faast@2x.png */; };
-		DA4A13F911E04BB99D3B3B8E /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 003276220D9E46DEB1AC6CFF /* FontAwesome.ttf */; };
-		DA6B702D21275B21009C72C9 /* libRNCamera.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA6B702C212755D3009C72C9 /* libRNCamera.a */; };
-		DA6B705521276BCB009C72C9 /* libAbcCoreJsUi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DACFA6C21F8817B6004F8BD9 /* libAbcCoreJsUi.a */; };
 		DA89DDF820F2CFD70012B4BD /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DA89DDF720F2CFD70012B4BD /* GoogleService-Info.plist */; };
-		DA93C74E2128A90A00178601 /* RNBackgroundFetch+AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DA93C74D2128A90A00178601 /* RNBackgroundFetch+AppDelegate.m */; };
-		DABD013820086A3300C51EF3 /* TSBackgroundFetch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6240E2A20055A9300BA8177 /* TSBackgroundFetch.framework */; };
-		DAC215CF214C21FA00D17326 /* libRNMail.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E6CBD1ED2008075200A967E7 /* libRNMail.a */; };
 		DAF7C41220C505CC005B7898 /* plugins in Resources */ = {isa = PBXBuildFile; fileRef = DAF7C41120C505CC005B7898 /* plugins */; };
-		DFFE6C72345D4A3C8350CCFC /* SourceSansPro-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 842BCA6BE88D4CCDAAC176C5 /* SourceSansPro-BoldItalic.ttf */; };
 		E616C50E20F50FDB00F9252F /* iPadOnboarding2Horiz.png in Resources */ = {isa = PBXBuildFile; fileRef = E616C50120F50FDA00F9252F /* iPadOnboarding2Horiz.png */; };
 		E616C51020F50FDB00F9252F /* iPadOnboarding4Horiz.png in Resources */ = {isa = PBXBuildFile; fileRef = E616C50320F50FDA00F9252F /* iPadOnboarding4Horiz.png */; };
 		E616C51120F50FDB00F9252F /* iPadOnboarding1Horiz.png in Resources */ = {isa = PBXBuildFile; fileRef = E616C50420F50FDA00F9252F /* iPadOnboarding1Horiz.png */; };
@@ -104,7 +63,6 @@
 		E638432C20EFE33B00EA9FE9 /* onboard2.png in Resources */ = {isa = PBXBuildFile; fileRef = E638432020EFE33900EA9FE9 /* onboard2.png */; };
 		E638432E20EFE33B00EA9FE9 /* onboard3.png in Resources */ = {isa = PBXBuildFile; fileRef = E638432220EFE33A00EA9FE9 /* onboard3.png */; };
 		E638433020EFE33B00EA9FE9 /* onboard4.png in Resources */ = {isa = PBXBuildFile; fileRef = E638432420EFE33A00EA9FE9 /* onboard4.png */; };
-		E63A3C47200DF09A00142D79 /* libRCTPushNotification.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E63A3C1C200DF08400142D79 /* libRCTPushNotification.a */; };
 		E6C089A7217E7ADB003DE9B9 /* exchange_logo_changelly.png in Resources */ = {isa = PBXBuildFile; fileRef = E6C0899B217E7AD7003DE9B9 /* exchange_logo_changelly.png */; };
 		E6C089A9217E7ADB003DE9B9 /* exchange_logo_changenow.png in Resources */ = {isa = PBXBuildFile; fileRef = E6C0899D217E7AD8003DE9B9 /* exchange_logo_changenow.png */; };
 		E6C089AA217E7ADB003DE9B9 /* exchange_logo_changenow@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E6C0899E217E7AD9003DE9B9 /* exchange_logo_changenow@2x.png */; };
@@ -121,608 +79,64 @@
 		E6DBE8B2210C937200C52ABE /* onboardX3.png in Resources */ = {isa = PBXBuildFile; fileRef = E6DBE8AB210C937200C52ABE /* onboardX3.png */; };
 		E6DBE8B3210C937200C52ABE /* onboardX5.png in Resources */ = {isa = PBXBuildFile; fileRef = E6DBE8AC210C937200C52ABE /* onboardX5.png */; };
 		E6DBE8B4210C937200C52ABE /* onboardX4.png in Resources */ = {isa = PBXBuildFile; fileRef = E6DBE8AD210C937200C52ABE /* onboardX4.png */; };
-		E6DE0C2820054CCC0004097A /* libRNBackgroundFetch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E6DE0C1A20054BF30004097A /* libRNBackgroundFetch.a */; };
-		E7EED819FAD546EC8B171EBC /* Feather.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1452E793F4134740BD7F189A /* Feather.ttf */; };
-		F17017B55F6C4821845FE684 /* SourceSansPro-SemiboldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 35B7C9406B7E4DCDACBBFCAC /* SourceSansPro-SemiboldItalic.ttf */; };
-		F340EA8A354D45F9B7E8A5FE /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0384684FFB764B78ADE84A03 /* FontAwesome.ttf */; };
-		F4A1362EDC4D400FAF32088B /* font.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0B2C1EBCE00B4AB2B3795968 /* font.ttf */; };
-		FA970440AC4B42D28C64CB75 /* SourceSansPro-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C239BC5B07794717978CEF5D /* SourceSansPro-ExtraLight.ttf */; };
-		FD6D9F211FABEF8300D4998E /* libRCTSplashScreen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FD6D9F011FABEF3A00D4998E /* libRCTSplashScreen.a */; };
+		E7AF9B4D9E8A4729BC45EAC1 /* RNBackgroundFetch+AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D4EB636094148199D949ED1 /* RNBackgroundFetch+AppDelegate.m */; };
+		ED5310DCFBF946DFA36CC462 /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A4F20FA41E19409A93306235 /* Ionicons.ttf */; };
+		F0D7D6C909584919867CD8B5 /* SourceSansPro-BlackItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3174EFC33129444580156447 /* SourceSansPro-BlackItalic.ttf */; };
+		F3343A739BF04CF1B73A6AA6 /* SourceSansPro-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8203ECA416CB4127BE7B00B3 /* SourceSansPro-Regular.ttf */; };
+		F4A41DF580AB4DA18363D332 /* SourceSansPro-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 67EDE898A18B445AB08D1ED3 /* SourceSansPro-ExtraLight.ttf */; };
 		FD982BCC1FACDEF00057F035 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = FD982BCB1FACDEF00057F035 /* LaunchScreen.xib */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		00C302AB1ABCB8CE00DB3ED1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RCTActionSheet;
-		};
-		00C302B91ABCB90400DB3ED1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RCTGeolocation;
-		};
-		00C302BF1ABCB91800DB3ED1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 58B5115D1A9E6B3D00147676;
-			remoteInfo = RCTImage;
-		};
-		00C302DB1ABCB9D200DB3ED1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 58B511DB1A9E6C8500147676;
-			remoteInfo = RCTNetwork;
-		};
-		00C302E31ABCB9EE00DB3ED1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 832C81801AAF6DEF007FA2F7;
-			remoteInfo = RCTVibration;
-		};
-		139105C01AF99BAD00B5F7CC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RCTSettings;
-		};
-		139FDEF31B06529B00C62182 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3C86DF461ADF2C930047B81A;
-			remoteInfo = RCTWebSocket;
-		};
-		146834031AC3E56700842450 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
-			remoteInfo = React;
-		};
-		3DAD3E831DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A283A1D9B042B00D4039D;
-			remoteInfo = "RCTImage-tvOS";
-		};
-		3DAD3E871DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28471D9B043800D4039D;
-			remoteInfo = "RCTLinking-tvOS";
-		};
-		3DAD3E8B1DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28541D9B044C00D4039D;
-			remoteInfo = "RCTNetwork-tvOS";
-		};
-		3DAD3E8F1DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28611D9B046600D4039D;
-			remoteInfo = "RCTSettings-tvOS";
-		};
-		3DAD3E931DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A287B1D9B048500D4039D;
-			remoteInfo = "RCTText-tvOS";
-		};
-		3DAD3E981DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28881D9B049200D4039D;
-			remoteInfo = "RCTWebSocket-tvOS";
-		};
-		3DAD3EA21DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28131D9B038B00D4039D;
-			remoteInfo = "React-tvOS";
-		};
-		3DAD3EA41DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D3C059A1DE3340900C268FA;
-			remoteInfo = yoga;
-		};
-		3DAD3EA61DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D3C06751DE3340C00C268FA;
-			remoteInfo = "yoga-tvOS";
-		};
-		3DAD3EA81DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D3CD9251DE5FBEC00167DC4;
-			remoteInfo = cxxreact;
-		};
-		3DAD3EAA1DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D3CD9321DE5FBEE00167DC4;
-			remoteInfo = "cxxreact-tvOS";
-		};
-		3DAD3EAC1DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D3CD90B1DE5FBD600167DC4;
-			remoteInfo = jschelpers;
-		};
-		3DAD3EAE1DF850E9000B6D8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D3CD9181DE5FBD800167DC4;
-			remoteInfo = "jschelpers-tvOS";
-		};
-		5A815B2D1F84B4AA003D8190 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 97E65DB6D2464A14AA289DCA /* BVLinearGradient.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 64AA15081EF7F30100718508;
-			remoteInfo = "BVLinearGradient-tvOS";
-		};
-		5A815B611F84B4AA003D8190 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9FAF874E8B104A9B88AD9E6C /* RNRandomBytes.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 73EEC9391BFE4B1D00D468EB;
-			remoteInfo = RNRandomBytes;
-		};
-		5A815B6A1F84B4AA003D8190 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 24A1BC4D1FC647CC8F52B48A /* RNShare.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RNShare;
-		};
-		5E9157321DD0AC6500FF2AA8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RCTAnimation;
-		};
-		5E9157341DD0AC6500FF2AA8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28201D9B03D100D4039D;
-			remoteInfo = "RCTAnimation-tvOS";
-		};
-		65A317F71F01B95B009F4207 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = ADB2A160FF8046E6B3DCE8BA /* RCTLocale.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = DB248BF21C18396500105A5D;
-			remoteInfo = RCTLocale;
-		};
-		6E1090FC1EB0512100947A0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2A2684F551B44D0AB6288C90 /* RCTContacts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 1441618E1BD0A79300FA4F59;
-			remoteInfo = RCTContacts;
-		};
-		6E1091041EB0512100947A0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 52A081BF9D7D41028708C710 /* RCTMaterialKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8A1B8E771B22E4E300DB45C2;
-			remoteInfo = RCTMaterialKit;
-		};
-		6E1091211EB0512100947A0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 22412DEE8F26420E8952DE97 /* RNImagePicker.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 014A3B5C1C6CF33500B6D375;
-			remoteInfo = RNImagePicker;
-		};
-		6E1091271EB0512100947A0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 892B05950477468DB932A014 /* RNVectorIcons.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 5DBEB1501B18CEA900B34395;
-			remoteInfo = RNVectorIcons;
-		};
-		6E10912C1EB0512100947A0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 97E65DB6D2464A14AA289DCA /* BVLinearGradient.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = BVLinearGradient;
-		};
-		6E1091361EB0512200947A0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F4D44BFC0C7E41B4BEBA4B07 /* TcpSockets.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = TcpSockets;
-		};
-		6E1091451EB0512200947A0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1B6A6174519B479885305633 /* RNFS.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F12AFB9B1ADAF8F800E0535D;
-			remoteInfo = RNFS;
-		};
-		6E10914A1EB0512200947A0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BEEE73DC1247486781D6157A /* ContactsWrapper.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2B58405A1D10DE8700235F31;
-			remoteInfo = RCTContactsWrapper;
-		};
-		6E4C2A352247FC6D00B0EB5D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1F9F651A5AFA4DDFBEA752ED /* Disklet.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = Disklet;
-		};
-		6EDA1047217E76BC0084C5DD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E08A0470E99A412CB00E7140 /* RNOpenAppSettings.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RNOpenAppSettings;
-		};
-		78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RCTLinking;
-		};
-		832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
-			remoteInfo = RCTText;
-		};
-		980AF5C81F9907460014FACB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 980AF5931F9907460014FACB /* RNSound.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 19825A1E1BD4A89800EE0337;
-			remoteInfo = RNSound;
-		};
-		B3478FBD1FC60E0000FDA94E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2BF0E6DD44C34212B790AA9C /* RCTBEEPickerManager.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 17D41E551D7EE0CA0031415E;
-			remoteInfo = RCTBEEPickerManager;
-		};
-		DA22C3822124E49800B2F007 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EBF21BDC1FC498900052F4D5;
-			remoteInfo = jsinspector;
-		};
-		DA22C3842124E49800B2F007 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EBF21BFA1FC4989A0052F4D5;
-			remoteInfo = "jsinspector-tvOS";
-		};
-		DA22C3932124E49800B2F007 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9FAF874E8B104A9B88AD9E6C /* RNRandomBytes.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 163CDE4E2087CAD3001065FB;
-			remoteInfo = "RNRandomBytes-tvOS";
-		};
-		DA22C55D2124F82E00B2F007 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DA22C5592124F82E00B2F007 /* BugsnagReactNative.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8AD256131D6DE5F600C7D842;
-			remoteInfo = BugsnagReactNative;
-		};
-		DA22C73F2125021100B2F007 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DA22C73A2125021100B2F007 /* RNDeviceInfo.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = DA5891D81BA9A9FC002B4DB2;
-			remoteInfo = RNDeviceInfo;
-		};
-		DA22C7412125021100B2F007 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DA22C73A2125021100B2F007 /* RNDeviceInfo.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = E72EC1401F7ABB5A0001BC90;
-			remoteInfo = "RNDeviceInfo-tvOS";
-		};
-		DA297CEA1FF790070075E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3DBE0D001F3B181A0099AA32;
-			remoteInfo = fishhook;
-		};
-		DA297CEC1FF790070075E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3DBE0D0D1F3B181C0099AA32;
-			remoteInfo = "fishhook-tvOS";
-		};
-		DA297CFC1FF790070075E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9936F3131F5F2E4B0010BF04;
-			remoteInfo = privatedata;
-		};
-		DA297CFE1FF790070075E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9936F32F1F5F2E5B0010BF04;
-			remoteInfo = "privatedata-tvOS";
-		};
-		DA297D101FF790080075E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BDCC0C82B5E64518B315ED90 /* ReactNativePermissions.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9D23B34F1C767B80008B4819;
-			remoteInfo = ReactNativePermissions;
-		};
-		DA6569461F17436100226952 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 139D7ECE1E25DB7D00323FB7;
-			remoteInfo = "third-party";
-		};
-		DA6569481F17436100226952 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D383D3C1EBD27B6005632C8;
-			remoteInfo = "third-party-tvOS";
-		};
-		DA65694A1F17436100226952 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 139D7E881E25C6D100323FB7;
-			remoteInfo = "double-conversion";
-		};
-		DA65694C1F17436100226952 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D383D621EBD27B9005632C8;
-			remoteInfo = "double-conversion-tvOS";
-		};
-		DA6569511F17436100226952 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4071F13220774C1E884D7CE6 /* RNFastCrypto.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RNFastCrypto;
-		};
-		DA6569551F17436100226952 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1B6A6174519B479885305633 /* RNFS.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6456441F1EB8DA9100672408;
-			remoteInfo = "RNFS-tvOS";
-		};
-		DA6B702B212755D3009C72C9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DA6B7027212755D2009C72C9 /* RNCamera.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4107012F1ACB723B00C6AA39;
-			remoteInfo = RNCamera;
-		};
-		DA89DDF520F2CF670012B4BD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B9A285CF05C64584ADBBE7ED /* RNFirebase.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RNFirebase;
-		};
-		DACFA6C11F8817B6004F8BD9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D508A63DA69244B691ABB3A5 /* AbcCoreJsUi.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = AbcCoreJsUi;
-		};
-		E6051D4921D51E91007F87B9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 892B05950477468DB932A014 /* RNVectorIcons.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = A39873CE1EA65EE60051E01A;
-			remoteInfo = "RNVectorIcons-tvOS";
-		};
-		E6051D5021D51E92007F87B9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 31B27BFCD5764FDCB4999E72 /* RNCWebView.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RNCWebView;
-		};
-		E63A3C1B200DF08400142D79 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E63A3C01200DF08400142D79 /* RCTPushNotification.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RCTPushNotification;
-		};
-		E63A3C1D200DF08400142D79 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E63A3C01200DF08400142D79 /* RCTPushNotification.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D05745F1DE6004600184BB4;
-			remoteInfo = "RCTPushNotification-tvOS";
-		};
-		E64D31E921BEEB3D0038693B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8C6E36B511F84168AD949B10 /* RNCookieManagerIOS.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 1BD725DA1CF77A8B005DBD79;
-			remoteInfo = RNCookieManagerIOS;
-		};
-		E6CBD1EC2008075200A967E7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8A4F000025E4FB6B7D895BB /* RNMail.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 46FEDE7F1AFF192F00D3261C;
-			remoteInfo = RNMail;
-		};
-		E6CBD1EE2008075200A967E7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8A4F000025E4FB6B7D895BB /* RNMail.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 46FEDE8A1AFF192F00D3261C;
-			remoteInfo = RNMailTests;
-		};
-		E6DE0C1920054BF30004097A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E6DE0BE920054BF30004097A /* RNBackgroundFetch.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 835318541D52293F005738CD;
-			remoteInfo = RNBackgroundFetch;
-		};
-		FD6D9F001FABEF3A00D4998E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = FD6D9EE51FABEF3A00D4998E /* RCTSplashScreen.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9F90C2241D619E9400F3E238;
-			remoteInfo = RCTSplashScreen;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
-		003276220D9E46DEB1AC6CFF /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
-		00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTActionSheet.xcodeproj; path = "../node_modules/react-native/Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj"; sourceTree = "<group>"; };
-		00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTGeolocation.xcodeproj; path = "../node_modules/react-native/Libraries/Geolocation/RCTGeolocation.xcodeproj"; sourceTree = "<group>"; };
-		00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTImage.xcodeproj; path = "../node_modules/react-native/Libraries/Image/RCTImage.xcodeproj"; sourceTree = "<group>"; };
-		00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTNetwork.xcodeproj; path = "../node_modules/react-native/Libraries/Network/RCTNetwork.xcodeproj"; sourceTree = "<group>"; };
-		00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTVibration.xcodeproj; path = "../node_modules/react-native/Libraries/Vibration/RCTVibration.xcodeproj"; sourceTree = "<group>"; };
-		0384684FFB764B78ADE84A03 /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/native-base/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
-		04FF4D5C75964703B2A48184 /* Zocial.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Zocial.ttf; path = "../node_modules/native-base/Fonts/Zocial.ttf"; sourceTree = "<group>"; };
-		0750F8B0567B4CBBADEFD8F6 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
-		0B2C1EBCE00B4AB2B3795968 /* font.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = font.ttf; path = ../src/assets/fonts/font.ttf; sourceTree = "<group>"; };
+		067E24B3F6924143A3E3D7CA /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
 		0F91EE15341B486DB1AD6756 /* SF-UI-Text-Regular.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SF-UI-Text-Regular.otf"; path = "../src/assets/fonts/SF-UI-Text-Regular.otf"; sourceTree = "<group>"; };
-		1291273B8A2A4EAD88219964 /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
-		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
-		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* edge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = edge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = edge/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = edge/AppDelegate.m; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = edge/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = edge/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = edge/main.m; sourceTree = "<group>"; };
-		1452E793F4134740BD7F189A /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Feather.ttf"; sourceTree = "<group>"; };
-		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
-		182DA17E6C5B447AB76E288E /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/native-base/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
-		1B6A6174519B479885305633 /* RNFS.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFS.xcodeproj; path = "../node_modules/react-native-fs/RNFS.xcodeproj"; sourceTree = "<group>"; };
-		1C28B9E06CE740B69BDF8C55 /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/native-base/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
-		1F9F651A5AFA4DDFBEA752ED /* Disklet.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = Disklet.xcodeproj; path = ../node_modules/disklet/ios/Disklet.xcodeproj; sourceTree = "<group>"; };
-		21B066BA09454AA2818C01A2 /* SourceSansPro-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Black.ttf"; path = "../src/assets/fonts/SourceSansPro-Black.ttf"; sourceTree = "<group>"; };
-		22412DEE8F26420E8952DE97 /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNImagePicker.xcodeproj; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; };
-		24A1BC4D1FC647CC8F52B48A /* RNShare.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNShare.xcodeproj; path = "../node_modules/react-native-share/ios/RNShare.xcodeproj"; sourceTree = "<group>"; };
-		2A2684F551B44D0AB6288C90 /* RCTContacts.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTContacts.xcodeproj; path = "../node_modules/react-native-contacts/ios/RCTContacts.xcodeproj"; sourceTree = "<group>"; };
-		2BF0E6DD44C34212B790AA9C /* RCTBEEPickerManager.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTBEEPickerManager.xcodeproj; path = "../node_modules/react-native-picker/ios/RCTBEEPickerManager.xcodeproj"; sourceTree = "<group>"; };
+		1DFA24CFCCD34ED081EE86CB /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
+		1FA75A7FCCEA4AACBBC97934 /* font.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = font.ttf; path = ../src/assets/fonts/font.ttf; sourceTree = "<group>"; };
+		27D9F41192F8419DA0531DFF /* SourceSansPro-BoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-BoldItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-BoldItalic.ttf"; sourceTree = "<group>"; };
 		2FA801C9862A4F139CE441F6 /* Roboto_medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Roboto_medium.ttf; path = "../node_modules/native-base/Fonts/Roboto_medium.ttf"; sourceTree = "<group>"; };
-		31683FA3EE4F462EA116F298 /* FontAwesome5_Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Regular.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Regular.ttf"; sourceTree = "<group>"; };
-		31B27BFCD5764FDCB4999E72 /* RNCWebView.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNCWebView.xcodeproj; path = "../node_modules/react-native-webview/ios/RNCWebView.xcodeproj"; sourceTree = "<group>"; };
-		35B7C9406B7E4DCDACBBFCAC /* SourceSansPro-SemiboldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-SemiboldItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-SemiboldItalic.ttf"; sourceTree = "<group>"; };
-		3B43774D8E1D41F0A625BA1B /* SourceSansPro-Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Italic.ttf"; path = "../src/assets/fonts/SourceSansPro-Italic.ttf"; sourceTree = "<group>"; };
+		3174EFC33129444580156447 /* SourceSansPro-BlackItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-BlackItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-BlackItalic.ttf"; sourceTree = "<group>"; };
+		38A5524778E84A41B960E513 /* SourceSansPro-ExtraLightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-ExtraLightItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-ExtraLightItalic.ttf"; sourceTree = "<group>"; };
 		3D1368BC21DD76BB00DC8CE4 /* edge-core */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "edge-core"; sourceTree = "<group>"; };
-		4071F13220774C1E884D7CE6 /* RNFastCrypto.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFastCrypto.xcodeproj; path = "../node_modules/react-native-fast-crypto/ios/RNFastCrypto.xcodeproj"; sourceTree = "<group>"; };
-		4C82058B371B46CD92A82298 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
-		4E23DFF92A0149B1816FA4F2 /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
-		52A081BF9D7D41028708C710 /* RCTMaterialKit.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTMaterialKit.xcodeproj; path = "../node_modules/react-native-material-kit/iOS/RCTMaterialKit.xcodeproj"; sourceTree = "<group>"; };
-		532AA7D1068248558C022CEF /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
+		497F4AA15A3F4601A2F7027F /* MaterialCommunityIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialCommunityIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf"; sourceTree = "<group>"; };
+		49D445F8FCA448348B61F284 /* TSBackgroundFetch.framework */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = wrapper.framework; name = TSBackgroundFetch.framework; path = "../node_modules/react-native-background-fetch/ios/RNBackgroundFetch/TSBackgroundFetch.framework"; sourceTree = SDKROOT; };
+		5374C609A9164C53819F3FDD /* SourceSansPro-Semibold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Semibold.ttf"; path = "../src/assets/fonts/SourceSansPro-Semibold.ttf"; sourceTree = "<group>"; };
 		550016E295D7C4722CD35EF9 /* Pods-edge.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-edge.debug.xcconfig"; path = "Pods/Target Support Files/Pods-edge/Pods-edge.debug.xcconfig"; sourceTree = "<group>"; };
-		55A86B1EC39A4267BB7BE53A /* SourceSansPro-LightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-LightItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-LightItalic.ttf"; sourceTree = "<group>"; };
-		581BD78CAE5D4A1ABFD0B441 /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/native-base/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
-		5D0C6583E96C41568C4277CE /* SourceSansPro-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Bold.ttf"; path = "../src/assets/fonts/SourceSansPro-Bold.ttf"; sourceTree = "<group>"; };
-		5DB5F067BAB54454803A6B66 /* SourceSansPro-BlackItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-BlackItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-BlackItalic.ttf"; sourceTree = "<group>"; };
-		5E33C434CF774FE18A0B35D4 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/native-base/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
-		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
-		622C7E72CA724FB2B1F8DCD8 /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
-		64A64A9CD69342B3A6354C43 /* SourceSansPro-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Regular.ttf"; path = "../src/assets/fonts/SourceSansPro-Regular.ttf"; sourceTree = "<group>"; };
-		6A599ED42678408CB213F9CB /* SourceSansPro-Semibold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Semibold.ttf"; path = "../src/assets/fonts/SourceSansPro-Semibold.ttf"; sourceTree = "<group>"; };
+		5ECF5E5D3F9F4DF78B80C565 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
+		6315893BA6CF465CB1E166CF /* SourceSansPro-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Black.ttf"; path = "../src/assets/fonts/SourceSansPro-Black.ttf"; sourceTree = "<group>"; };
+		67EDE898A18B445AB08D1ED3 /* SourceSansPro-ExtraLight.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-ExtraLight.ttf"; path = "../src/assets/fonts/SourceSansPro-ExtraLight.ttf"; sourceTree = "<group>"; };
+		6BD0166F832945D4A07ABA82 /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		6ED8C11F21BB685C00CC03C7 /* splash.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = splash.png; sourceTree = "<group>"; };
-		6F1A6ED124A949CD8FD272E7 /* libRNCookieManagerIOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNCookieManagerIOS.a; sourceTree = "<group>"; };
-		6F375984341A4E6F997CF0A2 /* Zocial.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Zocial.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Zocial.ttf"; sourceTree = "<group>"; };
-		739B863F6D8546BBBC8DBF00 /* libDisklet.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libDisklet.a; sourceTree = "<group>"; };
-		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
-		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
-		842BCA6BE88D4CCDAAC176C5 /* SourceSansPro-BoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-BoldItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-BoldItalic.ttf"; sourceTree = "<group>"; };
-		87B423B0EE3B49EBA8F2D0CC /* FontAwesome5_Solid.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Solid.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf"; sourceTree = "<group>"; };
-		892B05950477468DB932A014 /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNVectorIcons.xcodeproj; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; };
-		8AE61E1C4DDF4FFD823E9883 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/native-base/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
-		8C6E36B511F84168AD949B10 /* RNCookieManagerIOS.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNCookieManagerIOS.xcodeproj; path = "../node_modules/react-native-cookies/ios/RNCookieManagerIOS.xcodeproj"; sourceTree = "<group>"; };
-		97E65DB6D2464A14AA289DCA /* BVLinearGradient.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = BVLinearGradient.xcodeproj; path = "../node_modules/react-native-linear-gradient/BVLinearGradient.xcodeproj"; sourceTree = "<group>"; };
-		980AF5931F9907460014FACB /* RNSound.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNSound.xcodeproj; path = "../node_modules/react-native-sound/RNSound.xcodeproj"; sourceTree = "<group>"; };
-		98A4A26A585B4A0993EB30FE /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/native-base/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
+		70AF6ADFA804412A874E948C /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
+		7F94D33AFE62415995DED277 /* SourceSansPro-SemiboldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-SemiboldItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-SemiboldItalic.ttf"; sourceTree = "<group>"; };
+		813EA91F40DF41ECAB6C8C83 /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
+		8203ECA416CB4127BE7B00B3 /* SourceSansPro-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Regular.ttf"; path = "../src/assets/fonts/SourceSansPro-Regular.ttf"; sourceTree = "<group>"; };
+		8D378044B6F0404F992F36CD /* SourceSansPro-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Bold.ttf"; path = "../src/assets/fonts/SourceSansPro-Bold.ttf"; sourceTree = "<group>"; };
+		974007B695574483B608D669 /* SourceSansPro-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Light.ttf"; path = "../src/assets/fonts/SourceSansPro-Light.ttf"; sourceTree = "<group>"; };
 		98AF3B031F99F7D10083E087 /* audio_sent.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; name = audio_sent.mp3; path = ../android/app/src/main/res/raw/audio_sent.mp3; sourceTree = "<group>"; };
 		98AF3B3A1F99F7D10083E087 /* audio_received.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; name = audio_received.mp3; path = ../android/app/src/main/res/raw/audio_received.mp3; sourceTree = "<group>"; };
 		9A4EAE0CED4F4DBE9099BE5B /* Roboto.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Roboto.ttf; path = "../node_modules/native-base/Fonts/Roboto.ttf"; sourceTree = "<group>"; };
-		9FAF874E8B104A9B88AD9E6C /* RNRandomBytes.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNRandomBytes.xcodeproj; path = "../node_modules/react-native-randombytes/RNRandomBytes.xcodeproj"; sourceTree = "<group>"; };
+		9D4EB636094148199D949ED1 /* RNBackgroundFetch+AppDelegate.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; name = "RNBackgroundFetch+AppDelegate.m"; path = "../node_modules/react-native-background-fetch/ios/RNBackgroundFetch/RNBackgroundFetch+AppDelegate.m"; sourceTree = "<group>"; };
+		9EAB0D55879A45ADA4669286 /* SourceSansPro-LightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-LightItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-LightItalic.ttf"; sourceTree = "<group>"; };
 		A0587BF5EC0B93837E5E83BE /* Pods-edge.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-edge.release.xcconfig"; path = "Pods/Target Support Files/Pods-edge/Pods-edge.release.xcconfig"; sourceTree = "<group>"; };
-		A3DA0EB68E294A3591B2AEEB /* SourceSansPro-ExtraLightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-ExtraLightItalic.ttf"; path = "../src/assets/fonts/SourceSansPro-ExtraLightItalic.ttf"; sourceTree = "<group>"; };
-		ADB2A160FF8046E6B3DCE8BA /* RCTLocale.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTLocale.xcodeproj; path = "../node_modules/react-native-locale/ios/RCTLocale.xcodeproj"; sourceTree = "<group>"; };
-		B33C2D198A6D43A589A90307 /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/native-base/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
-		B9A285CF05C64584ADBBE7ED /* RNFirebase.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFirebase.xcodeproj; path = "../node_modules/react-native-firebase/ios/RNFirebase.xcodeproj"; sourceTree = "<group>"; };
-		BC960AB014EF4BF1AA8168B3 /* MaterialCommunityIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialCommunityIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf"; sourceTree = "<group>"; };
-		BDCC0C82B5E64518B315ED90 /* ReactNativePermissions.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = ReactNativePermissions.xcodeproj; path = "../node_modules/react-native-permissions/ios/ReactNativePermissions.xcodeproj"; sourceTree = "<group>"; };
-		BDFF01E9980F4B789F21E1E1 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
-		BE8F675658884B9F9B064110 /* SourceSansPro-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Light.ttf"; path = "../src/assets/fonts/SourceSansPro-Light.ttf"; sourceTree = "<group>"; };
-		BEEE73DC1247486781D6157A /* ContactsWrapper.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = ContactsWrapper.xcodeproj; path = "../node_modules/react-native-contacts-wrapper/ios/ContactsWrapper.xcodeproj"; sourceTree = "<group>"; };
-		C239BC5B07794717978CEF5D /* SourceSansPro-ExtraLight.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-ExtraLight.ttf"; path = "../src/assets/fonts/SourceSansPro-ExtraLight.ttf"; sourceTree = "<group>"; };
-		C946DE90C10A4211A8B15054 /* libRNCWebView.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNCWebView.a; sourceTree = "<group>"; };
+		A4F20FA41E19409A93306235 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
+		AA0A843F10D9480786517FEF /* SourceSansPro-Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SourceSansPro-Italic.ttf"; path = "../src/assets/fonts/SourceSansPro-Italic.ttf"; sourceTree = "<group>"; };
+		B3F94957529C4939AD4E8BD9 /* FontAwesome5_Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Regular.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Regular.ttf"; sourceTree = "<group>"; };
+		BC9BE38812E748DE91169D0A /* AntDesign.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = AntDesign.ttf; path = "../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf"; sourceTree = "<group>"; };
 		CB5F84A172E9414BB03C915D /* rubicon-icon-font.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "rubicon-icon-font.ttf"; path = "../node_modules/native-base/Fonts/rubicon-icon-font.ttf"; sourceTree = "<group>"; };
-		D4734E70511C4A4EA9A26574 /* FontAwesome5_Brands.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Brands.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf"; sourceTree = "<group>"; };
-		D508A63DA69244B691ABB3A5 /* AbcCoreJsUi.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = AbcCoreJsUi.xcodeproj; path = "../node_modules/edge-login-ui-rn/ios/AbcCoreJsUi.xcodeproj"; sourceTree = "<group>"; };
-		D8A4F000025E4FB6B7D895BB /* RNMail.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNMail.xcodeproj; path = "../node_modules/react-native-mail/RNMail.xcodeproj"; sourceTree = "<group>"; };
-		DA22C5512124F60100B2F007 /* libBugsnagStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libBugsnagStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		DA22C5592124F82E00B2F007 /* BugsnagReactNative.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BugsnagReactNative.xcodeproj; path = "../node_modules/bugsnag-react-native/cocoa/BugsnagReactNative.xcodeproj"; sourceTree = "<group>"; };
-		DA22C73A2125021100B2F007 /* RNDeviceInfo.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNDeviceInfo.xcodeproj; path = "../node_modules/react-native-device-info/ios/RNDeviceInfo.xcodeproj"; sourceTree = "<group>"; };
 		DA285EA92203BF2F00F79CE6 /* exchange_logo_faast@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "exchange_logo_faast@3x.png"; sourceTree = "<group>"; };
 		DA285EAA2203BF2F00F79CE6 /* exchange_logo_faast.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = exchange_logo_faast.png; sourceTree = "<group>"; };
 		DA285EAB2203BF2F00F79CE6 /* exchange_logo_faast@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "exchange_logo_faast@2x.png"; sourceTree = "<group>"; };
-		DA6B7027212755D2009C72C9 /* RNCamera.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNCamera.xcodeproj; path = "../node_modules/react-native-camera/ios/RNCamera.xcodeproj"; sourceTree = "<group>"; };
 		DA89DDF720F2CFD70012B4BD /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "edge/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		DA93C74D2128A90A00178601 /* RNBackgroundFetch+AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RNBackgroundFetch+AppDelegate.m"; path = "../node_modules/react-native-background-fetch/ios/RNBackgroundFetch/RNBackgroundFetch+AppDelegate.m"; sourceTree = "<group>"; };
 		DAF7C41120C505CC005B7898 /* plugins */ = {isa = PBXFileReference; lastKnownFileType = folder; path = plugins; sourceTree = "<group>"; };
 		DCFC9E062F0D18DD4E39B5C5 /* libPods-edge.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-edge.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E08A0470E99A412CB00E7140 /* RNOpenAppSettings.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNOpenAppSettings.xcodeproj; path = "../node_modules/react-native-app-settings/ios/RNOpenAppSettings.xcodeproj"; sourceTree = "<group>"; };
+		DF62D00B1BE94D6E8890A424 /* Zocial.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Zocial.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Zocial.ttf"; sourceTree = "<group>"; };
+		E22452AEA7F9422FA609E7B4 /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
 		E616C50120F50FDA00F9252F /* iPadOnboarding2Horiz.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = iPadOnboarding2Horiz.png; sourceTree = "<group>"; };
 		E616C50320F50FDA00F9252F /* iPadOnboarding4Horiz.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = iPadOnboarding4Horiz.png; sourceTree = "<group>"; };
 		E616C50420F50FDA00F9252F /* iPadOnboarding1Horiz.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = iPadOnboarding1Horiz.png; sourceTree = "<group>"; };
@@ -731,14 +145,12 @@
 		E616C51C20F51B1900F9252F /* iPadOnboarding4Vert.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = iPadOnboarding4Vert.png; sourceTree = "<group>"; };
 		E616C52020F51B1900F9252F /* iPadOnboarding2Vert.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = iPadOnboarding2Vert.png; sourceTree = "<group>"; };
 		E616C52120F51B1A00F9252F /* iPadOnboarding3Vert.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = iPadOnboarding3Vert.png; sourceTree = "<group>"; };
-		E6240E2A20055A9300BA8177 /* TSBackgroundFetch.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TSBackgroundFetch.framework; path = "../node_modules/react-native-background-fetch/ios/RNBackgroundFetch/TSBackgroundFetch.framework"; sourceTree = "<group>"; };
 		E62A1694210BBBA7002D2665 /* onboard1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = onboard1.png; sourceTree = "<group>"; };
 		E62A1696210BBD3D002D2665 /* onboard5.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = onboard5.png; sourceTree = "<group>"; };
 		E63842DA20EFE23300EA9FE9 /* alt_splash.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = alt_splash.png; sourceTree = "<group>"; };
 		E638432020EFE33900EA9FE9 /* onboard2.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = onboard2.png; sourceTree = "<group>"; };
 		E638432220EFE33A00EA9FE9 /* onboard3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = onboard3.png; sourceTree = "<group>"; };
 		E638432420EFE33A00EA9FE9 /* onboard4.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = onboard4.png; sourceTree = "<group>"; };
-		E63A3C01200DF08400142D79 /* RCTPushNotification.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTPushNotification.xcodeproj; path = "../node_modules/react-native/Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj"; sourceTree = "<group>"; };
 		E682D9AD200DF9A70042F9BA /* edge.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = edge.entitlements; path = edge/edge.entitlements; sourceTree = "<group>"; };
 		E6C0899B217E7AD7003DE9B9 /* exchange_logo_changelly.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = exchange_logo_changelly.png; sourceTree = "<group>"; };
 		E6C0899D217E7AD8003DE9B9 /* exchange_logo_changenow.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = exchange_logo_changenow.png; sourceTree = "<group>"; };
@@ -756,12 +168,10 @@
 		E6DBE8AB210C937200C52ABE /* onboardX3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = onboardX3.png; sourceTree = "<group>"; };
 		E6DBE8AC210C937200C52ABE /* onboardX5.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = onboardX5.png; sourceTree = "<group>"; };
 		E6DBE8AD210C937200C52ABE /* onboardX4.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = onboardX4.png; sourceTree = "<group>"; };
-		E6DE0BE920054BF30004097A /* RNBackgroundFetch.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNBackgroundFetch.xcodeproj; path = "../node_modules/react-native-background-fetch/ios/RNBackgroundFetch.xcodeproj"; sourceTree = "<group>"; };
-		E8F5DE7F82BD4582985D7792 /* AntDesign.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = AntDesign.ttf; path = "../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf"; sourceTree = "<group>"; };
-		F4D44BFC0C7E41B4BEBA4B07 /* TcpSockets.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = TcpSockets.xcodeproj; path = "../node_modules/react-native-tcp/ios/TcpSockets.xcodeproj"; sourceTree = "<group>"; };
-		FD6D9EE51FABEF3A00D4998E /* RCTSplashScreen.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSplashScreen.xcodeproj; path = "../node_modules/react-native-smart-splash-screen/ios/RCTSplashScreen/RCTSplashScreen.xcodeproj"; sourceTree = "<group>"; };
+		F7BCB7447264484B9199BD43 /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Feather.ttf"; sourceTree = "<group>"; };
+		F7C7D268E2FC4EF68EACC927 /* FontAwesome5_Brands.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Brands.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf"; sourceTree = "<group>"; };
+		FD256E3EDE9A4D5CA794D8AD /* FontAwesome5_Solid.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Solid.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf"; sourceTree = "<group>"; };
 		FD982BCB1FACDEF00057F035 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
-		FE827F7FBEC849DABA8C4BB5 /* libRNOpenAppSettings.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNOpenAppSettings.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -769,93 +179,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DAC215CF214C21FA00D17326 /* libRNMail.a in Frameworks */,
-				DA6B705521276BCB009C72C9 /* libAbcCoreJsUi.a in Frameworks */,
-				DA22C7482125050600B2F007 /* libBVLinearGradient.a in Frameworks */,
-				DA22C74C212505E500B2F007 /* libRCTContactsWrapper.a in Frameworks */,
-				E63A3C47200DF09A00142D79 /* libRCTPushNotification.a in Frameworks */,
-				DA22C55F2124FB1600B2F007 /* libBugsnagReactNative.a in Frameworks */,
-				146834051AC3E58100842450 /* libReact.a in Frameworks */,
-				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
-				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
-				DA22C74D2125068300B2F007 /* libRCTBEEPickerManager.a in Frameworks */,
-				DA6B702D21275B21009C72C9 /* libRNCamera.a in Frameworks */,
-				DA22C74E2125068300B2F007 /* libRNImagePicker.a in Frameworks */,
-				DA22C74B212505E500B2F007 /* libRCTContacts.a in Frameworks */,
-				DA22C74A212505AD00B2F007 /* libReactNativePermissions.a in Frameworks */,
-				DA22C7492125055C00B2F007 /* libTcpSockets.a in Frameworks */,
-				DABD013820086A3300C51EF3 /* TSBackgroundFetch.framework in Frameworks */,
-				DA22C747212504FD00B2F007 /* libRNFastCrypto.a in Frameworks */,
-				DA22C746212504C200B2F007 /* libRCTLocale.a in Frameworks */,
-				DA22C7442125023800B2F007 /* libRNShare.a in Frameworks */,
-				DA22C7432125021A00B2F007 /* libRNDeviceInfo.a in Frameworks */,
-				DA22C739212501CE00B2F007 /* libRNRandomBytes.a in Frameworks */,
-				DA22C6F8212501B100B2F007 /* libRNFS.a in Frameworks */,
-				DA22C68E2125003C00B2F007 /* libRNFirebase.a in Frameworks */,
-				98C72D521F99E7AC00A92AE0 /* libRNSound.a in Frameworks */,
-				00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */,
-				00C302E81ABCBA2D00DB3ED1 /* libRCTImage.a in Frameworks */,
-				133E29F31AD74F7200F7D852 /* libRCTLinking.a in Frameworks */,
-				00C302E91ABCBA2D00DB3ED1 /* libRCTNetwork.a in Frameworks */,
-				139105C61AF99C1200B5F7CC /* libRCTSettings.a in Frameworks */,
-				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
-				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
-				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
-				FD6D9F211FABEF8300D4998E /* libRCTSplashScreen.a in Frameworks */,
-				E6DE0C2820054CCC0004097A /* libRNBackgroundFetch.a in Frameworks */,
 				D6181FED10025926C9F176BD /* libPods-edge.a in Frameworks */,
-				4E198631156B46B4B3639242 /* libRNOpenAppSettings.a in Frameworks */,
-				0A9941B39E5E4145BD2C54E8 /* libRNCookieManagerIOS.a in Frameworks */,
-				15FCD3C75DEF4703ABEED695 /* libRNCWebView.a in Frameworks */,
-				A453881724A5452A8A0333FB /* libDisklet.a in Frameworks */,
+				6FCB4F1AA1904A75B01966D6 /* TSBackgroundFetch.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		00C302A81ABCB8CE00DB3ED1 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		00C302B61ABCB90400DB3ED1 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		00C302BC1ABCB91800DB3ED1 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				00C302C01ABCB91800DB3ED1 /* libRCTImage.a */,
-				3DAD3E841DF850E9000B6D8A /* libRCTImage-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		00C302D41ABCB9D200DB3ED1 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				00C302DC1ABCB9D200DB3ED1 /* libRCTNetwork.a */,
-				3DAD3E8C1DF850E9000B6D8A /* libRCTNetwork-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		00C302E01ABCB9EE00DB3ED1 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				00C302E41ABCB9EE00DB3ED1 /* libRCTVibration.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		1189D14E429D3398A100CB8A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -865,26 +196,6 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		139105B71AF99BAD00B5F7CC /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				139105C11AF99BAD00B5F7CC /* libRCTSettings.a */,
-				3DAD3E901DF850E9000B6D8A /* libRCTSettings-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		139FDEE71B06529A00C62182 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				139FDEF41B06529B00C62182 /* libRCTWebSocket.a */,
-				3DAD3E991DF850E9000B6D8A /* libRCTWebSocket-tvOS.a */,
-				DA297CEB1FF790070075E037 /* libfishhook.a */,
-				DA297CED1FF790070075E037 /* libfishhook-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		13B07FAE1A68108700A75B9A /* edge */ = {
 			isa = PBXGroup;
 			children = (
@@ -892,221 +203,62 @@
 				E682D9AD200DF9A70042F9BA /* edge.entitlements */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
-				DA93C74D2128A90A00178601 /* RNBackgroundFetch+AppDelegate.m */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				9D4EB636094148199D949ED1 /* RNBackgroundFetch+AppDelegate.m */,
 			);
 			name = edge;
-			sourceTree = "<group>";
-		};
-		146834001AC3E56700842450 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				146834041AC3E56700842450 /* libReact.a */,
-				3DAD3EA31DF850E9000B6D8A /* libReact.a */,
-				3DAD3EA51DF850E9000B6D8A /* libyoga.a */,
-				3DAD3EA71DF850E9000B6D8A /* libyoga.a */,
-				3DAD3EA91DF850E9000B6D8A /* libcxxreact.a */,
-				3DAD3EAB1DF850E9000B6D8A /* libcxxreact.a */,
-				3DAD3EAD1DF850E9000B6D8A /* libjschelpers.a */,
-				3DAD3EAF1DF850E9000B6D8A /* libjschelpers.a */,
-				DA22C3832124E49800B2F007 /* libjsinspector.a */,
-				DA22C3852124E49800B2F007 /* libjsinspector-tvOS.a */,
-				DA6569471F17436100226952 /* libthird-party.a */,
-				DA6569491F17436100226952 /* libthird-party.a */,
-				DA65694B1F17436100226952 /* libdouble-conversion.a */,
-				DA65694D1F17436100226952 /* libdouble-conversion.a */,
-				DA297CFD1FF790070075E037 /* libprivatedata.a */,
-				DA297CFF1FF790070075E037 /* libprivatedata-tvOS.a */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		3BB21E930C5F437EB1EAE492 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				3D1368BC21DD76BB00DC8CE4 /* edge-core */,
-				DAF7C41120C505CC005B7898 /* plugins */,
+				BC9BE38812E748DE91169D0A /* AntDesign.ttf */,
 				98AF3B3A1F99F7D10083E087 /* audio_received.mp3 */,
 				98AF3B031F99F7D10083E087 /* audio_sent.mp3 */,
-				BC960AB014EF4BF1AA8168B3 /* MaterialCommunityIcons.ttf */,
-				0B2C1EBCE00B4AB2B3795968 /* font.ttf */,
-				5DB5F067BAB54454803A6B66 /* SourceSansPro-BlackItalic.ttf */,
-				5D0C6583E96C41568C4277CE /* SourceSansPro-Bold.ttf */,
-				842BCA6BE88D4CCDAAC176C5 /* SourceSansPro-BoldItalic.ttf */,
-				C239BC5B07794717978CEF5D /* SourceSansPro-ExtraLight.ttf */,
-				A3DA0EB68E294A3591B2AEEB /* SourceSansPro-ExtraLightItalic.ttf */,
-				3B43774D8E1D41F0A625BA1B /* SourceSansPro-Italic.ttf */,
-				BE8F675658884B9F9B064110 /* SourceSansPro-Light.ttf */,
-				55A86B1EC39A4267BB7BE53A /* SourceSansPro-LightItalic.ttf */,
-				64A64A9CD69342B3A6354C43 /* SourceSansPro-Regular.ttf */,
-				6A599ED42678408CB213F9CB /* SourceSansPro-Semibold.ttf */,
-				35B7C9406B7E4DCDACBBFCAC /* SourceSansPro-SemiboldItalic.ttf */,
-				21B066BA09454AA2818C01A2 /* SourceSansPro-Black.ttf */,
-				5E33C434CF774FE18A0B35D4 /* Entypo.ttf */,
-				1C28B9E06CE740B69BDF8C55 /* EvilIcons.ttf */,
-				0384684FFB764B78ADE84A03 /* FontAwesome.ttf */,
-				98A4A26A585B4A0993EB30FE /* Foundation.ttf */,
-				8AE61E1C4DDF4FFD823E9883 /* Ionicons.ttf */,
-				B33C2D198A6D43A589A90307 /* MaterialIcons.ttf */,
-				581BD78CAE5D4A1ABFD0B441 /* Octicons.ttf */,
+				3D1368BC21DD76BB00DC8CE4 /* edge-core */,
+				5ECF5E5D3F9F4DF78B80C565 /* Entypo.ttf */,
+				6BD0166F832945D4A07ABA82 /* EvilIcons.ttf */,
+				F7BCB7447264484B9199BD43 /* Feather.ttf */,
+				1FA75A7FCCEA4AACBBC97934 /* font.ttf */,
+				067E24B3F6924143A3E3D7CA /* FontAwesome.ttf */,
+				F7C7D268E2FC4EF68EACC927 /* FontAwesome5_Brands.ttf */,
+				B3F94957529C4939AD4E8BD9 /* FontAwesome5_Regular.ttf */,
+				FD256E3EDE9A4D5CA794D8AD /* FontAwesome5_Solid.ttf */,
+				813EA91F40DF41ECAB6C8C83 /* Foundation.ttf */,
+				A4F20FA41E19409A93306235 /* Ionicons.ttf */,
+				497F4AA15A3F4601A2F7027F /* MaterialCommunityIcons.ttf */,
+				70AF6ADFA804412A874E948C /* MaterialIcons.ttf */,
+				E22452AEA7F9422FA609E7B4 /* Octicons.ttf */,
+				DAF7C41120C505CC005B7898 /* plugins */,
 				2FA801C9862A4F139CE441F6 /* Roboto_medium.ttf */,
 				9A4EAE0CED4F4DBE9099BE5B /* Roboto.ttf */,
 				CB5F84A172E9414BB03C915D /* rubicon-icon-font.ttf */,
-				182DA17E6C5B447AB76E288E /* SimpleLineIcons.ttf */,
-				04FF4D5C75964703B2A48184 /* Zocial.ttf */,
-				4C82058B371B46CD92A82298 /* Entypo.ttf */,
-				1291273B8A2A4EAD88219964 /* EvilIcons.ttf */,
-				003276220D9E46DEB1AC6CFF /* FontAwesome.ttf */,
-				4E23DFF92A0149B1816FA4F2 /* Foundation.ttf */,
-				BDFF01E9980F4B789F21E1E1 /* Ionicons.ttf */,
-				622C7E72CA724FB2B1F8DCD8 /* MaterialIcons.ttf */,
-				532AA7D1068248558C022CEF /* Octicons.ttf */,
-				0750F8B0567B4CBBADEFD8F6 /* SimpleLineIcons.ttf */,
-				6F375984341A4E6F997CF0A2 /* Zocial.ttf */,
-				1452E793F4134740BD7F189A /* Feather.ttf */,
 				0F91EE15341B486DB1AD6756 /* SF-UI-Text-Regular.otf */,
-				E8F5DE7F82BD4582985D7792 /* AntDesign.ttf */,
-				D4734E70511C4A4EA9A26574 /* FontAwesome5_Brands.ttf */,
-				31683FA3EE4F462EA116F298 /* FontAwesome5_Regular.ttf */,
-				87B423B0EE3B49EBA8F2D0CC /* FontAwesome5_Solid.ttf */,
+				1DFA24CFCCD34ED081EE86CB /* SimpleLineIcons.ttf */,
+				6315893BA6CF465CB1E166CF /* SourceSansPro-Black.ttf */,
+				3174EFC33129444580156447 /* SourceSansPro-BlackItalic.ttf */,
+				8D378044B6F0404F992F36CD /* SourceSansPro-Bold.ttf */,
+				27D9F41192F8419DA0531DFF /* SourceSansPro-BoldItalic.ttf */,
+				67EDE898A18B445AB08D1ED3 /* SourceSansPro-ExtraLight.ttf */,
+				38A5524778E84A41B960E513 /* SourceSansPro-ExtraLightItalic.ttf */,
+				AA0A843F10D9480786517FEF /* SourceSansPro-Italic.ttf */,
+				974007B695574483B608D669 /* SourceSansPro-Light.ttf */,
+				9EAB0D55879A45ADA4669286 /* SourceSansPro-LightItalic.ttf */,
+				8203ECA416CB4127BE7B00B3 /* SourceSansPro-Regular.ttf */,
+				5374C609A9164C53819F3FDD /* SourceSansPro-Semibold.ttf */,
+				7F94D33AFE62415995DED277 /* SourceSansPro-SemiboldItalic.ttf */,
+				DF62D00B1BE94D6E8890A424 /* Zocial.ttf */,
 			);
 			name = Resources;
-			sourceTree = "<group>";
-		};
-		5A815B291F84B4AA003D8190 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				5A815B621F84B4AA003D8190 /* libRNRandomBytes.a */,
-				DA22C3942124E49800B2F007 /* libRNRandomBytes-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		5A815B671F84B4AA003D8190 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				5A815B6B1F84B4AA003D8190 /* libRNShare.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		5E91572E1DD0AC6500FF2AA8 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */,
-				5E9157351DD0AC6500FF2AA8 /* libRCTAnimation.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		65A317E81F01B95B009F4207 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				65A317F81F01B95B009F4207 /* libRCTLocale.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6E1090EF1EB0512100947A0B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E1091051EB0512100947A0B /* libRCTMaterialKit.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6E1090F31EB0512100947A0B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E1090FD1EB0512100947A0B /* libRCTContacts.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6E10911A1EB0512100947A0B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E1091221EB0512100947A0B /* libRNImagePicker.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6E10911C1EB0512100947A0B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E1091281EB0512100947A0B /* libRNVectorIcons.a */,
-				E6051D4A21D51E91007F87B9 /* libRNVectorIcons-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6E1091291EB0512100947A0B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E10912D1EB0512100947A0B /* libBVLinearGradient.a */,
-				5A815B2E1F84B4AA003D8190 /* libBVLinearGradient.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6E10912E1EB0512200947A0B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E1091371EB0512200947A0B /* libTcpSockets.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6E1091421EB0512200947A0B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E1091461EB0512200947A0B /* libRNFS.a */,
-				DA6569561F17436100226952 /* libRNFS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6E1091471EB0512200947A0B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E10914B1EB0512200947A0B /* libRCTContactsWrapper.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6E4C2A322247FC6D00B0EB5D /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E4C2A362247FC6D00B0EB5D /* libDisklet.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6EDA1044217E76BC0084C5DD /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6EDA1048217E76BC0084C5DD /* libRNOpenAppSettings.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		78C398B11ACF4ADC00677621 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				78C398B91ACF4ADC00677621 /* libRCTLinking.a */,
-				3DAD3E881DF850E9000B6D8A /* libRCTLinking-tvOS.a */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		82DAC2543B5A97898904086F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E6240E2A20055A9300BA8177 /* TSBackgroundFetch.framework */,
 				DCFC9E062F0D18DD4E39B5C5 /* libPods-edge.a */,
-				DA22C5512124F60100B2F007 /* libBugsnagStatic.a */,
+				49D445F8FCA448348B61F284 /* TSBackgroundFetch.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1114,56 +266,8 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
-				D508A63DA69244B691ABB3A5 /* AbcCoreJsUi.xcodeproj */,
-				97E65DB6D2464A14AA289DCA /* BVLinearGradient.xcodeproj */,
-				BEEE73DC1247486781D6157A /* ContactsWrapper.xcodeproj */,
-				DA22C5592124F82E00B2F007 /* BugsnagReactNative.xcodeproj */,
-				146833FF1AC3E56700842450 /* React.xcodeproj */,
-				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
-				5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */,
-				2BF0E6DD44C34212B790AA9C /* RCTBEEPickerManager.xcodeproj */,
-				2A2684F551B44D0AB6288C90 /* RCTContacts.xcodeproj */,
-				00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */,
-				00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */,
-				78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */,
-				ADB2A160FF8046E6B3DCE8BA /* RCTLocale.xcodeproj */,
-				52A081BF9D7D41028708C710 /* RCTMaterialKit.xcodeproj */,
-				00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */,
-				E63A3C01200DF08400142D79 /* RCTPushNotification.xcodeproj */,
-				139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */,
-				FD6D9EE51FABEF3A00D4998E /* RCTSplashScreen.xcodeproj */,
-				832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */,
-				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
-				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
-				BDCC0C82B5E64518B315ED90 /* ReactNativePermissions.xcodeproj */,
-				E6DE0BE920054BF30004097A /* RNBackgroundFetch.xcodeproj */,
-				DA6B7027212755D2009C72C9 /* RNCamera.xcodeproj */,
-				DA22C73A2125021100B2F007 /* RNDeviceInfo.xcodeproj */,
-				4071F13220774C1E884D7CE6 /* RNFastCrypto.xcodeproj */,
-				B9A285CF05C64584ADBBE7ED /* RNFirebase.xcodeproj */,
-				1B6A6174519B479885305633 /* RNFS.xcodeproj */,
-				22412DEE8F26420E8952DE97 /* RNImagePicker.xcodeproj */,
-				D8A4F000025E4FB6B7D895BB /* RNMail.xcodeproj */,
-				9FAF874E8B104A9B88AD9E6C /* RNRandomBytes.xcodeproj */,
-				24A1BC4D1FC647CC8F52B48A /* RNShare.xcodeproj */,
-				980AF5931F9907460014FACB /* RNSound.xcodeproj */,
-				892B05950477468DB932A014 /* RNVectorIcons.xcodeproj */,
-				F4D44BFC0C7E41B4BEBA4B07 /* TcpSockets.xcodeproj */,
-				E08A0470E99A412CB00E7140 /* RNOpenAppSettings.xcodeproj */,
-				8C6E36B511F84168AD949B10 /* RNCookieManagerIOS.xcodeproj */,
-				31B27BFCD5764FDCB4999E72 /* RNCWebView.xcodeproj */,
-				1F9F651A5AFA4DDFBEA752ED /* Disklet.xcodeproj */,
 			);
 			name = Libraries;
-			sourceTree = "<group>";
-		};
-		832341B11AAA6A8300B99B32 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				832341B51AAA6A8300B99B32 /* libRCTText.a */,
-				3DAD3E941DF850E9000B6D8A /* libRCTText-tvOS.a */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		83CBB9F61A601CBA00E9B192 = {
@@ -1190,138 +294,11 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		980AF5941F9907460014FACB /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				980AF5C91F9907460014FACB /* libRNSound.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		B3478FBA1FC60DFF00FDA94E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				B3478FBE1FC60E0000FDA94E /* libRCTBEEPickerManager.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		DA22C55A2124F82E00B2F007 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DA22C55E2124F82E00B2F007 /* libBugsnagReactNative.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		DA22C73B2125021100B2F007 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DA22C7402125021100B2F007 /* libRNDeviceInfo.a */,
-				DA22C7422125021100B2F007 /* libRNDeviceInfo-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		DA297D0D1FF790080075E037 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DA297D111FF790080075E037 /* libReactNativePermissions.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		DA600D001F8F1D57001F3096 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
-				FE827F7FBEC849DABA8C4BB5 /* libRNOpenAppSettings.a */,
-				6F1A6ED124A949CD8FD272E7 /* libRNCookieManagerIOS.a */,
-				C946DE90C10A4211A8B15054 /* libRNCWebView.a */,
-				739B863F6D8546BBBC8DBF00 /* libDisklet.a */,
 			);
 			name = "Recovered References";
-			sourceTree = "<group>";
-		};
-		DA6569211F17436100226952 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DA6569521F17436100226952 /* libRNFastCrypto.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		DA6B7028212755D2009C72C9 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DA6B702C212755D3009C72C9 /* libRNCamera.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		DA89DDF220F2CF670012B4BD /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DA89DDF620F2CF670012B4BD /* libRNFirebase.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		DACFA6BE1F8817B5004F8BD9 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DACFA6C21F8817B6004F8BD9 /* libAbcCoreJsUi.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		E6051D4D21D51E92007F87B9 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				E6051D5121D51E92007F87B9 /* libRNCWebView.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		E63A3C02200DF08400142D79 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				E63A3C1C200DF08400142D79 /* libRCTPushNotification.a */,
-				E63A3C1E200DF08400142D79 /* libRCTPushNotification-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		E64D31E621BEEB3D0038693B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				E64D31EA21BEEB3D0038693B /* libRNCookieManagerIOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		E6CBD1E82008075200A967E7 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				E6CBD1ED2008075200A967E7 /* libRNMail.a */,
-				E6CBD1EF2008075200A967E7 /* RNMailTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		E6DE0BEA20054BF30004097A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				E6DE0C1A20054BF30004097A /* libRNBackgroundFetch.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		FD6D9EE61FABEF3A00D4998E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				FD6D9F011FABEF3A00D4998E /* libRCTSplashScreen.a */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		FD982BC41FABFA020057F035 /* SplashScreenResource */ = {
@@ -1378,6 +355,7 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				2AA364716BF34DF609A9E9B4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1401,7 +379,7 @@
 						DevelopmentTeam = G5LQ7MERPK;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
-								enabled = 1;
+								enabled = true;
 							};
 							com.apple.Push = {
 								enabled = 0;
@@ -1421,663 +399,12 @@
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = DACFA6BE1F8817B5004F8BD9 /* Products */;
-					ProjectRef = D508A63DA69244B691ABB3A5 /* AbcCoreJsUi.xcodeproj */;
-				},
-				{
-					ProductGroup = DA22C55A2124F82E00B2F007 /* Products */;
-					ProjectRef = DA22C5592124F82E00B2F007 /* BugsnagReactNative.xcodeproj */;
-				},
-				{
-					ProductGroup = 6E1091291EB0512100947A0B /* Products */;
-					ProjectRef = 97E65DB6D2464A14AA289DCA /* BVLinearGradient.xcodeproj */;
-				},
-				{
-					ProductGroup = 6E1091471EB0512200947A0B /* Products */;
-					ProjectRef = BEEE73DC1247486781D6157A /* ContactsWrapper.xcodeproj */;
-				},
-				{
-					ProductGroup = 6E4C2A322247FC6D00B0EB5D /* Products */;
-					ProjectRef = 1F9F651A5AFA4DDFBEA752ED /* Disklet.xcodeproj */;
-				},
-				{
-					ProductGroup = 00C302A81ABCB8CE00DB3ED1 /* Products */;
-					ProjectRef = 00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */;
-				},
-				{
-					ProductGroup = 5E91572E1DD0AC6500FF2AA8 /* Products */;
-					ProjectRef = 5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */;
-				},
-				{
-					ProductGroup = B3478FBA1FC60DFF00FDA94E /* Products */;
-					ProjectRef = 2BF0E6DD44C34212B790AA9C /* RCTBEEPickerManager.xcodeproj */;
-				},
-				{
-					ProductGroup = 6E1090F31EB0512100947A0B /* Products */;
-					ProjectRef = 2A2684F551B44D0AB6288C90 /* RCTContacts.xcodeproj */;
-				},
-				{
-					ProductGroup = 00C302B61ABCB90400DB3ED1 /* Products */;
-					ProjectRef = 00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */;
-				},
-				{
-					ProductGroup = 00C302BC1ABCB91800DB3ED1 /* Products */;
-					ProjectRef = 00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */;
-				},
-				{
-					ProductGroup = 78C398B11ACF4ADC00677621 /* Products */;
-					ProjectRef = 78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */;
-				},
-				{
-					ProductGroup = 65A317E81F01B95B009F4207 /* Products */;
-					ProjectRef = ADB2A160FF8046E6B3DCE8BA /* RCTLocale.xcodeproj */;
-				},
-				{
-					ProductGroup = 6E1090EF1EB0512100947A0B /* Products */;
-					ProjectRef = 52A081BF9D7D41028708C710 /* RCTMaterialKit.xcodeproj */;
-				},
-				{
-					ProductGroup = 00C302D41ABCB9D200DB3ED1 /* Products */;
-					ProjectRef = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
-				},
-				{
-					ProductGroup = E63A3C02200DF08400142D79 /* Products */;
-					ProjectRef = E63A3C01200DF08400142D79 /* RCTPushNotification.xcodeproj */;
-				},
-				{
-					ProductGroup = 139105B71AF99BAD00B5F7CC /* Products */;
-					ProjectRef = 139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */;
-				},
-				{
-					ProductGroup = FD6D9EE61FABEF3A00D4998E /* Products */;
-					ProjectRef = FD6D9EE51FABEF3A00D4998E /* RCTSplashScreen.xcodeproj */;
-				},
-				{
-					ProductGroup = 832341B11AAA6A8300B99B32 /* Products */;
-					ProjectRef = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
-				},
-				{
-					ProductGroup = 00C302E01ABCB9EE00DB3ED1 /* Products */;
-					ProjectRef = 00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */;
-				},
-				{
-					ProductGroup = 139FDEE71B06529A00C62182 /* Products */;
-					ProjectRef = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
-				},
-				{
-					ProductGroup = 146834001AC3E56700842450 /* Products */;
-					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-				},
-				{
-					ProductGroup = DA297D0D1FF790080075E037 /* Products */;
-					ProjectRef = BDCC0C82B5E64518B315ED90 /* ReactNativePermissions.xcodeproj */;
-				},
-				{
-					ProductGroup = E6DE0BEA20054BF30004097A /* Products */;
-					ProjectRef = E6DE0BE920054BF30004097A /* RNBackgroundFetch.xcodeproj */;
-				},
-				{
-					ProductGroup = DA6B7028212755D2009C72C9 /* Products */;
-					ProjectRef = DA6B7027212755D2009C72C9 /* RNCamera.xcodeproj */;
-				},
-				{
-					ProductGroup = E64D31E621BEEB3D0038693B /* Products */;
-					ProjectRef = 8C6E36B511F84168AD949B10 /* RNCookieManagerIOS.xcodeproj */;
-				},
-				{
-					ProductGroup = E6051D4D21D51E92007F87B9 /* Products */;
-					ProjectRef = 31B27BFCD5764FDCB4999E72 /* RNCWebView.xcodeproj */;
-				},
-				{
-					ProductGroup = DA22C73B2125021100B2F007 /* Products */;
-					ProjectRef = DA22C73A2125021100B2F007 /* RNDeviceInfo.xcodeproj */;
-				},
-				{
-					ProductGroup = DA6569211F17436100226952 /* Products */;
-					ProjectRef = 4071F13220774C1E884D7CE6 /* RNFastCrypto.xcodeproj */;
-				},
-				{
-					ProductGroup = DA89DDF220F2CF670012B4BD /* Products */;
-					ProjectRef = B9A285CF05C64584ADBBE7ED /* RNFirebase.xcodeproj */;
-				},
-				{
-					ProductGroup = 6E1091421EB0512200947A0B /* Products */;
-					ProjectRef = 1B6A6174519B479885305633 /* RNFS.xcodeproj */;
-				},
-				{
-					ProductGroup = 6E10911A1EB0512100947A0B /* Products */;
-					ProjectRef = 22412DEE8F26420E8952DE97 /* RNImagePicker.xcodeproj */;
-				},
-				{
-					ProductGroup = E6CBD1E82008075200A967E7 /* Products */;
-					ProjectRef = D8A4F000025E4FB6B7D895BB /* RNMail.xcodeproj */;
-				},
-				{
-					ProductGroup = 6EDA1044217E76BC0084C5DD /* Products */;
-					ProjectRef = E08A0470E99A412CB00E7140 /* RNOpenAppSettings.xcodeproj */;
-				},
-				{
-					ProductGroup = 5A815B291F84B4AA003D8190 /* Products */;
-					ProjectRef = 9FAF874E8B104A9B88AD9E6C /* RNRandomBytes.xcodeproj */;
-				},
-				{
-					ProductGroup = 5A815B671F84B4AA003D8190 /* Products */;
-					ProjectRef = 24A1BC4D1FC647CC8F52B48A /* RNShare.xcodeproj */;
-				},
-				{
-					ProductGroup = 980AF5941F9907460014FACB /* Products */;
-					ProjectRef = 980AF5931F9907460014FACB /* RNSound.xcodeproj */;
-				},
-				{
-					ProductGroup = 6E10911C1EB0512100947A0B /* Products */;
-					ProjectRef = 892B05950477468DB932A014 /* RNVectorIcons.xcodeproj */;
-				},
-				{
-					ProductGroup = 6E10912E1EB0512200947A0B /* Products */;
-					ProjectRef = F4D44BFC0C7E41B4BEBA4B07 /* TcpSockets.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* edge */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTActionSheet.a;
-			remoteRef = 00C302AB1ABCB8CE00DB3ED1 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTGeolocation.a;
-			remoteRef = 00C302B91ABCB90400DB3ED1 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		00C302C01ABCB91800DB3ED1 /* libRCTImage.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTImage.a;
-			remoteRef = 00C302BF1ABCB91800DB3ED1 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		00C302DC1ABCB9D200DB3ED1 /* libRCTNetwork.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTNetwork.a;
-			remoteRef = 00C302DB1ABCB9D200DB3ED1 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		00C302E41ABCB9EE00DB3ED1 /* libRCTVibration.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTVibration.a;
-			remoteRef = 00C302E31ABCB9EE00DB3ED1 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		139105C11AF99BAD00B5F7CC /* libRCTSettings.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTSettings.a;
-			remoteRef = 139105C01AF99BAD00B5F7CC /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		139FDEF41B06529B00C62182 /* libRCTWebSocket.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTWebSocket.a;
-			remoteRef = 139FDEF31B06529B00C62182 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		146834041AC3E56700842450 /* libReact.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libReact.a;
-			remoteRef = 146834031AC3E56700842450 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3E841DF850E9000B6D8A /* libRCTImage-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTImage-tvOS.a";
-			remoteRef = 3DAD3E831DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3E881DF850E9000B6D8A /* libRCTLinking-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTLinking-tvOS.a";
-			remoteRef = 3DAD3E871DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3E8C1DF850E9000B6D8A /* libRCTNetwork-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTNetwork-tvOS.a";
-			remoteRef = 3DAD3E8B1DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3E901DF850E9000B6D8A /* libRCTSettings-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTSettings-tvOS.a";
-			remoteRef = 3DAD3E8F1DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3E941DF850E9000B6D8A /* libRCTText-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTText-tvOS.a";
-			remoteRef = 3DAD3E931DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3E991DF850E9000B6D8A /* libRCTWebSocket-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTWebSocket-tvOS.a";
-			remoteRef = 3DAD3E981DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3EA31DF850E9000B6D8A /* libReact.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libReact.a;
-			remoteRef = 3DAD3EA21DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3EA51DF850E9000B6D8A /* libyoga.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libyoga.a;
-			remoteRef = 3DAD3EA41DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3EA71DF850E9000B6D8A /* libyoga.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libyoga.a;
-			remoteRef = 3DAD3EA61DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3EA91DF850E9000B6D8A /* libcxxreact.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libcxxreact.a;
-			remoteRef = 3DAD3EA81DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3EAB1DF850E9000B6D8A /* libcxxreact.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libcxxreact.a;
-			remoteRef = 3DAD3EAA1DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3EAD1DF850E9000B6D8A /* libjschelpers.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libjschelpers.a;
-			remoteRef = 3DAD3EAC1DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3DAD3EAF1DF850E9000B6D8A /* libjschelpers.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libjschelpers.a;
-			remoteRef = 3DAD3EAE1DF850E9000B6D8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		5A815B2E1F84B4AA003D8190 /* libBVLinearGradient.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libBVLinearGradient.a;
-			remoteRef = 5A815B2D1F84B4AA003D8190 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		5A815B621F84B4AA003D8190 /* libRNRandomBytes.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNRandomBytes.a;
-			remoteRef = 5A815B611F84B4AA003D8190 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		5A815B6B1F84B4AA003D8190 /* libRNShare.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNShare.a;
-			remoteRef = 5A815B6A1F84B4AA003D8190 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTAnimation.a;
-			remoteRef = 5E9157321DD0AC6500FF2AA8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		5E9157351DD0AC6500FF2AA8 /* libRCTAnimation.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTAnimation.a;
-			remoteRef = 5E9157341DD0AC6500FF2AA8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		65A317F81F01B95B009F4207 /* libRCTLocale.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTLocale.a;
-			remoteRef = 65A317F71F01B95B009F4207 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E1090FD1EB0512100947A0B /* libRCTContacts.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTContacts.a;
-			remoteRef = 6E1090FC1EB0512100947A0B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E1091051EB0512100947A0B /* libRCTMaterialKit.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTMaterialKit.a;
-			remoteRef = 6E1091041EB0512100947A0B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E1091221EB0512100947A0B /* libRNImagePicker.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNImagePicker.a;
-			remoteRef = 6E1091211EB0512100947A0B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E1091281EB0512100947A0B /* libRNVectorIcons.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNVectorIcons.a;
-			remoteRef = 6E1091271EB0512100947A0B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E10912D1EB0512100947A0B /* libBVLinearGradient.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libBVLinearGradient.a;
-			remoteRef = 6E10912C1EB0512100947A0B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E1091371EB0512200947A0B /* libTcpSockets.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libTcpSockets.a;
-			remoteRef = 6E1091361EB0512200947A0B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E1091461EB0512200947A0B /* libRNFS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNFS.a;
-			remoteRef = 6E1091451EB0512200947A0B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E10914B1EB0512200947A0B /* libRCTContactsWrapper.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTContactsWrapper.a;
-			remoteRef = 6E10914A1EB0512200947A0B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E4C2A362247FC6D00B0EB5D /* libDisklet.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libDisklet.a;
-			remoteRef = 6E4C2A352247FC6D00B0EB5D /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6EDA1048217E76BC0084C5DD /* libRNOpenAppSettings.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNOpenAppSettings.a;
-			remoteRef = 6EDA1047217E76BC0084C5DD /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		78C398B91ACF4ADC00677621 /* libRCTLinking.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTLinking.a;
-			remoteRef = 78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		832341B51AAA6A8300B99B32 /* libRCTText.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTText.a;
-			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		980AF5C91F9907460014FACB /* libRNSound.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNSound.a;
-			remoteRef = 980AF5C81F9907460014FACB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B3478FBE1FC60E0000FDA94E /* libRCTBEEPickerManager.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTBEEPickerManager.a;
-			remoteRef = B3478FBD1FC60E0000FDA94E /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA22C3832124E49800B2F007 /* libjsinspector.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libjsinspector.a;
-			remoteRef = DA22C3822124E49800B2F007 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA22C3852124E49800B2F007 /* libjsinspector-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libjsinspector-tvOS.a";
-			remoteRef = DA22C3842124E49800B2F007 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA22C3942124E49800B2F007 /* libRNRandomBytes-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRNRandomBytes-tvOS.a";
-			remoteRef = DA22C3932124E49800B2F007 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA22C55E2124F82E00B2F007 /* libBugsnagReactNative.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libBugsnagReactNative.a;
-			remoteRef = DA22C55D2124F82E00B2F007 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA22C7402125021100B2F007 /* libRNDeviceInfo.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNDeviceInfo.a;
-			remoteRef = DA22C73F2125021100B2F007 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA22C7422125021100B2F007 /* libRNDeviceInfo-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRNDeviceInfo-tvOS.a";
-			remoteRef = DA22C7412125021100B2F007 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA297CEB1FF790070075E037 /* libfishhook.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libfishhook.a;
-			remoteRef = DA297CEA1FF790070075E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA297CED1FF790070075E037 /* libfishhook-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libfishhook-tvOS.a";
-			remoteRef = DA297CEC1FF790070075E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA297CFD1FF790070075E037 /* libprivatedata.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libprivatedata.a;
-			remoteRef = DA297CFC1FF790070075E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA297CFF1FF790070075E037 /* libprivatedata-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libprivatedata-tvOS.a";
-			remoteRef = DA297CFE1FF790070075E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA297D111FF790080075E037 /* libReactNativePermissions.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libReactNativePermissions.a;
-			remoteRef = DA297D101FF790080075E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA6569471F17436100226952 /* libthird-party.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libthird-party.a";
-			remoteRef = DA6569461F17436100226952 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA6569491F17436100226952 /* libthird-party.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libthird-party.a";
-			remoteRef = DA6569481F17436100226952 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA65694B1F17436100226952 /* libdouble-conversion.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libdouble-conversion.a";
-			remoteRef = DA65694A1F17436100226952 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA65694D1F17436100226952 /* libdouble-conversion.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libdouble-conversion.a";
-			remoteRef = DA65694C1F17436100226952 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA6569521F17436100226952 /* libRNFastCrypto.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNFastCrypto.a;
-			remoteRef = DA6569511F17436100226952 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA6569561F17436100226952 /* libRNFS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNFS.a;
-			remoteRef = DA6569551F17436100226952 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA6B702C212755D3009C72C9 /* libRNCamera.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNCamera.a;
-			remoteRef = DA6B702B212755D3009C72C9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA89DDF620F2CF670012B4BD /* libRNFirebase.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNFirebase.a;
-			remoteRef = DA89DDF520F2CF670012B4BD /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DACFA6C21F8817B6004F8BD9 /* libAbcCoreJsUi.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libAbcCoreJsUi.a;
-			remoteRef = DACFA6C11F8817B6004F8BD9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E6051D4A21D51E91007F87B9 /* libRNVectorIcons-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRNVectorIcons-tvOS.a";
-			remoteRef = E6051D4921D51E91007F87B9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E6051D5121D51E92007F87B9 /* libRNCWebView.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNCWebView.a;
-			remoteRef = E6051D5021D51E92007F87B9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E63A3C1C200DF08400142D79 /* libRCTPushNotification.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTPushNotification.a;
-			remoteRef = E63A3C1B200DF08400142D79 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E63A3C1E200DF08400142D79 /* libRCTPushNotification-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTPushNotification-tvOS.a";
-			remoteRef = E63A3C1D200DF08400142D79 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E64D31EA21BEEB3D0038693B /* libRNCookieManagerIOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNCookieManagerIOS.a;
-			remoteRef = E64D31E921BEEB3D0038693B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E6CBD1ED2008075200A967E7 /* libRNMail.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNMail.a;
-			remoteRef = E6CBD1EC2008075200A967E7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E6CBD1EF2008075200A967E7 /* RNMailTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = RNMailTests.xctest;
-			remoteRef = E6CBD1EE2008075200A967E7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E6DE0C1A20054BF30004097A /* libRNBackgroundFetch.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNBackgroundFetch.a;
-			remoteRef = E6DE0C1920054BF30004097A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		FD6D9F011FABEF3A00D4998E /* libRCTSplashScreen.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTSplashScreen.a;
-			remoteRef = FD6D9F001FABEF3A00D4998E /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		13B07F8E1A680F5B00A75B9A /* Resources */ = {
@@ -2092,43 +419,23 @@
 				E6C089AC217E7ADB003DE9B9 /* exchange_logo_shapeshift.png in Resources */,
 				E62A1697210BBD3D002D2665 /* onboard5.png in Resources */,
 				E62A1695210BBBA7002D2665 /* onboard1.png in Resources */,
-				52C52276F2F94D9BB9320EBA /* MaterialCommunityIcons.ttf in Resources */,
 				E6DBE8B0210C937200C52ABE /* iPadOnboarding5Vert.png in Resources */,
-				F4A1362EDC4D400FAF32088B /* font.ttf in Resources */,
-				4F81D22B9DB543B0AE7F2FFD /* SourceSansPro-BlackItalic.ttf in Resources */,
-				98A28FD8CA854DA0A8B7578E /* SourceSansPro-Bold.ttf in Resources */,
-				DFFE6C72345D4A3C8350CCFC /* SourceSansPro-BoldItalic.ttf in Resources */,
 				E616C51020F50FDB00F9252F /* iPadOnboarding4Horiz.png in Resources */,
-				FA970440AC4B42D28C64CB75 /* SourceSansPro-ExtraLight.ttf in Resources */,
-				357C0DB2C7AC476D8CE815FF /* SourceSansPro-ExtraLightItalic.ttf in Resources */,
 				E6DBE8B4210C937200C52ABE /* onboardX4.png in Resources */,
-				715ACAB2685D48069807A4D5 /* SourceSansPro-Italic.ttf in Resources */,
 				DA89DDF820F2CFD70012B4BD /* GoogleService-Info.plist in Resources */,
-				C87C995B7DD04A7184195CAA /* SourceSansPro-Light.ttf in Resources */,
-				182BD69D20D94D4BAEB40D43 /* SourceSansPro-LightItalic.ttf in Resources */,
 				E6C089AB217E7ADB003DE9B9 /* exchange_logo_changenow@3x.png in Resources */,
-				2425AB9EBD224B2CB72EB5A9 /* SourceSansPro-Semibold.ttf in Resources */,
 				E616C52C20F51B1A00F9252F /* iPadOnboarding2Vert.png in Resources */,
-				F17017B55F6C4821845FE684 /* SourceSansPro-SemiboldItalic.ttf in Resources */,
 				E6C089A9217E7ADB003DE9B9 /* exchange_logo_changenow.png in Resources */,
 				E638432E20EFE33B00EA9FE9 /* onboard3.png in Resources */,
-				85B89D30F0DB45F7B93DB2C1 /* SourceSansPro-Black.ttf in Resources */,
 				E6DBE8B3210C937200C52ABE /* onboardX5.png in Resources */,
 				E6C089AE217E7ADB003DE9B9 /* exchange_logo_shapeshift@3x.png in Resources */,
-				93D657C1D1194E61B95E8E49 /* Entypo.ttf in Resources */,
-				AF0E365272B24E1C89BB7452 /* EvilIcons.ttf in Resources */,
 				E616C52820F51B1A00F9252F /* iPadOnboarding4Vert.png in Resources */,
-				F340EA8A354D45F9B7E8A5FE /* FontAwesome.ttf in Resources */,
-				B316E8323117440B901AE33D /* Foundation.ttf in Resources */,
 				E638431C20EFE23300EA9FE9 /* alt_splash.png in Resources */,
 				6ED8C12021BB685C00CC03C7 /* splash.png in Resources */,
 				E6DBE8AF210C937200C52ABE /* iPadOnboarding5Horiz.png in Resources */,
-				CFC169ACDFF24F3B8D8A38D6 /* Ionicons.ttf in Resources */,
 				E616C51420F50FDB00F9252F /* iPadOnboarding3Horiz.png in Resources */,
-				8E503D0B1DA74158AA730B37 /* MaterialIcons.ttf in Resources */,
 				E6C089B0217E7ADB003DE9B9 /* exchange_logo_changelly@3x.png in Resources */,
 				DAF7C41220C505CC005B7898 /* plugins in Resources */,
-				79D627E0AF47498FB03B5D40 /* Octicons.ttf in Resources */,
 				E6C089A7217E7ADB003DE9B9 /* exchange_logo_changelly.png in Resources */,
 				E616C51120F50FDB00F9252F /* iPadOnboarding1Horiz.png in Resources */,
 				B524052E4B614E5DB1524555 /* Roboto_medium.ttf in Resources */,
@@ -2138,33 +445,45 @@
 				049D53B0E7A04E8E9FB81225 /* Roboto.ttf in Resources */,
 				5753E201C6234F3D898201B7 /* rubicon-icon-font.ttf in Resources */,
 				E6DBE8B2210C937200C52ABE /* onboardX3.png in Resources */,
-				9054AE0B96DA43BE8F84812E /* SimpleLineIcons.ttf in Resources */,
 				E616C52320F51B1A00F9252F /* iPadOnboarding1Vert.png in Resources */,
 				E6C089AD217E7ADB003DE9B9 /* exchange_logo_shapeshift@2x.png in Resources */,
 				FD982BCC1FACDEF00057F035 /* LaunchScreen.xib in Resources */,
-				1DADC5E648C2487D9786E11A /* Zocial.ttf in Resources */,
 				3D1368BD21DD76BB00DC8CE4 /* edge-core in Resources */,
 				E616C50E20F50FDB00F9252F /* iPadOnboarding2Horiz.png in Resources */,
-				C598D213BA5B4A13B2C02A44 /* Entypo.ttf in Resources */,
-				AB99B56D46BE4362B90C6E93 /* EvilIcons.ttf in Resources */,
 				E638432C20EFE33B00EA9FE9 /* onboard2.png in Resources */,
 				98AF3B3B1F99F7D20083E087 /* audio_sent.mp3 in Resources */,
-				DA4A13F911E04BB99D3B3B8E /* FontAwesome.ttf in Resources */,
-				4739EE2C3B5B44ED8FFE1DBC /* Foundation.ttf in Resources */,
 				E638433020EFE33B00EA9FE9 /* onboard4.png in Resources */,
 				E6C089B1217E7ADB003DE9B9 /* exchange_logo_changelly@2x.png in Resources */,
-				C0B8DCFF972C447AA62321BF /* Ionicons.ttf in Resources */,
-				349FD63F8F054B2AAA775162 /* MaterialIcons.ttf in Resources */,
-				409217C1E0564E669BF105DF /* Octicons.ttf in Resources */,
-				B1E9C434242946E08D4599B2 /* SimpleLineIcons.ttf in Resources */,
 				DA285EAE2203BF3000F79CE6 /* exchange_logo_faast@2x.png in Resources */,
-				72F8DA229BCB44F6905F658B /* Zocial.ttf in Resources */,
-				E7EED819FAD546EC8B171EBC /* Feather.ttf in Resources */,
 				AC40390740E9458CBD92E01B /* SF-UI-Text-Regular.otf in Resources */,
-				9958B956282245938D6C6898 /* AntDesign.ttf in Resources */,
-				492BBE74AA384E29A8AB2F44 /* FontAwesome5_Brands.ttf in Resources */,
-				D2ABB4584F0842688F83A019 /* FontAwesome5_Regular.ttf in Resources */,
-				319D7141C5F34FAFAB916A0D /* FontAwesome5_Solid.ttf in Resources */,
+				A32373B436A54BE09CB501C5 /* font.ttf in Resources */,
+				77105E1044684D61B6B0B1EA /* SourceSansPro-Black.ttf in Resources */,
+				F0D7D6C909584919867CD8B5 /* SourceSansPro-BlackItalic.ttf in Resources */,
+				224A82278CB1465E9E84DC30 /* SourceSansPro-Bold.ttf in Resources */,
+				31BE19EEE2CA4692A7873F5F /* SourceSansPro-BoldItalic.ttf in Resources */,
+				F4A41DF580AB4DA18363D332 /* SourceSansPro-ExtraLight.ttf in Resources */,
+				5872448FDFE840DEBB46A6BA /* SourceSansPro-ExtraLightItalic.ttf in Resources */,
+				50FDCD65EBE045E282509085 /* SourceSansPro-Italic.ttf in Resources */,
+				D4AFF217F0F5431F869AC7C6 /* SourceSansPro-Light.ttf in Resources */,
+				AF471FA30819438C9BA580DD /* SourceSansPro-LightItalic.ttf in Resources */,
+				F3343A739BF04CF1B73A6AA6 /* SourceSansPro-Regular.ttf in Resources */,
+				8CBFB9E2496842FC8F06CE3C /* SourceSansPro-Semibold.ttf in Resources */,
+				BBF0CDD08FB044868A4B510C /* SourceSansPro-SemiboldItalic.ttf in Resources */,
+				5F0AA175FFCB452283063917 /* AntDesign.ttf in Resources */,
+				B0EBAEF96518483CAAC1AE18 /* Entypo.ttf in Resources */,
+				72FEADA163204A53BB83DDB1 /* EvilIcons.ttf in Resources */,
+				ABAD41DADC5F4A96990A421E /* Feather.ttf in Resources */,
+				772873537EE6422F8F8E8CD3 /* FontAwesome.ttf in Resources */,
+				8E1B3057B68149CCA355FDBF /* FontAwesome5_Brands.ttf in Resources */,
+				5BAD66699331448D82B24104 /* FontAwesome5_Regular.ttf in Resources */,
+				26B52E61E77947A1A4E07707 /* FontAwesome5_Solid.ttf in Resources */,
+				B1804E036A3340F9AB0CD987 /* Foundation.ttf in Resources */,
+				ED5310DCFBF946DFA36CC462 /* Ionicons.ttf in Resources */,
+				A88329F9AD044FEB8B7D2AA1 /* MaterialCommunityIcons.ttf in Resources */,
+				237AB7A9983F4B67B540A565 /* MaterialIcons.ttf in Resources */,
+				9C77109EF9C7495E83B65835 /* Octicons.ttf in Resources */,
+				96C02F0519DD4F08B16B79C9 /* SimpleLineIcons.ttf in Resources */,
+				7C52DF4E7F844CC48347C9B4 /* Zocial.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2184,6 +503,56 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
+		};
+		2AA364716BF34DF609A9E9B4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-edge/Pods-edge-resources.sh",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Feather.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Regular.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Foundation.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Octicons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf",
+				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Zocial.ttf",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AntDesign.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Entypo.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EvilIcons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Feather.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Brands.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Regular.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FontAwesome5_Solid.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Foundation.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Ionicons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialCommunityIcons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialIcons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Octicons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SimpleLineIcons.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Zocial.ttf",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-edge/Pods-edge-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		87B486B70BE20E76388C9872 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2210,9 +579,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DA93C74E2128A90A00178601 /* RNBackgroundFetch+AppDelegate.m in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				E7AF9B4D9E8A4729BC45EAC1 /* RNBackgroundFetch+AppDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2235,40 +604,16 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-camera/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-contacts/ios/RCTContacts",
-					"$(SRCROOT)/../node_modules/react-native-contacts-wrapper/ios/RCTContactsWrapper",
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
-					"$(SRCROOT)/../node_modules/react-native-fs/**",
-					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
-					"$(SRCROOT)/../node_modules/react-native-linear-gradient/BVLinearGradient",
-					"$(SRCROOT)/../node_modules/react-native-material-kit/iOS/RCTMaterialKit",
 					"$(SRCROOT)/../node_modules/react-native-permissions/**",
-					"$(SRCROOT)/../node_modules/react-native-tcp/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
-					"$(SRCROOT)/../node_modules/react-native-locale/ios/RCTLocale",
-					"$(SRCROOT)/../node_modules/react-native-fast-crypto/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-smart-splash-screen/ios/RCTSplashScreen/RCTSplashScreen",
 					"$(SRCROOT)/../../../react-native/React/**",
-					"$(SRCROOT)/../node_modules/react-native-randombytes",
-					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/edge-login-ui-rn/ios",
-					"$(SRCROOT)/../node_modules/react-native-picker/ios/RCTBEEPickerManager",
-					"$(SRCROOT)/../node_modules/react-native-mail/RNMail",
 					"$(SRCROOT)/../node_modules/react-native-background-fetch/ios/RNBackgroundFetch",
-					"$(SRCROOT)/../node_modules/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/bugsnag-react-native/cocoa",
-					"$(SRCROOT)/../node_modules/react-native-app-settings/ios",
-					"$(SRCROOT)/../node_modules/react-native-cookies/ios/RNCookieManagerIOS",
-					"$(SRCROOT)/../node_modules/react-native-webview/ios",
-					"$(SRCROOT)/../node_modules/disklet/ios",
 				);
 				INFOPLIST_FILE = edge/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2296,41 +641,17 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-camera/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-contacts/ios/RCTContacts",
-					"$(SRCROOT)/../node_modules/react-native-contacts-wrapper/ios/RCTContactsWrapper",
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
-					"$(SRCROOT)/../node_modules/react-native-fs/**",
-					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
-					"$(SRCROOT)/../node_modules/react-native-linear-gradient/BVLinearGradient",
-					"$(SRCROOT)/../node_modules/react-native-material-kit/iOS/RCTMaterialKit",
 					"$(SRCROOT)/../node_modules/react-native-permissions/**",
-					"$(SRCROOT)/../node_modules/react-native-tcp/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
-					"$(SRCROOT)/../node_modules/react-native-locale/ios/RCTLocale",
-					"$(SRCROOT)/../node_modules/react-native-fast-crypto/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
-					"$(SRCROOT)/../node_modules/react-native-randombytes",
-					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/edge-login-ui-rn/ios",
-					"$(SRCROOT)/../node_modules/react-native-smart-splash-screen/ios/RCTSplashScreen/RCTSplashScreen",
 					"$(SRCROOT)/../../../react-native/React/**",
-					"$(SRCROOT)/../node_modules/react-native-picker/ios/RCTBEEPickerManager",
-					"$(SRCROOT)/../node_modules/react-native-mail/RNMail",
 					"$(SRCROOT)/../node_modules/react-native-background-fetch/ios/RNBackgroundFetch",
-					"$(SRCROOT)/../node_modules/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/bugsnag-react-native/cocoa",
-					"$(SRCROOT)/../node_modules/react-native-app-settings/ios",
-					"$(SRCROOT)/../node_modules/react-native-cookies/ios/RNCookieManagerIOS",
-					"$(SRCROOT)/../node_modules/react-native-webview/ios",
-					"$(SRCROOT)/../node_modules/disklet/ios",
 				);
 				INFOPLIST_FILE = edge/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/edge.xcodeproj/project.pbxproj
+++ b/ios/edge.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -336,13 +335,6 @@
 			remoteGlobalIDString = 8A1B8E771B22E4E300DB45C2;
 			remoteInfo = RCTMaterialKit;
 		};
-		6E1091181EB0512100947A0B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 140335BE384C400688DF5C1C /* UdpSockets.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = UdpSockets;
-		};
 		6E1091211EB0512100947A0B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 22412DEE8F26420E8952DE97 /* RNImagePicker.xcodeproj */;
@@ -653,7 +645,6 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = edge/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = edge/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = edge/main.m; sourceTree = "<group>"; };
-		140335BE384C400688DF5C1C /* UdpSockets.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = UdpSockets.xcodeproj; path = "../node_modules/react-native-udp/ios/UdpSockets.xcodeproj"; sourceTree = "<group>"; };
 		1452E793F4134740BD7F189A /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Feather.ttf"; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
 		182DA17E6C5B447AB76E288E /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/native-base/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
@@ -1018,14 +1009,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		6E1090ED1EB0512100947A0B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E1091191EB0512100947A0B /* libUdpSockets.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		6E1090EF1EB0512100947A0B /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1166,7 +1149,6 @@
 				980AF5931F9907460014FACB /* RNSound.xcodeproj */,
 				892B05950477468DB932A014 /* RNVectorIcons.xcodeproj */,
 				F4D44BFC0C7E41B4BEBA4B07 /* TcpSockets.xcodeproj */,
-				140335BE384C400688DF5C1C /* UdpSockets.xcodeproj */,
 				E08A0470E99A412CB00E7140 /* RNOpenAppSettings.xcodeproj */,
 				8C6E36B511F84168AD949B10 /* RNCookieManagerIOS.xcodeproj */,
 				31B27BFCD5764FDCB4999E72 /* RNCWebView.xcodeproj */,
@@ -1596,10 +1578,6 @@
 					ProductGroup = 6E10912E1EB0512200947A0B /* Products */;
 					ProjectRef = F4D44BFC0C7E41B4BEBA4B07 /* TcpSockets.xcodeproj */;
 				},
-				{
-					ProductGroup = 6E1090ED1EB0512100947A0B /* Products */;
-					ProjectRef = 140335BE384C400688DF5C1C /* UdpSockets.xcodeproj */;
-				},
 			);
 			projectRoot = "";
 			targets = (
@@ -1810,13 +1788,6 @@
 			fileType = archive.ar;
 			path = libRCTMaterialKit.a;
 			remoteRef = 6E1091041EB0512100947A0B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6E1091191EB0512100947A0B /* libUdpSockets.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libUdpSockets.a;
-			remoteRef = 6E1091181EB0512100947A0B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		6E1091221EB0512100947A0B /* libRNImagePicker.a */ = {
@@ -2274,7 +2245,6 @@
 					"$(SRCROOT)/../node_modules/react-native-material-kit/iOS/RCTMaterialKit",
 					"$(SRCROOT)/../node_modules/react-native-permissions/**",
 					"$(SRCROOT)/../node_modules/react-native-tcp/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-udp/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-locale/ios/RCTLocale",
 					"$(SRCROOT)/../node_modules/react-native-fast-crypto/ios/**",
@@ -2298,10 +2268,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/edge\"",
-					"\"$(SRCROOT)/edge\"",
-					"\"$(SRCROOT)/edge\"",
-					"\"$(SRCROOT)/edge\"",
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2340,7 +2306,6 @@
 					"$(SRCROOT)/../node_modules/react-native-material-kit/iOS/RCTMaterialKit",
 					"$(SRCROOT)/../node_modules/react-native-permissions/**",
 					"$(SRCROOT)/../node_modules/react-native-tcp/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-udp/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-locale/ios/RCTLocale",
 					"$(SRCROOT)/../node_modules/react-native-fast-crypto/ios/**",
@@ -2365,10 +2330,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/edge\"",
-					"\"$(SRCROOT)/edge\"",
-					"\"$(SRCROOT)/edge\"",
-					"\"$(SRCROOT)/edge\"",
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme
+++ b/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme
@@ -3,23 +3,9 @@
    LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "83CBBA2D1A601D0E00E9B192"
-               BuildableName = "libReact.a"
-               BlueprintName = "React"
-               ReferencedContainer = "container:../node_modules/react-native/React/React.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -34,20 +20,6 @@
                ReferencedContainer = "container:edge.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
-               BuildableName = "edgeTests.xctest"
-               BlueprintName = "edgeTests"
-               ReferencedContainer = "container:edge.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -56,16 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
-               BuildableName = "edgeTests.xctest"
-               BlueprintName = "edgeTests"
-               ReferencedContainer = "container:edge.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/ios/podspecs/react-native-contacts-wrapper.podspec
+++ b/ios/podspecs/react-native-contacts-wrapper.podspec
@@ -1,0 +1,17 @@
+require "json"
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = 'todo'
+  s.homepage     = 'todo'
+  s.license      = 'todo'
+  s.authors      = 'todo'
+  s.platform     = :ios, "8.0"
+  s.requires_arc = true
+  s.source       = { :git => "https://github.com/EdgeApp/edge-react-gui.git" }
+  s.source_files = "ios/**/*.{h,m}"
+
+  s.dependency "React"
+end

--- a/ios/podspecs/react-native-cookies.podspec
+++ b/ios/podspecs/react-native-cookies.podspec
@@ -1,0 +1,17 @@
+require "json"
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = 'todo'
+  s.homepage     = 'todo'
+  s.license      = 'todo'
+  s.authors      = 'todo'
+  s.platform     = :ios, "8.0"
+  s.requires_arc = true
+  s.source       = { :git => "https://github.com/EdgeApp/edge-react-gui.git" }
+  s.source_files = "ios/**/*.{h,m}"
+
+  s.dependency "React"
+end

--- a/ios/podspecs/react-native-firebase.podspec
+++ b/ios/podspecs/react-native-firebase.podspec
@@ -1,0 +1,20 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = 'todo'
+  s.homepage     = 'todo'
+  s.license      = 'todo'
+  s.authors      = 'todo'
+
+  s.platform     = :ios, "8.0"
+  s.requires_arc = true
+  s.source       = { :git => "https://github.com/invertase/react-native-firebase.git" }
+  s.source_files = "ios/**/*.{h,m}"
+
+  s.dependency "React"
+  s.dependency "Firebase/Core"
+end

--- a/ios/podspecs/react-native-smart-splash-screen.podspec
+++ b/ios/podspecs/react-native-smart-splash-screen.podspec
@@ -1,0 +1,17 @@
+require "json"
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = 'todo'
+  s.homepage     = 'todo'
+  s.license      = 'todo'
+  s.authors      = 'todo'
+  s.platform     = :ios, "8.0"
+  s.requires_arc = true
+  s.source       = { :git => "https://github.com/EdgeApp/edge-react-gui.git" }
+  s.source_files = "ios/**/*.{h,m}"
+
+  s.dependency "React"
+end

--- a/ios/podspecs/react-native-tcp.podspec
+++ b/ios/podspecs/react-native-tcp.podspec
@@ -1,0 +1,17 @@
+require "json"
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = 'todo'
+  s.homepage     = 'todo'
+  s.license      = 'todo'
+  s.authors      = 'todo'
+  s.platform     = :ios, "8.0"
+  s.requires_arc = true
+  s.source       = { :git => "https://github.com/EdgeApp/edge-react-gui.git" }
+  s.source_files = "ios/**/*.{h,m}"
+
+  s.dependency "React"
+end

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "react-native-sound": "^0.10.4",
     "react-native-swipe-gestures": "^1.0.2",
     "react-native-tcp": "git://github.com/Airbitz/react-native-tcp.git#c6af8f728fcbbae23d20c0211fd5b6c322f7a446",
-    "react-native-udp": "^2.0.0",
     "react-native-vector-icons": "^6.1.0",
     "react-native-webview": "^3.1.3",
     "react-redux": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-native-dropdown": "git://github.com/g6ling/react-native-dropdown.git",
     "react-native-dropdownalert": "git://github.com/EdgeApp/react-native-dropdownalert.git",
     "react-native-extra-dimensions-android": "git://github.com/EdgeApp/react-native-extra-dimensions-android.git",
-    "react-native-fast-crypto": "^1.7.0",
+    "react-native-fast-crypto": "1.8.0",
     "react-native-firebase": "4.3.8",
     "react-native-flip-view": "git://github.com/EdgeApp/react-native-flip-view.git",
     "react-native-fs": "git://github.com/EdgeApp/react-native-fs.git#edge/removeEncoding",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "core-js": "2.5.2",
     "dateformat": "^3.0.3",
     "detect-bundler": "^1.0.0",
+    "disklet": "^0.4.1",
     "dns.js": "^1.0.1",
     "domain-browser": "^1.1.7",
     "edge-components": "^0.0.19",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -90,11 +90,16 @@ cp ./node_modules/edge-currency-monero/lib/react-native/edge-currency-monero.js 
 cp ./node_modules/edge-exchange-plugins/lib/react-native/edge-exchange-plugins.js ./ios/edge-core
 cp -r ./ios/edge-core ./android/app/src/main/assets/
 
+# Set up CocoaPods on iOS:
 unamestr=`uname`
 if [[ "$unamestr" == 'Darwin' ]]; then
-    cd ios
-    pod install
-    cd ..
+  # Copy missing podspecs:
+  for package in $(ls ios/podspecs | sed s/.podspec//); do
+    cp ios/podspecs/$package.podspec node_modules/$package/$package.podspec
+  done
+
+  # Install the dependencies:
+  (cd ios; pod install)
 fi
 
 # Apply patches

--- a/yarn.lock
+++ b/yarn.lock
@@ -8445,17 +8445,6 @@ react-native-swipe-gestures@^1.0.2:
     stream-browserify "^1.0.0"
     util "^0.10.3"
 
-react-native-udp@^2.0.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-udp/-/react-native-udp-2.3.1.tgz#88eb0f548ed8c7e35065392526ecf8ce2e2be91e"
-  integrity sha1-iOsPVI7Yx+NQZTklJuz4zi4r6R4=
-  dependencies:
-    base64-js "0.0.8"
-    events "^1.0.2"
-    inherits "^2.0.1"
-    ip-regex "^1.0.3"
-    util "^0.10.3"
-
 react-native-vector-icons@4.6.0, react-native-vector-icons@^4.4.2:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.6.0.tgz#e4014311ffa6de397d914ffc31b7097a874cc8d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3082,6 +3082,13 @@ disklet@^0.4.0:
   dependencies:
     rfc4648 "^0.9.1"
 
+disklet@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/disklet/-/disklet-0.4.1.tgz#e98900934eedb73aef67f4b89444729b98e94f71"
+  integrity sha512-Ui7iVznycaVQwRvGra9qVsG1IwcCDiGetclSXlWfiXamEVplb05U3DK06DhsHJEL1V+fGgKQRigA+BmR+7w7pQ==
+  dependencies:
+    rfc4648 "^0.9.1"
+
 dlv@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.2.tgz#270f6737b30d25b6657a7e962c784403f85137e5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8307,7 +8307,7 @@ react-native-mail@^3.0.5:
 
 "react-native-material-kit@git://github.com/EdgeApp/react-native-material-kit.git#fix-threadpool":
   version "0.4.1"
-  resolved "git://github.com/EdgeApp/react-native-material-kit.git#3b262f7fb0bb7856dd047acc7788d00a3a4d1806"
+  resolved "git://github.com/EdgeApp/react-native-material-kit.git#bcdd8d5227b2e800779c273b661a754621764999"
   dependencies:
     prop-types "^15.5.10"
     ramda "^0.24.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8225,10 +8225,10 @@ react-native-easy-grid@0.2.0:
   version "0.17.0"
   resolved "git://github.com/EdgeApp/react-native-extra-dimensions-android.git#4e1c03f0c5ee3dc26d820d3980796ac41eb51528"
 
-react-native-fast-crypto@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/react-native-fast-crypto/-/react-native-fast-crypto-1.7.0.tgz#41cea5b037216c22b44b82227934cc7ea4105f1b"
-  integrity sha512-3K3c4L8IJ/gtYG5mVje5a9fL9nqGxImvipNj2BvnY1ErXEKADb7VYzy3G795GxFoVwYr6X3sMcunIZjj/xrB/w==
+react-native-fast-crypto@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-fast-crypto/-/react-native-fast-crypto-1.8.0.tgz#b2955fecb72e8f133a3fe17ac26ce41d39a340a1"
+  integrity sha512-Wfwykyi+uuMNb3NWSr1mteGzYxD6yXBfF6nj1W80MMY6/ZEKI33aCpoc5iky77yv63Yz/Y0Ens9IjP8bJbVJsA==
   dependencies:
     buffer "^5.0.8"
     rfc4648 "^1.0.0"


### PR DESCRIPTION
This switches our iOS build infrastructure over to use CocoaPods. This greatly simplifies the upgrade to React Native 0.59, and also un-breaks the `react-native link` command going forward.