### PR TITLE
Removed flex for tile container.

### DIFF
--- a/src/components/themed/Tile.js
+++ b/src/components/themed/Tile.js
@@ -68,7 +68,6 @@ class TileComponent extends React.PureComponent<Props> {
 
 const getStyles = cacheStyles((theme: Theme) => ({
   container: {
-    flex: 1,
     backgroundColor: theme.tileBackground,
     marginHorizontal: theme.rem(1),
     marginTop: theme.rem(1),

--- a/src/modules/FioAddress/components/SelectFioAddress.js
+++ b/src/modules/FioAddress/components/SelectFioAddress.js
@@ -2,21 +2,22 @@
 
 import type { EdgeCurrencyWallet } from 'edge-core-js'
 import * as React from 'react'
-import { ActivityIndicator, View } from 'react-native'
+import { ActivityIndicator, TouchableWithoutFeedback, View } from 'react-native'
 import { Actions } from 'react-native-router-flux'
 import { connect } from 'react-redux'
 
+import { ArrowDownTextIconButton } from '../../../components/common/ArrowDownTextIconButton.js'
 import { AddressModal } from '../../../components/modals/AddressModal'
 import { ButtonsModal } from '../../../components/modals/ButtonsModal'
 import { TransactionDetailsNotesInput } from '../../../components/modals/TransactionDetailsNotesInput'
 import { Airship, showError } from '../../../components/services/AirshipInstance'
 import { type Theme, type ThemeProps, cacheStyles, withTheme } from '../../../components/services/ThemeContext.js'
 import { EdgeText } from '../../../components/themed/EdgeText'
-import { Tile } from '../../../components/themed/Tile'
 import * as Constants from '../../../constants/indexConstants'
 import s from '../../../locales/strings.js'
 import { type Dispatch, type RootState } from '../../../types/reduxTypes'
 import type { FioAddress, FioRequest, GuiWallet } from '../../../types/types'
+import Text from '../../UI/components/FormattedText/FormattedText.ui.js'
 import * as UI_SELECTORS from '../../UI/selectors.js'
 import { refreshAllFioAddresses } from '../action'
 import { checkRecordSendFee, findWalletByFioAddress, FIO_NO_BUNDLED_ERR_CODE } from '../util'
@@ -209,10 +210,23 @@ class SelectFioAddress extends React.Component<Props, LocalState> {
     if (loading) return <ActivityIndicator color={theme.icon} style={styles.loading} size="small" />
 
     if (fioRequest) {
-      return <Tile type="static" title={s.strings.fragment_send_from_label} body={selected} />
+      return (
+        <View>
+          <Text style={styles.selectAddressText}>
+            {s.strings.fragment_send_from_label}: {selected}
+          </Text>
+        </View>
+      )
     }
 
-    return <Tile type="touchable" title={s.strings.fragment_send_from_label} body={selected} onPress={this.selectAddress} />
+    return (
+      <View style={styles.textIconContainer}>
+        <ArrowDownTextIconButton
+          onPress={this.selectAddress}
+          title={<Text style={styles.selectAddressText} ellipsizeMode="middle" numberOfLines={1}>{`${s.strings.fragment_send_from_label}: ${selected}`}</Text>}
+        />
+      </View>
+    )
   }
 
   render() {
@@ -231,9 +245,16 @@ class SelectFioAddress extends React.Component<Props, LocalState> {
     }
 
     return (
-      <View>
+      <View style={styles.selectContainer}>
         {this.renderFioAddress()}
-        {!loading && <Tile type="editable" title={s.strings.fio_sender_memo_label} body={memo} onPress={this.openMessageInput} />}
+        {!loading && (
+          <TouchableWithoutFeedback onPress={this.openMessageInput}>
+            <View style={styles.memoContainer}>
+              <Text style={styles.selectAddressText}>{s.strings.fio_sender_memo_label}:</Text>
+              <Text style={styles.selectAddressTextPressed}>{memo || s.strings.fio_sender_memo_placeholder}</Text>
+            </View>
+          </TouchableWithoutFeedback>
+        )}
         {memoError ? <EdgeText style={styles.error}>{memoError}</EdgeText> : null}
       </View>
     )
@@ -255,6 +276,25 @@ const getStyles = cacheStyles((theme: Theme) => ({
     flex: 1,
     marginTop: theme.rem(2.5),
     alignSelf: 'center'
+  },
+  selectAddressText: {
+    marginTop: theme.rem(0.75),
+    color: theme.primaryText,
+    fontSize: theme.rem(0.875)
+  },
+  selectAddressTextPressed: {
+    color: theme.secondaryText,
+    fontSize: theme.rem(0.875)
+  },
+  memoContainer: {
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  textIconContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: theme.rem(1.25)
   }
 }))
 


### PR DESCRIPTION
* Transaction details

<img width="370" alt="Снимок экрана 2020-12-24 в 19 44 19" src="https://user-images.githubusercontent.com/22767467/103101731-af122880-4621-11eb-9dfb-09897bf2dc9b.png">
<img width="365" alt="Снимок экрана 2020-12-24 в 19 44 28" src="https://user-images.githubusercontent.com/22767467/103101732-afaabf00-4621-11eb-9e54-448b10a7d880.png">

* Advanced transaction details

<img width="362" alt="Снимок экрана 2020-12-24 в 19 44 52" src="https://user-images.githubusercontent.com/22767467/103101733-b0435580-4621-11eb-89a9-25422b66d892.png">

* FIO Send Domain

<img width="367" alt="Снимок экрана 2020-12-24 в 19 47 32" src="https://user-images.githubusercontent.com/22767467/103101723-a9b4de00-4621-11eb-9872-b7f3f9e26e64.png">

* FIO send request details

<img width="365" alt="Снимок экрана 2020-12-24 в 19 46 40" src="https://user-images.githubusercontent.com/22767467/103101736-b0dbec00-4621-11eb-8efb-c482bb939767.png">

* FIO address settings

<img width="366" alt="Снимок экрана 2020-12-24 в 19 45 48" src="https://user-images.githubusercontent.com/22767467/103101735-b0dbec00-4621-11eb-99ae-ae092e624502.png">

* FIO domain settings (the scene is not using Tile, PR for domain scenes is not reviewed #2298, waiting for new FIO designs)
<img width="371" alt="Снимок экрана 2020-12-24 в 19 50 19" src="https://user-images.githubusercontent.com/22767467/103101727-ad486500-4621-11eb-9ce9-205257e232cd.png">

* Send Confirmation Scene
<img width="369" alt="Снимок экрана 2020-12-24 в 19 41 05" src="https://user-images.githubusercontent.com/22767467/103101730-ae799200-4621-11eb-8028-501475a3fbc5.png">



