### PR TITLE
Re-enable the network connectivity checker

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -344,6 +344,8 @@ PODS:
     - React
   - react-native-mymonero-core (0.1.0):
     - React
+  - react-native-netinfo (5.9.10):
+    - React-Core
   - react-native-randombytes (3.5.3):
     - React
   - react-native-safari-view (1.0.0):
@@ -512,6 +514,7 @@ DEPENDENCIES:
   - react-native-fast-crypto (from `../node_modules/react-native-fast-crypto`)
   - react-native-mail (from `../node_modules/react-native-mail`)
   - react-native-mymonero-core (from `../node_modules/react-native-mymonero-core`)
+  - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
   - react-native-safari-view (from `../node_modules/react-native-safari-view`)
   - react-native-smart-splash-screen (from `../node_modules/react-native-smart-splash-screen`)
@@ -628,6 +631,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-mail"
   react-native-mymonero-core:
     :path: "../node_modules/react-native-mymonero-core"
+  react-native-netinfo:
+    :path: "../node_modules/@react-native-community/netinfo"
   react-native-randombytes:
     :path: "../node_modules/react-native-randombytes"
   react-native-safari-view:
@@ -747,6 +752,7 @@ SPEC CHECKSUMS:
   react-native-fast-crypto: b6dea8324fb1b095dd4f29a80356b43acb3ee2e9
   react-native-mail: 685104c633d50ea3e15595acc89ab0eb9ee9cfd2
   react-native-mymonero-core: c5e0e039b4977be65ed936a1d5301da3448edff7
+  react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd
   react-native-randombytes: 3638d24759d67c68f6ccba60c52a7a8a8faa6a23
   react-native-safari-view: 955d7160d159241b8e9395d12d10ea0ef863dcdd
   react-native-smart-splash-screen: a961513689f11d63e8496684c2fa4be2d24fe23b

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@react-native-community/blur": "^3.6.0",
     "@react-native-community/clipboard": "^1.5.1",
     "@react-native-community/datetimepicker": "^3.0.2",
+    "@react-native-community/netinfo": "^5.9.10",
     "@react-native-firebase/analytics": "^6.0.0",
     "@react-native-firebase/app": "^6.0.0",
     "@react-native-firebase/iid": "^6.0.0",

--- a/src/components/services/NetworkActivity.js
+++ b/src/components/services/NetworkActivity.js
@@ -1,9 +1,6 @@
 // @flow
 
-// todo: enable @react-native-community/netinfo for react-native >= 0.60 or figure out how to use with Jetifier for current version
-// "@react-native-community/netinfo": "3.2.1"
-// import NetInfo from '@react-native-community/netinfo'
-
+import NetInfo, { type NetInfoState } from '@react-native-community/netinfo'
 import * as React from 'react'
 import { connect } from 'react-redux'
 
@@ -15,23 +12,24 @@ type Props = {
   changeConnectivity: (isConnected: boolean) => void
 }
 
-const NetInfo = {}
-
 class NetworkActivityComponent extends React.Component<Props> {
-  netInfoUnsubscribe: Function | null = null
+  netInfoUnsubscribe: void | (() => void)
+
+  handleNetworkState = (info: NetInfoState) => {
+    console.log('NetworkActivity - isConnected changed: ', info.isConnected)
+    this.props.changeConnectivity(info.isConnected)
+    if (!info.isConnected) {
+      showError(`${s.strings.network_alert_title}`)
+    }
+  }
 
   componentDidMount() {
-    this.netInfoUnsubscribe = NetInfo.addEventListener(state => {
-      console.log('NetworkActivity - isConnected changed: ', state.isConnected)
-      this.props.changeConnectivity(state.isConnected)
-      if (!state.isConnected) {
-        showError(`${s.strings.network_alert_title}`)
-      }
-    })
+    this.netInfoUnsubscribe = NetInfo.addEventListener(this.handleNetworkState)
+    NetInfo.fetch().then(this.handleNetworkState)
   }
 
   componentWillUnmount() {
-    this.netInfoUnsubscribe && this.netInfoUnsubscribe()
+    if (this.netInfoUnsubscribe != null) this.netInfoUnsubscribe()
   }
 
   render() {

--- a/src/components/services/Services.js
+++ b/src/components/services/Services.js
@@ -26,6 +26,7 @@ import { DeepLinkingManager } from './DeepLinkingManager.js'
 import EdgeAccountCallbackManager from './EdgeAccountCallbackManager.js'
 import EdgeContextCallbackManager from './EdgeContextCallbackManager.js'
 import EdgeWalletsCallbackManager from './EdgeWalletsCallbackManager.js'
+import { NetworkActivity } from './NetworkActivity.js'
 import { PasswordReminderService } from './PasswordReminderService.js'
 import { PermissionsManager } from './PermissionsManager.js'
 
@@ -90,6 +91,7 @@ export class Services extends React.PureComponent<Props> {
           <EdgeWalletsCallbackManager />
           <ModalProvider />
           <PermissionsManager />
+          <NetworkActivity />
           <PasswordReminderService />
         </>
       </Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,6 +2163,11 @@
   dependencies:
     invariant "^2.2.4"
 
+"@react-native-community/netinfo@^5.9.10":
+  version "5.9.10"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.10.tgz#97d3a9fa62a3a4838ec7a6ec91cfec5a26e365b6"
+  integrity sha512-1NPlBA2Hu/KWc3EnQcDRPRX0x8Dg9tuQlQQVWVQjlg+u+PjCq7ANEtbikOFKp5yQqfF8tqzU5+84/IfDO8zpiA==
+
 "@react-native-firebase/analytics@^6.0.0":
   version "6.7.2"
   resolved "https://registry.yarnpkg.com/@react-native-firebase/analytics/-/analytics-6.7.2.tgz#5f5d6cdefbee09e2a45e33e8dbf55cbc3452c64b"


### PR DESCRIPTION
Now that we are on RN63, we can get this working again. Otherwise, if we don't actually want this feature, we should just delete the whole thing (removing `isConnected` altogether). I assume we still want this feature, so here is a PR to put it back.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a