### PR TITLE
Tile bug fix not being tappable

### DIFF
--- a/src/components/themed/Tile.js
+++ b/src/components/themed/Tile.js
@@ -43,7 +43,7 @@ class TileComponent extends React.PureComponent<Props> {
     }
     return (
       <TouchableWithoutFeedback onPress={onPress} disabled={type === 'static'}>
-        <>
+        <View>
           <View style={styles.container}>
             <View style={styles.content}>
               {type === 'editable' && <FontAwesomeIcon name="edit" style={styles.editIcon} />}
@@ -63,7 +63,7 @@ class TileComponent extends React.PureComponent<Props> {
             )}
           </View>
           <View style={styles.divider} />
-        </>
+        </View>
       </TouchableWithoutFeedback>
     )
   }


### PR DESCRIPTION
Having <> as a children of TouchableWithoutFeedback renders it not tappable.
Tested it with TouchableOpacity and TouchableHighlight and it works, so only TouchableWithoutFeedback is affected
Replace it with `<View />` instead

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
