### PR TITLE
Set overridePrimaryDecimalAmount's default value to '0'

### DIFF
--- a/src/components/themed/FlipInput.js
+++ b/src/components/themed/FlipInput.js
@@ -144,7 +144,7 @@ const getInitialState = (props: Props) => {
     isToggled: false,
     textInputFrontFocus: false,
     textInputBackFocus: false,
-    overridePrimaryDecimalAmount: '',
+    overridePrimaryDecimalAmount: '0',
     primaryDisplayAmount: '',
     forceUpdateGuiCounter: 0,
     secondaryDisplayAmount: '',


### PR DESCRIPTION
state.overridePrimaryDecimalAmount's default value is '' if it is not explicitly set in the incoming props. This ends up later getting set to '0' in UNSAFE_componentWillReceiveProps, causing a re-render, overwriting any user input that may have already been set before the re-render.

Change the default value of overridePrimaryDecimalAmount's to '0' instead of ''

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202109297809356