### PR TITLE
Exchange slider ux changes. Exchange error msg paddings.

### DIFF
--- a/src/components/scenes/CryptoExchangeQuoteScene.js
+++ b/src/components/scenes/CryptoExchangeQuoteScene.js
@@ -222,7 +222,7 @@ export class CryptoExchangeQuoteScreenComponent extends React.Component<Props, S
             walletName={toWallet.name || ''}
           />
           {isEstimate && (
-            <Card warning marginRem={[1.5, 1]}>
+            <Card warning marginRem={[1.5, 1, 0]}>
               <ClickableText paddingRem={0} onPress={this.showExplanationForEstimate}>
                 <View style={styles.estimatedContainer}>
                   <IonIcon
@@ -276,6 +276,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
     color: theme.warningText
   },
   slider: {
+    marginTop: theme.rem(1.5),
     alignItems: 'center'
   },
   spacer: {

--- a/src/components/themed/CryptoExchangeMessageBoxComponent.js
+++ b/src/components/themed/CryptoExchangeMessageBoxComponent.js
@@ -20,7 +20,9 @@ export class CryptoExchangeMessageBoxComponent extends React.PureComponent<Props
 
     return (
       <View style={styles.container}>
-        <EdgeText style={styles.text}>{this.props.message}</EdgeText>
+        <EdgeText style={styles.text} numberOfLines={3}>
+          {this.props.message}
+        </EdgeText>
       </View>
     )
   }
@@ -33,10 +35,12 @@ const getStyles = cacheStyles((theme: Theme) => ({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'space-around',
-    paddingTop: theme.rem(1)
+    paddingTop: theme.rem(1),
+    paddingHorizontal: theme.rem(1)
   },
   text: {
     color: theme.dangerText,
+    textAlign: 'center',
     fontSize: theme.rem(0.75)
   }
 }))

--- a/src/modules/UI/components/Slider/Slider.js
+++ b/src/modules/UI/components/Slider/Slider.js
@@ -2,12 +2,13 @@
 
 // $FlowFixMe
 import React, { useEffect, useState } from 'react'
-import { ActivityIndicator, Image, StyleSheet, Text, View } from 'react-native'
+import { ActivityIndicator, Image, StyleSheet, View } from 'react-native'
 import { PanGestureHandler } from 'react-native-gesture-handler'
 import Animated, { Easing, runOnJS, useAnimatedGestureHandler, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated'
 
 import leftArrowImg from '../../../../assets/images/slider/keyboard-arrow-left.png'
 import { type Theme, type ThemeProps, cacheStyles, withTheme } from '../../../../components/services/ThemeContext.js'
+import { EdgeText } from '../../../../components/themed/EdgeText'
 import s from '../../../../locales/strings.js'
 
 const COMPLETE_POINT: number = 3
@@ -126,7 +127,7 @@ export const SliderComponent = (props: Props) => {
         {showSpinner ? (
           <ActivityIndicator color={theme.iconTappable} style={styles.activityIndicator} />
         ) : (
-          <Text style={sliderDisabled ? [styles.textOverlay, styles.textOverlayDisabled] : styles.textOverlay}>{sliderText}</Text>
+          <EdgeText style={sliderDisabled ? [styles.textOverlay, styles.textOverlayDisabled] : styles.textOverlay}>{sliderText}</EdgeText>
         )}
       </View>
     </View>
@@ -166,7 +167,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
     position: 'absolute',
     color: theme.confirmationSliderText,
     alignSelf: 'center',
-    top: theme.rem(1),
+    lineHeight: theme.confirmationSliderThumbWidth,
     zIndex: 1
   },
   textOverlayDisabled: {

--- a/src/theme/variables/edgeDark.js
+++ b/src/theme/variables/edgeDark.js
@@ -59,6 +59,7 @@ const palette = {
   blackOp50: 'rgba(0, 0, 0, .5)',
 
   whiteOp10: 'rgba(255, 255, 255, .1)',
+  whiteOp05: 'rgba(255, 255, 255, .05)',
   whiteOp75: 'rgba(255, 255, 255, .75)',
 
   grayOp80: 'rgba(135, 147, 158, .8)',
@@ -180,13 +181,13 @@ export const edgeDark: Theme = {
   // warningBubble: palette.accentOrange,
 
   // Confirmation slider
-  confirmationSlider: palette.whiteOp10,
-  confirmationSliderText: palette.edgeMint,
+  confirmationSlider: palette.whiteOp05,
+  confirmationSliderText: palette.white,
   confirmationSliderArrow: palette.edgeBlue,
   confirmationSliderThumb: palette.edgeMint,
   confirmationSliderTextDeactivated: palette.gray,
   confirmationThumbDeactivated: palette.gray,
-  confirmationSliderWidth: PLATFORM.deviceWidth >= 720 ? 680 : PLATFORM.deviceWidth - 45,
+  confirmationSliderWidth: PLATFORM.deviceWidth >= 340 ? 295 : PLATFORM.deviceWidth - 45,
   confirmationSliderThumbWidth: 55,
 
   // Lines

--- a/src/theme/variables/edgeLight.js
+++ b/src/theme/variables/edgeLight.js
@@ -184,7 +184,7 @@ export const edgeLight: Theme = {
   confirmationSliderThumb: palette.edgeBlue,
   confirmationSliderTextDeactivated: palette.gray,
   confirmationThumbDeactivated: palette.gray,
-  confirmationSliderWidth: PLATFORM.deviceWidth >= 720 ? 680 : PLATFORM.deviceWidth - 45,
+  confirmationSliderWidth: PLATFORM.deviceWidth >= 340 ? 295 : PLATFORM.deviceWidth - 45,
   confirmationSliderThumbWidth: 55,
 
   // Lines


### PR DESCRIPTION
<img width="895" alt="ipad" src="https://user-images.githubusercontent.com/22767467/117835946-f4598e80-b280-11eb-98a4-bc08f7df244e.png">
<img width="357" alt="touch" src="https://user-images.githubusercontent.com/22767467/117835956-f7547f00-b280-11eb-8874-35086b41af23.png">
<img width="351" alt="touch err msg" src="https://user-images.githubusercontent.com/22767467/117835960-f885ac00-b280-11eb-99c1-ef697ea4fe69.png">
<img width="422" alt="12 err msg" src="https://user-images.githubusercontent.com/22767467/117835966-f91e4280-b280-11eb-9701-c0e41a25de14.png">
<img width="889" alt="iPad err msg" src="https://user-images.githubusercontent.com/22767467/117835969-f9b6d900-b280-11eb-8d12-6883c3bdc243.png">
<img width="424" alt="12" src="https://user-images.githubusercontent.com/22767467/117835973-fa4f6f80-b280-11eb-947a-950d0f895290.png">
