### PR TITLE
Show the minimum amount of parent currency necessary to pay transaction fee

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "disklet": "^0.4.5",
     "edge-components": "^0.0.31",
     "edge-core-js": "^0.18.1",
-    "edge-currency-accountbased": "^0.7.62",
+    "edge-currency-accountbased": "^0.7.63",
     "edge-currency-bitcoin": "^4.9.15",
     "edge-currency-monero": "^0.3.2",
     "edge-exchange-plugins": "^0.11.28",

--- a/src/__tests__/fixtures.json
+++ b/src/__tests__/fixtures.json
@@ -114,5 +114,37 @@
       "multiplier": "10000000000000000000000000000000000000000000000000",
       "walletType": "wallet:ethereum"
     }]
+  },
+  "zerosAfterDecimal": {
+    "title": "Zeros after decimal place of",
+    "input": ["0.00036270", "128372", "12392.0123", "123.456"],
+    "output": [3, 0, 1, 0]
+  },
+  "roundUpToLeastSignificant": {
+    "title": "Rounded up to least significant digit of",
+    "input": ["123.4567", "0.0001239", "123"],
+    "output": ["123.4568", "0.000124", "123"]
+  },
+  "roundedFee": {
+    "title": "Truncate and rounded up to least significant digit of",
+    "input": [{
+      "amount": "1234567",
+      "decimalPlacesBeyondLeadingZeros": 2,
+      "multiplier": "1000000000000"
+    },
+    {
+      "amount": "548735948753",
+      "decimalPlacesBeyondLeadingZeros": 4,
+      "multiplier": "1000"
+    }, {
+      "amount": "92837289000037373",
+      "decimalPlacesBeyondLeadingZeros": 1,
+      "multiplier": "1000000000000000000"
+    }, {
+      "amount": "",
+      "decimalPlacesBeyondLeadingZeros": 12,
+      "multiplier": "1000000000"
+    }],
+    "output": ["0.0000013 ", "548735948.753 ", "0.1 ", ""]
   }
 }

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -23,7 +23,10 @@ import {
   mergeTokens,
   MILLISECONDS_PER_DAY,
   precisionAdjust,
-  truncateDecimals
+  roundedFee,
+  roundUpToLeastSignificant,
+  truncateDecimals,
+  zerosAfterDecimal
 } from '../util/utils.js'
 import fixtures from './fixtures.json'
 
@@ -701,6 +704,40 @@ describe('getExchangeDenomination', function () {
   input.forEach((currency, index) => {
     test(`${title} ${currency}`, function () {
       expect(getDenomination(currency, fixtures.settings, 'exchange')).toMatchObject(output[index])
+    })
+  })
+})
+
+describe('zerosAfterDecimal', function () {
+  const tests = fixtures.zerosAfterDecimal
+  const { title, input, output } = tests
+
+  input.forEach((amount, index) => {
+    test(`${title} ${amount}`, function () {
+      expect(zerosAfterDecimal(amount)).toBe(output[index])
+    })
+  })
+})
+
+describe('roundUpToLeastSignificant', function () {
+  const tests = fixtures.roundUpToLeastSignificant
+  const { title, input, output } = tests
+
+  input.forEach((amount, index) => {
+    test(`${title} ${amount}`, function () {
+      expect(roundUpToLeastSignificant(amount)).toBe(output[index])
+    })
+  })
+})
+
+describe('roundedFee', function () {
+  const tests = fixtures.roundedFee
+  const { title, input, output } = tests
+
+  input.forEach((obj, index) => {
+    const { amount, decimalPlacesBeyondLeadingZeros, multiplier } = obj
+    test(`${title} ${amount}`, function () {
+      expect(roundedFee(amount, decimalPlacesBeyondLeadingZeros, multiplier)).toBe(output[index])
     })
   })
 })

