### PR TITLE
Send Logs on clicking edge logo 5x

### DIFF
--- a/src/components/scenes/LoginScene.js
+++ b/src/components/scenes/LoginScene.js
@@ -20,7 +20,8 @@ type Props = {
   account: ?EdgeAccount,
   recoveryLogin: string,
   dispatch: Dispatch,
-  username?: string
+  username?: string,
+  showSendLogsModal: () => void
 }
 type State = { key: number }
 
@@ -71,6 +72,7 @@ export default class Login extends Component<Props, State> {
           appName={s.strings.app_name_short}
           backgroundImage={edgeBackgroundImage}
           primaryLogo={edgeLogo}
+          primaryLogoCallback={this.props.showSendLogsModal}
           parentButton={{ text: s.strings.string_help, callback: this.onClickHelp }}
         />
       </View>

--- a/src/connectors/scenes/LoginConnector.js
+++ b/src/connectors/scenes/LoginConnector.js
@@ -2,6 +2,7 @@
 
 import { connect } from 'react-redux'
 
+import { showSendLogsModal } from '../../actions/SettingsActions'
 import Login from '../../components/scenes/LoginScene'
 import * as CORE_SELECTORS from '../../modules/Core/selectors'
 import { initializeAccount } from '../../modules/Login/action'
@@ -20,6 +21,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       type: 'CORE/CONTEXT/ADD_USERNAMES',
       data: { usernames }
     }),
+  showSendLogsModal: () => dispatch(showSendLogsModal()),
   initializeAccount: (account, touchIdInfo) => dispatch(initializeAccount(account, touchIdInfo))
 })
 


### PR DESCRIPTION
Task: Send Logs  from Login screen tap logo 5 times like Airbitz (https://app.asana.com/0/361770107085503/1135306975343601)

Note: Approve https://github.com/EdgeApp/edge-login-ui/pull/185 for this to be functional

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android