### PR TITLE
Create utility to safely use a GuiWallet where it may not exist yet

### DIFF
--- a/src/components/scenes/ManageTokensScene.js
+++ b/src/components/scenes/ManageTokensScene.js
@@ -12,7 +12,7 @@ import { getSpecialCurrencyInfo, PREFERRED_TOKENS } from '../../constants/Wallet
 import s from '../../locales/strings.js'
 import { connect } from '../../types/reactRedux.js'
 import { type NavigationProp, type RouteProp } from '../../types/routerTypes.js'
-import type { CustomTokenInfo, GuiWallet } from '../../types/types.js'
+import { type CustomTokenInfo, type GuiWallet, asSafeDefaultGuiWallet } from '../../types/types.js'
 import { mergeTokensRemoveInvisible } from '../../util/utils'
 import { SceneWrapper } from '../common/SceneWrapper.js'
 import { WalletListModal } from '../modals/WalletListModal'
@@ -266,7 +266,7 @@ export const ManageTokensScene = connect<StateProps, DispatchProps, OwnProps>(
     manageTokensPending: state.ui.wallets.manageTokensPending,
     settingsCustomTokens: state.ui.settings.customTokens,
     wallets: state.ui.wallets.byId,
-    enabledTokens: state.ui.wallets.byId[params.walletId].enabledTokens
+    enabledTokens: asSafeDefaultGuiWallet(state.ui.wallets.byId[params.walletId]).enabledTokens
   }),
   dispatch => ({
     setEnabledTokensList(walletId: string, enabledTokens: string[], oldEnabledTokensList: string[]) {

--- a/src/components/themed/WalletList.js
+++ b/src/components/themed/WalletList.js
@@ -11,6 +11,7 @@ import { type SettingsState } from '../../reducers/scenes/SettingsReducer.js'
 import { calculateWalletFiatBalanceUsingDefaultIsoFiat } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
 import type { CreateTokenType, CreateWalletType, CustomTokenInfo, FlatListItem, GuiWallet, MostRecentWallet } from '../../types/types.js'
+import { asSafeDefaultGuiWallet } from '../../types/types.js'
 import { getCreateWalletTypes, getCurrencyIcon, getCurrencyInfos } from '../../util/CurrencyInfoHelpers.js'
 import { type FilterDetailsType, alphabeticalSort, checkCurrencyCodes, checkFilterWallet } from '../../util/utils'
 import { WalletListMenuModal } from '../modals/WalletListMenuModal.js'
@@ -158,17 +159,16 @@ class WalletListComponent extends React.PureComponent<Props> {
             : () => {}
         })
       } else if (wallet != null) {
-        const { enabledTokens } = wallet
+        const { enabledTokens, name, currencyCode, currencyNames } = asSafeDefaultGuiWallet(wallet)
         const { customTokens } = this.props
 
         // Initialize wallets
-        if (this.checkFilterWallet({ name: wallet.name, currencyCode: wallet.currencyCode, currencyName: wallet.currencyNames[wallet.currencyCode] })) {
+        if (this.checkFilterWallet({ name, currencyCode, currencyName: currencyNames[currencyCode] })) {
           walletList.push({
             id: walletId,
-            fullCurrencyCode: wallet.currencyCode,
-            key: `${walletId}-${wallet.currencyCode}`,
-            onPress: () =>
-              this.props.onPress != null ? this.props.onPress(walletId, wallet.currencyCode) : this.props.selectWallet(walletId, wallet.currencyCode)
+            fullCurrencyCode: currencyCode,
+            key: `${walletId}-${currencyCode}`,
+            onPress: () => (this.props.onPress != null ? this.props.onPress(walletId, currencyCode) : this.props.selectWallet(walletId, currencyCode))
           })
         }
 
@@ -182,18 +182,16 @@ class WalletListComponent extends React.PureComponent<Props> {
         })
 
         // Initialize tokens
-        for (const currencyCode of enabledNotHiddenTokens) {
-          const fullCurrencyCode = `${wallet.currencyCode}-${currencyCode}`
-          const customTokenInfo = wallet.currencyNames[currencyCode] ? undefined : customTokens.find(token => token.currencyCode === currencyCode)
+        for (const tokenCode of enabledNotHiddenTokens) {
+          const fullCurrencyCode = `${currencyCode}-${tokenCode}`
+          const customTokenInfo = currencyNames[tokenCode] ? undefined : customTokens.find(token => token.currencyCode === tokenCode)
 
-          if (
-            this.checkFilterWallet({ name: wallet.name, currencyCode, currencyName: customTokenInfo?.currencyName ?? wallet.currencyNames[currencyCode] ?? '' })
-          ) {
+          if (this.checkFilterWallet({ name, currencyCode, currencyName: customTokenInfo?.currencyName ?? currencyNames[tokenCode] ?? '' })) {
             walletList.push({
               id: walletId,
               fullCurrencyCode: fullCurrencyCode,
               key: `${walletId}-${fullCurrencyCode}`,
-              onPress: () => (this.props.onPress != null ? this.props.onPress(walletId, currencyCode) : this.props.selectWallet(walletId, currencyCode))
+              onPress: () => (this.props.onPress != null ? this.props.onPress(walletId, tokenCode) : this.props.selectWallet(walletId, tokenCode))
             })
           }
         }

--- a/src/components/themed/WalletListCurrencyRow.js
+++ b/src/components/themed/WalletListCurrencyRow.js
@@ -8,7 +8,7 @@ import { formatNumber } from '../../locales/intl.js'
 import { getDisplayDenomination, getExchangeDenomination } from '../../selectors/DenominationSelectors.js'
 import { calculateWalletFiatBalanceWithoutState } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
-import { type GuiExchangeRates } from '../../types/types.js'
+import { type GuiExchangeRates, asSafeDefaultGuiWallet } from '../../types/types.js'
 import { getCryptoAmount, getCurrencyInfo, getDenomFromIsoCode, getFiatSymbol, getYesterdayDateRoundDownHour, zeroString } from '../../util/utils'
 import { type Theme, type ThemeProps, cacheStyles, withTheme } from '../services/ThemeContext.js'
 import { CardContent } from './CardContent'
@@ -171,7 +171,7 @@ export const WalletListCurrencyRow = connect<StateProps, {}, OwnProps>(
   (state, ownProps) => {
     const { currencyCode, walletName, walletId } = ownProps
     const wallet = state.core.account.currencyWallets[walletId]
-    const guiWallet = state.ui.wallets.byId[walletId]
+    const guiWallet = asSafeDefaultGuiWallet(state.ui.wallets.byId[walletId])
 
     const exchangeRates = state.exchangeRates
     const showBalance = state.ui.settings.isAccountBalanceVisible

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -33,6 +33,19 @@ export type GuiWallet = {
   blockHeight: number | null
 }
 
+// FIXME: Bandaid for when the GuiWallet object isn't quite ready when some components are loaded
+export const asSafeDefaultGuiWallet = <T>(guiWallet: T): T => ({
+  ...asOptional(
+    asObject({
+      name: asOptional(asString, ''),
+      currencyNames: asOptional(asObject(asString), {}),
+      currencyCode: asOptional(asString, ''),
+      enabledTokens: asOptional(asArray(asString), [])
+    })
+  )(guiWallet),
+  ...guiWallet
+})
+
 export type GuiDenomination = EdgeDenomination
 export type GuiCurrencyInfo = {
   displayCurrencyCode: string,


### PR DESCRIPTION
There are some scenes and components that attempt to access new GuiWallets before they exist in state. This utility wraps the GuiWallet and returns safe defaults where these edge cases exist.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201744067064433