### PR TITLE
fix state management in EdgeProvider class

### DIFF
--- a/src/components/scenes/PluginViewYAOBScene.js
+++ b/src/components/scenes/PluginViewYAOBScene.js
@@ -59,6 +59,7 @@ class PluginView extends React.Component<PluginProps, PluginState> {
   webview: any
   yaobBridge: Bridge
   counter: number
+  edgeProvider: EdgeProvider
   constructor (props) {
     super(props)
     this.state = {
@@ -86,6 +87,12 @@ class PluginView extends React.Component<PluginProps, PluginState> {
 
   componentWillUnmount () {
     BackHandler.removeEventListener('hardwareBackPress', EdgeProvider.handleBack)
+  }
+
+  UNSAFE_componentWillReceiveProps (nextProps: PluginProps) {
+    if (this.edgeProvider) {
+      this.edgeProvider.updateState(nextProps.currentState)
+    }
   }
 
   _renderWebView = () => {
@@ -126,8 +133,8 @@ class PluginView extends React.Component<PluginProps, PluginState> {
     this.yaobBridge = new Bridge({
       sendMessage: message => this.webview.injectJavaScript(`window.bridge.handleMessage(${JSON.stringify(message)})`)
     })
-    const edgeProvider = new EdgeProvider(this.props.plugin, this.props.currentState, this.props.thisDispatch, this.backButtonClickHandler)
-    this.yaobBridge.sendRoot(edgeProvider)
+    this.edgeProvider = new EdgeProvider(this.props.plugin, this.props.currentState, this.props.thisDispatch, this.backButtonClickHandler)
+    this.yaobBridge.sendRoot(this.edgeProvider)
   }
 
   _onNavigationStateChange = navState => {

--- a/src/modules/UI/scenes/Plugins/bridgeApi.js
+++ b/src/modules/UI/scenes/Plugins/bridgeApi.js
@@ -79,6 +79,9 @@ class EdgeProvider extends Bridgeable {
   navStackClear () {
     this._navStack = []
   }
+  updateState = (arg: any) => {
+    this._state = arg
+  }
   async setBackHandler (handler: { handleBack(): Promise<number> }): Promise<mixed> {
     this.backHandler = handler
   }


### PR DESCRIPTION
There is a bug with edgeProvider `getReceiveAddress` returning the old address after a wallet changed. The instance needed to be updated with the current state in order to get the correct wallet

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a