### PR TITLE
Add Toggle for Warning and Error Messages

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@
 
 import Bugsnag from '@bugsnag/react-native'
 import * as React from 'react'
-import { Platform, StatusBar, Text, TextInput } from 'react-native'
+import { LogBox, Platform, StatusBar, Text, TextInput } from 'react-native'
 import RNFS from 'react-native-fs'
 
 import ENV from '../env.json'
@@ -43,6 +43,9 @@ global.clog = console.log
 const IGNORED_WARNINGS = ['slowlog', 'Setting a timer for a long period of time', 'Warning: isMounted(...) is deprecated']
 // $FlowExpectedError
 console.ignoredYellowBox = IGNORED_WARNINGS
+
+// Ignore errors and warnings(used for device testing)
+if (ENV.DISABLE_WARNINGS) LogBox.ignoreAllLogs()
 
 global.OS = Platform.OS
 // Disable the font scaling


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ X ] n/a

---
<img src="https://user-images.githubusercontent.com/19967356/116941650-55ec7e00-ac2d-11eb-852e-8c6eed460e26.png" alt="In App" width="400"/>


### Purpose
To add a warning and error toggle to the warning/error box that appears in the app when running in debug mode. These boxes may reduce the visibility of controls causing tests to fail. Some test automation workflows are more efficient when the app can be changed and refreshed in debug mode(eg adding testIDs)

### To toggle  
Add "DISABLE_WARNINGS" to your .env file at the top of the repo to "true". 

<img src="https://user-images.githubusercontent.com/19967356/116941892-c85d5e00-ac2d-11eb-9b67-e303752d5460.png" alt=".env" width="400"/>