### PR TITLE
Pass currencyCode to parseUri when verifying clipboard

### DIFF
--- a/src/components/themed/AddressTile.js
+++ b/src/components/themed/AddressTile.js
@@ -152,14 +152,14 @@ class AddressTileComponent extends React.PureComponent<Props, State> {
   }
 
   _setClipboard = async props => {
-    const coreWallet = props.coreWallet
+    const { coreWallet, currencyCode } = props
 
     try {
       this.setState({ loading: true })
       const uri = await Clipboard.getString()
 
       // Will throw in case uri is invalid
-      await coreWallet.parseUri(uri)
+      await coreWallet.parseUri(uri, currencyCode)
 
       this.setState({
         clipboard: uri,


### PR DESCRIPTION
EIP-681 plugin support requires a currencyCode for added security.
Without a currencyCode, the plugin cannot determine if the intent is to
pay using a token transfer for a particular contract address in the URI.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a