### PR TITLE
fix backbutton to callback for Edge Provider

### DIFF
--- a/src/components/scenes/SendConfirmationScene.js
+++ b/src/components/scenes/SendConfirmationScene.js
@@ -164,10 +164,7 @@ export class SendConfirmation extends Component<Props, State> {
   componentWillUnmount () {
     this.props.reset()
     if (this.props.guiMakeSpendInfo && this.props.guiMakeSpendInfo.onBack) {
-      const cb = this.props.guiMakeSpendInfo.onBack ? this.props.guiMakeSpendInfo.onBack : ''
-      if (cb) {
-        cb()
-      }
+      this.props.guiMakeSpendInfo.onBack()
     }
   }
 

--- a/src/components/scenes/SendConfirmationScene.js
+++ b/src/components/scenes/SendConfirmationScene.js
@@ -164,7 +164,10 @@ export class SendConfirmation extends Component<Props, State> {
   componentWillUnmount () {
     this.props.reset()
     if (this.props.guiMakeSpendInfo && this.props.guiMakeSpendInfo.onBack) {
-      this.props.guiMakeSpendInfo.onBack()
+      const cb = this.props.guiMakeSpendInfo.onBack ? this.props.guiMakeSpendInfo.onBack : ''
+      if (cb) {
+        cb()
+      }
     }
   }
 

--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -213,7 +213,9 @@ export class EdgeProvider extends Bridgeable {
       name: wallet.name,
       receiveAddress: wallet.receiveAddress,
       currencyCode: wallet.currencyCode,
-      fiatCurrencyCode: wallet.fiatCurrencyCode
+      fiatCurrencyCode: wallet.fiatCurrencyCode,
+      currencyIcon: wallet.symbolImage,
+      currencyIconDark: wallet.symbolImageDarkMono
     }
     return Promise.resolve(returnObject)
   }
@@ -246,7 +248,7 @@ export class EdgeProvider extends Bridgeable {
   }
 
   // Request that the user spend to an address or multiple addresses
-  async requestSpend (spendTargets: Array<EdgeSpendTarget>, options?: EdgeRequestSpendOptions) {
+  async requestSpend (spendTargets: Array<EdgeSpendTarget>, options?: EdgeRequestSpendOptions): Promise<EdgeTransaction> {
     const info: GuiMakeSpendInfo = {
       spendTargets
     }
@@ -267,7 +269,9 @@ export class EdgeProvider extends Bridgeable {
     }
     try {
       const transaction = await this.makeSpendRequest(info)
-      Actions.pop()
+      if (transaction) {
+        Actions.pop()
+      }
       return Promise.resolve(transaction)
     } catch (e) {
       return Promise.reject(e)
@@ -301,7 +305,9 @@ export class EdgeProvider extends Bridgeable {
     }
     try {
       const transaction = await this.makeSpendRequest(info)
-      Actions.pop()
+      if (transaction) {
+        Actions.pop()
+      }
       return Promise.resolve(transaction)
     } catch (e) {
       return Promise.reject(e)
@@ -333,6 +339,9 @@ export class EdgeProvider extends Bridgeable {
       }
       guiMakeSpendInfo.onDone = (error: Error | null, edgeTransaction?: EdgeTransaction) => {
         error ? reject(error) : resolve(edgeTransaction)
+      }
+      guiMakeSpendInfo.onBack = () => {
+        resolve()
       }
       guiMakeSpendInfo.lockInputs = true
       Actions[SEND_CONFIRMATION]({ guiMakeSpendInfo })


### PR DESCRIPTION
This pr solves the issue where a user clicks to make a spend from a partner plugin, and then they hit the back button. Edge provider did not resolve. Now it resolves a transaction to null if there is no transaction so the partner can handle null
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a