### PR TITLE
Fix exchange rate fetches not querying other exchange rates when one server is down

### DIFF
--- a/src/modules/ExchangeRates/action.js
+++ b/src/modules/ExchangeRates/action.js
@@ -48,7 +48,16 @@ async function buildExchangeRates(state: RootState) {
   }
   const exchangeRateKeys = Object.keys(exchangeRates)
   const exchangeRatePromises = Object.values(exchangeRates)
-  const rates = await Promise.all(exchangeRatePromises)
+  // Promise.allSettled() is the correct function for this but somehow not included in Promise
+  const rates = await Promise.all(
+    exchangeRatePromises.map(promise =>
+      // $FlowExpectedError - Object.values() always produce mixed type so .catch will produce error
+      promise.catch(e => {
+        console.log(e)
+        return 0
+      })
+    )
+  )
   for (let i = 0; i < exchangeRateKeys.length; i++) {
     const key = exchangeRateKeys[i]
     const codes = key.split('_')


### PR DESCRIPTION
`Promise.all()` will halt/reject when any of the promise does catch error. Fix is to suppress the error and just returns 0 upon rejection of any individual fetches. Promise.allSettled() is the correct function for this scenario but somehow not included in this javascript

Tested this by just introducing a new entry `new Promise((_, reject) => setTimeout(reject, 100))`. No real life test has been done

####  PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android