### PR TITLE
Fix falsy evaluation

### DIFF
--- a/src/modules/UI/scenes/SendConfirmation/selectors.js
+++ b/src/modules/UI/scenes/SendConfirmation/selectors.js
@@ -97,7 +97,7 @@ const getSpendTargetOtherParams = (state: RootState): Object => {
 }
 
 export const getSpendInfo = (state: RootState, newSpendInfo?: GuiMakeSpendInfo = {}, selectedCurrencyCode?: string): EdgeSpendInfo => {
-  const uniqueIdentifier = newSpendInfo.uniqueIdentifier || getUniqueIdentifier(state)
+  const uniqueIdentifier = newSpendInfo.uniqueIdentifier != null ? newSpendInfo.uniqueIdentifier : getUniqueIdentifier(state)
   let spendTargets = []
   if (newSpendInfo.spendTargets) {
     spendTargets = newSpendInfo.spendTargets
@@ -107,8 +107,8 @@ export const getSpendInfo = (state: RootState, newSpendInfo?: GuiMakeSpendInfo =
         nativeAmount: newSpendInfo.nativeAmount || getNativeAmount(state),
         publicAddress: newSpendInfo.publicAddress || getPublicAddress(state),
         otherParams: {
-          uniqueIdentifier,
-          ...getSpendTargetOtherParams(state)
+          ...getSpendTargetOtherParams(state),
+          uniqueIdentifier
         }
       }
     ]


### PR DESCRIPTION
uniqueIdentifiers can be an empty string so we need to use it as such if it is present. Since we're grabbing it from newSpendInfo (or state) already we shouldn't stomp on top of it with the result of getSpendTargetOtherParams.