### PR TITLE
Power un-themed Airship modals using upstream code

### DIFF
--- a/src/components/common/AirshipModal.js
+++ b/src/components/common/AirshipModal.js
@@ -1,13 +1,13 @@
 // @flow
 
+import { BlurView } from '@react-native-community/blur'
 import * as React from 'react'
-import { Animated, BackHandler, Dimensions, StyleSheet, TouchableWithoutFeedback } from 'react-native'
-import { type AirshipBridge, type Unsubscribe } from 'react-native-airship'
+import { StyleSheet } from 'react-native'
+import { type AirshipBridge, AirshipModal as RealAirshipModal } from 'react-native-airship'
 
 import { THEME } from '../../theme/variables/airbitz.js'
 import { scale } from '../../util/scaling.js'
-import { KeyboardTracker } from './KeyboardTracker.js'
-import { type SafeAreaGap, LayoutContext } from './LayoutContext.js'
+import { type SafeAreaGap } from './LayoutContext.js'
 
 type Props<T> = {
   bridge: AirshipBridge<T>,
@@ -18,7 +18,7 @@ type Props<T> = {
   center?: boolean,
 
   // Called when the user taps outside the modal or clicks the back button:
-  onCancel: () => mixed,
+  onCancel: () => void,
 
   // This is to have marginTop when there is an icon on the modal
   icon?: boolean,
@@ -31,197 +31,19 @@ type Props<T> = {
  * A modal that slides a modal up from the bottom of the screen
  * and dims the rest of the app.
  */
-export class AirshipModal<T> extends React.Component<Props<T>> {
-  backHandler: { remove(): mixed } | void
-  opacity: Animated.Value
-  offset: Animated.Value
-  unclear: Unsubscribe
-  unresult: Unsubscribe
-
-  constructor(props: Props<T>) {
-    super(props)
-    this.opacity = new Animated.Value(0)
-    this.offset = new Animated.Value(Dimensions.get('window').height)
-  }
-
-  componentDidMount() {
-    this.backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
-      this.props.onCancel()
-      return true
-    })
-
-    // Animate in:
-    Animated.parallel([
-      Animated.timing(this.opacity, {
-        toValue: THEME.OPACITY.MODAL_DARKNESS,
-        duration: 300,
-        useNativeDriver: true
-      }),
-      Animated.timing(this.offset, {
-        toValue: 0,
-        duration: 300,
-        useNativeDriver: true
-      })
-    ]).start()
-
-    // Animate out:
-    this.unclear = this.props.bridge.on('clear', this.props.onCancel)
-    this.unresult = this.props.bridge.on('result', () =>
-      Animated.parallel([
-        Animated.timing(this.opacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true
-        }),
-        Animated.timing(this.offset, {
-          toValue: Dimensions.get('window').height,
-          duration: 300,
-          useNativeDriver: true
-        })
-      ]).start(this.props.bridge.remove)
-    )
-  }
-
-  componentWillUnmount() {
-    if (this.backHandler != null) this.backHandler.remove()
-    if (this.unclear != null) this.unclear()
-    if (this.unresult != null) this.unresult()
-  }
-
-  render() {
-    return (
-      <LayoutContext>
-        {metrics => {
-          const { layout, safeAreaInsets } = metrics
-          const downValue = safeAreaInsets.bottom
-          const upValue = keyboardHeight => Math.max(keyboardHeight, downValue)
-
-          return (
-            <KeyboardTracker downValue={downValue} upValue={upValue}>
-              {(keyboardAnimation, keyboardLayout) => this.renderModal(layout.height, safeAreaInsets, keyboardAnimation, keyboardLayout)}
-            </KeyboardTracker>
-          )
-        }}
-      </LayoutContext>
-    )
-  }
-
-  /**
-   * Draws the actual visual elements, given the current layout information:
-   */
-  renderModal(height: number, gap: SafeAreaGap, keyboardAnimation: Animated.Value, keyboardLayout: number) {
-    const { children, center, icon, padding = 0 } = this.props
-
-    // Set up the dynamic CSS values:
-    const screenPadding = {
-      paddingBottom: keyboardAnimation,
-      paddingLeft: gap.left,
-      paddingRight: gap.right,
-      paddingTop: gap.top
-    }
-    const transform = [{ translateY: this.offset }]
-    const bodyStyle = center
-      ? [styles.centerBody, { padding, transform }]
-      : [
-          styles.bottomBody,
-          {
-            marginTop: icon && keyboardLayout > 0 ? THEME.rem(1.75) : 0,
-            marginBottom: -keyboardLayout,
-            maxHeight: keyboardLayout + 0.75 * (height - gap.bottom - gap.top),
-            paddingBottom: keyboardLayout + padding,
-            paddingLeft: padding,
-            paddingRight: padding,
-            paddingTop: padding,
-            transform
-          }
-        ]
-
-    return (
-      <Animated.View style={[styles.screen, screenPadding]}>
-        <TouchableWithoutFeedback onPress={() => this.props.onCancel()}>
-          <Animated.View style={[styles.darkness, { opacity: this.opacity }]} />
-        </TouchableWithoutFeedback>
-        <Animated.View style={bodyStyle}>
-          {typeof children === 'function'
-            ? children({
-                bottom: center ? padding : keyboardLayout + padding,
-                left: padding,
-                right: padding,
-                top: padding
-              })
-            : children}
-        </Animated.View>
-      </Animated.View>
-    )
-  }
+export function AirshipModal<T>(props: Props<T>) {
+  const { bridge, children, center, onCancel } = props
+  return (
+    <RealAirshipModal
+      backgroundColor={THEME.COLORS.WHITE}
+      borderRadius={scale(16)}
+      bridge={bridge}
+      center={center}
+      margin={[THEME.rem(2), 0, 0, 0]}
+      onCancel={onCancel}
+      underlay={<BlurView blurType="dark" style={StyleSheet.absoluteFill} />}
+    >
+      {typeof children === 'function' ? children({ bottom: 50, left: 0, right: 0, top: 0 }) : children}
+    </RealAirshipModal>
+  )
 }
-
-const borderRadius = scale(16)
-const commonBody = {
-  // Layout:
-  flexShrink: 1,
-  width: 500,
-
-  // Visuals:
-  backgroundColor: THEME.COLORS.WHITE,
-  shadowOpacity: 1,
-  shadowOffset: {
-    width: 0,
-    height: scale(2)
-  },
-  shadowRadius: scale(4),
-
-  // Children:
-  alignItems: 'stretch',
-  flexDirection: 'column',
-  justifyContent: 'flex-start'
-}
-
-const styles = StyleSheet.create({
-  bottomBody: {
-    ...commonBody,
-
-    // Layout:
-    alignSelf: 'flex-end',
-
-    // Visuals:
-    borderTopLeftRadius: borderRadius,
-    borderTopRightRadius: borderRadius
-  },
-
-  centerBody: {
-    ...commonBody,
-
-    // Layout:
-    alignSelf: 'center',
-    marginHorizontal: scale(12),
-
-    // Visuals:
-    borderRadius: borderRadius
-  },
-
-  darkness: {
-    // Layout:
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    top: 0,
-
-    // Visuals:
-    backgroundColor: THEME.COLORS.SHADOW
-  },
-
-  screen: {
-    // Layout:
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    top: 0,
-
-    // Children:
-    flexDirection: 'row',
-    justifyContent: 'center'
-  }
-})


### PR DESCRIPTION
The upstream react-native-airship library has more stable layout code, so use that modal implementation to fix cut-off text on Android.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a