### PR TITLE
updates to bity

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "edge-plugin-bitrefill": "https://github.com/EdgeApp/edge-plugin-bitrefill.git#2627b9d",
     "edge-plugin-simplex": "https://github.com/Airbitz/edge-plugin-simplex.git#29163e3",
     "edge-plugin-wyre": "https://github.com/EdgeApp/edge-plugin-wyre.git#3a67fdf",
-    "edge-plugin-bity": "https://github.com/EdgeApp/edge-plugin-bity.git#cf3d13c8",
+    "edge-plugin-bity": "https://github.com/EdgeApp/edge-plugin-bity.git#67450e6",
     "eslint": "^4.17.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-flowtype": "^2.35.0",

--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -13,7 +13,7 @@ import { createCurrencyWalletAndSelectForPlugins } from '../../../../actions/ind
 import { selectWallet } from '../../../../actions/WalletActions'
 import { launchModal } from '../../../../components/common/ModalProvider.js'
 import { createCryptoExchangeWalletSelectorModal } from '../../../../components/modals/CryptoExchangeWalletSelectorModal'
-import { showError } from '../../../../components/services/AirshipInstance.js'
+import { showError, showToast } from '../../../../components/services/AirshipInstance.js'
 import { DEFAULT_STARTER_WALLET_NAMES, EXCLAMATION, MATERIAL_COMMUNITY } from '../../../../constants/indexConstants'
 import { SEND_CONFIRMATION } from '../../../../constants/SceneKeys.js'
 import s from '../../../../locales/strings'
@@ -213,10 +213,16 @@ export class EdgeProvider extends Bridgeable {
 
   getCurrentWalletInfo (): Promise<WalletDetails> {
     const wallet: GuiWallet = UI_SELECTORS.getSelectedWallet(this._state)
+    const currentCode = UI_SELECTORS.getSelectedCurrencyCode(this._state)
+    let walletName = wallet.name
+    if (wallet.enabledTokens.length > 1) {
+      console.log('EP: We have tokens.. what do we do with them ')
+      walletName = currentCode
+    }
     const returnObject: WalletDetails = {
-      name: wallet.name,
+      name: walletName,
       receiveAddress: wallet.receiveAddress,
-      currencyCode: wallet.currencyCode,
+      currencyCode: currentCode,
       fiatCurrencyCode: wallet.fiatCurrencyCode,
       currencyIcon: wallet.symbolImage,
       currencyIconDark: wallet.symbolImageDarkMono
@@ -427,5 +433,8 @@ export class EdgeProvider extends Bridgeable {
   }
   async displayError (error: Error | string) {
     showError(error)
+  }
+  async displayToast (arg: string) {
+    showToast(arg)
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4223,9 +4223,9 @@ edge-login-ui-rn@0.5.43:
   dependencies:
     moment "^2.22.2"
 
-"edge-plugin-bity@https://github.com/EdgeApp/edge-plugin-bity.git#cf3d13c8":
+"edge-plugin-bity@https://github.com/EdgeApp/edge-plugin-bity.git#67450e6":
   version "0.0.1"
-  resolved "https://github.com/EdgeApp/edge-plugin-bity.git#cf3d13c8b79126cf44d6395a264a43bc6546100d"
+  resolved "https://github.com/EdgeApp/edge-plugin-bity.git#67450e6783f517ec643e99272dc962bc23f6a8f2"
 
 "edge-plugin-simplex@https://github.com/Airbitz/edge-plugin-simplex.git#29163e3":
   version "0.0.3"


### PR DESCRIPTION
This pr brings in latest bity changes that are also awaiting pr's. 
In addition it adds toast to Edge provider. 
Also in edge provider, tokens are now correctly spendable as well as select able.
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a