### PR TITLE
Blur the keyboard before re-focus works for some Android devices

### DIFF
--- a/src/components/themed/FlipInput.js
+++ b/src/components/themed/FlipInput.js
@@ -366,6 +366,7 @@ class FlipInputComponent extends React.PureComponent<Props, State> {
   textInputFrontFocus = async () => {
     this.openClipboardMenu()
     if (this.textInputFront) {
+      this.textInputFront.blur()
       this.textInputFront.focus()
     }
   }
@@ -426,6 +427,7 @@ class FlipInputComponent extends React.PureComponent<Props, State> {
   textInputBackFocus = async () => {
     this.openClipboardMenu()
     if (this.textInputBack) {
+      this.textInputFront.blur()
       this.textInputBack.focus()
     }
   }


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a