### PR TITLE
Remove in-place sort on stake/reward assets in policyInfo

### DIFF
--- a/src/plugins/stake-plugins/stakePolicy.js
+++ b/src/plugins/stake-plugins/stakePolicy.js
@@ -14,26 +14,12 @@ export type StakePolicyInfo = {|
   mustClaimRewards: boolean
 |}
 
-const sortAssetIds = (a: AssetId, b: AssetId): number => {
-  if (a.pluginId < b.pluginId) return -1
-  if (a.pluginId > b.pluginId) return 1
-  if (a.tokenId < b.tokenId) return -1
-  if (a.tokenId > b.tokenId) return 1
-  return 0
-}
-
 // Generate a unique deterministic ID for the policy
 const deriveStakePolicyId = (policyInfo: StakePolicyInfo): string => {
   const { liquidityPool } = policyInfo
   const liquidityPoolPart = liquidityPool ? `${liquidityPool.pluginId}:${liquidityPool.lpId}/` : ''
-  const stakePart = policyInfo.stakeAssets
-    .sort(sortAssetIds)
-    .map(asset => `${asset.pluginId}:${asset.tokenId}`)
-    .join('+')
-  const rewardPart = policyInfo.rewardAssets
-    .sort(sortAssetIds)
-    .map(asset => `${asset.pluginId}:${asset.tokenId}`)
-    .join('+')
+  const stakePart = policyInfo.stakeAssets.map(asset => `${asset.pluginId}:${asset.tokenId}`).join('+')
+  const rewardPart = policyInfo.rewardAssets.map(asset => `${asset.pluginId}:${asset.tokenId}`).join('+')
   return `${liquidityPoolPart}${stakePart}=${rewardPart}`.toLowerCase()
 }
 


### PR DESCRIPTION
Because `.sort()` mutates the array in-place, this causes the mutation
to leak outside of the scope of the `deriveStakePolicyId`.
One solution is to clone the array before the sort, but a conscious
decision to revert this sorting is made because it is actually
unnecessary to sort.
Furthermore, it makes more sense to not sort because it matches the
official pool names by Tomb Finance (e.g. TOMB_FTM_LP not FTM_TOMB_LP)
and it avoids the need for yet another change to the `stakePolicyIds`
on the info-server.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202169512131807