### PR TITLE
Add additional bitpay url handling to address tile

### DIFF
--- a/src/components/themed/AddressTile.js
+++ b/src/components/themed/AddressTile.js
@@ -124,9 +124,16 @@ class AddressTileComponent extends React.PureComponent<Props, State> {
     } catch (e) {
       const currencyInfo = coreWallet.currencyInfo
       const ercTokenStandard = currencyInfo.defaultSettings?.otherSettings?.ercTokenStandard ?? ''
-      if (ercTokenStandard === 'ERC20' && parseDeepLink(address).type === 'bitPay')
-        showError(new BitPayError('CurrencyNotSupported', { text: currencyInfo.currencyCode }))
-      else showError(`${s.strings.scan_invalid_address_error_title} ${s.strings.scan_invalid_address_error_description}`)
+      if (parseDeepLink(address).type === 'bitPay') {
+        if (ercTokenStandard === 'ERC20') {
+          showError(new BitPayError('CurrencyNotSupported', { text: currencyInfo.currencyCode }))
+        } else {
+          await launchBitPay(address, { wallet: coreWallet }).catch(showError)
+        }
+      } else {
+        showError(`${s.strings.scan_invalid_address_error_title} ${s.strings.scan_invalid_address_error_description}`)
+      }
+
       this.setState({ loading: false })
     }
   }


### PR DESCRIPTION
Bitpay v2 isn't widely supported across the plugins so parseUri would throw and skip the bitpay check.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201931726642895