### PR TITLE
Fix bug on Transaction Details where fiat amount is blank and closing the modal will make the fiat amount blank

### DIFF
--- a/src/components/scenes/TransactionDetailsScene.js
+++ b/src/components/scenes/TransactionDetailsScene.js
@@ -182,7 +182,12 @@ export class TransactionDetailsComponent extends React.Component<Props, State> {
         amount={this.state.amountFiat}
         onChange={this.onChangeFiat}
       />
-    )).then(_ => {})
+    )).then(_ => {
+      const { amountFiat } = this.state
+      if (UTILS.zeroString(amountFiat)) {
+        this.onChangeFiat('0.00')
+      }
+    })
   }
 
   onChangeCategory = (category: string, subCategory: string) => this.setState({ category, subCategory })


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android