### PR TITLE
Add more space to txList bottom

### DIFF
--- a/src/components/scenes/TransactionListScene.js
+++ b/src/components/scenes/TransactionListScene.js
@@ -160,7 +160,7 @@ export class TransactionList extends Component<Props, State> {
                 <FlatList
                   ListEmptyComponent={this.renderBuyCrypto()}
                   ListHeaderComponent={this.currentRenderBalanceBox()}
-                  ListFooterComponent={<View style={{ height: isAndroid ? 50 : 0 }} />}
+                  ListFooterComponent={<View style={{ height: isAndroid ? 80 : 0 }} />}
                   style={styles.transactionsScrollWrap}
                   data={txs}
                   renderItem={this.renderTx}


### PR DESCRIPTION
The purpose of this task is to add more spacing to the bottom of the txList so that Android devices without a bottom menu bar will not cause the last item in the txList to be cut off.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Asana Task: https://app.asana.com/0/361770107085503/1124490608274766/f