### PR TITLE
Fix random extra space

### DIFF
--- a/src/components/scenes/SendScene.js
+++ b/src/components/scenes/SendScene.js
@@ -456,7 +456,8 @@ class SendComponent extends React.PureComponent<Props, State> {
       const feeDefaultDenomination = getExchangeDenomination(wallet.currencyInfo.pluginId, wallet.currencyInfo.currencyCode)
       const transactionFee = convertTransactionFeeToDisplayFee(wallet, exchangeRates, transaction, feeDisplayDenomination, feeDefaultDenomination)
 
-      const feeSyntax = `${transactionFee.cryptoSymbol ?? ''} ${transactionFee.cryptoAmount} (${transactionFee.fiatSymbol ?? ''} ${transactionFee.fiatAmount})`
+      const fiatAmount = transactionFee.fiatAmount === '0' ? '0' : ` ${transactionFee.fiatAmount}`
+      const feeSyntax = `${transactionFee.cryptoSymbol ?? ''} ${transactionFee.cryptoAmount} (${transactionFee.fiatSymbol ?? ''}${fiatAmount})`
       const feeSyntaxStyle = transactionFee.fiatStyle
 
       return (


### PR DESCRIPTION
The little fix got lost in a rebase. The current default string is:

Fee
0 ( 0)

This changes it to:

Fee
0 (0)