### PR TITLE
Use our own `react-native-webview` to fix plugins

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -80,7 +80,7 @@ PODS:
     - React
   - react-native-tcp (3.2.2):
     - React
-  - react-native-webview (5.6.2):
+  - react-native-webview (5.12.0):
     - React
   - React/Core (0.59.8):
     - yoga (= 0.59.8.React)
@@ -310,7 +310,7 @@ SPEC CHECKSUMS:
   react-native-safari-view: 955d7160d159241b8e9395d12d10ea0ef863dcdd
   react-native-smart-splash-screen: a961513689f11d63e8496684c2fa4be2d24fe23b
   react-native-tcp: ec39d0ce136873220a2895a0e89dc33804fe0def
-  react-native-webview: c0ddb07676492d983068b0dbfe38ff82d49b1175
+  react-native-webview: 8b2761a9bf84bbbbe7f90f49743b9b74c7cb11e7
   ReactNativePermissions: bf462424ca7823d1b8e6cb463184d6e7f151971b
   RNBackgroundFetch: 8098db4fee60e99afd8bcefa950e8d1760d733ba
   RNDeviceInfo: e7c5fcde13d40e161d8a27f6c5dc69c638936002
@@ -323,4 +323,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 5fc2d51a47ea6bef872004d3bd946edb628639af
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.1

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "react-native-swipe-gestures": "^1.0.2",
     "react-native-tcp": "git://github.com/EdgeApp/react-native-tcp.git#77c60e4a38a46b19ffd7f69c07b95f6f43c9c999",
     "react-native-vector-icons": "^6.1.0",
-    "react-native-webview": "^5.6.2",
+    "react-native-webview": "git://github.com/swansontec/react-native-webview#edge-version",
     "react-redux": "^5.0.5",
     "react-timer-mixin": "^0.13.4",
     "readable-stream": "^1.0.33",

--- a/src/components/scenes/PluginViewListScene.js
+++ b/src/components/scenes/PluginViewListScene.js
@@ -188,7 +188,9 @@ class PluginList extends Component<Props, State> {
       filteredPlugins = data.filter(plugin => {
         return (
           // needed because "Spend" scene doesn't have a plugins JSON currently
-          plugin && plugin.name && EDGE_PLUGIN_REGIONS[plugin.name.toLowerCase()] && EDGE_PLUGIN_REGIONS[plugin.name.toLowerCase()].countryCodes[countryCode]
+          plugin &&
+          (plugin.pluginId === 'custom' ||
+            (plugin.name && EDGE_PLUGIN_REGIONS[plugin.name.toLowerCase()] && EDGE_PLUGIN_REGIONS[plugin.name.toLowerCase()].countryCodes[countryCode]))
         )
       })
     }

--- a/src/modules/UI/scenes/Plugins/BackButton.js
+++ b/src/modules/UI/scenes/Plugins/BackButton.js
@@ -2,13 +2,12 @@
 
 import React from 'react'
 import { Actions } from 'react-native-router-flux'
-import { WebView } from 'react-native-webview'
 
 import s from '../../../../locales/strings'
 import BackButton from '../../components/Header/Component/BackButton.ui'
 
 // The scene holds a ref to the webview:
-type PluginScene = { webview: WebView | void }
+type PluginScene = { goBack(): boolean }
 let currentPlugin: PluginScene | void
 
 export function setPluginScene (plugin: PluginScene | void) {
@@ -20,9 +19,7 @@ export function renderPluginBackButton (label: string = s.strings.title_back) {
 }
 
 export function handlePluginBack () {
-  if (currentPlugin != null && currentPlugin.webview != null) {
-    currentPlugin.webview.goBack()
-  } else {
+  if (currentPlugin == null || !currentPlugin.goBack()) {
     Actions.pop()
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9214,10 +9214,9 @@ react-native-vector-icons@^6.1.0:
     prop-types "^15.6.2"
     yargs "^8.0.2"
 
-react-native-webview@^5.6.2:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-5.6.2.tgz#aa257f01d0038c514874d1c41d99528f83274d8c"
-  integrity sha512-VSn3dMm/OpZH30AgoQ5IQZSgH3//1dCOrTC+63rmHQL3bhggMvk6C+OWen/YL2w3FCw0R0Z+PFs/uccCQI+aEw==
+"react-native-webview@git://github.com/swansontec/react-native-webview#edge-version":
+  version "5.12.0"
+  resolved "git://github.com/swansontec/react-native-webview#273f7a080fd1e64ef903280a5f171611e1a10562"
   dependencies:
     escape-string-regexp "1.0.5"
     invariant "2.2.4"


### PR DESCRIPTION
This fork includes a native solution to the back-button woes.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a