### PR TITLE
Sweep Private Key: Updated process of sweep private key on the sidebar menu

### DIFF
--- a/src/components/Main.ui.js
+++ b/src/components/Main.ui.js
@@ -281,7 +281,6 @@ export class MainComponent extends React.Component<Props> {
                 }}
                 onExit={this.props.dispatchDisableScan}
                 component={ifLoggedIn(Scan)}
-                renderTitle={<HeaderTitle title={s.strings.send_scan_header_text} />}
                 renderLeftButton={<BackButton withArrow onPress={this.handleBack} label={s.strings.title_back} />}
                 renderRightButton={<SideMenuButton />}
               />

--- a/src/components/scenes/ScanScene.js
+++ b/src/components/scenes/ScanScene.js
@@ -109,7 +109,7 @@ export class Scan extends React.Component<Props> {
       return (
         <RNCamera style={styles.cameraArea} captureAudio={false} flashMode={flashMode} onBarCodeRead={this.onBarCodeRead} type={RNCamera.Constants.Type.back}>
           <View style={styles.overlayTop}>
-            <T style={styles.overlayTopText}>{s.strings.send_scan_header_text}</T>
+            <T style={styles.overlayTopText}>{s.strings.send_scan_edge_login_or_sweep_private_key}</T>
           </View>
         </RNCamera>
       )

--- a/src/constants/WalletAndCurrencyConstants.js
+++ b/src/constants/WalletAndCurrencyConstants.js
@@ -184,7 +184,8 @@ type SpecialCurrencyInfo = {|
   needsAccountNameSetup?: boolean,
   noChangeMiningFee?: boolean,
   noMaxSpend?: boolean,
-  keysOnlyMode?: boolean
+  keysOnlyMode?: boolean,
+  isPrivateKeySweepable?: boolean
 |}
 
 export const getSpecialCurrencyInfo = (currencyCode: string): SpecialCurrencyInfo => {
@@ -197,29 +198,45 @@ export const getSpecialCurrencyInfo = (currencyCode: string): SpecialCurrencyInf
   }
 }
 
