### PR TITLE
Show BitPay error properly for ERC20 wallets

### DIFF
--- a/src/components/themed/AddressTile.js
+++ b/src/components/themed/AddressTile.js
@@ -124,7 +124,7 @@ class AddressTileComponent extends React.PureComponent<Props, State> {
       onChangeAddress({ fioAddress, isSendUsingFioAddress: !!fioAddress }, parsedUri)
     } catch (e) {
       const currencyInfo = coreWallet.currencyInfo
-      const ercTokenStandard = currencyInfo.defaultSettings?.otherSettings ?? ''
+      const ercTokenStandard = currencyInfo.defaultSettings?.otherSettings?.ercTokenStandard ?? ''
       if (ercTokenStandard === 'ERC20' && parseDeepLink(address).type === 'bitPay')
         showError(new BitPayError(BitPayErrorCode.CurrencyNotSupported, { text: currencyInfo.currencyCode }))
       else showError(`${s.strings.scan_invalid_address_error_title} ${s.strings.scan_invalid_address_error_description}`)


### PR DESCRIPTION
Previous fix was not properly detecting if the selected wallet was ERC20

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ x] Tested on iOS Tablet
- [ x] Tested on small Android
- [ ] n/a

https://user-images.githubusercontent.com/90650827/152460273-41cefec6-dc28-4595-8d67-67b6429fde13.mp4


