### PR TITLE
Fio Names redirect to register fix.

### DIFF
--- a/src/modules/FioAddress/action.js
+++ b/src/modules/FioAddress/action.js
@@ -6,9 +6,8 @@ import { checkExpiredFioNames } from '../../actions/FioActions'
 import * as Constants from '../../constants/indexConstants'
 import s from '../../locales/strings'
 import type { Dispatch, GetState } from '../../types/reduxTypes'
-import type { FioAddress, FioDomain } from '../../types/types'
 import { getDefaultIsoFiat } from '../Settings/selectors'
-import { findWalletByFioAddress, refreshConnectedWalletsForFioAddress } from './util'
+import { refreshConnectedWalletsForFioAddress, refreshFioNames } from './util'
 
 export const createFioWallet =
   () =>
@@ -26,20 +25,8 @@ export const refreshAllFioAddresses =
     const state = getState()
     const { currencyWallets } = state.core.account
     const fioWallets: EdgeCurrencyWallet[] = checkExpiredWallets.length !== 0 ? checkExpiredWallets : state.ui.wallets.fioWallets
-    const fioWalletsById: { [string]: EdgeCurrencyWallet } = {}
-    let fioAddresses: FioAddress[] = []
-    let fioDomains: FioDomain[] = []
 
-    if (fioWallets != null) {
-      for (const wallet of fioWallets) {
-        const walletId = wallet.id
-        const walletFioAddresses = await wallet.otherMethods.getFioAddresses()
-        fioAddresses = [...fioAddresses, ...walletFioAddresses.map(({ name, expiration }) => ({ name, expiration, walletId }))]
-        const walletFioDomains = await wallet.otherMethods.getFioDomains()
-        fioDomains = [...fioDomains, ...walletFioDomains.map(({ name, expiration, isPublic }) => ({ name, expiration, isPublic, walletId }))]
-        fioWalletsById[walletId] = wallet
-      }
-    }
+    const { fioAddresses, fioDomains, fioWalletsById } = await refreshFioNames(fioWallets)
 
     window.requestAnimationFrame(() => {
       dispatch({
@@ -51,14 +38,13 @@ export const refreshAllFioAddresses =
         data: { fioDomains }
       })
     })
-
     if (checkExpiredWallets.length !== 0) return dispatch(checkExpiredFioNames([...fioAddresses, ...fioDomains], fioWalletsById))
 
     const { connectedWalletsByFioAddress } = state.ui.fio
     const wallets = Object.keys(currencyWallets).map(walletKey => currencyWallets[walletKey])
