### PR TITLE
Add handling for undefined allowedCurrencyCodes from EdgeProviders

### DIFF
--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -91,7 +91,7 @@ const asEdgeTokenIdExtended = asObject({
   currencyCode: asOptional(asString)
 })
 
-const asCurrencyCodesArray = asArray(asEither(asString, asEdgeTokenIdExtended))
+const asCurrencyCodesArray = asOptional(asArray(asEither(asString, asEdgeTokenIdExtended)))
 type ExtendedCurrencyCode = string | $Call<typeof asEdgeTokenIdExtended>
 
 export class EdgeProvider extends Bridgeable {
@@ -137,7 +137,7 @@ export class EdgeProvider extends Bridgeable {
   // Set the currency wallet to interact with. This will show a wallet selector modal
   // for the user to pick a wallet within their list of wallets that match `currencyCodes`
   // Returns the currencyCode chosen by the user (store: Store)
-  async chooseCurrencyWallet(allowedCurrencyCodes: ExtendedCurrencyCode[]): Promise<ExtendedCurrencyCode> {
+  async chooseCurrencyWallet(allowedCurrencyCodes: ExtendedCurrencyCode[] | void): Promise<ExtendedCurrencyCode> {
     // Sanity-check our untrusted input:
     asCurrencyCodesArray(allowedCurrencyCodes)
 
@@ -154,7 +154,7 @@ export class EdgeProvider extends Bridgeable {
     if (walletId && currencyCode) {
       this._dispatch(selectWallet(walletId, currencyCode))
       // If allowedCurrencyCodes is an array of EdgeTokenIdExtended objects
-      if (allowedCurrencyCodes.length > 0 && allowedCurrencyCodes.every(code => typeof code === 'object')) {
+      if (allowedCurrencyCodes != null && allowedCurrencyCodes.length > 0 && allowedCurrencyCodes.every(code => typeof code === 'object')) {
         const { pluginId } = this._state.core.account.currencyWallets[walletId].currencyInfo
         const tokenId = getTokenId(this._state.core.account, pluginId, currencyCode)
         return {


### PR DESCRIPTION
Changes to the wallet list asset filtering cause wallet lists shown for providers to crash when the providers provide invalid allowed currency codes.

The pre-existing functionality in these scenarios was to simply show a wallet list modal with no filtering.

Update so the pre-existing functionality is retained and all wallets are shown when invalid allowedCurrencyCodes are given from our providers.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202255988900613
  - https://app.asana.com/0/0/1202263028533454