### PR TITLE
Enforce theme font for TickerText

### DIFF
--- a/src/components/text/TickerText.js
+++ b/src/components/text/TickerText.js
@@ -7,6 +7,7 @@ import { Text } from 'react-native'
 
 import { useFiatText } from '../../hooks/useFiatText'
 import { useTokenDisplayData } from '../../hooks/useTokenDisplayData'
+import { useMemo } from '../../types/reactHooks'
 import { type Theme } from '../../types/Theme'
 import { truncateDecimals, zeroString } from '../../util/utils'
 import { useTheme } from '../services/ThemeContext'
@@ -59,5 +60,8 @@ export const TickerText = ({ wallet, tokenId }: Props) => {
   const { percentString, deltaColorStyle } = getPercentDeltaString(currencyCode, assetToFiatRate, assetToYestFiatRate, usdToWalletFiatRate, theme)
 
   const tickerText = `${fiatText} ${percentString}`
-  return <Text style={{ color: deltaColorStyle }}>{tickerText}</Text>
+
+  const textStyle = useMemo(() => ({ color: deltaColorStyle, fontFamily: theme.fontFaceDefault }), [deltaColorStyle, theme.fontFaceDefault])
+
+  return <Text style={textStyle}>{tickerText}</Text>
 }


### PR DESCRIPTION
TickerText ultimately returns a plain Text object , but the font is not enforced. Update TickerText to enforce the font set by the theme.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x ] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202270489802954