### PR TITLE
Fix wallet list empty row crashing the app when being swiped

### DIFF
--- a/src/components/themed/WalletList.js
+++ b/src/components/themed/WalletList.js
@@ -197,7 +197,7 @@ class WalletListComponent extends React.PureComponent<Props> {
     const guiWallet = wallets[walletId]
 
     if (guiWallet == null || !data.item.fullCurrencyCode) {
-      return <WalletListEmptyRow rowKey={data.item.key} rowMap={rowMap} walletId={walletId} />
+      return <WalletListEmptyRow walletId={walletId} swipeRow={rowMap[data.item.key]} />
     } else {
       const isToken = guiWallet.currencyCode !== data.item.fullCurrencyCode
       const walletCodesArray = data.item.fullCurrencyCode.split('-')

--- a/src/components/themed/WalletListEmptyRow.js
+++ b/src/components/themed/WalletListEmptyRow.js
@@ -13,26 +13,22 @@ import { EdgeText } from './EdgeText.js'
 
 type Props = {
   walletId?: string,
-  rowKey: string,
   swipeRef: ?React.ElementRef<typeof SwipeRow>,
-  rowMap: { [string]: SwipeRow }
+  swipeRow?: SwipeRow
 }
 
 class WalletListEmptyRowComponent extends React.PureComponent<Props & ThemeProps> {
-  handleOpenWalletListMenuModal = async () => {
-    const { rowKey, rowMap } = this.props
-    rowMap[rowKey].closeRow()
-    if (this.props.walletId) {
-      await Airship.show(bridge => <WalletListMenuModal bridge={bridge} walletId={this.props.walletId} />)
+  closeRow = () => {
+    const { swipeRow } = this.props
+    if (swipeRow) {
+      swipeRow.closeRow()
     }
   }
 
-  handleRowOpen = () => {
-    const { rowKey, rowMap } = this.props
-    for (const key in rowMap) {
-      if (rowMap.hasOwnProperty(key) && key !== rowKey) {
-        rowMap[key].closeRow()
-      }
+  handleOpenWalletListMenuModal = async () => {
+    this.closeRow()
+    if (this.props.walletId) {
+      await Airship.show(bridge => <WalletListMenuModal bridge={bridge} walletId={this.props.walletId} />)
     }
   }
 
@@ -40,7 +36,7 @@ class WalletListEmptyRowComponent extends React.PureComponent<Props & ThemeProps
     const { theme } = this.props
     const styles = getStyles(theme)
     return (
-      <SwipeRow onRowOpen={this.handleRowOpen} rightOpenValue={theme.rem(-2.5)} disableRightSwipe ref={this.props.swipeRef} useNativeDriver>
+      <SwipeRow {...this.props} rightOpenValue={theme.rem(-2.5)} disableRightSwipe ref={this.props.swipeRef} useNativeDriver>
         <View style={styles.swipeContainer}>
           <TouchableOpacity style={styles.swipeButton} onPress={this.handleOpenWalletListMenuModal}>
             <EdgeText style={styles.swipeIcon}>{WALLET_LIST_OPTIONS_ICON}</EdgeText>


### PR DESCRIPTION
- Make the Wallet List Empty Row have the same behavior as the Wallet List Row

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android