### PR TITLE
fix negatives with USDC on exchange quotes

### DIFF
--- a/src/actions/CryptoExchangeActions.js
+++ b/src/actions/CryptoExchangeActions.js
@@ -298,7 +298,7 @@ const getShiftTransaction = (fromWallet: GuiWallet, toWallet: GuiWallet, info: S
   const fee = feeDisplayAmount + ' ' + feeDenomination.name
 
   const currencyConverter = CORE_SELECTORS.getCurrencyConverter(state)
-  const fromExchangeDenomination = SETTINGS_SELECTORS.getExchangeDenomination(state, fromWallet.currencyCode)
+  const fromExchangeDenomination = SETTINGS_SELECTORS.getExchangeDenomination(state, fromCurrencyCode)
   const fromBalanceInCryptoDisplay = UTILS.convertNativeToExchange(fromExchangeDenomination.multiplier)(edgeCoinExchangeQuote.fromNativeAmount)
   const fromBalanceInFiatRaw = await currencyConverter.convertCurrency(fromCurrencyCode, fromWallet.isoFiatCurrencyCode, Number(fromBalanceInCryptoDisplay))
   const fromBalanceInFiat = intl.formatNumber(fromBalanceInFiatRaw || 0, { toFixed: 2 })


### PR DESCRIPTION
This is similar to the problem with USDC from before. when it was the to wallet. 
Fixes Asana : Exchange - If USDC is the sending source, the amounts are shown as negative at the confirmation screen
https://app.asana.com/0/361770107085503/1131139664426679

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a