### PR TITLE
Add custom tabs launched to Edge Provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "react-native-check-version": "^1.0.5",
     "react-native-confetti-cannon": "^1.5.2",
     "react-native-contacts": "^7.0.4",
+    "react-native-custom-tabs": "https://github.com/adminphoeniixx/react-native-custom-tabs#develop",
     "react-native-device-info": "^8.7.1",
     "react-native-extra-dimensions-android": "^1.2.5",
     "react-native-fast-crypto": "^2.2.0",

--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -13,7 +13,8 @@ import type {
   JsonObject
 } from 'edge-core-js'
 import * as React from 'react'
-import { Linking } from 'react-native'
+import { Linking, Platform } from 'react-native'
+import { CustomTabs } from 'react-native-custom-tabs'
 import Mailer from 'react-native-mail'
 import SafariView from 'react-native-safari-view'
 import { sprintf } from 'sprintf-js'
@@ -444,8 +445,8 @@ export class EdgeProvider extends Bridgeable {
     }
   }
 
-  hasSafariView(): Promise<boolean> {
-    return SafariView.isAvailable()
+  hasSafariView(): boolean {
+    return true
   }
 
   // window.fetch.catch(console log then throw)
@@ -519,7 +520,8 @@ export class EdgeProvider extends Bridgeable {
   }
 
   async openSafariView(url: string): Promise<mixed> {
-    SafariView.show({ url })
+    if (Platform.OS === 'ios') SafariView.show({ url })
+    else CustomTabs.openURL(url)
   }
 
   async displayError(error: Error | string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12302,6 +12302,10 @@ react-native-contacts@^7.0.4:
   resolved "https://registry.yarnpkg.com/react-native-contacts/-/react-native-contacts-7.0.4.tgz#6f084f651bb5dde433acc22553c6d1ca909e46b7"
   integrity sha512-x6K9TMC0XBH/yyfqYh5BGS9JI1PpA2Ac/XHVVFVP8F8lPLNexQ0qPsNBo1cy9l2pPqlijpC33+FU0ty/N5iOWA==
 
+"react-native-custom-tabs@https://github.com/adminphoeniixx/react-native-custom-tabs#develop":
+  version "0.1.8"
+  resolved "https://github.com/adminphoeniixx/react-native-custom-tabs#7605cda9d9d691c36367e98d8513937454627ecd"
+
 react-native-device-info@^8.7.1:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.7.1.tgz#fbb06f87dbbc4423abe713874699fb2e6e99fd15"


### PR DESCRIPTION
Add react-native-custom-tabs as described here: https://github.com/adminphoeniixx/react-native-custom-tabs

The original react-native-custom-tabs package is obsolete and the one above is a fork with a couple commits so it works with RN >60

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1199681412563301