### PR TITLE
Fix our `versionCode` calculation for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -170,7 +170,7 @@ android {
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
-                        defaultConfig.versionCode * 1000 + versionCodes.get(abi)
+                        defaultConfig.versionCode * 10 + versionCodes.get(abi)
             }
 
         }


### PR DESCRIPTION
Edge uses the current date as the version code, such as "21042201" for the first build made on 2021-04-22. If we multiply these dates by 1000, that will exceed the maximum possible version code of 2^31 (about 2 billion).

Instead, simply multiply by 10. This will slide the date over one decimal place, allowing the platform number to become the final digit.

Since we are multiplying our dates by 10 now, the new version codes will definitely be larger than the old version codes, so uploads will work without trouble. Before, the version codes were just the date plus roughly one year per platform (actually 1048576 * platform number, which happened to line up with the year slot).

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a