### PR TITLE
Fix 'highest' wallet sort

### DIFF
--- a/src/components/themed/WalletList.js
+++ b/src/components/themed/WalletList.js
@@ -132,7 +132,9 @@ export function WalletList(props: Props) {
     if (walletsSort === 'highest') {
       walletList.sort((itemA, itemB) => {
         if (itemA.id == null || itemB.id == null || wallets[itemA.id] === undefined || wallets[itemB.id] === undefined) return 0
-        return getFiatBalance(wallets[itemB.id ?? ''], itemB.fullCurrencyCode || '') - getFiatBalance(wallets[itemA.id ?? ''], itemA.fullCurrencyCode || '')
+        const aBalance = getFiatBalance(wallets[itemB.id ?? ''], itemB.fullCurrencyCode || '')
+        const bBalance = getFiatBalance(wallets[itemA.id ?? ''], itemA.fullCurrencyCode || '')
+        return aBalance - bBalance
       })
     }
 

--- a/src/components/themed/WalletListSortableRow.js
+++ b/src/components/themed/WalletListSortableRow.js
@@ -1,13 +1,13 @@
 // @flow
 
-import { div } from 'biggystring'
+import { div, gt } from 'biggystring'
 import { type EdgeCurrencyWallet, type EdgeDenomination } from 'edge-core-js'
 import * as React from 'react'
 import { ActivityIndicator, TouchableOpacity, View } from 'react-native'
 import Ionicon from 'react-native-vector-icons/Ionicons'
 
-import { getSymbolFromCurrency } from '../../constants/WalletAndCurrencyConstants.js'
-import { formatNumberInput } from '../../locales/intl.js'
+import { FIAT_PRECISION, getSymbolFromCurrency } from '../../constants/WalletAndCurrencyConstants.js'
+import { formatNumber, formatNumberInput } from '../../locales/intl.js'
 import { getDisplayDenominationFromState, getExchangeDenomination } from '../../selectors/DenominationSelectors.js'
 import { calculateFiatBalance } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
@@ -65,9 +65,9 @@ export class WalletListSortableRowComponent extends React.PureComponent<Props> {
     const finalCryptoAmount = formatNumberInput(decimalOrZero(preliminaryCryptoAmount, 6)) // make it show zero if infinitesimal number
     const finalCryptoAmountString = showBalance ? `${symbol || ''} ${finalCryptoAmount}` : ''
     const fiatBalance = calculateFiatBalance(wallet, exchangeDenomination, exchangeRates)
-    const fiatBalanceFormat = fiatBalance && parseFloat(fiatBalance) > 0.000001 ? fiatBalance : 0
+    const fiatBalanceFormat = fiatBalance && gt(fiatBalance, '0.000001') ? fiatBalance : 0
     const fiatBalanceSymbol = showBalance && walletFiatSymbol ? walletFiatSymbol : ''
-    const fiatBalanceString = showBalance ? fiatBalanceFormat : ''
+    const fiatBalanceString = showBalance ? formatNumber(fiatBalanceFormat, { toFixed: FIAT_PRECISION }) : ''
 
     return (
       <View style={styles.container}>

--- a/src/selectors/WalletSelectors.js
+++ b/src/selectors/WalletSelectors.js
@@ -3,8 +3,6 @@
 import { mul } from 'biggystring'
 import { type EdgeCurrencyWallet, type EdgeDenomination } from 'edge-core-js'
 
-import { FIAT_PRECISION } from '../constants/WalletAndCurrencyConstants.js'
-import { formatNumber } from '../locales/intl.js'
 import { type Dispatch, type GetState, type RootState } from '../types/reduxTypes'
 import { type GuiWallet } from '../types/types.js'
 import { getWalletFiat } from '../util/CurrencyWalletHelpers.js'
@@ -88,7 +86,7 @@ export const calculateFiatBalance = (wallet: EdgeCurrencyWallet, exchangeDenomin
   const cryptoAmount = convertNativeToExchange(nativeToExchangeRatio)(nativeBalance)
   const { isoFiatCurrencyCode } = getWalletFiat(wallet)
   const fiatValue = convertCurrencyFromExchangeRates(exchangeRates, currencyCode, isoFiatCurrencyCode, cryptoAmount)
-  return formatNumber(fiatValue, { toFixed: FIAT_PRECISION }) || '0'
+  return fiatValue
 }
 
 export const findWalletByFioAddress = async (state: RootState, fioAddress: string): Promise<EdgeCurrencyWallet | null> => {


### PR DESCRIPTION
The problem was we were using `parseFloat` on a formatted number string.
We fix this by moving the formatting into the component, where it
more rightly belongs.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201771696787124