### PR TITLE
Fix/tomb staking v2/init claim row

### DIFF
--- a/src/components/scenes/Staking/StakeModifyScene.js
+++ b/src/components/scenes/Staking/StakeModifyScene.js
@@ -241,17 +241,19 @@ export const StakeModifyScene = (props: Props) => {
         : sprintf(s.strings.stake_amount_claim, quoteCurrencyCode)
 
     const nativeAmount = zeroString(quoteAllocation?.nativeAmount) ? '' : quoteAllocation?.nativeAmount ?? ''
+    const earnedAmount = existingAllocations?.earned[0].nativeAmount ?? '0'
 
+    const isClaim = allocationType === 'claim'
     return (
       <EditableAmountTile
         title={title}
         exchangeRates={guiExchangeRates}
-        nativeAmount={nativeAmount}
+        nativeAmount={isClaim ? earnedAmount : nativeAmount}
         currencyWallet={currencyWallet}
         currencyCode={quoteCurrencyCode}
         exchangeDenomination={quoteDenom}
         displayDenomination={quoteDenom}
-        lockInputs={allocationType === 'claim'}
+        lockInputs={isClaim}
         onPress={handleShowFlipInputModal(quoteCurrencyCode)}
       />
     )

--- a/src/components/themed/EditableAmountTile.js
+++ b/src/components/themed/EditableAmountTile.js
@@ -34,7 +34,7 @@ export const EditableAmountTile = (props: Props) => {
   const fiatSymbol = fiatDenomination.symbol ? fiatDenomination.symbol : ''
   const theme = useTheme()
   const styles = getStyles(theme)
-  if (nativeAmount === '') {
+  if (nativeAmount === '' && !lockInputs) {
     cryptoAmountSyntax = s.strings.string_tap_to_edit
     cryptoAmountStyle = styles.amountTextMuted
   } else if (!zeroString(nativeAmount)) {


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

Earned tile normally relies on an initial quote fetch request (Claim Rewards scene) or an unstake amount (Unstake and Claim Rewards scene). 
Force the earned tile to always show the amount pulled from the existing allocations instead of the fetched quote based on user amount modifications.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202090255556889