### PR TITLE
Fix success icon after importing wallet.

### DIFF
--- a/src/styles/scenes/CreateWalletStyle.js
+++ b/src/styles/scenes/CreateWalletStyle.js
@@ -119,7 +119,8 @@ export const styles = {
   currencyLogo: {
     alignSelf: 'center',
     marginTop: scale(24),
-    height: scale(64)
+    height: scale(64),
+    width: scale(64)
   },
   instructionalArea: {
     paddingVertical: scale(16),


### PR DESCRIPTION
Task: After successfully importing a XRP, ETH, XLM wallet, the success icon is very slightly cut off on the sides

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
