### PR TITLE
Limit WalletListTokenRow Calculations

### DIFF
--- a/src/components/common/WalletListTokenRow.js
+++ b/src/components/common/WalletListTokenRow.js
@@ -8,6 +8,7 @@ import { Actions } from 'react-native-router-flux'
 import { intl } from '../../locales/intl'
 import T from '../../modules/UI/components/FormattedText/index'
 import styles, { styles as styleRaw } from '../../styles/scenes/WalletListStyle'
+import { type GuiWallet } from '../../types'
 import * as UTILS from '../../util/utils'
 
 type OwnProps = {
@@ -20,8 +21,11 @@ type OwnProps = {
 
 export type StateProps = {
   displayDenomination: EdgeDenomination,
-  fiatBalance: string,
-  isWalletFiatBalanceVisible: boolean
+  isWalletFiatBalanceVisible: boolean,
+  settings: Object,
+  exchangeRates: Object,
+  currencyCode: string,
+  wallet: GuiWallet
 }
 
 export type DispatchProps = {
@@ -38,6 +42,8 @@ export class WalletListTokenRow extends PureComponent<Props> {
   }
 
   render () {
+    const { wallet, currencyCode, settings, exchangeRates } = this.props
+    const fiatBalance = UTILS.getCurrencyAccountFiatBalanceFromWalletWithoutState(wallet, currencyCode, settings, exchangeRates)
     return (
       <TouchableHighlight
         style={styles.tokenRowContainer}
@@ -55,7 +61,7 @@ export class WalletListTokenRow extends PureComponent<Props> {
           <View style={[styles.rowBalanceTextWrap]}>
             <View style={styles.rowBalanceText}>
               {this.props.isWalletFiatBalanceVisible ? (
-                <T style={[styles.rowBalanceAmountText]}>{this.props.fiatSymbol + ' ' + this.props.fiatBalance}</T>
+                <T style={[styles.rowBalanceAmountText]}>{this.props.fiatSymbol + ' ' + fiatBalance}</T>
               ) : (
                 <T style={[styles.rowBalanceAmountText]}>
                   {intl.formatNumber(UTILS.convertNativeToDisplay(this.props.displayDenomination.multiplier)(this.props.balance) || '0')}

--- a/src/connectors/WalletListTokenRowConnector.js
+++ b/src/connectors/WalletListTokenRowConnector.js
@@ -9,20 +9,23 @@ import { WalletListTokenRow } from '../components/common/WalletListTokenRow.js'
 import type { Dispatch, State } from '../modules/ReduxTypes'
 import * as SETTINGS_SELECTORS from '../modules/Settings/selectors'
 import { getWallet } from '../modules/UI/selectors.js'
-import { getCurrencyAccountFiatBalanceFromWallet } from '../util/utils.js'
 
 const mapStateToProps = (state: State, ownProps): StateProps => {
-  const isWalletFiatBalanceVisible = state.ui.settings.isWalletFiatBalanceVisible
   const currencyCode: string = ownProps.currencyCode
+  const settings = state.ui.settings
+  const isWalletFiatBalanceVisible = settings.isWalletFiatBalanceVisible
+  const exchangeRates = state.exchangeRates
   // $FlowFixMe
   const displayDenomination: EdgeDenomination = SETTINGS_SELECTORS.getDisplayDenominationFull(state, currencyCode)
   const wallet = getWallet(state, ownProps.parentId)
 
-  const formattedFiatBalance = getCurrencyAccountFiatBalanceFromWallet(wallet, currencyCode, state)
   return {
     displayDenomination,
-    fiatBalance: formattedFiatBalance,
-    isWalletFiatBalanceVisible
+    isWalletFiatBalanceVisible,
+    wallet,
+    currencyCode,
+    settings,
+    exchangeRates
   }
 }
 

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -201,7 +201,6 @@ export const decimalOrZero = (input: string, decimalPlaces: number): string => {
 // uses default fiat setting to decide currency to convert to
 // this is *not* to be used for tallying because it returns a string
 export const getCurrencyAccountFiatBalanceFromWallet = (wallet: GuiWallet, currencyCode: string, state: State): string => {
-  console.log('inside getCurrencyAccountFiatBalanceFromWallet')
   const settings = state.ui.settings
   const nativeBalance = wallet.nativeBalances[currencyCode]
   if (!nativeBalance || nativeBalance === '0') return '0'
@@ -231,7 +230,6 @@ export const getCurrencyAccountFiatBalanceFromWalletWithoutState = (
   settings: Object,
   exchangeRates: Object
 ): string => {
-  console.log('inside getCurrencyAccountFiatBalanceFromWalletWithoutState')
   const nativeBalance = wallet.nativeBalances[currencyCode]
   if (!nativeBalance || nativeBalance === '0') return '0'
   let denominations


### PR DESCRIPTION
The purpose of this task is to limit the number of times that `getCurrencyAccountFiatBalanceFromWallet` is called. Looks to reduce the number of times method is called by a factor of ~5-10x for a wallet with a few tokens enabled.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/1114902118803440/f