### PR TITLE
Fix the unique identifier modal crash

### DIFF
--- a/src/components/modals/UniqueIdentifierModal.js
+++ b/src/components/modals/UniqueIdentifierModal.js
@@ -99,7 +99,7 @@ class UniqueIdentifierModalComponent extends React.Component<Props> {
     )
   }
 
-  onConfirm() {
+  onConfirm = () => {
     const { uniqueIdentifier } = this.props
     this.props.onDeactivated()
     this.props.onConfirm({ uniqueIdentifier })


### PR DESCRIPTION
### Fixed

- Do not crash when submitting a unique identifier.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a