### PR TITLE
Make wallet progress bar loader start at 5% and stop at 95% until it reaches 100%

### DIFF
--- a/src/components/themed/WalletProgressIcon.js
+++ b/src/components/themed/WalletProgressIcon.js
@@ -54,11 +54,21 @@ export class WalletProgressIconComponent extends React.PureComponent<Props, Stat
     if (!icon) {
       return null
     }
+
+    let formattedProgress
+    if (progress < 5) {
+      formattedProgress = 5
+    } else if (progress > 95 && progress < 100) {
+      formattedProgress = 95
+    } else {
+      formattedProgress = progress
+    }
+
     return (
       <AnimatedCircularProgress
         size={size ? size + theme.rem(0.25) : theme.rem(2.25)}
         width={theme.rem(3 / 16)}
-        fill={progress}
+        fill={formattedProgress}
         tintColor={isDone ? theme.walletProgressIconFillDone : theme.walletProgressIconFill}
         backgroundColor={theme.walletProgressIconBackground}
         rotation={0}


### PR DESCRIPTION
Task: https://app.asana.com/0/281171002982981/1199605136645462

Task description:
"Difficult to distinguish if an individual wallet icon is fully loaded or not.

Set wallet to begin with green circle at 5% start and stop at 95%. If it is able to fully sync completely then go 100% and green circle disappear.

Otherwise if the wallet cannot sync it should either be stuck between 5% or 95%."


#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android