### PR TITLE
Revert change to TickerText font

### DIFF
--- a/src/components/text/TickerText.js
+++ b/src/components/text/TickerText.js
@@ -7,7 +7,6 @@ import { Text } from 'react-native'
 
 import { useFiatText } from '../../hooks/useFiatText'
 import { useTokenDisplayData } from '../../hooks/useTokenDisplayData'
-import { useMemo } from '../../types/reactHooks'
 import { type Theme } from '../../types/Theme'
 import { truncateDecimals, zeroString } from '../../util/utils'
 import { useTheme } from '../services/ThemeContext'
@@ -60,8 +59,5 @@ export const TickerText = ({ wallet, tokenId }: Props) => {
   const { percentString, deltaColorStyle } = getPercentDeltaString(currencyCode, assetToFiatRate, assetToYestFiatRate, usdToWalletFiatRate, theme)
 
   const tickerText = `${fiatText} ${percentString}`
-
-  const textStyle = useMemo(() => ({ color: deltaColorStyle, fontFamily: theme.fontFaceDefault }), [deltaColorStyle, theme.fontFaceDefault])
-
-  return <Text style={textStyle}>{tickerText}</Text>
+  return <Text style={{ color: deltaColorStyle }}>{tickerText}</Text>
 }


### PR DESCRIPTION
Original issue reported was pre-existing on live on all scenes and components by system-wide custom font changes on Android.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ x] n/a