--- a/src/actions/CryptoExchangeActions.js
+++ b/src/actions/CryptoExchangeActions.js
@@ -74,12 +74,14 @@ export const getQuoteForTransaction = (info: SetNativeAmountInfo) => async (disp
     Actions.popTo(Constants.EXCHANGE_SCENE)
     const insufficientFunds = asMaybeInsufficientFundsError(error)
     if (insufficientFunds != null && insufficientFunds.currencyCode != null && fromCurrencyCode !== insufficientFunds.currencyCode) {
-      const { currencyCode } = insufficientFunds
+      const { currencyCode, networkFee = '' } = insufficientFunds
+      const multiplier = SETTINGS_SELECTORS.getExchangeDenomination(state, currencyCode).multiplier
+      const amountString = UTILS.roundedFee(networkFee, 2, multiplier)
       const result = await Airship.show(bridge => (
         <ButtonsModal
           bridge={bridge}
           title={s.strings.buy_crypto_modal_title}
-          message={sprintf(s.strings.buy_parent_crypto_modal_message, currencyCode)}
+          message={`${amountString}${sprintf(s.strings.buy_parent_crypto_modal_message, currencyCode)}`}
           buttons={{
             buy: { label: sprintf(s.strings.buy_crypto_modal_buy_action, currencyCode) },
             exchange: { label: s.strings.buy_crypto_modal_exchange },

--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -87,12 +87,14 @@ export const sendConfirmationUpdateTx =
         console.log(error)
         const insufficientFunds = asMaybeInsufficientFundsError(error)
         if (insufficientFunds != null && insufficientFunds.currencyCode != null && spendInfo.currencyCode !== insufficientFunds.currencyCode) {
-          const { currencyCode } = insufficientFunds
+          const { currencyCode, networkFee = '' } = insufficientFunds
+          const multiplier = settingsGetExchangeDenomination(state, currencyCode).multiplier
+          const amountString = UTILS.roundedFee(networkFee, 2, multiplier)
           const result = await Airship.show(bridge => (
             <ButtonsModal
               bridge={bridge}
               title={s.strings.buy_crypto_modal_title}
-              message={sprintf(s.strings.buy_parent_crypto_modal_message, currencyCode)}
+              message={`${amountString}${sprintf(s.strings.buy_parent_crypto_modal_message, currencyCode)}`}
               buttons={{
                 buy: { label: sprintf(s.strings.buy_crypto_modal_buy_action, currencyCode) },
                 exchange: { label: s.strings.buy_crypto_modal_exchange },

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { bns, div, eq, gte, mul, toFixed } from 'biggystring'
+import { bns, div, eq, gt, gte, mul, toFixed } from 'biggystring'
 import type { EdgeCurrencyInfo, EdgeCurrencyWallet, EdgeDenomination, EdgeMetaToken, EdgeReceiveAddress, EdgeTransaction } from 'edge-core-js'
 import _ from 'lodash'
 import { Linking, Platform } from 'react-native'
@@ -122,6 +122,29 @@ export const truncateDecimals = (input: string, precision: number, allowBlank: b
   return precision > 0 ? `${integers}.${decimals.slice(0, precision)}` : integers
 }
 
+// Counts zeros after decimal place in number. '0.00036' => 3
+export const zerosAfterDecimal = (input: string): number => {
+  if (!input.includes('.')) return 0
+  const decimals = input.split('.')[1]
+  let numZeros = 0
+  for (let i = 0; i <= decimals.length; i++) {
+    if (decimals[i] === '0') {
+      numZeros++
+    } else {
+      break
+    }
+  }
+  return numZeros
+}
+
+// Adds 1 to the least significant digit of a number. '12.00256' => '12.00257'
+export const roundUpToLeastSignificant = (input: string): string => {
+  if (!input.includes('.')) return input
+  const precision = input.split('.')[1].length
+  const oneExtra = `0.${'1'.padStart(precision, '0')}`
+  return bns.add(input, oneExtra)
+}
+
 export const decimalOrZero = (input: string, decimalPlaces: number): string => {
   if (gte(input, '1')) {
     // do nothing to numbers greater than one
@@ -136,6 +159,15 @@ export const decimalOrZero = (input: string, decimalPlaces: number): string => {
       return truncatedToDecimals.replace(/0+$/, '') // then return the truncation
     }
   }
+}
+
+export const roundedFee = (nativeAmount: string, decimalPlacesBeyondLeadingZeros: number, multiplier: string): string => {
+  if (nativeAmount === '') return nativeAmount
+  const displayAmount = div(nativeAmount, multiplier, DIVIDE_PRECISION)
+  const precision = zerosAfterDecimal(displayAmount) + decimalPlacesBeyondLeadingZeros
+  const truncatedAmount = truncateDecimals(displayAmount, precision)
+  if (gt(displayAmount, truncatedAmount)) return `${roundUpToLeastSignificant(truncatedAmount)} `
+  return `${truncatedAmount} `
 }
 
 // Used to convert outputs from core into other denominations (exchangeDenomination, displayDenomination)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4710,10 +4710,10 @@ edge-core-js@^0.18.1:
     yaob "^0.3.7"
     yavent "^0.1.1"
 
-edge-currency-accountbased@^0.7.62:
-  version "0.7.62"
-  resolved "https://registry.yarnpkg.com/edge-currency-accountbased/-/edge-currency-accountbased-0.7.62.tgz#7441c1950e660365c45b82e87925884aad0d8520"
-  integrity sha512-cUMhzXqZ9LCclwXAGZt2I7K2p0zcBXXxWDG/X9Ul+fulLVCA2R5wCA9Rb7Da38OcheB0V/pNExXSH0MCCrFjVg==
+edge-currency-accountbased@^0.7.63:
+  version "0.7.63"
+  resolved "https://registry.yarnpkg.com/edge-currency-accountbased/-/edge-currency-accountbased-0.7.63.tgz#13a766225f46f697cf4faae1abec4c0a66e0f927"
+  integrity sha512-jjRPxQvIvUo0JnrOt06akChYZ6hFKlk73CtEAk10zaUE1g5pLnPuTYx1vfw8PnrsmvQwRWSjssnVVw+Ibz7iKA==
   dependencies:
     "@binance-chain/javascript-sdk" "^2.14.4"
     "@fioprotocol/fiosdk" "^1.2.1"


### PR DESCRIPTION
This adds an amount to the insufficient funds error modal when attempting to send a token but can't due to having an insufficient amount of the parent currency to pay the transaction fee.