### PR TITLE
Fix changing countries does not update the plugin list

### DIFF
--- a/src/components/scenes/GuiPluginListScene.js
+++ b/src/components/scenes/GuiPluginListScene.js
@@ -288,7 +288,7 @@ class GuiPluginList extends React.PureComponent<Props, State> {
             </EdgeText>
           </View>
         ) : (
-          <FlatList data={plugins} renderItem={this.renderPlugin} keyExtractor={(item: GuiPluginRow) => item.pluginId} />
+          <FlatList data={plugins} renderItem={this.renderPlugin} keyExtractor={(item: GuiPluginRow) => item.pluginId + item.title} />
         )}
       </SceneWrapper>
     )


### PR DESCRIPTION
Fix: Problem with Flatlist id having duplicates. Added more stuff to make it unique

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android