### PR TITLE
Force Android to create a compressed APK

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
     android:icon="@mipmap/ic_launcher"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:allowBackup="false"
+    android:extractNativeLibs="true"
     android:theme="@style/AppTheme"
     android:usesCleartextTraffic="true">
     <meta-data android:name="com.bugsnag.android.API_KEY"


### PR DESCRIPTION
[Stackoverflow](https://stackoverflow.com/questions/62440105/apk-size-increased-35mb-when-bumping-min-sdk-from-21-to-24)

I also tested it on the Yolo branch and it seems to be working

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201411731543821