### PR TITLE
[UTXO][BTCV] Add Bitcoin Vault cryptocurrency

### DIFF
--- a/src/constants/WalletAndCurrencyConstants.js
+++ b/src/constants/WalletAndCurrencyConstants.js
@@ -13,6 +13,7 @@ export const IMAGE_SERVER_URL = 'https://content.edge.app'
 export const CURRENCY_SYMBOL_IMAGES = {
   BCH: `${IMAGE_SERVER_URL}/bitcoincash-logo-solo-64.png`,
   BTC: `${IMAGE_SERVER_URL}/bitcoin-logo-solo-64.png`,
+  BTCV: `${IMAGE_SERVER_URL}/bitcoinvault-logo-solo-64.png`,
   ETH: `${IMAGE_SERVER_URL}/ethereum-logo-solo-64.png`,
   ETC: `${IMAGE_SERVER_URL}/ethereum-classic-logo-solo-64.png`
 }
@@ -29,6 +30,7 @@ export const DEFAULT_STARTER_WALLET_NAMES = {
   BNB: s.strings.string_first_bnb_wallet_name,
   BSV: s.strings.string_first_bitcoin_sv_wallet_name,
   BTC: s.strings.string_first_bitcoin_wallet_name,
+  BTCV: s.strings.string_first_bitcoinvault_wallet_name,
   BTG: s.strings.string_first_bitcoin_gold_wallet_name,
   DASH: s.strings.string_first_dash_wallet_name,
   DGB: s.strings.string_first_digibyte_wallet_name,
@@ -444,6 +446,9 @@ export const SPECIAL_CURRENCY_INFO: {
   QTUM: {
     isPrivateKeySweepable: true
   },
+  BTCV: {
+    isPrivateKeySweepable: true
+  },
   FTM: {
     dummyPublicAddress: '0x0d73358506663d484945ba85d0cd435ad610b0a0',
     isImportKeySupported: {
@@ -451,9 +456,6 @@ export const SPECIAL_CURRENCY_INFO: {
       privateKeyInstructions: s.strings.create_wallet_import_instructions
     },
     isCustomTokensSupported: true
-  },
-  BTCV: {
-    isPrivateKeySweepable: true
   }
 }
 

--- a/src/constants/WalletAndCurrencyConstants.js
+++ b/src/constants/WalletAndCurrencyConstants.js
@@ -81,7 +81,9 @@ export const CURRENCY_SETTINGS_KEYS = [
   'smartcash',
   'groestlcoin',
   'eboost',
-  'ufo'
+  'ufo',
+  'bitcoinvault',
+  'bitcoinvaulttestnet'
 ]
 
 /**
@@ -115,7 +117,9 @@ export const WALLET_TYPE_ORDER = [
   'wallet:ufo',
   'wallet:telos',
   'wallet:wax',
-  'wallet:fantom'
+  'wallet:fantom',
+  'wallet:bitcoinvault',
+  'wallet:bitcoinvaulttestnet'
 ]
 
 // Put these in reverse order of preference
@@ -153,7 +157,9 @@ export const CURRENCY_PLUGIN_NAMES = {
   XMR: 'monero',
   XRP: 'ripple',
   XTZ: 'tezos',
-  FIRO: 'zcoin'
+  FIRO: 'zcoin',
+  BTCV: 'bitcoinvault',
+  TBTCV: 'bitcoinvaulttestnet'
 }
 
 type SpecialCurrencyInfo = {|
@@ -445,6 +451,9 @@ export const SPECIAL_CURRENCY_INFO: {
       privateKeyInstructions: s.strings.create_wallet_import_instructions
     },
     isCustomTokensSupported: true
+  },
+  BTCV: {
+    isPrivateKeySweepable: true
   }
 }
 
@@ -502,7 +511,9 @@ export const WALLET_LIST_MENU: Array<{
       'RVN',
       'RBTC',
       'TESTBTC',
-      'XMR'
+      'XMR',
+      'BTCV',
+      'TBTCV'
     ],
     label: s.strings.fragment_wallets_view_xpub,
     value: 'viewXPub'

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -321,6 +321,7 @@ const strings = {
   string_first_ethereum_wallet_name: 'My Ether',
   string_first_bitcoin_wallet_name: 'My Bitcoin',
   string_first_bitcoincash_wallet_name: 'My Bitcoin Cash',
+  string_first_bitcoinvault_wallet_name: 'My Bitcoin Vault',
   string_first_bitcoin_sv_wallet_name: 'My Bitcoin SV',
   string_first_bitcoin_gold_wallet_name: 'My Bitcoin Gold',
   string_first_dash_wallet_name: 'My Dash',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -300,6 +300,7 @@
   "string_first_ethereum_wallet_name": "My Ether",
   "string_first_bitcoin_wallet_name": "My Bitcoin",
   "string_first_bitcoincash_wallet_name": "My Bitcoin Cash",
+  "string_first_bitcoinvault_wallet_name": "My Bitcoin Vault",
   "string_first_bitcoin_sv_wallet_name": "My Bitcoin SV",
   "string_first_bitcoin_gold_wallet_name": "My Bitcoin Gold",
   "string_first_dash_wallet_name": "My Dash",

--- a/src/util/corePlugins.js
+++ b/src/util/corePlugins.js
@@ -47,6 +47,8 @@ export const currencyPlugins = {
   bitcoingoldtestnet: false,
   bitcoinsv: true,
   bitcointestnet: true,
+  bitcoinvault: true,
+  bitcoinvaulttestnet: true,
   dash: true,
   digibyte: true,
   dogecoin: true,


### PR DESCRIPTION
Hello!
 We would like to add BTCV (Bitcoin Vault) cryptocurrency to your wallet app but during preparation of PR we identified a major blocker: your solution does not support WSS (web socket secure) and non-ssl solution is not accepted according to our security standards.
 We see currently 2 solutions for this situation as we want to proceed with implementation of BTCV into Edge Wallet app:
 1. Setting up a WSS connection on Edge Wallet side to the following public servers:
* mainnet
  * electrums://electrumx-mainnet1.bitcoinvault.global:443
  * electrums://electrumx-mainnet2.bitcoinvault.global:443
* testnet:
  * electrums://electrumx.testnet.btcv.stage.rnd.land:443
2. Setting up your own local instance of ElectrumX (along with BTCV node).

Please let us know which option you would like to pursue. We are ready to support you with explanations and guidance within both solutions.

related PR to edge-currency-bitcoin: https://github.com/EdgeApp/edge-currency-bitcoin/pull/259

Kind regards
Jakub Rojek