### PR TITLE
Set webview flag mediaPlaybackRequiresUserAction to false

### DIFF
--- a/src/components/scenes/GuiPluginViewScene.js
+++ b/src/components/scenes/GuiPluginViewScene.js
@@ -251,6 +251,7 @@ class GuiPluginView extends React.Component<Props, State> {
           source={{ uri }}
           userAgent={userAgent + ' hasEdgeProvider edge/app.edge.'}
           useWebKit
+          mediaPlaybackRequiresUserAction={false}
         />
       </SceneWrapper>
     )


### PR DESCRIPTION
Initializing the webview with the default true value prevents camera initialization for Moonpay's widget