### PR TITLE
Mute one specific warning and error that is causing too much noise

### DIFF
--- a/src/__tests__/LoginAction.test.js
+++ b/src/__tests__/LoginAction.test.js
@@ -1,8 +1,20 @@
-/* globals test expect */
+/* globals test expect beforeAll afterAll */
 /* eslint-disable flowtype/require-valid-file-annotation */
 
 import { LOCAL_ACCOUNT_DEFAULTS, LOCAL_ACCOUNT_TYPES, SYNCED_ACCOUNT_DEFAULTS, SYNCED_ACCOUNT_TYPES } from '../modules/Core/Account/settings.js'
 import { mergeSettings } from '../modules/Login/action.js'
+
+// Mute dependency warnings
+const originalWarn = console.warn.bind(console.warn)
+const originalError = console.error.bind(console.error)
+beforeAll(() => {
+  console.warn = msg => !msg.toString().includes('Settings overwrite') && originalWarn(msg)
+  console.error = msg => !msg.toString().includes('MismatchedDefaultSettingType') && originalError(msg)
+})
+afterAll(() => {
+  console.warn = originalWarn
+  console.error = originalError
+})
 
 test('synced settings missing properties are replaced', () => {
   const loadedSyncedSettings = {}


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ x ] n/a

Currently on develop, running yarn test will spit out a large number of errors.

Seems counterproductive to have a ton of warnings spewing out. Makes it more likely for someone to miss something with all the noise.
This PR mutes the specific error and warning in `LoginAction.test.js` that contains the issue.

While I proposed fixing the issues, according to @paullinator , 

> there are a lot of warnings which are out of our control and in the dependencies. Not too much we can do there to fix the warnings. 

Therefore it might be best to mute the issues as the noise might cause developers to overlook actual problems.
![image](https://user-images.githubusercontent.com/61520543/121792708-3c840d80-cbad-11eb-80e4-88035aa0aa3b.png)
