### PR TITLE
Trim and lowercase the domain before resolving

### DIFF
--- a/src/components/modals/AddressModal.js
+++ b/src/components/modals/AddressModal.js
@@ -87,6 +87,7 @@ export class AddressModal extends Component<AddressModalProps, AddressModalState
   }
 
   fetchDomain = async (domain: string, currencyTicker: string) => {
+    if (!domain) return ;
     domain = domain.trim().toLowerCase();
     if (!this.checkIfDomain(domain)) {
       throw new ResolutionError(ResolutionErrorCode.UnsupportedDomain, { domain })

--- a/src/components/modals/AddressModal.js
+++ b/src/components/modals/AddressModal.js
@@ -87,6 +87,7 @@ export class AddressModal extends Component<AddressModalProps, AddressModalState
   }
 
   fetchDomain = async (domain: string, currencyTicker: string) => {
+    domain = domain.trim().toLowerCase();
     if (!this.checkIfDomain(domain)) {
       throw new ResolutionError(ResolutionErrorCode.UnsupportedDomain, { domain })
     }


### PR DESCRIPTION
It is a one-liner to increase the UI for users. on mobile phones, most of the time domains are going to be capitalized and it is very annoying to back and fix from "Brad.crypto" to "brad.crypto" 
this change should allow us to stop being the case-sensitive 