### PR TITLE
Work around old WebView versions

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -53,12 +53,12 @@ cat >ios/edge-core/index.html <<HTML
   <body>
     <script src="edge-core.js"></script>
     <script>
-      let loading = 0
+      var loading = 0
 
       function load (path) {
         ++loading
 
-        const script = document.createElement('script')
+        var script = document.createElement('script')
         script.charset = 'utf-8'
         script.async = true
         function scriptDone () {


### PR DESCRIPTION
We cannot use `let` or `const` on these old WebView versions.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a