### PR TITLE
When using the share on request scene, the wallet address is the only text shared

### DIFF
--- a/src/components/scenes/RequestScene.js
+++ b/src/components/scenes/RequestScene.js
@@ -346,8 +346,7 @@ export class Request extends Component<Props, State> {
         const shareOptions = {
           url,
           title,
-          message,
-          subject: sprintf(s.strings.request_qr_email_title, s.strings.app_name, this.props.currencyCode) //  for email,
+          message: this.state.encodedURI
         }
         Share.open(shareOptions).catch(e => console.log(e))
       })


### PR DESCRIPTION
Task: Share button Request Address - Remove unnecessary extra text to just address only (makes it difficult to copy/paste)

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [ ] Tested on small Android