### PR TITLE
Fix broken navigation on the security alerts

### DIFF
--- a/src/components/scenes/SecurityAlertsScene.js
+++ b/src/components/scenes/SecurityAlertsScene.js
@@ -21,7 +21,7 @@ type Props = StateProps & OwnProps
 class SecurityAlertsComponent extends React.Component<Props> {
   render() {
     const { context, account, navigation } = this.props
-    const handleComplete = () => navigation.goBack()
+    const handleComplete = () => navigation.pop()
 
     return (
       <View style={styles.container}>


### PR DESCRIPTION
Because of our complicated scene stacking order, `goBack` doesn't work in here (although it's fine in other scenes). Use `pop` instead.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a