### PR TITLE
Restore bold text on the delete wallet modal

### DIFF
--- a/src/actions/DeleteWalletModalActions.js
+++ b/src/actions/DeleteWalletModalActions.js
@@ -4,11 +4,13 @@ import * as React from 'react'
 
 import { ButtonsModal } from '../components/modals/ButtonsModal.js'
 import { Airship, showError } from '../components/services/AirshipInstance.js'
+import { ModalMessage } from '../components/themed/ModalParts.js'
 import s from '../locales/strings.js'
+import { B } from '../styles/common/textStyles.js'
 import type { Dispatch, GetState } from '../types/reduxTypes.js'
 import { getWalletName } from '../util/CurrencyWalletHelpers.js'
 
-export const showDeleteWalletModal = (walletId: string, additionalMsg: string = '') => async (dispatch: Dispatch, getState: GetState) => {
+export const showDeleteWalletModal = (walletId: string, additionalMsg?: string) => async (dispatch: Dispatch, getState: GetState) => {
   const state = getState()
   const { account } = state.core
   const { currencyWallets = {} } = account
@@ -17,12 +19,19 @@ export const showDeleteWalletModal = (walletId: string, additionalMsg: string = 
     <ButtonsModal
       bridge={bridge}
       title={s.strings.fragment_wallets_delete_wallet}
-      message={`${s.strings.fragmet_wallets_delete_wallet_first_confirm_message_mobile} ${getWalletName(currencyWallets[walletId])}?\n\n${additionalMsg}`}
       buttons={{
         confirm: { label: s.strings.string_delete },
         cancel: { label: s.strings.string_cancel_cap, type: 'secondary' }
       }}
-    />
+    >
+      <>
+        <ModalMessage>
+          {s.strings.fragmet_wallets_delete_wallet_first_confirm_message_mobile}
+          <B>{getWalletName(currencyWallets[walletId])}?</B>
+        </ModalMessage>
+        {additionalMsg == null ? null : <ModalMessage>{additionalMsg}</ModalMessage>}
+      </>
+    </ButtonsModal>
   ))
 
   if (resolveValue === 'confirm') {

--- a/src/components/modals/ButtonsModal.js
+++ b/src/components/modals/ButtonsModal.js
@@ -12,18 +12,31 @@ type ButtonInfo = {
   type?: 'primary' | 'secondary'
 }
 
+/**
+ * A modal with a title, message, and buttons.
+ * This is an alternative to the native `Alert` component.
+ *
+ * Child components appear between the message and the buttons,
+ * but this feature is only meant for inserting extra message elements,
+ * like images or custom text formatting.
+ *
+ * Build a custom modal component if you need form fields, check boxes,
+ * or other interactive elements.
+ */
 export function ButtonsModal<Buttons: { [key: string]: ButtonInfo }>(props: {
   bridge: AirshipBridge<$Keys<Buttons> | void>,
   title?: string,
   message?: string,
+  children?: React.Node,
   buttons: Buttons
 }) {
-  const { bridge, title, message, buttons } = props
+  const { bridge, title, message, children, buttons } = props
 
   return (
     <ThemedModal bridge={bridge} onCancel={() => bridge.resolve(undefined)} paddingRem={1}>
       {title != null ? <ModalTitle>{title}</ModalTitle> : null}
       {message != null ? <ModalMessage>{message}</ModalMessage> : null}
+      {children}
       {Object.keys(buttons).map(key => {
         const { label, type = 'primary' } = buttons[key]
 

--- a/src/components/themed/ModalParts.js
+++ b/src/components/themed/ModalParts.js
@@ -45,7 +45,6 @@ const getStyles = cacheStyles((theme: Theme) => ({
     textAlign: 'center'
   },
   messageText: {
-    alignSelf: 'center',
     color: theme.primaryText,
     fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(1),

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -113,7 +113,7 @@ const strings = {
   fragment_wallets_split_wallet_first_confirm_message_mobile: 'Are you sure you want to split \n',
   fragment_wallets_get_seed_wallet_first_confirm_message_mobile: 'Are you sure you want to reveal the private seed for the following wallet?\n',
   fragment_wallets_get_raw_key_wallet_confirm_message: 'Are you sure you want to reveal the private keys for this wallet?',
-  fragmet_wallets_delete_wallet_first_confirm_message_mobile: 'Are you sure you want to delete \n',
+  fragmet_wallets_delete_wallet_first_confirm_message_mobile: 'Are you sure you want to delete ',
   fragmet_wallets_delete_fio_extra_message_mobile: 'Deleting this FIO wallet will remove access to any FIO addresses you have linked to this wallet.',
   wallet_list_add_wallet: 'Add Wallet',
   wallet_list_add_token: 'Add Token',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -98,7 +98,7 @@
   "fragment_wallets_split_wallet_first_confirm_message_mobile": "Are you sure you want to split \n",
   "fragment_wallets_get_seed_wallet_first_confirm_message_mobile": "Are you sure you want to reveal the private seed for the following wallet?\n",
   "fragment_wallets_get_raw_key_wallet_confirm_message": "Are you sure you want to reveal the private keys for this wallet?",
-  "fragmet_wallets_delete_wallet_first_confirm_message_mobile": "Are you sure you want to delete \n",
+  "fragmet_wallets_delete_wallet_first_confirm_message_mobile": "Are you sure you want to delete ",
   "fragmet_wallets_delete_fio_extra_message_mobile": "Deleting this FIO wallet will remove access to any FIO addresses you have linked to this wallet.",
   "wallet_list_add_wallet": "Add Wallet",
   "wallet_list_add_token": "Add Token",


### PR DESCRIPTION
I left a comment on #2199, but it's too late to do anything since it's already merged. Here is the code change I was proposing over there.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a