### PR TITLE
Fix bug when filtering tokens not showing up

### DIFF
--- a/src/components/common/CryptoExchangeWalletListRow.js
+++ b/src/components/common/CryptoExchangeWalletListRow.js
@@ -195,15 +195,8 @@ export class CryptoExchangeWalletListRow extends React.Component<Props, LocalSta
       currencyCodeString.includes(searchFilterLowerCase)
     const mostRecentUsedCheck = isMostRecentWallet ? currencyCodeString === currencyCodeFilter.toLowerCase() : true
 
-    if (!checkAllowedCurrencyCodes || checkExcludeCurrencyCodes) {
-      return null
-    }
-    if (searchFilter === '' && !filterMatched) {
-      return null
-    }
-    if (!mostRecentUsedCheck) {
-      return null
-    }
+    if (!checkAllowedCurrencyCodes || checkExcludeCurrencyCodes || !filterMatched || !mostRecentUsedCheck) return null
+
     return (
       <TouchableHighlight underlayColor={THEME.COLORS.TRANSPARENT} onPress={this.onPress}>
         <View style={styles.rowContainerTop}>


### PR DESCRIPTION
Task: Wallet picker shows parent ETH wallet when searching for tokens - https://app.asana.com/0/281171002982981/1191574370628988

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android