### PR TITLE
Change check expired fio names algorithm to show reminder

### DIFF
--- a/src/__tests__/__snapshots__/RootReducer.test.js.snap
+++ b/src/__tests__/__snapshots__/RootReducer.test.js.snap
@@ -93,7 +93,8 @@ Object {
   "ui": Object {
     "fio": Object {
       "connectedWalletsByFioAddress": Object {},
-      "needToCheckExpired": false,
+      "expiredChecking": Object {},
+      "expiredLastChecks": Object {},
     },
     "passwordReminder": Object {
       "lastLoginDate": -Infinity,

--- a/src/modules/Core/Wallets/action.js
+++ b/src/modules/Core/Wallets/action.js
@@ -3,7 +3,7 @@
 import type { EdgeCurrencyWallet } from 'edge-core-js'
 import _ from 'lodash'
 
-import { checkExpiredFioNames, refreshConnectedWallets } from '../../../actions/FioActions'
+import { refreshConnectedWallets } from '../../../actions/FioActions'
 import { getEnabledTokens } from '../../../actions/WalletActions.js'
 import type { Dispatch, GetState } from '../../../types/reduxTypes.js'
 import { getReceiveAddresses } from '../../../util/utils.js'
@@ -36,7 +36,6 @@ export const updateWalletsRequest = () => async (dispatch: Dispatch, getState: G
     await getEnabledTokens(walletId)(dispatch, getState)
   }
   refreshConnectedWallets(dispatch, getState, currencyWallets)
-  dispatch(checkExpiredFioNames())
   updateWalletsEnabledTokens(getState)
 }
 

--- a/src/modules/FioAddress/util.js
+++ b/src/modules/FioAddress/util.js
@@ -103,19 +103,17 @@ const setConnectedWalletsFromFile = async (fioWallet: EdgeCurrencyWallet, fioAdd
   }
 }
 
-const getFioExpiredCheckFromDislket = async (disklet: Disklet): Promise<Date> => {
+export const getFioExpiredCheckFromDisklet = async (disklet: Disklet): Promise<{ [walletId: string]: Date }> => {
   try {
-    const { lastCheck } = JSON.parse(await disklet.getText(FIO_EXPIRED_CHECK))
-    return new Date(lastCheck)
+    const lastChecks = JSON.parse(await disklet.getText(FIO_EXPIRED_CHECK))
+    return Object.keys(lastChecks).reduce((checkDates, walletId) => ({ ...checkDates, [walletId]: new Date(lastChecks[walletId]) }), {})
   } catch (error) {
-    const defaultDate = new Date()
-    defaultDate.setMonth(new Date().getMonth() - 1)
-    return defaultDate
+    return {}
   }
 }
-const setFioExpiredCheckToDislket = async (lastCheck: Date, disklet: Disklet): Promise<void> => {
+export const setFioExpiredCheckToDisklet = async (lastChecks: { [walletId: string]: Date }, disklet: Disklet): Promise<void> => {
   try {
-    await disklet.setText(FIO_EXPIRED_CHECK, JSON.stringify({ lastCheck }))
+    await disklet.setText(FIO_EXPIRED_CHECK, JSON.stringify(lastChecks))
   } catch (error) {
     console.log(error)
   }
@@ -832,22 +830,23 @@ export const expiredSoon = (expDate: string): boolean => {
   return new Date(expDate).getTime() - new Date().getTime() < MONTH
 }
 
-export const needToCheckExpired = async (disklet: Disklet): Promise<boolean> => {
+export const needToCheckExpired = (lastChecks: { [walletId: string]: Date }, walletId: string): boolean => {
   try {
-    const lastCheck = await getFioExpiredCheckFromDislket(disklet)
-    const now = new Date()
-    if (now.getMonth() !== lastCheck.getMonth() || now.getFullYear() !== lastCheck.getFullYear()) {
-      setFioExpiredCheckToDislket(new Date(), disklet)
-      return true
+    let lastCheck = lastChecks[walletId]
+    if (!lastCheck) {
+      lastCheck = new Date()
+      lastCheck.setMonth(new Date().getMonth() - 1)
     }
+    const now = new Date()
+    return now.getMonth() !== lastCheck.getMonth() || now.getFullYear() !== lastCheck.getFullYear()
   } catch (e) {
     //
   }
   return false
 }
-export const getExpiredSoonFioNames = (fioAddresses: FioAddress[], fioDomains: FioDomain[]): Array<FioAddress | FioDomain> => {
+export const getExpiredSoonFioNames = (fioNames: Array<FioAddress | FioDomain>): Array<FioAddress | FioDomain> => {
   const expiredFioNames: Array<FioAddress | FioDomain> = []
-  for (const fioName of [...fioAddresses, ...fioDomains]) {
+  for (const fioName of fioNames) {
     if (expiredSoon(fioName.expiration)) {
       expiredFioNames.push(fioName)
     }

--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -7,7 +7,7 @@ import { Actions } from 'react-native-router-flux'
 import { sprintf } from 'sprintf-js'
 
 import { loadAccountReferral, refreshAccountReferral } from '../../actions/AccountReferralActions.js'
-import { needToCheckExpiredFioNames } from '../../actions/FioActions.js'
+import { expiredFioNamesCheckDates } from '../../actions/FioActions.js'
 import { trackAccountEvent } from '../../actions/TrackingActions.js'
 import { checkEnabledTokensArray, getEnabledTokens, setWalletEnabledTokens } from '../../actions/WalletActions.js'
 import { showError } from '../../components/services/AirshipInstance.js'
@@ -175,7 +175,7 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: GuiTouchIdI
       dispatch(loadAccountReferral(account)).then(() => dispatch(refreshAccountReferral()))
     }
 
-    dispatch(needToCheckExpiredFioNames())
+    dispatch(expiredFioNamesCheckDates())
     await updateWalletsRequest()(dispatch, getState)
     for (const wId of activeWalletIds) {
       await getEnabledTokens(wId)(dispatch, getState)

--- a/src/reducers/FioReducer.js
+++ b/src/reducers/FioReducer.js
@@ -15,12 +15,14 @@ export type FioState = {
   connectedWalletsByFioAddress: {
     [fioAddress: string]: CcWalletMap
   },
-  needToCheckExpired: boolean
+  expiredLastChecks: { [walletId: string]: Date },
+  expiredChecking: { [walletId: string]: boolean }
 }
 
 const initialState: FioState = {
   connectedWalletsByFioAddress: {},
-  needToCheckExpired: false
+  expiredLastChecks: {},
+  expiredChecking: {}
 }
 
 export const fio: Reducer<FioState, Action> = (state = initialState, action: Action) => {
@@ -38,10 +40,16 @@ export const fio: Reducer<FioState, Action> = (state = initialState, action: Act
         connectedWalletsByFioAddress
       }
     }
-    case 'FIO/NEED_TO_CHECK_EXPIRED': {
+    case 'FIO/SET_LAST_EXPIRED_CHECKS': {
       return {
         ...state,
-        needToCheckExpired: action.data
+        expiredLastChecks: action.data
+      }
+    }
+    case 'FIO/CHECKING_EXPIRED': {
+      return {
+        ...state,
+        expiredChecking: { ...state.expiredChecking, ...action.data }
       }
     }
     default:

--- a/src/types/reduxActions.js
+++ b/src/types/reduxActions.js
@@ -246,4 +246,5 @@ export type Action =
   | { type: 'FIO/UPDATE_CONNECTED_WALLETS_FOR_FIO_ADDRESS', data: { fioAddress: string, ccWalletMap: CcWalletMap } }
   | { type: 'FIO/SET_OBT_DATA', data: FioObtRecord[] }
   | { type: 'FIO/SET_FIO_DOMAINS', data: { fioDomains: FioDomain[] } }
-  | { type: 'FIO/NEED_TO_CHECK_EXPIRED', data: boolean }
+  | { type: 'FIO/SET_LAST_EXPIRED_CHECKS', data: { [walletId: string]: Date } }
+  | { type: 'FIO/CHECKING_EXPIRED', data: { [walletId: string]: boolean } }


### PR DESCRIPTION
Change algorithm how fio names are checking for expiration after login. Now you could see reminder on new devices. Reminder would appear in all needed cases.


https://user-images.githubusercontent.com/22767467/121952076-721f2700-cd64-11eb-85cd-2e13baae78ad.mp4

