### PR TITLE
Tapping the Wallet List on the menu will always go to the Wallet List Scene

### DIFF
--- a/src/components/themed/MenuTab.js
+++ b/src/components/themed/MenuTab.js
@@ -26,6 +26,13 @@ const title = {
 }
 
 class MenuTabComponent extends React.PureComponent<Props> {
+  handleOnPress = (route: string) => {
+    if (route === Constants.WALLET_LIST) {
+      return Actions.jump(Constants.WALLET_LIST_SCENE)
+    }
+    Actions.jump(route)
+  }
+
   render() {
     const { theme } = this.props
     const styles = getStyles(theme)
@@ -42,7 +49,7 @@ class MenuTabComponent extends React.PureComponent<Props> {
             [Constants.EXCHANGE]: <Ionicon name="swap-horizontal" size={theme.rem(1.25)} color={color} />
           }
           return (
-            <TouchableOpacity style={styles.content} key={element.key} onPress={() => Actions.jump(element.key)}>
+            <TouchableOpacity style={styles.content} key={element.key} onPress={() => this.handleOnPress(element.key)}>
               {icon[element.key]}
               <EdgeText style={{ ...styles.text, color: color }}>{title[element.key]}</EdgeText>
             </TouchableOpacity>


### PR DESCRIPTION
As the default navigation routes are stacks, and `Constants.WALLET_LIST` is one of those stack. Tapping the menu tab bar of wallets will only point into the stack. Any current scene the stack has will always show when you navigate to it. This fix ensure that if the route will go to the  `Constants.WALLET_LIST` stack, it will specifically always go to the `Constants.WALLET_LIST_SCENE` itself

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android