### PR TITLE
Update WalletListModal search state logic

### DIFF
--- a/src/components/modals/WalletListModal.js
+++ b/src/components/modals/WalletListModal.js
@@ -81,9 +81,12 @@ export function WalletListModal(props: Props) {
     },
     [bridge]
   )
-  const handleClearText = useCallback(() => setSearchText(''), [])
-  const handleTextFieldBlur = useCallback(() => setSearching(false), [])
-  const handleTextFieldFocus = useCallback(() => setSearching(true), [])
+  const handleSearchClear = useCallback(() => {
+    setSearchText('')
+    setSearching(false)
+  }, [])
+  const handleSearchUnfocus = useCallback(() => setSearching(searchText.length > 0), [searchText.length])
+  const handleSearchFocus = useCallback(() => setSearching(true), [])
 
   return (
     <ThemedModal bridge={bridge} onCancel={handleCancel}>
@@ -92,9 +95,9 @@ export function WalletListModal(props: Props) {
         returnKeyType="search"
         label={s.strings.search_wallets}
         onChangeText={setSearchText}
-        onFocus={handleTextFieldFocus}
-        onBlur={handleTextFieldBlur}
-        onClear={handleClearText}
+        onFocus={handleSearchFocus}
+        onBlur={handleSearchUnfocus}
+        onClear={handleSearchClear}
         value={searchText}
         marginRem={[0.5, 0.75, 1.25]}
         searchIcon


### PR DESCRIPTION
The onBlur callback of OutlinedTextInput search box was hooked up to a call to setSearching(false), clearing the search whenever the user unfocused (onblur) the search box.

Additionally, the expected behavior is such that any time the search is focused OR the user has an active search entered (focused or not), the wallet list is NOT grouped.

Any time the  search input is blank AND unfocused, the wallet list IS grouped.

Update the search state logic such that the behavior is correct for all scenarios.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202259259603058