### PR TITLE
Add queries section to Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,13 @@
   <uses-sdk
     android:targetSdkVersion="28" />
 
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <category android:name="android.intent.category.BROWSABLE" />
+      <data android:scheme="https" />
+    </intent>
+  </queries>
   <application
     android:name=".MainApplication"
     android:label="@string/app_name"


### PR DESCRIPTION
This is a new requirement for Android version 30. Requests to launch other apps are filtered by this setting and is necessary to allow users to bounce out to the browser to view transaction and address explorer links.
