### PR TITLE
Work around an unexplained bugsnag crash

### DIFF
--- a/src/components/scenes/GuiPluginListScene.js
+++ b/src/components/scenes/GuiPluginListScene.js
@@ -243,7 +243,7 @@ class GuiPluginList extends React.PureComponent<Props, State> {
 
   render() {
     const { accountPlugins, accountReferral, countryCode, developerModeOn, theme, route } = this.props
-    const { direction } = route.params
+    const { direction } = route.params ?? { direction: 'buy' }
     const styles = getStyles(theme)
     const countryData = COUNTRY_CODES.find(country => country['alpha-2'] === countryCode)
 


### PR DESCRIPTION
There is nowhere in the code where `route.params` can be `undefined`, and yet we are getting rare crashes on iOS. Avoid that.

#### PR Requirements

I cannot test this because we don't know how to reproduce the crash. Let's get it in the stores and see if Bugsnag cleans up.

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a