### PR TITLE
Scan clipboard for address on return to send scene

### DIFF
--- a/src/components/themed/AddressTile.js
+++ b/src/components/themed/AddressTile.js
@@ -3,7 +3,7 @@
 import Clipboard from '@react-native-community/clipboard'
 import type { EdgeCurrencyConfig, EdgeCurrencyWallet, EdgeParsedUri } from 'edge-core-js'
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { AppState, TouchableOpacity, View } from 'react-native'
 import FontAwesome from 'react-native-vector-icons/FontAwesome'
 import FontAwesome5 from 'react-native-vector-icons/FontAwesome5'
 
@@ -63,6 +63,8 @@ class AddressTileComponent extends React.PureComponent<Props, State> {
   }
 
   componentDidMount(): void {
+    AppState.addEventListener('change', this.handleAppStateChange)
+
     this._setClipboard(this.props)
     this.props.addressTileRef(this)
     if (this.props.isCameraOpen) {
@@ -71,6 +73,8 @@ class AddressTileComponent extends React.PureComponent<Props, State> {
   }
 
   componentWillUnmount(): void {
+    AppState.removeEventListener('change', this.handleAppStateChange)
+
     this.props.addressTileRef(undefined)
   }
 
@@ -78,6 +82,10 @@ class AddressTileComponent extends React.PureComponent<Props, State> {
     if (this.props.isCameraOpen && !prevProps.isCameraOpen) {
       this.handleScan()
     }
+  }
+
+  handleAppStateChange = appState => {
+    if (appState === 'active') this._setClipboard(this.props)
   }
 
   reset() {


### PR DESCRIPTION
When the app is coming into foreground, read from the clipboard in case
a new address was copied while the app was in the background.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a