### PR TITLE
Focus upper flip input when flip or bottom number is pressed

### DIFF
--- a/src/modules/UI/components/FlipInput/FlipInput2.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput2.ui.js
@@ -209,7 +209,7 @@ export class FlipInput extends Component<Props, State> {
       isToggled: !this.state.isToggled
     })
     if (this.state.isToggled) {
-      if (this.state.textInputBackFocus && this.textInputFront) {
+      if (this.textInputFront) {
         this.textInputFront.focus()
       }
       Animated.spring(this.animatedValue, {
@@ -219,7 +219,7 @@ export class FlipInput extends Component<Props, State> {
       }).start()
     }
     if (!this.state.isToggled) {
-      if (this.state.textInputFrontFocus && this.textInputBack) {
+      if (this.textInputBack) {
         this.textInputBack.focus()
       }
       Animated.spring(this.animatedValue, {


### PR DESCRIPTION
Task: Auto popup numpad when user taps flip input (https://app.asana.com/0/361770107085503/1145262796979869)

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android