### PR TITLE
Fix crash when transaction is received before settings are loaded

### DIFF
--- a/src/modules/Settings/selectors.js
+++ b/src/modules/Settings/selectors.js
@@ -54,7 +54,7 @@ export const getDenominations = (state: RootState, currencyCode: string): EdgeDe
 export const getDisplayDenominationKey = (state: RootState, currencyCode: string) => {
   const settings = getSettings(state)
   const currencySettings = settings[currencyCode]
-  const selectedDenominationKey = currencySettings.denomination
+  const selectedDenominationKey = currencySettings ? currencySettings.denomination : '1'
   return selectedDenominationKey
 }
 


### PR DESCRIPTION
If the core sends back a transaction before the front end has loaded settings, it's possible for us to have a blank entry for the denomination of a currency code. In such a case, return a blank currency code which will fall back to a dummy denomination object preventing a crash.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a