### PR TITLE
Add style adjustments in edgeText for android.

### DIFF
--- a/src/__tests__/__snapshots__/SettingsScene.test.js.snap
+++ b/src/__tests__/__snapshots__/SettingsScene.test.js.snap
@@ -103,6 +103,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
                   "fontSize": 22,
+                  "includeFontPadding": false,
                 },
                 Object {
                   "color": "#FFFFFF",
@@ -112,6 +113,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
                   "fontSize": 22,
                   "textAlign": "left",
                 },
+                null,
               ]
             }
           >
@@ -524,6 +526,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
                   "fontSize": 22,
+                  "includeFontPadding": false,
                 },
                 Object {
                   "color": "#FFFFFF",
@@ -533,6 +536,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
                   "fontSize": 22,
                   "textAlign": "left",
                 },
+                null,
               ]
             }
           >
@@ -1520,6 +1524,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
                   "fontSize": 22,
+                  "includeFontPadding": false,
                 },
                 Object {
                   "color": "#FFFFFF",
@@ -1529,6 +1534,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
                   "fontSize": 22,
                   "textAlign": "left",
                 },
+                null,
               ]
             }
           >
@@ -1941,6 +1947,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
                   "fontSize": 22,
+                  "includeFontPadding": false,
                 },
                 Object {
                   "color": "#FFFFFF",
@@ -1950,6 +1957,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
                   "fontSize": 22,
                   "textAlign": "left",
                 },
+                null,
               ]
             }
           >

--- a/src/components/themed/EdgeText.js
+++ b/src/components/themed/EdgeText.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import { StyleSheet, Text } from 'react-native'
+import { Platform, StyleSheet, Text } from 'react-native'
 
 import { type Theme, type ThemeProps, cacheStyles, withTheme } from '../services/ThemeContext.js'
 
@@ -15,13 +15,20 @@ type OwnProps = {
 class EdgeTextComponent extends React.PureComponent<OwnProps & ThemeProps> {
   render() {
     const { children, style, theme, ...props } = this.props
-    const { text } = getStyles(theme)
+    const { text, androidAdjust } = getStyles(theme)
     let numberOfLines = this.props.numberOfLines || 1
     if (typeof children === 'string' && children.includes('\n')) {
       numberOfLines = numberOfLines + (children.match(/\n/g) || []).length
     }
     return (
-      <Text style={[text, style]} numberOfLines={numberOfLines} allowFontScaling adjustsFontSizeToFit minimumFontScale={0.65} {...props}>
+      <Text
+        style={[text, style, Platform.OS === 'android' ? androidAdjust : null]}
+        numberOfLines={numberOfLines}
+        allowFontScaling
+        adjustsFontSizeToFit
+        minimumFontScale={0.65}
+        {...props}
+      >
         {children}
       </Text>
     )
@@ -32,7 +39,11 @@ const getStyles = cacheStyles((theme: Theme) => ({
   text: {
     color: theme.primaryText,
     fontFamily: theme.fontFaceDefault,
-    fontSize: theme.rem(1)
+    fontSize: theme.rem(1),
+    includeFontPadding: false
+  },
+  androidAdjust: {
+    top: -1
   }
 }))
 


### PR DESCRIPTION
<img width="374" alt="Category android" src="https://user-images.githubusercontent.com/22767467/123794170-3a2eec80-d8eb-11eb-9bb3-16fa7cf2408b.png">
<img width="399" alt="Exchange android" src="https://user-images.githubusercontent.com/22767467/123794179-3c914680-d8eb-11eb-91a4-3c69a4b25188.png">
<img width="404" alt="category ios" src="https://user-images.githubusercontent.com/22767467/123794185-3dc27380-d8eb-11eb-867a-206b6b8ae4c1.png">
<img width="425" alt="Exchange ios" src="https://user-images.githubusercontent.com/22767467/123794190-3ef3a080-d8eb-11eb-9675-ffa3d94f9951.png">
