### PR TITLE
Prevent denominations crash in settings

### DIFF
--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -269,7 +269,7 @@ export const mergeSettings = (
       finalSettings[key] = loadedSettings[key]
     }
 
-    if (account) {
+    if (account && loadedSettings[key] != null) {
       const currencyName = Constants.CURRENCY_PLUGIN_NAMES[key]
       const doesHaveDenominations = loadedSettings[key].denominations
       const doesHavePlugin = account.currencyConfig[currencyName]


### PR DESCRIPTION
Kylan recently added the crashing line a few lines down, with no check that the object exists.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a