### PR TITLE
Fix convertCurrencyFromExchangeRates to accept only strings

### DIFF
--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -17,7 +17,7 @@ import { addToFioAddressCache, recordSend } from '../modules/FioAddress/util'
 import { getAuthRequired, getSpendInfo, getSpendInfoWithoutState, getTransaction } from '../modules/UI/scenes/SendConfirmation/selectors'
 import { type GuiMakeSpendInfo } from '../reducers/scenes/SendConfirmationReducer.js'
 import { getExchangeDenomination } from '../selectors/DenominationSelectors.js'
-import { convertCurrencyFromExchangeRates, getExchangeRate } from '../selectors/WalletSelectors.js'
+import { convertCurrencyFromExchangeRates, exchangeRatesToString, getExchangeRate } from '../selectors/WalletSelectors.js'
 import type { Dispatch, GetState } from '../types/reduxTypes.js'
 import { convertNativeToExchange } from '../util/utils'
 import * as UTILS from '../util/utils.js'
@@ -237,13 +237,13 @@ export const signBroadcastAndSave =
     // check hwo high fee is and decide whether to display warninig
     const exchangeConverter = convertNativeToExchange(exchangeDenomination.multiplier)
     const cryptoFeeExchangeAmount = exchangeConverter(edgeUnsignedTransaction.networkFee)
