### PR TITLE
Don't initiate onKeyPress for events triggered by tapping a number

### DIFF
--- a/src/modules/UI/components/FlipInput/FlipInput2.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput2.ui.js
@@ -360,8 +360,10 @@ export class FlipInput extends React.Component<Props, State> {
     this.onKeyPress(value.slice(value.length - 1), this.state.primaryDecimalAmount, this.props.primaryInfo.maxEntryDecimals, setPrimaryToSecondary)
   }
 
-  onPrimaryKeyPress = (e: Event) =>
+  onPrimaryKeyPress = (e: Event) => {
+    if (Platform.OS === 'android' && e.nativeEvent.key.match(/[0-9]/)) return
     this.onKeyPress(e.nativeEvent.key, this.state.primaryDecimalAmount, this.props.primaryInfo.maxEntryDecimals, setPrimaryToSecondary)
+  }
 
   topRowFront = () => {
     const { primaryDisplayAmount, primaryDecimalAmount } = this.state
@@ -420,8 +422,10 @@ export class FlipInput extends React.Component<Props, State> {
     this.onKeyPress(value.slice(value.length - 1), this.state.secondaryDecimalAmount, this.props.secondaryInfo.maxEntryDecimals, setSecondaryToPrimary)
   }
 
-  onSecondaryKeyPress = (e: Event) =>
+  onSecondaryKeyPress = (e: Event) => {
+    if (Platform.OS === 'android' && e.nativeEvent.key.match(/[0-9]/)) return
     this.onKeyPress(e.nativeEvent.key, this.state.secondaryDecimalAmount, this.props.secondaryInfo.maxEntryDecimals, setSecondaryToPrimary)
+  }
 
   topRowBack = () => {
     const { secondaryDisplayAmount, secondaryDecimalAmount } = this.state


### PR DESCRIPTION
Tapping a numeric key on some keyboards, like Samsung Keyboard, will create an event in addition to onChangeText. This causes onKeyPress to be called twice and duplicate the entered value. Fix is to prevent events with a 0-9 key from calling onKeyPress