### PR TITLE
nav update to fix transition

### DIFF
--- a/src/components/Main.ui.js
+++ b/src/components/Main.ui.js
@@ -870,7 +870,7 @@ export class MainComponent extends React.Component<Props> {
     }
     if (this.isCurrentScene(Constants.FIO_ADDRESS_REGISTER)) {
       if (Actions.currentParams.noAddresses) {
-        Actions.popTo(Constants.WALLET_LIST_SCENE)
+        Actions.jump(Constants.WALLET_LIST_SCENE)
         return true
       }
     }


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [X] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a

#### Issue Details ####
Clicking back button on the FIO Request Address Screen fails. Recommended fix found on this Github Issue thread: https://github.com/aksonov/react-native-router-flux/issues/3410

*Steps To Reproduce:*
1. Login to application
2. Go to any screen other than the wallet screen (such as the Exchange screen) in the bottom navigation bar 
3. Open the side menu and select the "FIO Names" navigation option
4. After the screen loads, click the back button and you will see that nothing happens

Actual Behavior: 
User name able to go back to previous screen when back button pressed

Expect Behavior: User should go back to the wallet screen

GIFs below showing the issue before fix and after fix. 

![BackButtonBug](https://user-images.githubusercontent.com/5866571/93005521-96648380-f506-11ea-8813-3f9f6b9ce87d.gif)
![BackButtonFix](https://user-images.githubusercontent.com/5866571/93005522-98c6dd80-f506-11ea-85ea-b653336c2875.gif)



