### PR TITLE
Fix pin not showing on send confirmation when hitting spend limits

### DIFF
--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -316,3 +316,7 @@ export const displayFeeAlert = async (feeAmountInFiatSyntax: string) => {
   console.log('resolveValue is: ', resolveValue)
   return resolveValue
 }
+
+export const getAuthRequiredDispatch = (spendInfo: EdgeSpendInfo) => (dispatch: Dispatch, getState: GetState) => {
+  return getAuthRequired(getState(), spendInfo)
+}

--- a/src/components/scenes/SendConfirmationScene.js
+++ b/src/components/scenes/SendConfirmationScene.js
@@ -96,8 +96,6 @@ type State = {|
 export class SendConfirmation extends Component<Props, State> {
   pinInput: any
   flipInput: any
-  count: number
-  lastSeenCount: number
 
   constructor (props: Props) {
     super(props)
@@ -116,8 +114,6 @@ export class SendConfirmation extends Component<Props, State> {
       isFiatOnTop: !!(props.guiMakeSpendInfo && props.guiMakeSpendInfo.nativeAmount && bns.eq(props.guiMakeSpendInfo.nativeAmount, '0')),
       isFocus: !!(props.guiMakeSpendInfo && props.guiMakeSpendInfo.nativeAmount && bns.eq(props.guiMakeSpendInfo.nativeAmount, '0'))
     }
-    this.count = 0
-    this.lastSeenCount = 0
     this.flipInput = React.createRef()
   }
 
@@ -342,10 +338,7 @@ export class SendConfirmation extends Component<Props, State> {
 
   onExchangeAmountChanged = async ({ nativeAmount, exchangeAmount }: ExchangedFlipInputAmounts) => {
     const { fiatPerCrypto, coreWallet, sceneState, currencyCode, newSpendInfo, updateTransaction, getAuthRequiredDispatch } = this.props
-    this.setState({
-      showSpinner: true
-    })
-    const count = ++this.count
+    this.setState({ showSpinner: true })
     const amountFiatString: string = bns.mul(exchangeAmount, fiatPerCrypto.toString())
     const amountFiat: number = parseFloat(amountFiatString)
     const metadata: EdgeMetadata = { amountFiat }
@@ -357,13 +350,8 @@ export class SendConfirmation extends Component<Props, State> {
     try {
       newSpendInfo(spendInfo, authType)
       const edgeTransaction = await coreWallet.makeSpend(spendInfo)
-      if (count === this.count) {
-        this.lastSeenCount = count
-        updateTransaction(edgeTransaction, guiMakeSpendInfoClone, false, null)
-        this.setState({ showSpinner: false })
-      } else if (count > this.lastSeenCount) {
-        this.lastSeenCount = count
-      }
+      updateTransaction(edgeTransaction, guiMakeSpendInfoClone, false, null)
+      this.setState({ showSpinner: false })
     } catch (e) {
       console.log(e)
       updateTransaction(null, guiMakeSpendInfoClone, false, e)

--- a/src/connectors/scenes/SendConfirmationConnector.js
+++ b/src/connectors/scenes/SendConfirmationConnector.js
@@ -4,6 +4,7 @@ import { type EdgeCurrencyInfo, type EdgeSpendInfo, type EdgeTransaction, errorN
 import { connect } from 'react-redux'
 
 import {
+  getAuthRequiredDispatch,
   newPin,
   newSpendInfo,
   reset,
@@ -78,8 +79,6 @@ const mapStateToProps = (state: State): SendConfirmationStateProps => {
   const exchangeRates = state.exchangeRates
   const { toggleCryptoOnTop } = sceneState
 
-  const { spendingLimits } = state.ui.settings
-
   const out = {
     balanceInCrypto,
     balanceInFiat,
@@ -111,7 +110,6 @@ const mapStateToProps = (state: State): SendConfirmationStateProps => {
     address: state.ui.scenes.sendConfirmation.address,
     sceneState,
     coreWallet,
-    spendingLimits,
     toggleCryptoOnTop
   }
   return out
@@ -134,7 +132,8 @@ const mapDispatchToProps = (dispatch: Dispatch): SendConfirmationDispatchProps =
   },
   updateTransaction: (transaction: ?EdgeTransaction, guiMakeSpendInfo: ?GuiMakeSpendInfo, forceUpdateGui: ?boolean, error: ?Error) => {
     dispatch(updateTransaction(transaction, guiMakeSpendInfo, forceUpdateGui, error))
-  }
+  },
+  getAuthRequiredDispatch: (spendInfo: EdgeSpendInfo): any => dispatch(getAuthRequiredDispatch(spendInfo)) // Type casting any cause dispatch returns a function
 })
 
 export default connect(


### PR DESCRIPTION
Task - PIN shows invalid even if PIN entry is not shown for BRZ - https://app.asana.com/0/361770107085503/1163402411159817

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a