### PR TITLE
Added loader on the create wallet EOS select wallet button

### DIFF
--- a/src/components/scenes/CreateWalletAccountSelectScene.js
+++ b/src/components/scenes/CreateWalletAccountSelectScene.js
@@ -170,11 +170,12 @@ export class CreateWalletAccountSelect extends Component<Props, State> {
   renderSelectWallet = () => {
     const { activationCost, selectedWalletType } = this.props
     const currencyCode = selectedWalletType.currencyCode
+    const isSelectWalletDisabled = !activationCost || activationCost === ''
     return (
       <View style={styles.selectPaymentLower}>
         <View style={styles.buttons}>
-          <PrimaryButton style={[styles.next]} onPress={this.onPressSelect}>
-            <PrimaryButton.Text>{s.strings.create_wallet_account_select_wallet}</PrimaryButton.Text>
+          <PrimaryButton disabled={isSelectWalletDisabled} style={[styles.next]} onPress={this.onPressSelect}>
+            {isSelectWalletDisabled ? <ActivityIndicator /> : <PrimaryButton.Text>{s.strings.create_wallet_account_select_wallet}</PrimaryButton.Text>}
           </PrimaryButton>
         </View>
         <View style={styles.paymentArea}>


### PR DESCRIPTION
Check if there is an activation cost and supported currencies before user can select an actiavtion wallet.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android