### PR TITLE
Make the Bugsnag error boundary optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,6 @@ import './src/app.js'
 import { AppRegistry } from 'react-native'
 
 import { name as appName } from './app.json'
-import { ErrorBoundary } from './src/components/services/ErrorBoundary.js'
+import { App } from './src/components/App.js'
 
-AppRegistry.registerComponent(appName, () => ErrorBoundary)
+AppRegistry.registerComponent(appName, () => App)

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,0 +1,18 @@
+// @flow
+
+import * as React from 'react'
+
+import { CrashScene } from './scenes/CrashScene.js'
+import { EdgeCoreManager } from './services/EdgeCoreManager.js'
+import { ErrorBoundary } from './services/ErrorBoundary.js'
+import { ThemeProvider } from './services/ThemeContext.js'
+
+export function App(props: {}) {
+  return (
+    <ThemeProvider>
+      <ErrorBoundary FallbackComponent={CrashScene}>
+        <EdgeCoreManager />
+      </ErrorBoundary>
+    </ThemeProvider>
+  )
+}

--- a/src/components/scenes/CrashScene.js
+++ b/src/components/scenes/CrashScene.js
@@ -1,0 +1,50 @@
+// @flow
+
+import * as React from 'react'
+import { Text } from 'react-native'
+import AntDesignIcon from 'react-native-vector-icons/AntDesign'
+
+import s from '../../locales/strings.js'
+import { SceneWrapper } from '../common/SceneWrapper.js'
+import { type Theme, type ThemeProps, cacheStyles, withTheme } from '../services/ThemeContext.js'
+
+/**
+ * This component will be displayed when an error boundary catches an error
+ */
+function CrashSceneComponent(props: ThemeProps): React.Node {
+  const { theme } = props
+  const styles = getStyles(theme)
+
+  return (
+    <SceneWrapper background="theme" padding={theme.rem(0.5)} scroll>
+      <AntDesignIcon name="frowno" style={styles.icon} />
+      <Text style={styles.titleText}>{s.strings.error_boundary_title}</Text>
+      <Text style={styles.messageText}>{s.strings.error_boundary_message}</Text>
+    </SceneWrapper>
+  )
+}
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  icon: {
+    alignSelf: 'center',
+    color: theme.primaryText,
+    fontSize: theme.rem(2),
+    margin: theme.rem(0.5)
+  },
+  titleText: {
+    color: theme.primaryText,
+    fontFamily: theme.fontFaceDefault,
+    fontSize: theme.rem(1.25),
+    margin: theme.rem(0.5),
+    textAlign: 'center'
+  },
+  messageText: {
+    color: theme.primaryText,
+    fontFamily: theme.fontFaceDefault,
+    fontSize: theme.rem(1),
+    margin: theme.rem(0.5),
+    textAlign: 'left'
+  }
+}))
+
+export const CrashScene = withTheme(CrashSceneComponent)

--- a/src/components/services/EdgeCoreManager.js
+++ b/src/components/services/EdgeCoreManager.js
@@ -15,7 +15,6 @@ import { allPlugins } from '../../util/corePlugins.js'
 import { fakeUser } from '../../util/fake-user.js'
 import { LoadingScene } from '../scenes/LoadingScene.js'
 import { Services } from './Services.js'
-import { ThemeProvider } from './ThemeContext.js'
 
 type Props = {}
 
@@ -120,12 +119,10 @@ export class EdgeCoreManager extends React.PureComponent<Props, State> {
     const key = `redux${counter}`
 
     return (
-      <ThemeProvider>
-        <>
-          {context == null ? <LoadingScene /> : <Services key={key} context={context} />}
-          {this.renderCore()}
-        </>
-      </ThemeProvider>
+      <>
+        {context == null ? <LoadingScene /> : <Services key={key} context={context} />}
+        {this.renderCore()}
+      </>
     )
   }
 }


### PR DESCRIPTION
If Bugsnag isn't loaded, such as in the debugger, provide our own Error boundary component instead.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a