### PR TITLE
Use currencyCode prop for FiatText in RequestScene

### DIFF
--- a/src/components/scenes/RequestScene.js
+++ b/src/components/scenes/RequestScene.js
@@ -314,7 +314,7 @@ export class RequestComponent extends React.Component<Props, State> {
                 <FiatText
                   format="primary"
                   nativeCryptoAmount={primaryCurrencyInfo.displayDenomination.multiplier}
-                  tokenId={primaryCurrencyInfo.displayCurrencyCode}
+                  currencyCode={primaryCurrencyInfo.displayCurrencyCode}
                   wallet={wallet}
                 />
               </EdgeText>


### PR DESCRIPTION
Use backwards-compatible  currencyCode prop for FiatText in RequestScene.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ x] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202268905852763