### PR TITLE
Fix formatting of currency symbols on Flip Input 

### DIFF
--- a/src/modules/UI/components/FlipInput/styles.js
+++ b/src/modules/UI/components/FlipInput/styles.js
@@ -95,14 +95,8 @@ export const top = StyleSheet.create({
     justifyContent: 'flex-end',
     alignItems: 'flex-end'
   },
-  symbol: {
-    fontSize: scale(15),
-    color: THEME.COLORS.WHITE,
-    fontFamily: THEME.FONTS.SYMBOLS,
-    marginRight: scale(5),
-    textAlign: 'right'
-  },
   amount: {
+    width: '100%',
     fontSize: scale(15),
     color: THEME.COLORS.WHITE,
     fontFamily: THEME.FONTS.SYMBOLS,
@@ -123,20 +117,8 @@ export const bottom = StyleSheet.create({
     alignItems: 'center',
     paddingTop: scale(8)
   },
-  amountContainer: {
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'flex-end'
-  },
-  symbol: {
-    fontSize: scale(10),
-    color: THEME.COLORS.WHITE,
-    opacity: THEME.OPACITY.MID,
-    fontFamily: THEME.FONTS.SYMBOLS,
-    marginRight: scale(5),
-    textAlign: 'right'
-  },
   amount: {
+    width: '100%',
     fontSize: scale(10),
     color: THEME.COLORS.WHITE,
     opacity: THEME.OPACITY.MID,


### PR DESCRIPTION
Task: Send Screen - Place fiat currency symbol next to input on android - https://app.asana.com/0/361770107085503/1164052871025755

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android