### PR TITLE
Fix bug on logout and auto-logout on screens that use account

### DIFF
--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -269,7 +269,9 @@ export const logoutRequest = (username?: string) => (dispatch: Dispatch, getStat
   Actions.popTo(Constants.LOGIN, { username })
   const state = getState()
   const account = CORE_SELECTORS.getAccount(state)
-  dispatch({ type: 'LOGOUT', data: { username } })
+  setTimeout(() => {
+    dispatch({ type: 'LOGOUT', data: { username } })
+  }, 1000)
   if (typeof account.logout === 'function') account.logout()
 }
 


### PR DESCRIPTION
Task: Spend confirmation Whitescreen - https://app.asana.com/0/361770107085503/1166325602115257

Comment: Added delay on removing account on state after logout so the screen changes before removing the account state.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android