### PR TITLE
Fix an annoying crash from react-native-tcp

### DIFF
--- a/patches/readable-stream+2.3.6.patch
+++ b/patches/readable-stream+2.3.6.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/readable-stream/lib/_stream_writable.js b/node_modules/readable-stream/lib/_stream_writable.js
+index b3f4e85..e2a2491 100644
+--- a/node_modules/readable-stream/lib/_stream_writable.js
++++ b/node_modules/readable-stream/lib/_stream_writable.js
+@@ -488,7 +488,7 @@ function onwrite(stream, er) {
+ function afterWrite(stream, state, finished, cb) {
+   if (!finished) onwriteDrain(stream, state);
+   state.pendingcb--;
+-  cb();
++  if (cb != null) cb();
+   finishMaybe(stream, state);
+ }
+


### PR DESCRIPTION
This doesn't seem to prevent the app from working, but it does produce frequent red-screen errors while debugging.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a