### PR TITLE
Tx with blockHeight greater than current wallet block height to show as pending (not negative)

### DIFF
--- a/src/components/common/TransactionRow.js
+++ b/src/components/common/TransactionRow.js
@@ -138,8 +138,8 @@ export class TransactionRowComponent extends Component<Props, State> {
     } else if (tx.blockHeight < 0) {
       pendingTimeSyntax = s.strings.fragment_transaction_list_tx_dropped
       pendingTimeStyle = styles.transactionPartialConfirmation
-    } else if (currentConfirmations === 0) {
-      // if completely unconfirmed or wallet uninitialized
+    } else if (currentConfirmations <= 0) {
+      // if completely unconfirmed or wallet uninitialized, or wallet lagging behind (tx block height larger than wallet block height)
       pendingTimeStyle = styles.transactionPending
       pendingTimeSyntax = UNCONFIRMED_TRANSACTION
     } else if (currentConfirmations < requiredConfirmations) {


### PR DESCRIPTION
The purpose of this task is to handle the case where the wallet block height is lagging behind the transaction block height and get the TransactionList to show as 'Pending' rather than a negative confirmation number.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/1116927447707180/f