### PR TITLE
exit from plugin view screens.

### DIFF
--- a/src/components/Main.ui.js
+++ b/src/components/Main.ui.js
@@ -61,6 +61,7 @@ import ControlPanel from '../modules/UI/components/ControlPanel/ControlPanelConn
 import ErrorAlert from '../modules/UI/components/ErrorAlert/ErrorAlertConnector'
 import T from '../modules/UI/components/FormattedText/index'
 import BackButton from '../modules/UI/components/Header/Component/BackButton.ui'
+import { ExitButton } from '../modules/UI/components/Header/Component/ExitButton.js'
 import HelpButton from '../modules/UI/components/Header/Component/HelpButton.ui.js'
 import Header from '../modules/UI/components/Header/Header.ui'
 import WalletName from '../modules/UI/components/Header/WalletName/WalletNameConnector.js'
@@ -606,7 +607,7 @@ export default class Main extends Component<Props> {
                     component={ifLoggedIn(PluginView, LoadingScene)}
                     renderTitle={this.renderTitle(PLUGIN_BUYSELL)}
                     renderLeftButton={renderPluginBackButton(BACK)}
-                    renderRightButton={this.renderEmptyButton()}
+                    renderRightButton={this.renderExitButton()}
                   />
                   <Scene
                     key={Constants.PLUGIN_BUY_LEGACY}
@@ -614,7 +615,7 @@ export default class Main extends Component<Props> {
                     component={ifLoggedIn(LegacyPluginView, LoadingScene)}
                     renderTitle={this.renderTitle(PLUGIN_BUYSELL)}
                     renderLeftButton={renderLegacyPluginBackButton(BACK)}
-                    renderRightButton={this.renderEmptyButton()}
+                    renderRightButton={this.renderExitButton()}
                   />
                 </Stack>
                 <Stack key={Constants.PLUGIN_BUY_DEEP} hideDrawerButton={true}>
@@ -624,7 +625,7 @@ export default class Main extends Component<Props> {
                     component={ifLoggedIn(PluginView, LoadingScene)}
                     renderTitle={this.renderTitle(PLUGIN_BUYSELL)}
                     renderLeftButton={renderPluginBackButton(BACK)}
-                    renderRightButton={this.renderEmptyButton()}
+                    renderRightButton={this.renderExitButton()}
                   />
                 </Stack>
 
@@ -644,7 +645,7 @@ export default class Main extends Component<Props> {
                     component={ifLoggedIn(PluginView, LoadingScene)}
                     renderTitle={this.renderTitle(PLUGIN_SPEND)}
                     renderLeftButton={renderPluginBackButton(BACK)}
-                    renderRightButton={this.renderEmptyButton()}
+                    renderRightButton={this.renderExitButton()}
                   />
                   <Scene
                     key={Constants.PLUGIN_SPEND_LEGACY}
@@ -652,7 +653,7 @@ export default class Main extends Component<Props> {
                     component={ifLoggedIn(LegacyPluginView, LoadingScene)}
                     renderTitle={this.renderTitle(PLUGIN_SPEND)}
                     renderLeftButton={renderLegacyPluginBackButton(BACK)}
-                    renderRightButton={this.renderEmptyButton()}
+                    renderRightButton={this.renderExitButton()}
                   />
                 </Stack>
                 <Stack key={Constants.TERMS_OF_SERVICE}>
@@ -715,6 +716,10 @@ export default class Main extends Component<Props> {
         <WalletName />
       </View>
     )
+  }
+
+  renderExitButton = () => {
+    return <ExitButton />
   }
 
   renderEmptyButton = () => {

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -285,6 +285,7 @@ const strings = {
   my_crypto_wallet_name: 'My %s',
   string_from_exchange_info: 'You are about to exchange\n %1$s %2$s\n (%3$s)\n from %4$s',
   string_help: 'Help',
+  string_exit: 'Exit',
   string_next: 'NEXT',
   string_next_capitalized: 'Next',
   string_no_name: 'No name',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -273,6 +273,7 @@
   "my_crypto_wallet_name": "My %s",
   "string_from_exchange_info": "You are about to exchange\n %1$s %2$s\n (%3$s)\n from %4$s",
   "string_help": "Help",
+  "string_exit": "Exit",
   "string_next": "NEXT",
   "string_next_capitalized": "Next",
   "string_no_name": "No name",

--- a/src/modules/UI/components/Header/Component/ExitButton.js
+++ b/src/modules/UI/components/Header/Component/ExitButton.js
@@ -8,8 +8,6 @@ import s from '../../../../../locales/strings.js'
 import T from '../../../components/FormattedText'
 import styles from '../style'
 
-const EXIT_TEXT = s.strings.string_exit
-
 type Props = {}
 
 class ExitButton extends Component<Props> {
@@ -19,7 +17,7 @@ class ExitButton extends Component<Props> {
   render () {
     return (
       <TouchableOpacity style={styles.sideTextWrap} onPress={this.popThis}>
-        <T style={[styles.sideText]}>{EXIT_TEXT}</T>
+        <T style={styles.sideText}>{s.strings.string_exit}</T>
       </TouchableOpacity>
     )
   }

--- a/src/modules/UI/components/Header/Component/ExitButton.js
+++ b/src/modules/UI/components/Header/Component/ExitButton.js
@@ -1,0 +1,27 @@
+// @flow
+
+import React, { Component } from 'react'
+import { TouchableOpacity } from 'react-native'
+import { Actions } from 'react-native-router-flux'
+
+import s from '../../../../../locales/strings.js'
+import T from '../../../components/FormattedText'
+import styles from '../style'
+
+const EXIT_TEXT = s.strings.string_exit
+
+type Props = {}
+
+class ExitButton extends Component<Props> {
+  popThis = () => {
+    Actions.pop()
+  }
+  render () {
+    return (
+      <TouchableOpacity style={styles.sideTextWrap} onPress={this.popThis}>
+        <T style={[styles.sideText]}>{EXIT_TEXT}</T>
+      </TouchableOpacity>
+    )
+  }
+}
+export { ExitButton }

--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -270,6 +270,10 @@ export class EdgeProvider extends Bridgeable {
     return Promise.resolve(returnObj)
   }
 
+  async exitPlugin () {
+    Actions.pop()
+  }
+
   // Request that the user spend to an address or multiple addresses
   async requestSpend (spendTargets: Array<EdgeSpendTarget>, options?: EdgeRequestSpendOptions): Promise<EdgeTransaction> {
     const info: GuiMakeSpendInfo = {


### PR DESCRIPTION
This pr adds an exit button to the right of the plugin header for exiting out of a plugin at any time. It also expands on the edgeProvider API to exit programmatically.
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a