### PR TITLE
Fix bug where clicking max spend and then toggling back will make the fiat amount load longer

### DIFF
--- a/src/components/themed/FlipInput.js
+++ b/src/components/themed/FlipInput.js
@@ -209,11 +209,6 @@ class FlipInputComponent extends React.PureComponent<Props, State> {
         duration: 0,
         useNativeDriver: true
       }).start()
-      setTimeout(() => {
-        this.setState({
-          secondaryDisplayAmount: ''
-        })
-      }, 10)
     }
 
     if (this.props.isFocus) {


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a