### PR TITLE
Fix walletSelector functions to have string inputs

### DIFF
--- a/src/components/themed/WalletList.js
+++ b/src/components/themed/WalletList.js
@@ -9,7 +9,7 @@ import { selectWallet } from '../../actions/WalletActions.js'
 import { WALLET_LIST_SCENE } from '../../constants/SceneKeys.js'
 import s from '../../locales/strings'
 import { SYNCED_ACCOUNT_DEFAULTS } from '../../modules/Core/Account/settings.js'
-import { calculateWalletFiatBalanceUsingDefaultIsoFiat } from '../../selectors/WalletSelectors.js'
+import { calculateWalletFiatBalanceUsingDefaultIsoFiat, exchangeRatesToString } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
 import type { CreateTokenType, CreateWalletType, CustomTokenInfo, FlatListItem, GuiWallet, MostRecentWallet } from '../../types/types.js'
 import { getCreateWalletTypes, getCurrencyIcon, getCurrencyInfos } from '../../util/CurrencyInfoHelpers.js'
@@ -81,7 +81,7 @@ class WalletListComponent extends React.PureComponent<Props> {
     const getFiatBalance = (wallet: GuiWallet, fullCurrencyCode: string): number => {
       const { settings, exchangeRates } = this.props
       const currencyCode = getSortOptionsCurrencyCode(fullCurrencyCode)
-      const fiatBalanceString = calculateWalletFiatBalanceUsingDefaultIsoFiat(wallet, currencyCode, settings, exchangeRates)
+      const fiatBalanceString = calculateWalletFiatBalanceUsingDefaultIsoFiat(wallet, currencyCode, settings, exchangeRatesToString(exchangeRates))
       return parseFloat(fiatBalanceString)
     }
 

--- a/src/components/themed/WalletListCurrencyRow.js
+++ b/src/components/themed/WalletListCurrencyRow.js
@@ -4,7 +4,7 @@ import type { EdgeCurrencyInfo } from 'edge-core-js'
 import * as React from 'react'
 
 import { formatNumber } from '../../locales/intl.js'
-import { calculateWalletFiatBalanceWithoutState } from '../../selectors/WalletSelectors.js'
+import { calculateWalletFiatBalanceWithoutState, exchangeRatesToString } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
 import { type GuiExchangeRates } from '../../types/types.js'
 import { getCryptoAmount, getCurrencyInfo, getDenomFromIsoCode, getDenomination, getFiatSymbol, getYesterdayDateRoundDownHour } from '../../util/utils'
@@ -181,7 +181,7 @@ export const WalletListCurrencyRow = connect<StateProps, {}, OwnProps>(
 
     // Fiat Balance
     const walletFiatSymbol = getFiatSymbol(guiWallet.isoFiatCurrencyCode)
-    const fiatBalance = calculateWalletFiatBalanceWithoutState(guiWallet, currencyCode, settings, exchangeRates)
+    const fiatBalance = calculateWalletFiatBalanceWithoutState(guiWallet, currencyCode, settings, exchangeRatesToString(exchangeRates))
     const fiatBalanceFormat = fiatBalance && parseFloat(fiatBalance) > 0.000001 ? fiatBalance : '0'
     const fiatBalanceSymbol = showBalance && exchangeRate ? walletFiatSymbol : ''
     const fiatBalanceString = showBalance && exchangeRate ? fiatBalanceFormat : ''

--- a/src/components/themed/WalletListSortableRow.js
+++ b/src/components/themed/WalletListSortableRow.js
@@ -9,7 +9,7 @@ import { formatNumberInput } from '../../locales/intl.js'
 import s from '../../locales/strings.js'
 import { type SettingsState } from '../../reducers/scenes/SettingsReducer.js'
 import { getDisplayDenominationFromSettings } from '../../selectors/DenominationSelectors.js'
-import { calculateWalletFiatBalanceWithoutState } from '../../selectors/WalletSelectors.js'
+import { calculateWalletFiatBalanceWithoutState, exchangeRatesToString } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
 import { type GuiExchangeRates, type GuiWallet } from '../../types/types.js'
 import { decimalOrZero, getFiatSymbol, truncateDecimals } from '../../util/utils'
@@ -59,7 +59,7 @@ class WalletListSortableRowComponent extends React.PureComponent<Props> {
     const preliminaryCryptoAmount = truncateDecimals(bns.div(guiWallet.primaryNativeBalance, multiplier, DIVIDE_PRECISION), 6)
     const finalCryptoAmount = formatNumberInput(decimalOrZero(preliminaryCryptoAmount, 6)) // make it show zero if infinitesimal number
     const finalCryptoAmountString = showBalance ? `${symbol || ''} ${finalCryptoAmount}` : ''
-    const fiatBalance = calculateWalletFiatBalanceWithoutState(guiWallet, currencyCode, settings, exchangeRates)
+    const fiatBalance = calculateWalletFiatBalanceWithoutState(guiWallet, currencyCode, settings, exchangeRatesToString(exchangeRates))
     const fiatBalanceFormat = fiatBalance && parseFloat(fiatBalance) > 0.000001 ? fiatBalance : 0
     const fiatBalanceSymbol = showBalance && walletFiatSymbol ? walletFiatSymbol : ''
     const fiatBalanceString = showBalance ? fiatBalanceFormat : ''

--- a/src/selectors/WalletSelectors.js
+++ b/src/selectors/WalletSelectors.js
@@ -77,7 +77,7 @@ export const calculateWalletFiatBalanceWithoutState = (
   wallet: GuiWallet,
   currencyCode: string,
   settings: Object,
-  exchangeRates: { [string]: number }
+  exchangeRates: { [string]: string }
 ): string => {
   let fiatValue = '0' // default to zero if not calculable
   const nativeBalance = wallet.nativeBalances[currencyCode]
@@ -87,7 +87,7 @@ export const calculateWalletFiatBalanceWithoutState = (
   if (!exchangeDenomination) return '0'
   const nativeToExchangeRatio: string = exchangeDenomination.multiplier
   const cryptoAmount = convertNativeToExchange(nativeToExchangeRatio)(nativeBalance)
-  fiatValue = convertCurrencyWithoutState(exchangeRatesToString(exchangeRates), currencyCode, wallet.isoFiatCurrencyCode, cryptoAmount)
+  fiatValue = convertCurrencyWithoutState(exchangeRates, currencyCode, wallet.isoFiatCurrencyCode, cryptoAmount)
   return formatNumber(fiatValue, { toFixed: 2 }) || '0'
 }
 
@@ -95,7 +95,7 @@ export const calculateWalletFiatBalanceUsingDefaultIsoFiat = (
   wallet: GuiWallet,
   currencyCode: string,
   settings: Object,
-  exchangeRates: { [string]: number }
+  exchangeRates: { [string]: string }
 ): string => {
   const nativeBalance = wallet.nativeBalances[currencyCode]
   if (!settings[currencyCode]) return '0'
@@ -105,7 +105,7 @@ export const calculateWalletFiatBalanceUsingDefaultIsoFiat = (
   if (!exchangeDenomination) return '0'
   const nativeToExchangeRatio: string = exchangeDenomination.multiplier
   const cryptoAmount = convertNativeToExchange(nativeToExchangeRatio)(nativeBalance)
-  return convertCurrencyWithoutState(exchangeRatesToString(exchangeRates), currencyCode, settings.defaultIsoFiat, cryptoAmount) || '0'
+  return convertCurrencyWithoutState(exchangeRates, currencyCode, settings.defaultIsoFiat, cryptoAmount) || '0'
 }
 
 export const convertNativeToExchangeRateDenomination = (settings: Object, currencyCode: string, nativeAmount: string): string => {
@@ -137,7 +137,7 @@ export const findWalletByFioAddress = async (state: RootState, fioAddress: strin
   }
 }
 
-const exchangeRatesToString = (exchangeRates: { [string]: number }): { [string]: string } => {
+export const exchangeRatesToString = (exchangeRates: { [string]: number }): { [string]: string } => {
   const exchangeRateString = {}
   for (const rate in exchangeRates) {
     exchangeRateString[rate] = `${exchangeRates[rate]}`


### PR DESCRIPTION
Specifically the calculateWalletFiatBalanceUsingDefaultIsoFiat and calculateWalletFiatBalanceWithoutState functions on WalletSelectors.js

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android