### PR TITLE
Added simplified Utils function to lookup settings currency multiplier

### DIFF
--- a/src/components/scenes/TransactionDetailsScene.js
+++ b/src/components/scenes/TransactionDetailsScene.js
@@ -47,7 +47,8 @@ type StateProps = {
   destinationWallet?: GuiWallet,
   guiWallet: GuiWallet,
   subcategoriesList: string[],
-  walletDefaultDenomProps: EdgeDenomination
+  walletDefaultDenomProps: EdgeDenomination,
+  settings: Object
 }
 type DispatchProps = {
   getSubcategories(): void,
@@ -252,15 +253,18 @@ export class TransactionDetailsComponent extends React.Component<Props, State> {
   }
 
   renderExchangeData = (symbolString: string) => {
-    const { destinationDenomination, destinationWallet, edgeTransaction, guiWallet, walletDefaultDenomProps, theme } = this.props
+    const { destinationDenomination, destinationWallet, edgeTransaction, guiWallet, walletDefaultDenomProps, theme, settings } = this.props
     const { swapData, spendTargets } = edgeTransaction
     const styles = getStyles(theme)
 
     if (!swapData || !spendTargets || !destinationDenomination) return null
 
+    const payoutMultiplier = UTILS.getMultiplierFromSettings(swapData.payoutCurrencyCode.toUpperCase(), settings) // "ETH", Settings object
+
     const { plugin, isEstimate, orderId, payoutAddress, refundAddress } = swapData
     const sourceAmount = UTILS.convertNativeToDisplay(walletDefaultDenomProps.multiplier)(spendTargets[0].nativeAmount)
-    const destinationAmount = UTILS.convertNativeToDisplay(destinationDenomination.multiplier)(swapData.payoutNativeAmount)
+
+    const destinationAmount = UTILS.convertNativeToDisplay(payoutMultiplier)(swapData.payoutNativeAmount)
     const destinationCurrencyCode = swapData.payoutCurrencyCode
 
     const createExchangeDataString = (newline: string = '\n') => {
@@ -623,7 +627,8 @@ export const TransactionDetailsScene = connect(
       destinationWallet,
       guiWallet: wallet,
       subcategoriesList,
-      walletDefaultDenomProps
+      walletDefaultDenomProps,
+      settings
     }
   },
   (dispatch: Dispatch): DispatchProps => ({

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -44,6 +44,12 @@ export const getSettingsCurrencyMultiplier = (currencyCode: string, settings: Ob
   return multiplier
 }
 
+// Gets the currency multiplier set in settings for specified currencyCode
+// i.e. getSettingsCurrencyMultiplier("ETH", settings)
+export const getMultiplierFromSettings = (currencyCode: string, settings: Object) => {
+  return settings[currencyCode].denomination
+}
+
 // tokens can only have one denomination / multiplier from what I understand
 export const getSettingsTokenMultiplier = (currencyCode: string, settings: Object, denomination: Object): string => {
   let multiplier


### PR DESCRIPTION
Added simplified Utils function to lookup settings currency multiplier and used it to lookup correct multiplier in exchange details.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a
- [x ] Tested on iOS emulator