### PR TITLE
William/export in gui

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "edge-currency-monero": "^0.2.9",
     "edge-exchange-plugins": "^0.11.23",
     "edge-login-ui-rn": "^0.8.3",
+    "json-csv": "^1.5.0",
     "lodash": "^4.17.19",
     "qrcode-generator": "^1.4.4",
     "react": "16.13.1",

--- a/src/__tests__/TransactionExportActions.test.js
+++ b/src/__tests__/TransactionExportActions.test.js
@@ -45,7 +45,7 @@ const edgeTxs: EdgeTransaction[] = [
 test('export CSV matches reference data', async function () {
   const out = await exportTransactionsToCSVInner(edgeTxs, 'BTC', 'USD', '100')
   expect(out).toEqual(
-    `CURRENCY_CODE,DATE,TIME,PAYEE_PAYER_NAME,AMT_BTC,USD,CATEGORY,NOTES,AMT_NETWORK_FEES_BTC,TXID,OUR_RECEIVE_ADDRESSES,VER\r\n"BTC","2018-04-23","09:49","Crazy Person","1230000","12000.45","Income: Mo Money","Hell yeah! Thanks for the fish <<&&>>","10","txid1","receiveaddress1,receiveaddress2",1\r\n"BTC","2018-04-23","12:36","Crazy Person 2","-3210000","36001.45","Expense: Less Money","Hell yeah! Here's a fish""","20","txid2","receiveaddress3,receiveaddress4",1\r\n`
+    `CURRENCY_CODE,DATE,TIME,PAYEE_PAYER_NAME,AMT_BTC,DENOMINATION,USD,CATEGORY,NOTES,AMT_NETWORK_FEES_BTC,TXID,OUR_RECEIVE_ADDRESSES,VER\r\n"BTC","2018-04-23","09:49","Crazy Person","1230000","","12000.45","Income: Mo Money","Hell yeah! Thanks for the fish <<&&>>","10","txid1","receiveaddress1,receiveaddress2",1\r\n"BTC","2018-04-23","12:36","Crazy Person 2","-3210000","","36001.45","Expense: Less Money","Hell yeah! Here's a fish""","20","txid2","receiveaddress3,receiveaddress4",1\r\n`
   )
 })
 

--- a/src/__tests__/TransactionExportActions.test.js
+++ b/src/__tests__/TransactionExportActions.test.js
@@ -1,0 +1,133 @@
+// @flow
+/* globals test expect */
+
+import { type EdgeTransaction } from 'edge-core-js'
+
+import { exportTransactionsToCSVInner, exportTransactionsToQBOInner } from '../actions/TransactionExportActions.js'
+
+const edgeTxs: EdgeTransaction[] = [
+  {
+    txid: 'txid1',
+    date: 1524476980,
+    currencyCode: 'BTC',
+    blockHeight: 500000,
+    nativeAmount: '123000000',
+    networkFee: '1000',
+    ourReceiveAddresses: ['receiveaddress1', 'receiveaddress2'],
+    signedTx: '298t983y4t983y4t93y4g98oeshfgi4t89w394t',
+    parentNetworkFee: '10002',
+    metadata: {
+      name: 'Crazy Person',
+      category: 'Income: Mo Money',
+      notes: 'Hell yeah! Thanks for the fish <<&&>>',
+      amountFiat: 12000.45
+    }
+  },
+  {
+    txid: 'txid2',
+    date: 1524486980,
+    currencyCode: 'BTC',
+    blockHeight: 500000,
+    nativeAmount: '-321000000',
+    networkFee: '2000',
+    ourReceiveAddresses: ['receiveaddress3', 'receiveaddress4'],
+    signedTx: 'fiuwh34f98h3tiuheirgserg',
+    parentNetworkFee: '20001',
+    metadata: {
+      name: 'Crazy Person 2',
+      category: 'Expense: Less Money',
+      notes: 'Hell yeah! Here\'s a fish"',
+      amountFiat: 36001.45
+    }
+  }
+]
+
+test('export CSV matches reference data', async function () {
+  const out = await exportTransactionsToCSVInner(edgeTxs, 'BTC', 'USD', '100')
+  expect(out).toEqual(
+    `CURRENCY_CODE,DATE,TIME,PAYEE_PAYER_NAME,AMT_BTC,USD,CATEGORY,NOTES,AMT_NETWORK_FEES_BTC,TXID,OUR_RECEIVE_ADDRESSES,VER\r\n"BTC","2018-04-23","09:49","Crazy Person","1230000","12000.45","Income: Mo Money","Hell yeah! Thanks for the fish <<&&>>","10","txid1","receiveaddress1,receiveaddress2",1\r\n"BTC","2018-04-23","12:36","Crazy Person 2","-3210000","36001.45","Expense: Less Money","Hell yeah! Here's a fish""","20","txid2","receiveaddress3,receiveaddress4",1\r\n`
+  )
+})
+
+test('export QBO matches reference data', function () {
+  const out = exportTransactionsToQBOInner(edgeTxs, 'BTC', 'USD', '100', 1524578071304)
+  expect(out).toEqual(
+    'OFXHEADER:100\n' +
+      'DATA:OFXSGML\n' +
+      'VERSION:102\n' +
+      'SECURITY:NONE\n' +
+      'ENCODING:USASCII\n' +
+      'CHARSET:1252\n' +
+      'COMPRESSION:NONE\n' +
+      'OLDFILEUID:NONE\n' +
+      'NEWFILEUID:NONE\n' +
+      '\n' +
+      '<OFX>\n' +
+      '<SIGNONMSGSRSV1>\n' +
+      '<SONRS>\n' +
+      '<STATUS>\n' +
+      '<CODE>0\n' +
+      '<SEVERITY>INFO\n' +
+      '</STATUS>\n' +
+      '<DTSERVER>20180424135431.000\n' +
+      '<LANGUAGE>ENG\n' +
+      '<INTU.BID>3000\n' +
+      '</SONRS>\n' +
+      '</SIGNONMSGSRSV1>\n' +
+      '<BANKMSGSRSV1>\n' +
+      '<STMTTRNRS>\n' +
+      '<TRNUID>20180424135431.000\n' +
+      '<STATUS>\n' +
+      '<CODE>0\n' +
+      '<SEVERITY>INFO\n' +
+      '<MESSAGE>OK\n' +
+      '</STATUS>\n' +
+      '<STMTRS>\n' +
+      '<CURDEF>USD\n' +
+      '<BANKACCTFROM>\n' +
+      '<BANKID>999999999\n' +
+      '<ACCTID>999999999999\n' +
+      '<ACCTTYPE>CHECKING\n' +
+      '</BANKACCTFROM>\n' +
+      '<BANKTRANLIST>\n' +
+      '<DTSTART>20180424135431.000\n' +
+      '<DTEND>20180424135431.000\n' +
+      '<STMTTRN>\n' +
+      '<TRNTYPE>CREDIT\n' +
+      '<DTPOSTED>20180423094940.000\n' +
+      '<TRNAMT>1230000\n' +
+      '<FITID>txid1\n' +
+      '<NAME>Crazy Person\n' +
+      '<MEMO>// Rate=0.00975646 USD=12000.45 category="Income: Mo Money" memo="Hell yeah! Thanks for the fish &lt;&lt;&amp;&amp;&gt;&gt;"\n' +
+      '<CURRENCY>\n' +
+      '<CURRATE>0.00975646\n' +
+      '<CURSYM>USD\n' +
+      '</CURRENCY>\n' +
+      '</STMTTRN>\n' +
+      '<STMTTRN>\n' +
+      '<TRNTYPE>DEBIT\n' +
+      '<DTPOSTED>20180423123620.000\n' +
+      '<TRNAMT>-3210000\n' +
+      '<FITID>txid2\n' +
+      '<NAME>Crazy Person 2\n' +
+      '<MEMO>// Rate=0.0112154 USD=36001.45 category="Expense: Less Money" memo="Hell yeah! Here\'s a fish""\n' +
+      '<CURRENCY>\n' +
+      '<CURRATE>0.0112154\n' +
+      '<CURSYM>USD\n' +
+      '</CURRENCY>\n' +
+      '</STMTTRN>\n' +
+      '</BANKTRANLIST>\n' +
+      '<LEDGERBAL>\n' +
+      '<BALAMT>0.00\n' +
+      '<DTASOF>20180424135431.000\n' +
+      '</LEDGERBAL>\n' +
+      '<AVAILBAL>\n' +
+      '<BALAMT>0.00\n' +
+      '<DTASOF>20180424135431.000\n' +
+      '</AVAILBAL>\n' +
+      '</STMTRS>\n' +
+      '</STMTTRNRS>\n' +
+      '</BANKMSGSRSV1>\n' +
+      '</OFX>\n'
+  )
+})

--- a/src/actions/TransactionExportActions.js
+++ b/src/actions/TransactionExportActions.js
@@ -14,7 +14,13 @@ export async function exportTransactionsToQBO(wallet: EdgeCurrencyWallet, opts: 
 export async function exportTransactionsToCSV(wallet: EdgeCurrencyWallet, opts: EdgeGetTransactionsOptions = {}): Promise<string> {
   const txs: EdgeTransaction[] = await wallet.getTransactions(opts)
   const { currencyCode = wallet.currencyInfo.currencyCode, denomination } = opts
-  return exportTransactionsToCSVInner(txs, currencyCode, wallet.fiatCurrencyCode, denomination)
+
+  let denomName = ''
+  if (denomination != null) {
+    const denomObj = wallet.currencyInfo.denominations.find(edgeDenom => edgeDenom.multiplier === denomination)
+    if (denomObj != null) denomName = denomObj.name
+  }
+  return exportTransactionsToCSVInner(txs, currencyCode, wallet.fiatCurrencyCode, denomination, denomName)
 }
 
 function padZero(val: string): string {
@@ -223,7 +229,8 @@ export async function exportTransactionsToCSVInner(
   edgeTransactions: EdgeTransaction[],
   currencyCode: string,
   fiatCurrencyCode: string,
-  denom?: string
+  denom?: string,
+  denomName: string = ''
 ): Promise<string> {
   const currencyField = 'AMT_' + currencyCode
   const networkFeeField = 'AMT_NETWORK_FEES_' + currencyCode
@@ -286,6 +293,11 @@ export async function exportTransactionsToCSVInner(
       {
         name: 'amount',
         label: currencyField,
+        quoted: true
+      },
+      {
+        name: 'denomName',
+        label: 'DENOMINATION',
         quoted: true
       },
       {

--- a/src/actions/TransactionExportActions.js
+++ b/src/actions/TransactionExportActions.js
@@ -1,0 +1,337 @@
+// @flow
+
+import { abs, div, lt } from 'biggystring'
+import { type EdgeCurrencyWallet, type EdgeGetTransactionsOptions, type EdgeTransaction } from 'edge-core-js'
+import jsoncsv from 'json-csv'
+
+export async function exportTransactionsToQBO(wallet: EdgeCurrencyWallet, opts: EdgeGetTransactionsOptions): Promise<string> {
+  const txs: EdgeTransaction[] = await this.getTransactions(opts)
+  const { currencyCode = wallet.currencyInfo.currencyCode, denomination } = opts
+  const qbo: string = exportTransactionsToQBOInner(txs, currencyCode, this.fiatCurrencyCode, denomination, Date.now())
+  return qbo
+}
+
+export async function exportTransactionsToCSV(wallet: EdgeCurrencyWallet, opts: EdgeGetTransactionsOptions = {}): Promise<string> {
+  const txs: EdgeTransaction[] = await wallet.getTransactions(opts)
+  const { currencyCode = wallet.currencyInfo.currencyCode, denomination } = opts
+  return exportTransactionsToCSVInner(txs, currencyCode, wallet.fiatCurrencyCode, denomination)
+}
+
+function padZero(val: string): string {
+  if (val.length === 1) {
+    return '0' + val
+  }
+  return val
+}
+
+function escapeOFXString(str: string): string {
+  str = str.replace(/&/g, '&amp;')
+  str = str.replace(/>/g, '&gt;')
+  return str.replace(/</g, '&lt;')
+}
+
+function exportOfxHeader(inputObj: any): string {
+  let out = ''
+  for (const key of Object.keys(inputObj)) {
+    let element = inputObj[key]
+    if (typeof element === 'string') {
+      element = escapeOFXString(element)
+      out += `${key}:${element}\n`
+    } else {
+      throw new Error('Invalid OFX header')
+    }
+  }
+  return out
+}
+
+function exportOfxBody(inputObj: any): string {
+  let out = ''
+  for (const key of Object.keys(inputObj)) {
+    let element = inputObj[key]
+    if (typeof element === 'string') {
+      element = escapeOFXString(element)
+      out += `<${key}>${element}\n`
+    } else if (element instanceof Array) {
+      for (const a of element) {
+        out += `<${key}>\n`
+        out += exportOfxBody(a)
+        out += `</${key}>\n`
+      }
+    } else if (typeof element === 'object') {
+      out += `<${key}>\n`
+      out += exportOfxBody(element)
+      out += `</${key}>\n`
+    } else {
+      throw new Error('Invalid OFX body')
+    }
+  }
+  return out
+}
+
+function exportOfx(header: any, body: any): string {
+  let out = exportOfxHeader(header) + '\n'
+  out += '<OFX>\n'
+  out += exportOfxBody(body)
+  out += '</OFX>\n'
+  return out
+}
+
+function makeOfxDate(date: number): string {
+  const d = new Date(date * 1000)
+  const yyyy = d.getUTCFullYear().toString()
+  const mm = padZero((d.getUTCMonth() + 1).toString())
+  const dd = padZero(d.getUTCDate().toString())
+  const hh = padZero(d.getUTCHours().toString())
+  const min = padZero(d.getUTCMinutes().toString())
+  const ss = padZero(d.getUTCSeconds().toString())
+  return `${yyyy}${mm}${dd}${hh}${min}${ss}.000`
+}
+
+function makeCsvDateTime(date: number): { date: string, time: string } {
+  const d = new Date(date * 1000)
+  const yyyy = d.getUTCFullYear().toString()
+  const mm = padZero((d.getUTCMonth() + 1).toString())
+  const dd = padZero(d.getUTCDate().toString())
+  const hh = padZero(d.getUTCHours().toString())
+  const min = padZero(d.getUTCMinutes().toString())
+
+  return {
+    date: `${yyyy}-${mm}-${dd}`,
+    time: `${hh}:${min}`
+  }
+}
+
+export function exportTransactionsToQBOInner(
+  edgeTransactions: EdgeTransaction[],
+  currencyCode: string,
+  fiatCurrencyCode: string,
+  denom?: string,
+  dateNow: number
+): string {
+  const STMTTRN: any[] = []
+  const now = makeOfxDate(dateNow / 1000)
+
+  for (const edgeTx of edgeTransactions) {
+    const TRNAMT: string = denom ? div(edgeTx.nativeAmount, denom, 18) : edgeTx.nativeAmount
+    const TRNTYPE = lt(edgeTx.nativeAmount, '0') ? 'DEBIT' : 'CREDIT'
+    const DTPOSTED = makeOfxDate(edgeTx.date)
+    let NAME: string = ''
+    let amountFiat: number = 0
+    let category: string = ''
+    let notes: string = ''
+    if (edgeTx.metadata) {
+      NAME = edgeTx.metadata.name ? edgeTx.metadata.name : ''
+      amountFiat = edgeTx.metadata.amountFiat ? edgeTx.metadata.amountFiat : 0
+      category = edgeTx.metadata.category ? edgeTx.metadata.category : ''
+      notes = edgeTx.metadata.notes ? edgeTx.metadata.notes : ''
+    }
+    const absFiat = abs(amountFiat.toString())
+    const absAmount = abs(TRNAMT)
+    const CURRATE = absAmount !== '0' ? div(absFiat, absAmount, 8) : '0'
+    let memo = `// Rate=${CURRATE} ${fiatCurrencyCode}=${amountFiat} category="${category}" memo="${notes}"`
+    if (memo.length > 250) {
+      memo = memo.substring(0, 250) + '...'
+    }
+    const qboTxNamed = {
+      TRNTYPE,
+      DTPOSTED,
+      TRNAMT,
+      FITID: edgeTx.txid,
+      NAME,
+      MEMO: memo,
+      CURRENCY: {
+        CURRATE: CURRATE,
+        CURSYM: fiatCurrencyCode
+      }
+    }
+    const qboTx = {
+      TRNTYPE,
+      DTPOSTED,
+      TRNAMT,
+      FITID: edgeTx.txid,
+      MEMO: memo,
+      CURRENCY: {
+        CURRATE: CURRATE,
+        CURSYM: fiatCurrencyCode
+      }
+    }
+    const use = NAME === '' ? qboTx : qboTxNamed
+    STMTTRN.push(use)
+  }
+
+  const header = {
+    OFXHEADER: '100',
+    DATA: 'OFXSGML',
+    VERSION: '102',
+    SECURITY: 'NONE',
+    ENCODING: 'USASCII',
+    CHARSET: '1252',
+    COMPRESSION: 'NONE',
+    OLDFILEUID: 'NONE',
+    NEWFILEUID: 'NONE'
+  }
+
+  const body = {
+    SIGNONMSGSRSV1: {
+      SONRS: {
+        STATUS: {
+          CODE: '0',
+          SEVERITY: 'INFO'
+        },
+        DTSERVER: now,
+        LANGUAGE: 'ENG',
+        'INTU.BID': '3000'
+      }
+    },
+    BANKMSGSRSV1: {
+      STMTTRNRS: {
+        TRNUID: now,
+        STATUS: {
+          CODE: '0',
+          SEVERITY: 'INFO',
+          MESSAGE: 'OK'
+        },
+        STMTRS: {
+          CURDEF: 'USD',
+          BANKACCTFROM: {
+            BANKID: '999999999',
+            ACCTID: '999999999999',
+            ACCTTYPE: 'CHECKING'
+          },
+          BANKTRANLIST: {
+            DTSTART: now,
+            DTEND: now,
+            STMTTRN
+          },
+          LEDGERBAL: {
+            BALAMT: '0.00',
+            DTASOF: now
+          },
+          AVAILBAL: {
+            BALAMT: '0.00',
+            DTASOF: now
+          }
+        }
+      }
+    }
+  }
+
+  return exportOfx(header, body)
+}
+
+export async function exportTransactionsToCSVInner(
+  edgeTransactions: EdgeTransaction[],
+  currencyCode: string,
+  fiatCurrencyCode: string,
+  denom?: string
+): Promise<string> {
+  const currencyField = 'AMT_' + currencyCode
+  const networkFeeField = 'AMT_NETWORK_FEES_' + currencyCode
+  const items: any[] = []
+
+  for (const edgeTx of edgeTransactions) {
+    const amount: string = denom ? div(edgeTx.nativeAmount, denom, 18) : edgeTx.nativeAmount
+    const networkFeeField: string = denom ? div(edgeTx.networkFee, denom, 18) : edgeTx.networkFee
+    const { date, time } = makeCsvDateTime(edgeTx.date)
+    let name: string = ''
+    let amountFiat: number = 0
+    let category: string = ''
+    let notes: string = ''
+    if (edgeTx.metadata) {
+      name = edgeTx.metadata.name ? edgeTx.metadata.name : ''
+      amountFiat = edgeTx.metadata.amountFiat ? edgeTx.metadata.amountFiat : 0
+      category = edgeTx.metadata.category ? edgeTx.metadata.category : ''
+      notes = edgeTx.metadata.notes ? edgeTx.metadata.notes : ''
+    }
+
+    const csvTx = {
+      date,
+      time,
+      name,
+      amount,
+      amountFiat,
+      category,
+      notes,
+      networkFeeField,
+      txid: edgeTx.txid,
+      ourReceiveAddresses: edgeTx.ourReceiveAddresses,
+      version: 1,
+      currencyCode
+    }
+    items.push(csvTx)
+  }
+
+  const options = {
+    fields: [
+      {
+        name: 'currencyCode',
+        label: 'CURRENCY_CODE',
+        quoted: true
+      },
+      {
+        name: 'date',
+        label: 'DATE',
+        quoted: true
+      },
+      {
+        name: 'time',
+        label: 'TIME',
+        quoted: true
+      },
+      {
+        name: 'name',
+        label: 'PAYEE_PAYER_NAME',
+        quoted: true
+      },
+      {
+        name: 'amount',
+        label: currencyField,
+        quoted: true
+      },
+      {
+        name: 'amountFiat',
+        label: fiatCurrencyCode,
+        quoted: true
+      },
+      {
+        name: 'category',
+        label: 'CATEGORY',
+        quoted: true
+      },
+      {
+        name: 'notes',
+        label: 'NOTES',
+        quoted: true
+      },
+      {
+        name: 'networkFeeField',
+        label: networkFeeField,
+        quoted: true
+      },
+      {
+        name: 'txid',
+        label: 'TXID',
+        quoted: true
+      },
+      {
+        name: 'ourReceiveAddresses',
+        label: 'OUR_RECEIVE_ADDRESSES',
+        quoted: true
+      },
+      {
+        name: 'version',
+        label: 'VER'
+      }
+    ]
+  }
+
+  return new Promise((resolve, reject) => {
+    jsoncsv.csvBuffered(items, options, (err, csv) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(csv)
+      }
+    })
+  })
+}

--- a/src/components/scenes/TransactionsExportScene.js
+++ b/src/components/scenes/TransactionsExportScene.js
@@ -8,6 +8,7 @@ import Share from 'react-native-share'
 import EntypoIcon from 'react-native-vector-icons/Entypo'
 import { connect } from 'react-redux'
 
+import { exportTransactionsToCSV, exportTransactionsToQBO } from '../../actions/TransactionExportActions.js'
 import { formatDate } from '../../locales/intl.js'
 import s from '../../locales/strings'
 import { getDisplayDenomination } from '../../modules/Settings/selectors.js'
@@ -203,7 +204,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<Props, State>
 
     // The non-string result appears to be a bug in the core,
     // which we are relying on to determine if the date range is empty:
-    const csvFile = await showActivity(s.strings.export_transaction_loading, this.props.sourceWallet.exportTransactionsToCSV(transactionOptions))
+    const csvFile = await showActivity(s.strings.export_transaction_loading, exportTransactionsToCSV(this.props.sourceWallet, transactionOptions))
     if (typeof csvFile !== 'string') {
       showError(s.strings.export_transaction_export_error)
       return
@@ -219,7 +220,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<Props, State>
     }
 
     if (isExportQbo) {
-      const qboFile = await showActivity(s.strings.export_transaction_loading, sourceWallet.exportTransactionsToQBO(transactionOptions))
+      const qboFile = await showActivity(s.strings.export_transaction_loading, exportTransactionsToQBO(sourceWallet, transactionOptions))
       files.push({
         contents: qboFile,
         mimeType: 'application/vnd.intu.qbo',


### PR DESCRIPTION
This moves the transaction export feature out of the core and into the GUI. Now we can begin the process of localization, and perhaps even offer the user more control over which columns the data includes, now that the UI controls this feature.

On the core side, this takes our JS bundle from 774 KiB -> 651 KiB, which should help relieve Webview memory pressure.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a