### PR TITLE
When exchange rate is present, the flip input fiat is on the top

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - disklet (0.4.3):
     - React
   - DoubleConversion (1.1.6)
-  - edge-login-ui-rn (0.6.0):
+  - edge-login-ui-rn (0.6.1):
     - React
   - Firebase/Core (5.3.0):
     - Firebase/CoreOnly
@@ -300,7 +300,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: 0d985ec461359c82bc254f26d11008bdae50d17a
   disklet: aad587c2ee9642a374c7f41117bf5e2ea0286b91
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
-  edge-login-ui-rn: 97f78d7acaa78ea975d64c32cb2237aa26cd4f83
+  edge-login-ui-rn: a351e843477cc7630ea7b6e00369bb36c46b3720
   Firebase: 68afeeb05461db02d7c9e3215cda28068670f4aa
   FirebaseAnalytics: b3628aea54c50464c32c393fb2ea032566e7ecc2
   FirebaseCore: 62f1b792a49bb9e8b4073f24606d2c93ffc352f0

--- a/src/modules/UI/components/FlipInput/ExchangedFlipInput2.js
+++ b/src/modules/UI/components/FlipInput/ExchangedFlipInput2.js
@@ -147,6 +147,13 @@ export class ExchangedFlipInput extends Component<Props, State> {
     this.props.onExchangeAmountChanged({ exchangeAmount, nativeAmount })
   }
 
+  isFiatOnTop = () => {
+    if (this.props.isFiatOnTop) {
+      return this.props.isFiatOnTop
+    }
+    return !bns.eq(this.state.exchangeSecondaryToPrimaryRatio, '0')
+  }
+
   render () {
     return (
       <FlipInput
@@ -158,7 +165,7 @@ export class ExchangedFlipInput extends Component<Props, State> {
         onAmountChanged={this.onAmountChanged}
         keyboardVisible={this.props.keyboardVisible}
         isEditable={this.props.isEditable}
-        isFiatOnTop={this.props.isFiatOnTop}
+        isFiatOnTop={this.isFiatOnTop()}
         isFocus={this.props.isFocus}
         onNext={this.props.onNext}
       />


### PR DESCRIPTION
Task: Send screen - fiat and crypto values flipped from rest of app (https://app.asana.com/0/361770107085503/1127823520648213)

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a