### PR TITLE
added x to wallet picker to close

### DIFF
--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -137,7 +137,7 @@ export class EdgeProvider extends Bridgeable {
       showWalletCreators: false,
       state: this._state,
       headerTitle: s.strings.choose_your_wallet,
-      cantCancel: true,
+      cantCancel: false,
       excludedTokens,
       noWalletCodes
     }


### PR DESCRIPTION
Fixes asana task 
Plugins Wallet Selector - In the Choose Wallet selector popup/dropdown, if that window is open unable to close it unless a wallet is selected
https://app.asana.com/0/361770107085503/1128194388068639
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a