### PR TITLE
Prevent the custom fee inputs from switching places

### DIFF
--- a/src/__tests__/__snapshots__/ChangeMiningFee.test.js.snap
+++ b/src/__tests__/__snapshots__/ChangeMiningFee.test.js.snap
@@ -202,7 +202,7 @@ exports[`Change Mining Fees should render with custom props 1`] = `
         label="Satoshi Per Byte"
         onChangeText={[Function]}
         returnKeyType="go"
-        value="0"
+        value=""
       />
     </View>
     <View


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a