### PR TITLE
Adjust header for cryptoExchange scene

### DIFF
--- a/src/styles/scenes/CryptoExchangeSceneStyles.js
+++ b/src/styles/scenes/CryptoExchangeSceneStyles.js
@@ -5,7 +5,7 @@ import THEME from '../../theme/variables/airbitz'
 import * as Styles from '../indexStyles'
 const CryptoExchangeSceneStyle = {
   gradient: {
-    height: THEME.SPACER.HEADER
+    height: THEME.HEADER
   },
   scene: Styles.SceneContainer,
   styleCatch: Styles,


### PR DESCRIPTION
The purpose of this task is to adjust the header for the cryptoExchangeScene, which was messed up from upgrading to React Native 59 and upgrading RNRF to a more recent version.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/1122906197217279/f