### PR TITLE
Add 'done' at top of keypad on both flip inputs

### DIFF
--- a/src/modules/UI/components/FlipInput/FlipInput2.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput2.ui.js
@@ -330,8 +330,7 @@ export class FlipInput extends Component<Props, State> {
           autoCorrect={false}
           keyboardType="numeric"
           selectionColor="white"
-          returnKeyType="next"
-          returnKeyLabel="next"
+          returnKeyType="done"
           underlineColorAndroid={'transparent'}
           ref={this.getTextInputBackRef}
           onFocus={this.textInputBackFocusTrue}


### PR DESCRIPTION
Task: Auto popup numpad when user taps flip input (https://app.asana.com/0/361770107085503/1145262796979869)

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android