### PR TITLE
Make the "CenteredModal" cover the entire available width on tablet devices

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -831,7 +831,7 @@ SPEC CHECKSUMS:
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   edge-login-ui-rn: 3de2a56437484e802e02c033e803ee1e8ff29aef
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: fa499e5f6bc9eb280639658945c847de7f769d9d
+  FBReactNativeSpec: 1f1db061efbcdc09d4e5b0788555aa44d451f234
   Firebase: e1e089d9aac215a52442583f818ab61de3c4581b
   FirebaseAnalytics: 9f8f4feab1f3fddf4e4515f8f022fe6aa9e51043
   FirebaseCore: 0a43b7f1c5b36f3358cd703011ca4c7e0df55870

--- a/src/components/modals/CenteredModal.js
+++ b/src/components/modals/CenteredModal.js
@@ -3,9 +3,14 @@
 import * as React from 'react'
 import { Dimensions, View } from 'react-native'
 import { type AirshipBridge } from 'react-native-airship'
+import { isTablet } from 'react-native-device-info'
 
 import { type Theme, cacheStyles, useTheme } from '../services/ThemeContext'
 import { ThemedModal } from '../themed/ThemedModal'
+
+const CONTENT_MAX_WIDTH = Dimensions.get('window').width
+
+const getContentWidth = (theme: Theme) => (isTablet() ? CONTENT_MAX_WIDTH - theme.rem(2) : CONTENT_MAX_WIDTH)
 
 type Props = {
   children: React.Node,
@@ -17,7 +22,7 @@ export function CenteredModal({ children, bridge }: Props) {
   const styles = getStyles(theme)
 
   return (
-    <ThemedModal bridge={bridge} position="center" onCancel={() => bridge.resolve(false)}>
+    <ThemedModal bridge={bridge} position="center" maxWidth={getContentWidth(theme)} onCancel={() => bridge.resolve(false)}>
       <View style={styles.container}>{children}</View>
     </ThemedModal>
   )
@@ -25,7 +30,7 @@ export function CenteredModal({ children, bridge }: Props) {
 
 const getStyles = cacheStyles((theme: Theme) => ({
   container: {
-    width: Dimensions.get('window').width,
-    height: Dimensions.get('window').width
+    width: getContentWidth(theme),
+    height: getContentWidth(theme)
   }
 }))

--- a/src/components/themed/ThemedModal.js
+++ b/src/components/themed/ThemedModal.js
@@ -23,14 +23,15 @@ type Props<T> = {
   flexDirection?: $PropertyType<ViewStyle, 'flexDirection'>,
   justifyContent?: $PropertyType<ViewStyle, 'justifyContent'>,
   paddingRem?: number[] | number,
-  position?: 'center' | 'bottom'
+  position?: 'center' | 'bottom',
+  maxWidth?: number
 }
 
 /**
  * The Airship modal, but connected to our theming system.
  */
 export function ThemedModal<T>(props: Props<T>) {
-  const { bridge, children = null, flexDirection, iconRem = 0, justifyContent, onCancel, position } = props
+  const { bridge, children = null, flexDirection, iconRem = 0, justifyContent, onCancel, position, maxWidth } = props
   const paddingRem = unpackEdges(props.paddingRem ?? 1)
   const theme = useTheme()
 
@@ -54,6 +55,7 @@ export function ThemedModal<T>(props: Props<T>) {
       margin={margin}
       onCancel={onCancel}
       center={isModalCentered}
+      maxWidth={maxWidth}
       padding={padding}
       underlay={<BlurView blurType={theme.modalBlurType} style={StyleSheet.absoluteFill} />}
     >


### PR DESCRIPTION


#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

<img width="646" alt="Screenshot 2021-08-11 at 14 35 59" src="https://user-images.githubusercontent.com/68349436/129022118-3cbc5095-9f15-4ecb-b4bb-34405c85c242.png">

<img width="896" alt="Screenshot 2021-08-11 at 14 34 48" src="https://user-images.githubusercontent.com/68349436/129022009-10924cdd-1469-496f-90ff-1842d390e1c8.png">
