### PR TITLE
Remove paid requests from the request list

### DIFF
--- a/src/components/scenes/FioRequestListScene.js
+++ b/src/components/scenes/FioRequestListScene.js
@@ -432,7 +432,7 @@ class FioRequestList extends React.Component<Props, LocalState> {
       },
       onDone: (err, edgeTransaction) => {
         if (!err && edgeTransaction != null) {
-          this.getFioRequestsPending()
+          this.removeFioPendingRequest(pendingRequest.fio_request_id)
           Actions.replace(TRANSACTION_DETAILS, { edgeTransaction })
         }
       }


### PR DESCRIPTION
Querying the blockchain will always be behind user action so this removes the FIO request from the list before the plugin returns an array without the paid request.