### PR TITLE
Fix scanning edge://swap links

### DIFF
--- a/src/actions/ScanActions.js
+++ b/src/actions/ScanActions.js
@@ -107,17 +107,19 @@ export const parseScannedUri = (data: string) => (dispatch: Dispatch, getState: 
   // Check for things other than coins:
   const deepLink = parseDeepLink(data)
   switch (deepLink.type) {
-    case 'edgeLogin':
-    case 'passwordRecovery':
-    case 'plugin':
-      dispatch(launchDeepLink(deepLink))
-      return
+    case 'other':
+      // Handle this link type below:
+      break
     case 'returnAddress':
       try {
         return doRequestAddress(dispatch, edgeWallet, guiWallet, deepLink)
       } catch (e) {
         console.log(e)
       }
+      break
+    default:
+      dispatch(launchDeepLink(deepLink))
+      return
   }
 
   edgeWallet.parseUri(data, currencyCode).then(


### PR DESCRIPTION
The barcode scanner had too much special-case logic which didn't include this link type. 

Scanning the barcode at https://deep.edge.app/swap didn't work before, but now it does.

- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a