### PR TITLE
Fix "create wallets" not filtered when wallets exist

### DIFF
--- a/src/components/modals/WalletListModal2.js
+++ b/src/components/modals/WalletListModal2.js
@@ -74,11 +74,13 @@ class WalletListModalConnected extends Component<Props, State> {
     // Initialize Create Wallets
     if (showCreateWallet) {
       const createWalletCurrencies = getGuiWalletTypes(account)
+      const walletsArray = Object.values(wallets)
       for (const createWalletCurrency of createWalletCurrencies) {
         const { currencyCode } = createWalletCurrency
         const checkAllowedCurrencyCodes = allowedCurrencyCodes ? allowedCurrencyCodes.find(code => code === currencyCode) : true
         const checkExcludeCurrencyCodes = excludeCurrencyCodes ? excludeCurrencyCodes.find(code => code === currencyCode) : false
-        if (checkAllowedCurrencyCodes && !checkExcludeCurrencyCodes) {
+        const checkExistingWallet = walletsArray.find(wallet => (wallet && wallet.currencyCode ? wallet.currencyCode === currencyCode : false))
+        if (checkAllowedCurrencyCodes && !checkExcludeCurrencyCodes && !checkExistingWallet) {
           records.push({
             walletItem: null,
             createWalletCurrency


### PR DESCRIPTION
Task: Exchange Screen - Receiving Wallet - Create Wallets list will still appear even if the wallet already exists - https://app.asana.com/0/361770107085503/1173045433614033

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a