### PR TITLE
Added error when XRP destination tag exceeds 9 characters

### DIFF
--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -458,7 +458,12 @@ export const updateTransactionAmount = (nativeAmount: string, exchangeAmount: st
       dispatch(updateTransaction(edgeTransaction, guiMakeSpendInfoClone, false, null))
     })
     .catch(error => {
-      dispatch(updateTransaction(null, guiMakeSpendInfoClone, false, error))
+      let customError
+      if (coreWallet.currencyInfo.defaultSettings.errorCodes.UNIQUE_IDENTIFIER_EXCEEDS_LENGTH === error.labelCode) {
+        customError = new Error(s.strings.send_make_spend_xrp_dest_tag_error)
+      }
+
       console.log(error)
+      dispatch(updateTransaction(null, guiMakeSpendInfoClone, false, customError ?? error))
     })
 }

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -789,6 +789,7 @@ const strings = {
   send_scene_send_to_address: 'Send to Address',
   send_scene_error_title: 'Error',
   send_scene_metadata_name_title: 'Payee',
+  send_make_spend_xrp_dest_tag_error: 'XRP Destination Tag must be 9 characters or less',
 
   // Request Scene
   request_balance: 'You have %s',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -728,6 +728,7 @@
   "send_scene_send_to_address": "Send to Address",
   "send_scene_error_title": "Error",
   "send_scene_metadata_name_title": "Payee",
+  "send_make_spend_xrp_dest_tag_error": "XRP Destination Tag must be 9 characters or less",
   "request_balance": "You have %s",
   "currency_label_AFN": "Afghani",
   "currency_label_ALL": "Lek",


### PR DESCRIPTION
NOTE: should merge with https://github.com/EdgeApp/edge-currency-accountbased/pull/274

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android