### PR TITLE
added custom end to user-agent

### DIFF
--- a/src/components/scenes/PluginViewYAOBScene.js
+++ b/src/components/scenes/PluginViewYAOBScene.js
@@ -157,7 +157,7 @@ class PluginView extends React.Component<PluginProps, PluginState> {
           scalesPageToFit={contentScaling}
           source={this._renderWebView()}
           userAgent={
-            'Mozilla/5.0 (Linux; Android 6.0.1; SM-G532G Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.83 Mobile Safari/537.36'
+            'Mozilla/5.0 (Linux; Android 6.0.1; SM-G532G Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.83 Mobile Safari/537.36 edge/app.edge.' + Platform.OS
           }
           setWebContentsDebuggingEnabled={true}
         />


### PR DESCRIPTION
Request from Liberty x to have a custom tag on the end of the user-agent to make it easier to know when dealing with edgeProvider. 
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a