### PR TITLE
Forced uppercase usage of currencyCode for lookup of corresponding se…

### DIFF
--- a/src/components/scenes/TransactionDetailsScene.js
+++ b/src/components/scenes/TransactionDetailsScene.js
@@ -611,6 +611,10 @@ export const TransactionDetailsScene = connect(
     const currentFiatAmount = convertCurrencyFromExchangeRates(state.exchangeRates, currencyCode, wallet.isoFiatCurrencyCode, parseFloat(cryptoAmount))
 
     const { swapData } = edgeTransaction
+    if (swapData != null && typeof swapData.payoutCurrencyCode === 'string') {
+      swapData.payoutCurrencyCode = swapData.payoutCurrencyCode.toUpperCase()
+    }
+
     const destinationDenomination = swapData ? getDisplayDenomination(state, swapData.payoutCurrencyCode) : undefined
     const destinationWallet = swapData ? getWallet(state, swapData.payoutWalletId) : undefined
 


### PR DESCRIPTION
Added a selector 'getMultiplierFromSettings' to lookup correct multiplier in case null denomination property in currencySettings object.

Original pr: https://github.com/EdgeApp/edge-react-gui/pull/2426

Rebased ontop of Dev and ran all precommits.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x ] Tested on iOS emulator