### PR TITLE
Fix flip input top input symbol to level it to amount. Remove placeholder 'amount' on top

### DIFF
--- a/src/modules/UI/components/FlipInput/FlipInput2.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput2.ui.js
@@ -352,7 +352,7 @@ export class FlipInput extends Component<Props, State> {
             <Text style={[top.symbol]}>{fieldInfo.currencySymbol}</Text>
             <TextInput
               style={[top.amount]}
-              placeholder={this.props.isFiatOnTop ? 'Amount' : '0'}
+              placeholder={'0'}
               placeholderTextColor={'rgba(255, 255, 255, 0.60)'}
               value={amount}
               onChangeText={onChangeText}

--- a/src/modules/UI/components/FlipInput/styles.js
+++ b/src/modules/UI/components/FlipInput/styles.js
@@ -99,7 +99,8 @@ export const top = StyleSheet.create({
     fontSize: scale(15),
     color: THEME.COLORS.WHITE,
     fontFamily: THEME.FONTS.SYMBOLS,
-    marginRight: scale(5),
+    marginRight: scale(2),
+    marginBottom: Platform.OS === 'ios' ? 0 : 3,
     textAlign: 'right'
   },
   amount: {


### PR DESCRIPTION
Task: Send Screen - Place fiat currency symbol next to input on android - https://app.asana.com/0/361770107085503/1164052871025755

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a