### PR TITLE
Replace calculateWalletFiatBalanceWithoutState and calculateWalletFiatBalanceUsingDefaultIsoFiat

### DIFF
--- a/src/components/themed/WalletListCurrencyRow.js
+++ b/src/components/themed/WalletListCurrencyRow.js
@@ -6,7 +6,7 @@ import * as React from 'react'
 
 import { formatNumber } from '../../locales/intl.js'
 import { getDisplayDenomination, getExchangeDenomination } from '../../selectors/DenominationSelectors.js'
-import { calculateWalletFiatBalanceWithoutState } from '../../selectors/WalletSelectors.js'
+import { calculateFiatBalance } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
 import { type GuiExchangeRates, asSafeDefaultGuiWallet } from '../../types/types.js'
 import { getCryptoAmount, getCurrencyInfo, getDenomFromIsoCode, getFiatSymbol, getYesterdayDateRoundDownHour, zeroString } from '../../util/utils'
@@ -192,7 +192,7 @@ export const WalletListCurrencyRow = connect<StateProps, {}, OwnProps>(
 
     // Fiat Balance
     const walletFiatSymbol = getFiatSymbol(guiWallet.isoFiatCurrencyCode)
-    const fiatBalance = calculateWalletFiatBalanceWithoutState(wallet, currencyCode, exchangeRates)
+    const fiatBalance = calculateFiatBalance(wallet, exchangeDenomination, exchangeRates)
     const fiatBalanceFormat = fiatBalance && parseFloat(fiatBalance) > 0.000001 ? fiatBalance : '0'
     const fiatBalanceSymbol = showBalance && exchangeRate ? walletFiatSymbol : ''
     const fiatBalanceString = showBalance && exchangeRate ? fiatBalanceFormat : ''


### PR DESCRIPTION
These two functions didn't handle custom tokens. They were replaced with a new function called calculateFiatBalance that accepts an exchange denomination instead of a currency code.

To see the specific tasks where the Asana app for GitHub is being used, see below:
https://app.asana.com/0/0/1201760396470480