### PR TITLE
Fix where pin input tile is being overlaid by the keyboard on android

### DIFF
--- a/src/components/scenes/SendScene.js
+++ b/src/components/scenes/SendScene.js
@@ -533,7 +533,7 @@ class SendComponent extends React.PureComponent<Props, State> {
 
     return (
       <SceneWrapper background="theme">
-        <KeyboardAwareScrollView extraScrollHeight={theme.rem(2.75)}>
+        <KeyboardAwareScrollView extraScrollHeight={theme.rem(2.75)} enableOnAndroid>
           {this.renderSelectedWallet()}
           {this.renderAddressTile()}
           {this.renderAmount()}


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android