### PR TITLE
tweak copy for plugin descriptions

### DIFF
--- a/copy-plugin.js
+++ b/copy-plugin.js
@@ -15,7 +15,7 @@ const pluginManifests = {
       pluginId: 'com.libertyx',
       pluginURL: 'https://libertyx.com/a/',
       name: 'LibertyX',
-      subtitle: 'Buy Bitcoin with cash at US merchants\nBTC\nFee: 3-8% / Settlement: instant',
+      subtitle: 'Buy Bitcoin with cash at US merchants\nBTC\nFee: 3-8% / Settlement: Instant',
       provider: 'Edge Wallet',
       iconUrl: 'https://edge.app/wp-content/uploads/2019/05/libertyXlogo.png',
       environment: {},
@@ -25,7 +25,7 @@ const pluginManifests = {
       pluginId: 'io.moonpay.buy',
       pluginURL: 'https://buy.moonpay.io?apiKey=pk_live_Y1vQHUgfppB4oMEZksB8DYNQAdA4sauy',
       name: 'MoonPay',
-      subtitle: 'Buy crypto in Europe with credit card or Apple Pay\nBTC, ETH, BCH\nFee: 5.5% / Settlement: 10 mins',
+      subtitle: 'Buy or sell Crypto with credit card or Apple Pay\nBTC, ETH, BCH\nFee: 5.5% / Settlement: 10 mins',
       provider: 'Edge Wallet',
       iconUrl: 'https://edge.app/wp-content/uploads/2019/05/icon_black_small.png',
       environment: {}
@@ -34,7 +34,7 @@ const pluginManifests = {
       pluginId: 'io.safello',
       pluginURL: 'https://safello.com/edge/',
       name: 'Safello',
-      subtitle: 'BTC, ETH, XRP, BCH\nSettlement - Instant \n3 seconds after confirmed payment',
+      subtitle: 'Fiat currencies EUR, SEK, DKK, NOK, GBP, CHF, HUF, PLN\nFee: 4.75%\nSettlement - Instant',
       provider: 'Edge Wallet',
       iconUrl: 'https://edge.app/wp-content/uploads/2019/06/Safello-Logo-Green-background.png',
       environment: {}

--- a/copy-plugin.js
+++ b/copy-plugin.js
@@ -25,7 +25,7 @@ const pluginManifests = {
       pluginId: 'io.moonpay.buy',
       pluginURL: 'https://buy.moonpay.io?apiKey=pk_live_Y1vQHUgfppB4oMEZksB8DYNQAdA4sauy',
       name: 'MoonPay',
-      subtitle: 'Buy Crypto with credit card or Apple Pay\nBTC, ETH, BCH\nFee: 5.5% / Settlement: 10 mins',
+      subtitle: 'Buy crypto with credit card or Apple Pay\nBTC, ETH, XRP, LTC, BCH\nFee: 5.5% / Settlement: 10 mins',
       provider: 'Edge Wallet',
       iconUrl: 'https://edge.app/wp-content/uploads/2019/05/icon_black_small.png',
       environment: {}

--- a/copy-plugin.js
+++ b/copy-plugin.js
@@ -34,7 +34,7 @@ const pluginManifests = {
       pluginId: 'io.safello',
       pluginURL: 'https://safello.com/edge/',
       name: 'Safello',
-      subtitle: 'Fee: 4.75%\nSettlement - Instant',
+      subtitle: 'Buy crypto with credit card\nBTC, ETH, XRP, BCH\nFee: 5.75% / Settlement - Instant',
       provider: 'Edge Wallet',
       iconUrl: 'https://edge.app/wp-content/uploads/2019/06/Safello-Logo-Green-background.png',
       environment: {}

--- a/copy-plugin.js
+++ b/copy-plugin.js
@@ -25,7 +25,7 @@ const pluginManifests = {
       pluginId: 'io.moonpay.buy',
       pluginURL: 'https://buy.moonpay.io?apiKey=pk_live_Y1vQHUgfppB4oMEZksB8DYNQAdA4sauy',
       name: 'MoonPay',
-      subtitle: 'Buy or sell Crypto with credit card or Apple Pay\nBTC, ETH, BCH\nFee: 5.5% / Settlement: 10 mins',
+      subtitle: 'Buy Crypto with credit card or Apple Pay\nBTC, ETH, BCH\nFee: 5.5% / Settlement: 10 mins',
       provider: 'Edge Wallet',
       iconUrl: 'https://edge.app/wp-content/uploads/2019/05/icon_black_small.png',
       environment: {}
@@ -34,7 +34,7 @@ const pluginManifests = {
       pluginId: 'io.safello',
       pluginURL: 'https://safello.com/edge/',
       name: 'Safello',
-      subtitle: 'Fiat currencies EUR, SEK, DKK, NOK, GBP, CHF, HUF, PLN\nFee: 4.75%\nSettlement - Instant',
+      subtitle: 'Fee: 4.75%\nSettlement - Instant',
       provider: 'Edge Wallet',
       iconUrl: 'https://edge.app/wp-content/uploads/2019/06/Safello-Logo-Green-background.png',
       environment: {}

--- a/copy-plugin.js
+++ b/copy-plugin.js
@@ -34,7 +34,7 @@ const pluginManifests = {
       pluginId: 'io.safello',
       pluginURL: 'https://safello.com/edge/',
       name: 'Safello',
-      subtitle: 'Buy crypto with credit card\nBTC, ETH, XRP, BCH\nFee: 5.75% / Settlement - Instant',
+      subtitle: 'Buy crypto with credit card\nBTC, ETH, XRP, BCH\nFee: 5.75% / Settlement: Instant',
       provider: 'Edge Wallet',
       iconUrl: 'https://edge.app/wp-content/uploads/2019/06/Safello-Logo-Green-background.png',
       environment: {}


### PR DESCRIPTION
Fix Asana : 
Moon pay should say “buy or sell Crypto with credit card or Apple Pay“ no need to mention Europe anymore since we have the filter
https://app.asana.com/0/361770107085503/1128104739220760

Safello Details
https://app.asana.com/0/361770107085503/1128134476977134

LibertyX - Capitalize the word "instant" to "Instant"
https://app.asana.com/0/361770107085503/1128104739220766

Safello - Remove the 3 seconds after confirmation text
https://app.asana.com/0/361770107085503/1128104739220764

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a