### PR TITLE
Side menu shows ETH icon when in token wallet

### DIFF
--- a/copy-bitcoin.sh
+++ b/copy-bitcoin.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Usage: copy-bitcoin
+set -e
+src=$(pwd)/../edge-currency-bitcoin/packages/edge-currency-bitcoin/lib/react-native
+dest=$(pwd)/node_modules/edge-currency-bitcoin/lib/react-native
+
+mkdir -p $dest
+
+cp -r $src/ $dest/
+
+src=$(pwd)/../edge-currency-bitcoin/packages/nidavellir/lib
+dest=$(pwd)/node_modules/nidavellir/lib
+
+mkdir -p $dest
+
+cp -r $src/ $dest/
+
+src=$(pwd)/../edge-currency-bitcoin/packages/nidavellir-networks-unsafe/lib
+dest=$(pwd)/node_modules/@nidavellir/networks-unsafe/lib
+
+mkdir -p $dest
+
+cp -r $src/ $dest/
+
+sh postinstall.sh

--- a/src/modules/UI/components/ControlPanel/ControlPanelConnector.js
+++ b/src/modules/UI/components/ControlPanel/ControlPanelConnector.js
@@ -20,7 +20,18 @@ const mapStateToProps = (state: State) => {
 
   if (guiWallet && currencyCode) {
     const isoFiatCurrencyCode = guiWallet.isoFiatCurrencyCode
-    currencyLogo = guiWallet.symbolImage
+    // if selected currencyCode is parent wallet currencyCode
+    if (guiWallet.currencyCode === currencyCode) {
+      currencyLogo = guiWallet.symbolImage
+    } else {
+      // otherwise it is likely a token, so find the metaToken object and get symbolImage
+      const metaToken = guiWallet.metaTokens.find(metaToken => currencyCode === metaToken.currencyCode)
+      if (metaToken && metaToken.symbolImage) {
+        currencyLogo = metaToken.symbolImage
+      } else {
+        currencyLogo = guiWallet.symbolImage
+      }
+    }
     secondaryDisplayCurrencyCode = guiWallet.fiatCurrencyCode
     secondaryToPrimaryRatio = getExchangeRate(state, currencyCode, isoFiatCurrencyCode)
     primaryDisplayDenomination = getDisplayDenominationFull(state, currencyCode)

--- a/src/styles/SettingsComponentsStyle.js
+++ b/src/styles/SettingsComponentsStyle.js
@@ -95,6 +95,7 @@ export const styles = {
     padding: 3
   },
   customNodesInput: {
+    height: 128,
     color: THEME.COLORS.GRAY_1,
     fontSize: 15,
     fontFamily: THEME.FONTS.DEFAULT,

--- a/src/styles/SettingsComponentsStyle.js
+++ b/src/styles/SettingsComponentsStyle.js
@@ -95,7 +95,6 @@ export const styles = {
     padding: 3
   },
   customNodesInput: {
-    height: 128,
     color: THEME.COLORS.GRAY_1,
     fontSize: 15,
     fontFamily: THEME.FONTS.DEFAULT,


### PR DESCRIPTION
The exchange rate in the side menu correctly shows the token exchange rate but shows the ETH icon rather than the token icon.

If it's a native token it should show the token icon. If there is no token it should show the ETH icon.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

Asana Task: https://app.asana.com/0/361770107085503/1108089014657894/f