### PR TITLE
Fix missing FIO handle on SendConfirmation

### DIFF
--- a/src/actions/SendConfirmationActions.js
+++ b/src/actions/SendConfirmationActions.js
@@ -85,7 +85,16 @@ export const sendConfirmationUpdateTx =
     })
 
     const amountRequired = getAmountRequired(spendInfo)
-    if (amountRequired && guiMakeSpendInfo.nativeAmount === '') return
+    if (amountRequired && guiMakeSpendInfo.nativeAmount === '')
+      return dispatch({
+        type: 'UI/SEND_CONFIRMATION/UPDATE_TRANSACTION',
+        data: {
+          error: null,
+          forceUpdateGui,
+          guiMakeSpendInfo: guiMakeSpendInfoClone,
+          transaction: null
+        }
+      })
 
     if (maxSpendSet && isFeeChanged) {
       return dispatch(updateMaxSpend(walletId, selectedCurrencyCode || state.ui.wallets.selectedCurrencyCode, guiMakeSpendInfoClone))

--- a/src/components/scenes/SendScene.js
+++ b/src/components/scenes/SendScene.js
@@ -100,7 +100,7 @@ class SendComponent extends React.PureComponent<Props, State> {
 
   constructor(props: Props) {
     super(props)
-    const { route } = this.props
+    const { route } = props
     const { selectedWalletId, selectedCurrencyCode, guiMakeSpendInfo } = route.params
     const fioPendingRequest = guiMakeSpendInfo?.fioPendingRequest
     this.state = {


### PR DESCRIPTION
After choosing a FIO handle, handleChangeAddress must update the guiMakeSpendInfo through sendConfirmationUpdateTx. However, since there is no amount at the time the address is chosen, sendConfirmationUpdateTx early exits and the fioAddress in the guiMakeSpendInfo is lost.

Fix by dispatching an update with a null tx but with guiMakeSpendInfo

Also fix bug where SendScene connector tries to access this.props instead of 'props'

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202052231522987