### PR TITLE
Bump up Bitpay fees

### DIFF
--- a/src/actions/BitPayActions.js
+++ b/src/actions/BitPayActions.js
@@ -155,7 +155,10 @@ export async function launchBitPay(
   const instructionOutput = invoiceInstruction.outputs[0]
 
   // Make the spend to generate the tx hexes
-  const requiredFeeRate = invoiceInstruction.requiredFeeRate
+  let requiredFeeRate = invoiceInstruction.requiredFeeRate
+  // This is in addition to the 1.5x multiplier in edge-currency-bitcoin. It's an additional buffer
+  // because the protocol doesn't discount segwit transactions and we want to make sure the transaction succeeds.
+  if (typeof requiredFeeRate === 'number') requiredFeeRate *= 1.2
   const spendInfo: EdgeSpendInfo = {
     selectedCurrencyCode,
     spendTargets: [


### PR DESCRIPTION
Bitpay doesn't seem to calculate the segwit discount so we need to bump the fees so transactions with many inputs have a larger chance of success


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201818782291351