### PR TITLE
Fix fee changing on send scene

### DIFF
--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -72,6 +72,12 @@ export const sendConfirmationUpdateTx =
     if (maxSpendSet && isFeeChanged) guiMakeSpendInfoClone.nativeAmount = '0'
     const spendInfo = getSpendInfo(state, guiMakeSpendInfoClone, selectedCurrencyCode || state.ui.wallets.selectedCurrencyCode)
 
+    if (isFeeChanged) {
+      spendInfo.spendTargets = spendInfo.spendTargets.map(spendTarget => ({
+        ...spendTarget,
+        nativeAmount: spendTarget.nativeAmount === '' ? '0' : spendTarget.nativeAmount
+      }))
+    }
     const authRequired = getAuthRequired(state, spendInfo)
     dispatch({
       type: 'UI/SEND_CONFIRMATION/NEW_SPEND_INFO',

--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -78,9 +78,7 @@ export const sendConfirmationUpdateTx =
       data: { spendInfo, authRequired }
     })
 
-    if (guiMakeSpendInfo.nativeAmount == null || guiMakeSpendInfo.nativeAmount === '') {
-      return
-    }
+    if (guiMakeSpendInfo.nativeAmount === '') return
 
     if (maxSpendSet && isFeeChanged) {
       return dispatch(updateMaxSpend(walletId, selectedCurrencyCode || state.ui.wallets.selectedCurrencyCode, guiMakeSpendInfoClone))
@@ -446,7 +444,7 @@ export const updateTransactionAmount =
       data: false
     })
 
-    if (guiMakeSpendInfo.nativeAmount == null || guiMakeSpendInfo.nativeAmount === '') {
+    if (guiMakeSpendInfo.nativeAmount === '') {
       return
     }
 

--- a/src/components/scenes/ChangeMiningFeeScene.js
+++ b/src/components/scenes/ChangeMiningFeeScene.js
@@ -72,7 +72,10 @@ export class ChangeMiningFee extends React.Component<Props, State> {
     const { networkFeeOption, customNetworkFee } = this.state
     const { currencyCode, wallet, spendTargets = [], maxSpendSet } = this.props
     const testSpendInfo = {
-      spendTargets: maxSpendSet ? spendTargets.map(spendTarget => ({ ...spendTarget, nativeAmount: '0' })) : spendTargets,
+      spendTargets: spendTargets.map(spendTarget => ({
+        ...spendTarget,
+        nativeAmount: maxSpendSet || spendTarget.nativeAmount === '' ? '0' : spendTarget.nativeAmount
+      })),
       networkFeeOption,
       customNetworkFee,
       currencyCode

--- a/src/components/scenes/SendScene.js
+++ b/src/components/scenes/SendScene.js
@@ -369,9 +369,9 @@ class SendComponent extends React.PureComponent<Props, State> {
       const cryptoExchangeDenomination = UTILS.getDenomination(selectedCurrencyCode, settings, 'exchange')
       const fiatDenomination = UTILS.getDenomFromIsoCode(guiWallet.fiatCurrencyCode)
       const fiatSymbol = fiatDenomination.symbol ? fiatDenomination.symbol : ''
-      if (nativeAmount == null || nativeAmount === '') {
+      if (nativeAmount === '') {
         cryptoAmountSyntax = s.strings.string_amount
-      } else if (!bns.eq(nativeAmount, '0')) {
+      } else if (nativeAmount && !bns.eq(nativeAmount, '0')) {
         const displayAmount = bns.div(nativeAmount, cryptoDisplayDenomination.multiplier, UTILS.DIVIDE_PRECISION)
         const exchangeAmount = bns.div(nativeAmount, cryptoExchangeDenomination.multiplier, UTILS.DIVIDE_PRECISION)
         const fiatAmount = convertCurrencyFromExchangeRates(exchangeRates, selectedCurrencyCode, guiWallet.isoFiatCurrencyCode, parseFloat(exchangeAmount))


### PR DESCRIPTION
These changes fix weird behavior on send scene when user tries to change fee. Now we set amount to 0 by default if amount is not set when user changes fee.