### PR TITLE
Reordered Banxa Buy Options

### DIFF
--- a/src/constants/plugins/buyPluginList.json
+++ b/src/constants/plugins/buyPluginList.json
@@ -881,7 +881,7 @@
   },
   {
     "id": "banxa.bank",
-    "sortIndex": 1
+    "sortIndex": 4.5
   },
   {
     "id": "banxa.sofort",
@@ -901,7 +901,7 @@
   },
   {
     "id": "banxa.credit",
-    "sortIndex": 4.5
+    "sortIndex": 1
   },
   {
     "id": "libertyx",


### PR DESCRIPTION
Reorder Banxa Buy options so that POLi is not the 1st option in the buy list for Australia. POLi does not accept new customers but returning customers only.
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1200457843986540