### PR TITLE
Fix the expired FIO button centering

### DIFF
--- a/src/components/modals/FioExpiredModal.js
+++ b/src/components/modals/FioExpiredModal.js
@@ -1,42 +1,24 @@
 // @flow
 
 import * as React from 'react'
-import { View } from 'react-native'
 import { type AirshipBridge } from 'react-native-airship'
-import { cacheStyles } from 'react-native-patina'
 
 import s from '../../locales/strings'
-import { type Theme, useTheme } from '../services/ThemeContext'
 import { MainButton } from '../themed/MainButton.js'
 import { ModalCloseArrow, ModalMessage, ModalTitle } from '../themed/ModalParts.js'
 import { ThemedModal } from '../themed/ThemedModal.js'
 
-export function FioExpiredModal(props: { bridge: AirshipBridge<boolean | void>, fioName: string, isAddress: boolean }) {
+export function FioExpiredModal(props: { bridge: AirshipBridge<boolean>, fioName: string, isAddress: boolean }) {
   const { bridge, fioName, isAddress } = props
   const title = `${s.strings.fio_address_confirm_screen_fio_label} ${s.strings.string_expiration}`
-  const styles = getStyles(useTheme())
 
   return (
-    <ThemedModal bridge={bridge} onCancel={() => bridge.resolve(undefined)} paddingRem={[1, 0.5]}>
+    <ThemedModal bridge={bridge} onCancel={() => bridge.resolve(false)}>
       <ModalTitle>{title}</ModalTitle>
       <ModalMessage>{isAddress ? s.strings.fio_address_details_expired_soon : s.strings.fio_domain_details_expired_soon}</ModalMessage>
       <ModalMessage>{fioName}</ModalMessage>
-      <View style={styles.center}>
-        <View style={styles.buttonWidth}>
-          <MainButton label={s.strings.title_fio_renew} marginRem={[1.75, 0, 1]} type="secondary" onPress={() => bridge.resolve(true)} />
-        </View>
-      </View>
-      <ModalCloseArrow onPress={() => bridge.resolve(undefined)} />
+      <MainButton alignSelf="center" label={s.strings.title_fio_renew} marginRem={[1, 0.5, 0.5]} type="secondary" onPress={() => bridge.resolve(true)} />
+      <ModalCloseArrow onPress={() => bridge.resolve(false)} />
     </ThemedModal>
   )
 }
-
-const getStyles = cacheStyles((theme: Theme) => ({
-  center: {
-    alignItems: 'center',
-    justifyContent: 'center'
-  },
-  buttonWidth: {
-    width: theme.rem(7)
-  }
-}))


### PR DESCRIPTION
The button supports this natively now, so we can delete a bunch of code.

Also fixed the Flow type of the modal, which would have triggered the sketchy-null checks if we had them enabled.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a