+export const getPrivateKeySweepableCurrencies = (): string[] => {
+  const sweepableCurrencies = []
+  for (const currencyCode in SPECIAL_CURRENCY_INFO) {
+    const currencyInfo = SPECIAL_CURRENCY_INFO[currencyCode]
+    if (currencyInfo.isPrivateKeySweepable) {
+      sweepableCurrencies.push(currencyCode)
+    }
+  }
+  return sweepableCurrencies
+}
+
 export const SPECIAL_CURRENCY_INFO: {
   [currencyCode: string]: SpecialCurrencyInfo
 } = {
   BTC: {
     displayBuyCrypto: true,
     isImportKeySupported: false,
-    showEarnInterestCard: false
+    showEarnInterestCard: false,
+    isPrivateKeySweepable: true
   },
   BCH: {
     displayBuyCrypto: true,
     isImportKeySupported: false,
-    showEarnInterestCard: false
+    showEarnInterestCard: false,
+    isPrivateKeySweepable: true
   },
   BSV: {
-    displayBuyCrypto: true
+    displayBuyCrypto: true,
+    isPrivateKeySweepable: true
   },
   DGB: {
-    displayBuyCrypto: true
+    displayBuyCrypto: true,
+    isPrivateKeySweepable: true
   },
   LTC: {
     displayBuyCrypto: true,
     isImportKeySupported: false,
-    showEarnInterestCard: false
+    showEarnInterestCard: false,
+    isPrivateKeySweepable: true
   },
   RBTC: {
     dummyPublicAddress: '0x74f9452e22fe58e27575f176fc884729d88267ba', // rj116
@@ -391,6 +408,21 @@ export const SPECIAL_CURRENCY_INFO: {
       privateKeyLabel: s.strings.create_wallet_import_input_key_or_seed_prompt,
       privateKeyInstructions: s.strings.create_wallet_import_input_key_or_seed_instructions
     }
+  },
+  DASH: {
+    isPrivateKeySweepable: true
+  },
+  RVN: {
+    isPrivateKeySweepable: true
+  },
+  DOGE: {
+    isPrivateKeySweepable: true
+  },
+  FIRO: {
+    isPrivateKeySweepable: true
+  },
+  SMART: {
+    isPrivateKeySweepable: true
   }
 }
 

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -218,7 +218,7 @@ const strings = {
   send_confirmation_eos_error_cpu: 'Insufficient CPU available to send EOS transaction. Please wait 1-3 days for CPU to recharge.',
   send_confirmation_eos_error_net: 'Insufficient NET available to send EOS transaction. Please wait 1-3 days for NET to recharge.',
   send_confirmation_eos_error_ram: 'Insufficient RAM available to send EOS transaction. Please see edge.app/eos for details on how to resolve.',
-  send_scan_header_text: 'Scan to Edge Login',
+  send_scan_edge_login_or_sweep_private_key: 'Edge Login or Sweep Private Key',
   send_scan_edge_login_success_title: 'Edge Login Successful',
   send_scan_edge_login_success_message: 'To continue, please return to the browser or application that requested the Edge Login.',
   send_to_title: 'To: %s',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -198,7 +198,7 @@
   "send_confirmation_eos_error_cpu": "Insufficient CPU available to send EOS transaction. Please wait 1-3 days for CPU to recharge.",
   "send_confirmation_eos_error_net": "Insufficient NET available to send EOS transaction. Please wait 1-3 days for NET to recharge.",
   "send_confirmation_eos_error_ram": "Insufficient RAM available to send EOS transaction. Please see edge.app/eos for details on how to resolve.",
-  "send_scan_header_text": "Scan to Edge Login",
+  "send_scan_edge_login_or_sweep_private_key": "Edge Login or Sweep Private Key",
   "send_scan_edge_login_success_title": "Edge Login Successful",
   "send_scan_edge_login_success_message": "To continue, please return to the browser or application that requested the Edge Login.",
   "send_to_title": "To: %s",

--- a/src/modules/UI/components/ControlPanel/Component/Main.js
+++ b/src/modules/UI/components/ControlPanel/Component/Main.js
@@ -19,7 +19,10 @@ import shareIcon from '../../../../../assets/images/sidenav/share.png'
 import sweepIcon from '../../../../../assets/images/sidenav/sweep.png'
 import termsIcon from '../../../../../assets/images/sidenav/terms.png'
 import walletIcon from '../../../../../assets/images/sidenav/wallets.png'
+import { type WalletListResult, WalletListModal } from '../../../../../components/modals/WalletListModal.js'
+import { Airship } from '../../../../../components/services/AirshipInstance.js'
 import * as Constants from '../../../../../constants/indexConstants.js'
+import { getPrivateKeySweepableCurrencies } from '../../../../../constants/WalletAndCurrencyConstants.js'
 import s from '../../../../../locales/strings.js'
 import { THEME } from '../../../../../theme/variables/airbitz.js'
 import { scale } from '../../../../../util/scaling.js'
@@ -30,11 +33,12 @@ import UserList from './UserListConnector'
 
 export type Props = {
   logout: (username?: string) => void,
-  usersView: boolean
+  usersView: boolean,
+  onSelectWallet: (walletId: string, currencyCode: string) => void
 }
 export default class Main extends React.Component<Props> {
   render() {
-    const { usersView } = this.props
+    const { onSelectWallet, usersView } = this.props
 
     return usersView ? (
       <UserList />
@@ -58,7 +62,7 @@ export default class Main extends React.Component<Props> {
               <Separator />
               <ScanButton />
               <Separator />
-              <SweepPrivateKeyButton />
+              <SweepPrivateKeyButton onSelectWallet={onSelectWallet} />
               <Separator />
               <RequestButton />
               <Separator />
@@ -166,10 +170,20 @@ const ScanButton = () => {
   )
 }
 
-const popToSweepPrivateKeyScene = () => Actions.jump(Constants.SCAN, { data: 'sweepPrivateKey' })
-const SweepPrivateKeyButton = () => {
+const SweepPrivateKeyButton = ({ onSelectWallet }) => {
+  const handlePress = () => {
+    Airship.show(bridge => (
+      <WalletListModal bridge={bridge} headerTitle={s.strings.select_wallet} allowedCurrencyCodes={getPrivateKeySweepableCurrencies()} showCreateWallet />
+    )).then(({ walletId, currencyCode }: WalletListResult) => {
+      if (walletId && currencyCode) {
+        onSelectWallet(walletId, currencyCode)
+        Actions.jump(Constants.SCAN, { data: 'sweepPrivateKey' })
+      }
+    })
+  }
+
   return (
-    <Button onPress={popToSweepPrivateKeyScene}>
+    <Button onPress={handlePress}>
       <Button.Row>
         <Button.Left>
           <Image source={sweepIcon} style={styles.iconImage} />

--- a/src/modules/UI/components/ControlPanel/Component/MainConnector.js
+++ b/src/modules/UI/components/ControlPanel/Component/MainConnector.js
@@ -2,6 +2,7 @@
 
 import { connect } from 'react-redux'
 
+import { selectWalletFromModal } from '../../../../../actions/WalletActions.js'
 import { type Dispatch, type RootState } from '../../../../../types/reduxTypes.js'
 import { logoutRequest } from '../../../../Login/action'
 import Main from './Main'
@@ -10,7 +11,8 @@ const mapStateToProps = (state: RootState) => ({
   usersView: state.ui.scenes.controlPanel.usersView
 })
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  logout: (username?: string) => dispatch(logoutRequest(username))
+  logout: (username?: string) => dispatch(logoutRequest(username)),
+  onSelectWallet: (walletId: string, currencyCode: string) => dispatch(selectWalletFromModal(walletId, currencyCode))
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Main)


### PR DESCRIPTION
NOTE: Enabled sweepable private keys as instructed verbatim. "BTC, LTC, BCH, DASH, BSV, dgb, rvn, doge, firo, Smart"

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a