### PR TITLE
Default display amount to empty string if undefined.

### DIFF
--- a/src/modules/UI/components/FlipInput/FlipInput2.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput2.ui.js
@@ -110,7 +110,7 @@ const addCurrencySymbol = (currencySymbol: string, displayAmount: string) =>
 const removeCurrencySymbol = (currencySymbol: string, previousDisplayAmount: string, displayAmount: string) => {
   // This looks for a number left if the currency symbol and moves it to the far right
   if (previousDisplayAmount === displayAmount.substring(1)) {
-    displayAmount = previousDisplayAmount + displayAmount[0]
+    displayAmount = previousDisplayAmount + (displayAmount[0] || '')
   }
   return displayAmount.replace(currencySymbol, '').trim()
 }


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android

`displayAmount` could be `undefined` and throws an error when trying to render it as a number.
Default to an empty string if so.