### PR TITLE
Transaction List, Wallet Crypto Amount, fix bug 0s of whole number being truncated

### DIFF
--- a/src/components/themed/TransactionListTop.js
+++ b/src/components/themed/TransactionListTop.js
@@ -337,7 +337,7 @@ export const TransactionListTop = connect(
     // Crypto Amount Formatting
     const currencyDenomination = getDenomination(selectedCurrencyCode, state.ui.settings)
     const cryptoAmount: string = convertNativeToDenomination(currencyDenomination.multiplier)(balance) // convert to correct denomination
-    const cryptoAmountFormat = cryptoAmount && !bns.eq(cryptoAmount, '0') ? intl.formatNumber(cryptoAmount.replace(/0+$/, '')) : '0' // only cut off trailing zeroes (to the right of significant figures)
+    const cryptoAmountFormat = intl.formatNumber(bns.add(cryptoAmount, '0'))
 
     // Fiat Balance Formatting
     const defaultDenomination = getDefaultDenomination(selectedCurrencyCode, state.ui.settings)


### PR DESCRIPTION
Added new truncate decimals function in utils with test and implement on Transaction List Wallet Crypto Amount

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android