### PR TITLE
Adjust background color for gap on Android

### DIFF
--- a/src/modules/UI/components/ControlPanel/style.js
+++ b/src/modules/UI/components/ControlPanel/style.js
@@ -35,7 +35,7 @@ export default {
     alignItems: 'center'
   },
   safeAreaView: {
-    backgroundColor: 'transparent',
+    backgroundColor: THEME.COLORS.PRIMARY,
     height: Number.isNaN(safeAreaHeight) ? void 0 : safeAreaHeight,
     position: 'relative',
     top: StatusBar.currentHeight


### PR DESCRIPTION
The purpose of this task is to fix the blank white area that shows up on Android devices that have no menu bar at the bottom.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a

Asana Taks: https://app.asana.com/0/361770107085503/1124490608274765/f