### PR TITLE
Allen/add to sofello whitelist

### DIFF
--- a/src/components/modals/SimpleConfirmationModal.js
+++ b/src/components/modals/SimpleConfirmationModal.js
@@ -32,7 +32,7 @@ export class SimpleConfirmationModal extends Component<SimpleConfirmationModalPr
             <Icon type={FONT_AWESOME} name={EXCLAMATION} size={36} color={colors.primary} />
           </IconCircle>
           <View style={{ flex: 1, paddingLeft: scale(12), paddingRight: scale(12), paddingTop: scale(12) }}>
-            <FormattedText>{this.props.text}</FormattedText>
+            <FormattedText style={{ textAlign: 'center' }}>{this.props.text}</FormattedText>
           </View>
           <PrimaryButton onPress={() => bridge.resolve('complete')}>
             <PrimaryButton.Text>{buttonText}</PrimaryButton.Text>

--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -306,7 +306,6 @@ export class EdgeProvider extends Bridgeable {
     const guiWallet = UI_SELECTORS.getSelectedWallet(this._state)
     const coreWallet = CORE_SELECTORS.getWallet(this._state, guiWallet.id)
     const result = await coreWallet.parseUri(uri)
-    const currencyCode = result.currencyCode || ''
     const info: GuiMakeSpendInfo = {
       currencyCode: result.currencyCode,
       nativeAmount: result.nativeAmount,
@@ -332,7 +331,7 @@ export class EdgeProvider extends Bridgeable {
       if (transaction) {
         Actions.pop()
       }
-      this.trackConversion('sell crypto: ' + currencyCode)
+      this.trackConversion()
       return Promise.resolve(transaction)
     } catch (e) {
       return Promise.reject(e)

--- a/src/modules/UI/scenes/Plugins/plugins.js
+++ b/src/modules/UI/scenes/Plugins/plugins.js
@@ -32,7 +32,7 @@ const hostedBuySellPlugins: Array<BuySellPlugin> = [
     name: 'Safello',
     subtitle: 'Buy crypto with credit card\nBTC, ETH, XRP, BCH\nFee: 5.75% / Settlement: Instant',
     imageUrl: 'https://edge.app/wp-content/uploads/2019/06/Safello-Logo-Green-background.png',
-    originWhitelist: ['https://safello.com']
+    originWhitelist: ['https://safello.com', 'https://app.safello.com']
   }
 ]
 


### PR DESCRIPTION
Fixes: 
Add plugin warning when user first enters that any personal information sent is not to Edge but with partners similar to Airbitz
https://app.asana.com/0/361770107085503/1129102831376325

Safello - After selecting wallet/currency, it opens Safari instead of Safello inside Edge
https://app.asana.com/0/361770107085503/1134340726426437


#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a