### PR TITLE
Fix startup crash on Android 12

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -201,7 +201,7 @@ dependencies {
     }
 
     // Edge additions:
-    implementation 'androidx.work:work-runtime:2.0.1'
+    implementation 'androidx.work:work-runtime:2.7.1'
     api 'com.google.guava:guava:31.0.1-android'
 
     // If your app supports Android versions before Ice Cream Sandwich (API level 14)


### PR DESCRIPTION
We had an outdated native dependency that wasn't compatible.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [x] Tested on small Android
- [ ] n/a