### PR TITLE
Remove Scrollview on Password Recovery Screen

### DIFF
--- a/src/components/scenes/PasswordRecoveryScene.js
+++ b/src/components/scenes/PasswordRecoveryScene.js
@@ -2,10 +2,7 @@
 
 import { PasswordRecoveryScreen } from 'edge-login-ui-rn'
 import React, { Component } from 'react'
-import { ScrollView, View } from 'react-native'
 
-import { THEME } from '../../theme/variables/airbitz'
-import { scale } from '../../util/scaling.js'
 import { SceneWrapper } from '../common/SceneWrapper.js'
 
 type Props = {
@@ -18,16 +15,13 @@ export default class PasswordRecovery extends Component<Props> {
   render () {
     return (
       <SceneWrapper hasTabs={false} background="body">
-        <ScrollView keyboardShouldPersistTaps={'always'}>
-          <PasswordRecoveryScreen
-            account={this.props.account}
-            context={this.props.context}
-            onComplete={this.props.onComplete}
-            onCancel={this.props.onComplete}
-            showHeader={this.props.showHeader}
-          />
-          <View style={{ backgroundColor: THEME.COLORS.WHITE, height: scale(150) }} />
-        </ScrollView>
+        <PasswordRecoveryScreen
+          account={this.props.account}
+          context={this.props.context}
+          onComplete={this.props.onComplete}
+          onCancel={this.props.onComplete}
+          showHeader={this.props.showHeader}
+        />
       </SceneWrapper>
     )
   }


### PR DESCRIPTION
Task: Password recovery questions list doesn't fill the screen - https://app.asana.com/0/361770107085503/1126866685130798

NOTE: Merge with - https://github.com/EdgeApp/edge-login-ui/pull/207

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android