### PR TITLE
Change LineTextDivider font weight from 'bold' to 'medium'

### DIFF
--- a/src/components/themed/LineTextDivider.js
+++ b/src/components/themed/LineTextDivider.js
@@ -44,7 +44,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   title: {
     fontSize: theme.rem(1),
     paddingHorizontal: theme.rem(0.75),
-    fontFamily: theme.fontFaceBold,
+    fontFamily: theme.fontFaceMedium,
     color: theme.secondaryText
   },
   lowerCase: {


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android