### PR TITLE
VERBOSE Build Parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,9 +13,11 @@ pipeline {
   parameters {
     booleanParam(name: 'ANDROID_BUILD', defaultValue: true, description: 'Build an Android version')
     booleanParam(name: 'IOS_BUILD', defaultValue: true, description: 'Build an iOS version')
+    booleanParam(name: 'VERBOSE', defaultValue: false, description: 'Complete build log output')
   }
   environment {
     LC_CTYPE = 'en_US.UTF-8'
+    DISABLE_XCPRETTY = "${params.VERBOSE}"
   }
 
   stages {

--- a/deploy.js
+++ b/deploy.js
@@ -172,7 +172,8 @@ function buildIos(buildObj) {
   call(`security set-keychain-settings -l ${process.env.HOME || ''}/Library/Keychains/login.keychain`)
 
   cmdStr = `xcodebuild -workspace ${buildObj.xcodeWorkspace} -scheme ${buildObj.xcodeScheme} archive`
-  cmdStr = cmdStr + ' | xcpretty && exit ${PIPE' + 'STATUS[0]}'
+  if (process.env.DISABLE_XCPRETTY === 'false') cmdStr = cmdStr + ' | xcpretty'
+  cmdStr = cmdStr + ' && exit ${PIPE' + 'STATUS[0]}'
   call(cmdStr)
 
   const buildDate = builddate()


### PR DESCRIPTION
This change purposes a new build parameter to optionally enable a verbosity mode to disable xcpretty and future silencing of noisy output in the build console output. The motivation is to add convenience to our process in troubleshooting build issues as they arise. This parameter is disabled by default; it is enabled only during a manual run (Build with parameters).

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a