### PR TITLE
Remove @react-native-community/art dependency

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -523,8 +523,6 @@ PODS:
     - React-jsi (= 0.67.2)
     - React-logger (= 0.67.2)
     - React-perflogger (= 0.67.2)
-  - ReactNativeART (1.2.0):
-    - React
   - RNCAsyncStorage (1.6.2):
     - React
   - RNCClipboard (1.5.1):
@@ -770,7 +768,6 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - "ReactNativeART (from `../node_modules/@react-native-community/art`)"
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
@@ -966,8 +963,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
-  ReactNativeART:
-    :path: "../node_modules/@react-native-community/art"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-community/async-storage"
   RNCClipboard:
@@ -1116,7 +1111,6 @@ SPEC CHECKSUMS:
   React-RCTVibration: 99c7f67fba7a5ade46e98e870c6ff2444484f995
   React-runtimeexecutor: 2450b43df7ffe8e805a0b3dcb2abd4282f1f1836
   ReactCommon: d98c6c96b567f9b3a15f9fd4cc302c1eda8e3cf2
-  ReactNativeART: 78edc68dd4a1e675338cd0cd113319cf3a65f2ab
   RNCAsyncStorage: 60a80e72d95bf02a01cace55d3697d9724f0d77f
   RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
   RNCPicker: 6d5d64e7b90c240c779ee0938ec433c11e2dd758

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   "dependencies": {
     "@bugsnag/react-native": "^7.3.5",
     "@ethersproject/shims": "^5.6.0",
-    "@react-native-community/art": "^1.2.0",
     "@react-native-community/async-storage": "^1.6.2",
     "@react-native-community/blur": "^3.6.0",
     "@react-native-community/clipboard": "^1.5.1",

--- a/patches/edge-login-ui-rn+0.9.32.patch
+++ b/patches/edge-login-ui-rn+0.9.32.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/edge-login-ui-rn/lib/components/common/QrCode.js b/node_modules/edge-login-ui-rn/lib/components/common/QrCode.js
+index e10398f..7009159 100644
+--- a/node_modules/edge-login-ui-rn/lib/components/common/QrCode.js
++++ b/node_modules/edge-login-ui-rn/lib/components/common/QrCode.js
+@@ -1,4 +1,4 @@
+-import { Shape, Surface } from '@react-native-community/art';
++import Svg, { Path } from 'react-native-svg';
+ import qrcodeGenerator from 'qrcode-generator';
+ import * as React from 'react';
+ /**
+@@ -14,6 +14,7 @@ export function QrCode(props) {
+     const path = svg.replace(/.*d="([^"]*)".*/, '$1');
+     // Create a drawing transform to scale QR cells to device pixels:
+     const sizeInCells = code.getModuleCount() + 2 * padding;
+-    return (React.createElement(Surface, { height: size, width: size, style: { backgroundColor } },
+-        React.createElement(Shape, { d: path, fill: foregroundColor, scale: size / sizeInCells })));
++    const viewBox = `0 0 ${sizeInCells} ${sizeInCells}`
++    return (React.createElement(Svg, { height: size, width: size, style: { backgroundColor }, viewBox: viewBox },
++        React.createElement(Path, { d: path, fill: foregroundColor })));
+ }

--- a/src/components/themed/QrCode.js
+++ b/src/components/themed/QrCode.js
@@ -1,10 +1,10 @@
 // @flow
 
-import { Shape, Surface, Transform } from '@react-native-community/art'
 import qrcodeGenerator from 'qrcode-generator'
 import * as React from 'react'
 import { ActivityIndicator, TouchableWithoutFeedback, View } from 'react-native'
 import Animated, { useAnimatedStyle, useDerivedValue, withTiming } from 'react-native-reanimated'
+import Svg, { Path } from 'react-native-svg'
 
 import { useState } from '../../types/reactHooks'
 import { fixSides, mapSides, sidesToMargin } from '../../util/sides.js'
@@ -46,7 +46,7 @@ export function QrCode(props: Props) {
 
   // Create a drawing transform to scale QR cells to device pixels:
   const sizeInCells = code.getModuleCount() + 2 * cellsPadding
-  const transform = new Transform().scale(size / sizeInCells)
+  const viewBox = `0 0 ${sizeInCells} ${sizeInCells}`
 
   return (
     <TouchableWithoutFeedback onPress={onPress}>
@@ -54,9 +54,9 @@ export function QrCode(props: Props) {
         <ActivityIndicator color={theme.iconTappable} />
         <Animated.View style={[styles.whiteBox, fadeStyle]}>
           {size <= 0 ? null : (
-            <Surface height={size} width={size} style={styles.surface}>
-              <Shape d={path} fill={theme.qrForegroundColor} transform={transform} />
-            </Surface>
+            <Svg height={size} width={size} viewBox={viewBox}>
+              <Path d={path} fill={theme.qrForegroundColor} />
+            </Svg>
           )}
         </Animated.View>
       </View>
@@ -81,8 +81,5 @@ const getStyles = cacheStyles((theme: Theme) => ({
     position: 'absolute',
     right: 0,
     top: 0
-  },
-  surface: {
-    backgroundColor: theme.qrBackgroundColor
   }
 }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,15 +2021,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-community/art@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/art/-/art-1.2.0.tgz#386d95393f6042d9006f9d4bc6063fb898794460"
-  integrity sha512-a+ZcRGl/BzLa89yi33Mbn5SHavsEXqKUMdbfLf3U8MDLElndPqUetoJyGkv63+BcPO49UMWiQRP1YUz6/zfJ+A==
-  dependencies:
-    art "^0.10.3"
-    invariant "^2.2.4"
-    prop-types "^15.7.2"
-
 "@react-native-community/async-storage@^1.6.2":
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.6.2.tgz#a19ca7149c4dfe8216f2330e6b1ebfe2d075ef92"
@@ -3498,11 +3489,6 @@ array.prototype.flatmap@^1.2.4:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
     function-bind "^1.1.1"
-
-art@^0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/art/-/art-0.10.3.tgz#b01d84a968ccce6208df55a733838c96caeeaea2"
-  integrity sha512-HXwbdofRTiJT6qZX/FnchtldzJjS3vkLJxQilc3Xj+ma2MXjY4UAyQ0ls1XZYVnDvVIBiFZbC6QsvtW86TD6tQ==
 
 asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"


### PR DESCRIPTION
Since we are using react-native-svg, we don't need a second native graphics library.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a