-    const feeAmountInUSD = convertCurrencyFromExchangeRates(state.exchangeRates, currencyCode, 'iso:USD', parseFloat(cryptoFeeExchangeAmount))
+    const feeAmountInUSD = convertCurrencyFromExchangeRates(exchangeRatesToString(state.exchangeRates), currencyCode, 'iso:USD', cryptoFeeExchangeAmount)
     if (parseFloat(feeAmountInUSD) > FEE_ALERT_THRESHOLD) {
       const feeAmountInWalletFiat = convertCurrencyFromExchangeRates(
-        state.exchangeRates,
+        exchangeRatesToString(state.exchangeRates),
         currencyCode,
         isoFiatCurrencyCode,
-        parseFloat(cryptoFeeExchangeAmount)
+        cryptoFeeExchangeAmount
       )
       const fiatDenomination = UTILS.getDenomFromIsoCode(guiWallet.fiatCurrencyCode)
       const fiatSymbol = fiatDenomination.symbol ? `${fiatDenomination.symbol} ` : ''

--- a/src/components/modals/FlipInputModal.js
+++ b/src/components/modals/FlipInputModal.js
@@ -11,7 +11,12 @@ import { updateMaxSpend, updateTransactionAmount } from '../../actions/SendConfi
 import { getSpecialCurrencyInfo } from '../../constants/WalletAndCurrencyConstants.js'
 import s from '../../locales/strings.js'
 import { getDisplayDenomination, getExchangeDenomination } from '../../selectors/DenominationSelectors.js'
-import { convertCurrencyFromExchangeRates, convertNativeToExchangeRateDenomination, getExchangeRate } from '../../selectors/WalletSelectors.js'
+import {
+  convertCurrencyFromExchangeRates,
+  convertNativeToExchangeRateDenomination,
+  exchangeRatesToString,
+  getExchangeRate
+} from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
 import type { GuiCurrencyInfo } from '../../types/types.js'
 import { convertTransactionFeeToDisplayFee, DIVIDE_PRECISION, getDenomFromIsoCode } from '../../util/utils.js'
@@ -247,7 +252,7 @@ export const FlipInputModal = connect<StateProps, DispatchProps, OwnProps>(
     // Balances
     const balanceInCrypto = guiWallet.nativeBalances[currencyCode]
     const balanceCrypto = convertNativeToExchangeRateDenomination(state.ui.settings, currencyCode, balanceInCrypto)
-    const balanceFiat = convertCurrencyFromExchangeRates(state.exchangeRates, currencyCode, isoFiatCurrencyCode, parseFloat(balanceCrypto))
+    const balanceFiat = convertCurrencyFromExchangeRates(exchangeRatesToString(state.exchangeRates), currencyCode, isoFiatCurrencyCode, balanceCrypto)
 
     // FlipInput
     const fiatPerCrypto = getExchangeRate(state, currencyCode, isoFiatCurrencyCode)

--- a/src/components/scenes/SendScene.js
+++ b/src/components/scenes/SendScene.js
@@ -22,7 +22,7 @@ import s from '../../locales/strings.js'
 import { checkRecordSendFee, FIO_NO_BUNDLED_ERR_CODE } from '../../modules/FioAddress/util'
 import { Slider } from '../../modules/UI/components/Slider/Slider'
 import { type GuiMakeSpendInfo } from '../../reducers/scenes/SendConfirmationReducer.js'
-import { convertCurrencyFromExchangeRates } from '../../selectors/WalletSelectors.js'
+import { convertCurrencyFromExchangeRates, exchangeRatesToString } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
 import { type GuiExchangeRates, type GuiWallet } from '../../types/types.js'
 import * as UTILS from '../../util/utils.js'
@@ -376,7 +376,12 @@ class SendComponent extends React.PureComponent<Props, State> {
       } else if (nativeAmount && !bns.eq(nativeAmount, '0')) {
         const displayAmount = bns.div(nativeAmount, cryptoDisplayDenomination.multiplier, UTILS.DIVIDE_PRECISION)
         const exchangeAmount = bns.div(nativeAmount, cryptoExchangeDenomination.multiplier, UTILS.DIVIDE_PRECISION)
-        const fiatAmount = convertCurrencyFromExchangeRates(exchangeRates, selectedCurrencyCode, guiWallet.isoFiatCurrencyCode, parseFloat(exchangeAmount))
+        const fiatAmount = convertCurrencyFromExchangeRates(
+          exchangeRatesToString(exchangeRates),
+          selectedCurrencyCode,
+          guiWallet.isoFiatCurrencyCode,
+          exchangeAmount
+        )
         cryptoAmountSyntax = `${displayAmount ?? '0'} ${cryptoDisplayDenomination.name}`
         if (fiatAmount) {
           fiatAmountSyntax = `${fiatSymbol} ${bns.toFixed(fiatAmount, 2, 2) ?? '0'}`

--- a/src/components/scenes/TransactionDetailsScene.js
+++ b/src/components/scenes/TransactionDetailsScene.js
@@ -15,7 +15,7 @@ import { getSpecialCurrencyInfo } from '../../constants/WalletAndCurrencyConstan
 import { formatNumber } from '../../locales/intl.js'
 import s from '../../locales/strings.js'
 import { getDisplayDenomination } from '../../selectors/DenominationSelectors.js'
-import { convertCurrencyFromExchangeRates, convertNativeToExchangeRateDenomination } from '../../selectors/WalletSelectors.js'
+import { convertCurrencyFromExchangeRates, convertNativeToExchangeRateDenomination, exchangeRatesToString } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
 import type { GuiContact, GuiWallet } from '../../types/types.js'
 import * as UTILS from '../../util/utils.js'
@@ -597,7 +597,12 @@ export const TransactionDetailsScene = connect<StateProps, DispatchProps, OwnPro
 
     const nativeAmount = getAbsoluteAmount(edgeTransaction)
     const cryptoAmount = convertNativeToExchangeRateDenomination(settings, currencyCode, nativeAmount)
-    const currentFiatAmount = convertCurrencyFromExchangeRates(state.exchangeRates, currencyCode, wallet.isoFiatCurrencyCode, parseFloat(cryptoAmount))
+    const currentFiatAmount = convertCurrencyFromExchangeRates(
+      exchangeRatesToString(state.exchangeRates),
+      currencyCode,
+      wallet.isoFiatCurrencyCode,
+      cryptoAmount
+    )
 
     const { swapData } = edgeTransaction
     if (swapData != null && typeof swapData.payoutCurrencyCode === 'string') {

--- a/src/selectors/WalletSelectors.js
+++ b/src/selectors/WalletSelectors.js
@@ -61,15 +61,15 @@ const convertCurrencyWithoutState = (exchangeRates: { [string]: string }, fromCu
 }
 
 export const convertCurrencyFromExchangeRates = (
-  exchangeRates: { [string]: number },
+  exchangeRates: { [string]: string },
   fromCurrencyCode: string,
   toCurrencyCode: string,
-  amount: number
+  amount: string
 ): string => {
   const rateKey = `${fromCurrencyCode}_${toCurrencyCode}`
   if (!exchangeRates || exchangeRates[rateKey] == null) return '0' // handle case of exchange rates not ready yet
   const rate = exchangeRates[rateKey]
-  const convertedAmount = bns.mul(amount.toFixed(18), rate.toFixed(18))
+  const convertedAmount = bns.mul(amount, rate)
   return convertedAmount
 }
 
@@ -137,7 +137,7 @@ export const findWalletByFioAddress = async (state: RootState, fioAddress: strin
   }
 }
 
-const exchangeRatesToString = (exchangeRates: { [string]: number }): { [string]: string } => {
+export const exchangeRatesToString = (exchangeRates: { [string]: number }): { [string]: string } => {
   const exchangeRateString = {}
   for (const rate in exchangeRates) {
     exchangeRateString[rate] = `${exchangeRates[rate]}`

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -9,7 +9,7 @@ import SafariView from 'react-native-safari-view'
 import { FEE_ALERT_THRESHOLD, FEE_COLOR_THRESHOLD, FIAT_CODES_SYMBOLS, getSymbolFromCurrency } from '../constants/WalletAndCurrencyConstants.js'
 import { formatNumber } from '../locales/intl.js'
 import { emptyEdgeDenomination } from '../selectors/DenominationSelectors.js'
-import { convertCurrency, convertCurrencyFromExchangeRates } from '../selectors/WalletSelectors.js'
+import { convertCurrency, convertCurrencyFromExchangeRates, exchangeRatesToString } from '../selectors/WalletSelectors.js'
 import { type RootState } from '../types/reduxTypes.js'
 import type { CustomTokenInfo, ExchangeData, GuiDenomination, GuiWallet, TransactionListTx } from '../types/types.js'
 import { type GuiExchangeRates } from '../types/types.js'
@@ -715,8 +715,8 @@ export const convertToFiatFee = (
   isoFiatCurrencyCode: string
 ): { amount: string, style?: string } => {
   const cryptoFeeExchangeAmount = convertNativeToExchange(exchangeMultiplier)(networkFee)
-  const fiatFeeAmount = convertCurrencyFromExchangeRates(exchangeRates, currencyCode, isoFiatCurrencyCode, parseFloat(cryptoFeeExchangeAmount))
-  const feeAmountInUSD = convertCurrencyFromExchangeRates(exchangeRates, currencyCode, 'iso:USD', parseFloat(cryptoFeeExchangeAmount))
+  const fiatFeeAmount = convertCurrencyFromExchangeRates(exchangeRatesToString(exchangeRates), currencyCode, isoFiatCurrencyCode, cryptoFeeExchangeAmount)
+  const feeAmountInUSD = convertCurrencyFromExchangeRates(exchangeRatesToString(exchangeRates), currencyCode, 'iso:USD', cryptoFeeExchangeAmount)
   return {
     amount: bns.toFixed(fiatFeeAmount, 2, 2),
     style: parseFloat(feeAmountInUSD) > FEE_ALERT_THRESHOLD ? feeStyle.danger : parseFloat(feeAmountInUSD) > FEE_COLOR_THRESHOLD ? feeStyle.warning : undefined


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android