-    for (const { name } of fioAddresses) {
+    for (const { name, walletId } of fioAddresses) {
       if (!connectedWalletsByFioAddress[name]) {
-        const fioWallet = await findWalletByFioAddress(fioWallets, name)
+        const fioWallet = fioWalletsById[walletId]
         if (!fioWallet) continue
         const ccWalletMap = await refreshConnectedWalletsForFioAddress(name, fioWallet, wallets)
         dispatch({

--- a/src/modules/FioAddress/action.js
+++ b/src/modules/FioAddress/action.js
@@ -2,7 +2,6 @@
 import type { EdgeCurrencyWallet } from 'edge-core-js'
 
 import { createCurrencyWallet } from '../../actions/CreateWalletActions'
-import { checkExpiredFioNames } from '../../actions/FioActions'
 import * as Constants from '../../constants/indexConstants'
 import s from '../../locales/strings'
 import type { Dispatch, GetState } from '../../types/reduxTypes'
@@ -16,44 +15,41 @@ export const createFioWallet =
     return dispatch(createCurrencyWallet(s.strings.fio_address_register_default_fio_wallet_name, Constants.FIO_WALLET_TYPE, fiatCurrencyCode, false, false))
   }
 
-export const refreshAllFioAddresses =
-  (checkExpiredWallets: EdgeCurrencyWallet[] = []) =>
-  async (dispatch: Dispatch, getState: GetState) => {
+export const refreshAllFioAddresses = () => async (dispatch: Dispatch, getState: GetState) => {
+  dispatch({
+    type: 'FIO/SET_FIO_ADDRESSES_PROGRESS'
+  })
+  const state = getState()
+  const { currencyWallets } = state.core.account
+  const fioWallets: EdgeCurrencyWallet[] = state.ui.wallets.fioWallets
+
+  const { fioAddresses, fioDomains, fioWalletsById } = await refreshFioNames(fioWallets)
+
+  window.requestAnimationFrame(() => {
     dispatch({
-      type: 'FIO/SET_FIO_ADDRESSES_PROGRESS'
+      type: 'FIO/SET_FIO_ADDRESSES',
+      data: { fioAddresses }
     })
-    const state = getState()
-    const { currencyWallets } = state.core.account
-    const fioWallets: EdgeCurrencyWallet[] = checkExpiredWallets.length !== 0 ? checkExpiredWallets : state.ui.wallets.fioWallets
-
-    const { fioAddresses, fioDomains, fioWalletsById } = await refreshFioNames(fioWallets)
-
-    window.requestAnimationFrame(() => {
-      dispatch({
-        type: 'FIO/SET_FIO_ADDRESSES',
-        data: { fioAddresses }
-      })
-      dispatch({
-        type: 'FIO/SET_FIO_DOMAINS',
-        data: { fioDomains }
-      })
+    dispatch({
+      type: 'FIO/SET_FIO_DOMAINS',
+      data: { fioDomains }
     })
-    if (checkExpiredWallets.length !== 0) return dispatch(checkExpiredFioNames([...fioAddresses, ...fioDomains], fioWalletsById))
+  })
 
-    const { connectedWalletsByFioAddress } = state.ui.fio
-    const wallets = Object.keys(currencyWallets).map(walletKey => currencyWallets[walletKey])
-    for (const { name, walletId } of fioAddresses) {
-      if (!connectedWalletsByFioAddress[name]) {
-        const fioWallet = fioWalletsById[walletId]
-        if (!fioWallet) continue
-        const ccWalletMap = await refreshConnectedWalletsForFioAddress(name, fioWallet, wallets)
-        dispatch({
-          type: 'FIO/UPDATE_CONNECTED_WALLETS_FOR_FIO_ADDRESS',
-          data: {
-            fioAddress: name,
-            ccWalletMap
-          }
-        })
-      }
+  const { connectedWalletsByFioAddress } = state.ui.fio
+  const wallets = Object.keys(currencyWallets).map(walletKey => currencyWallets[walletKey])
+  for (const { name, walletId } of fioAddresses) {
+    if (!connectedWalletsByFioAddress[name]) {
+      const fioWallet = fioWalletsById[walletId]
+      if (!fioWallet) continue
+      const ccWalletMap = await refreshConnectedWalletsForFioAddress(name, fioWallet, wallets)
+      dispatch({
+        type: 'FIO/UPDATE_CONNECTED_WALLETS_FOR_FIO_ADDRESS',
+        data: {
+          fioAddress: name,
+          ccWalletMap
+        }
+      })
     }
   }
+}

--- a/src/modules/FioAddress/util.js
+++ b/src/modules/FioAddress/util.js
@@ -854,3 +854,24 @@ export const getExpiredSoonFioNames = (fioNames: Array<FioAddress | FioDomain>):
 
   return expiredFioNames
 }
+
+export const refreshFioNames = async (
+  fioWallets: EdgeCurrencyWallet[]
+): Promise<{ fioAddresses: FioAddress[], fioDomains: FioDomain[], fioWalletsById: { string: EdgeCurrencyWallet } }> => {
+  const fioWalletsById: { [string]: EdgeCurrencyWallet } = {}
+  let fioAddresses: FioAddress[] = []
+  let fioDomains: FioDomain[] = []
+
+  if (fioWallets != null) {
+    for (const wallet of fioWallets) {
+      const walletId = wallet.id
+      const walletFioAddresses = await wallet.otherMethods.getFioAddresses()
+      fioAddresses = [...fioAddresses, ...walletFioAddresses.map(({ name, expiration }) => ({ name, expiration, walletId }))]
+      const walletFioDomains = await wallet.otherMethods.getFioDomains()
+      fioDomains = [...fioDomains, ...walletFioDomains.map(({ name, expiration, isPublic }) => ({ name, expiration, isPublic, walletId }))]
+      fioWalletsById[walletId] = wallet
+    }
+  }
+
+  return { fioAddresses, fioDomains, fioWalletsById }
+}


### PR DESCRIPTION
This PR fixes auto redirect to fio address registration on fio names scene. In 'expire reminder' algorithm we need check for fio names separately, because it causing refreshing fio names scene.