### PR TITLE
Deprecate currency code from FiatAmountTile and FiatText

### DIFF
--- a/src/__tests__/modals/FlipInputModal.test.js
+++ b/src/__tests__/modals/FlipInputModal.test.js
@@ -20,6 +20,7 @@ describe('FlipInputModalComponent', () => {
       balanceCrypto: '10000',
       flipInputHeaderText: 'Exchange Header',
       primaryInfo: {
+        tokenId: undefined,
         displayCurrencyCode: 'BTC',
         exchangeCurrencyCode: 'BTC',
         displayDenomination: { multiplier: '100000000000', name: 'BTC' },

--- a/src/__tests__/modals/__snapshots__/FlipInputModal.test.js.snap
+++ b/src/__tests__/modals/__snapshots__/FlipInputModal.test.js.snap
@@ -52,6 +52,7 @@ exports[`FlipInputModalComponent should render with loading props 1`] = `
                 "multiplier": "100000000000",
                 "name": "BTC",
               },
+              "tokenId": undefined,
             }
           }
           secondaryCurrencyInfo={
@@ -141,7 +142,6 @@ exports[`FlipInputModalComponent should render with loading props 1`] = `
             1 BTC 
             (
             <FiatText
-              currencyCode="BTC"
               nativeCryptoAmount="1"
             />
             )
@@ -178,6 +178,7 @@ exports[`FlipInputModalComponent should render with loading props 1`] = `
                   "multiplier": "100000000000",
                   "name": "BTC",
                 },
+                "tokenId": undefined,
               }
             }
             secondaryDisplayAmount="1000"
@@ -230,7 +231,6 @@ exports[`FlipInputModalComponent should render with loading props 1`] = `
             0.0000001 BTC 
             (
             <FiatText
-              currencyCode="BTC"
               nativeCryptoAmount="10000"
             />
             )

--- a/src/components/common/ExchangeRate.js
+++ b/src/components/common/ExchangeRate.js
@@ -72,7 +72,7 @@ class ExchangeRateComponent extends React.Component<OwnProps & ThemeProps & Stat
     return (
       <EdgeText style={style}>
         {primaryText}
-        <FiatText nativeCryptoAmount={primaryInfo.displayDenomination.multiplier} currencyCode={primaryInfo.exchangeCurrencyCode} wallet={wallet} />
+        <FiatText nativeCryptoAmount={primaryInfo.displayDenomination.multiplier} tokenId={primaryInfo.tokenId} wallet={wallet} />
       </EdgeText>
     )
   }

--- a/src/components/modals/FlipInputModal.js
+++ b/src/components/modals/FlipInputModal.js
@@ -19,6 +19,7 @@ import { getExchangeRate } from '../../selectors/WalletSelectors.js'
 import { deviceHeight } from '../../theme/variables/platform.js'
 import { connect } from '../../types/reactRedux.js'
 import type { GuiCurrencyInfo } from '../../types/types.js'
+import { getTokenId } from '../../util/CurrencyInfoHelpers.js'
 import { getAvailableBalance, getWalletFiat, getWalletName } from '../../util/CurrencyWalletHelpers.js'
 import { convertTransactionFeeToDisplayFee, DECIMAL_PRECISION, DEFAULT_TRUNCATE_PRECISION, getDenomFromIsoCode, truncateDecimals } from '../../util/utils.js'
 import { ExchangeRate } from '../common/ExchangeRate.js'
@@ -57,7 +58,6 @@ type StateProps = {
   wallet: EdgeCurrencyWallet,
 
   // Fees
-  feeCurrencyCode: string,
   feeDisplayDenomination: EdgeDenomination,
   feeNativeAmount: string,
   feeAmount: string,
@@ -170,7 +170,7 @@ export class FlipInputModalComponent extends React.PureComponent<Props, State> {
         <EdgeText style={styles.rateBalanceText}>
           {balance}
           (
-          <FiatText wallet={wallet} currencyCode={primaryInfo.displayCurrencyCode} nativeCryptoAmount={balanceCrypto} />)
+          <FiatText wallet={wallet} tokenId={primaryInfo.tokenId} nativeCryptoAmount={balanceCrypto} />)
         </EdgeText>
       </View>
     )
@@ -203,7 +203,7 @@ export class FlipInputModalComponent extends React.PureComponent<Props, State> {
   }
 
   renderFees = () => {
-    const { wallet, feeAmount, feeCurrencyCode, feeDisplayDenomination, feeNativeAmount, feeStyle, theme } = this.props
+    const { wallet, feeAmount, feeDisplayDenomination, feeNativeAmount, feeStyle, theme } = this.props
     const truncatedFeeAmount = truncateDecimals(feeAmount, DEFAULT_TRUNCATE_PRECISION, false)
     const feeCryptoText = `${truncatedFeeAmount} ${feeDisplayDenomination.name} `
     const styles = getStyles(theme)
@@ -217,7 +217,7 @@ export class FlipInputModalComponent extends React.PureComponent<Props, State> {
         </View>
         <EdgeText style={feeTextStyle}>
           {feeCryptoText}
-          (<FiatText nativeCryptoAmount={feeNativeAmount} currencyCode={feeCurrencyCode} wallet={wallet} />)
+          (<FiatText nativeCryptoAmount={feeNativeAmount} wallet={wallet} />)
         </EdgeText>
       </View>
     )
@@ -313,6 +313,7 @@ export const FlipInputModal = connect<StateProps, DispatchProps, OwnProps>(
     const name = getWalletName(wallet)
     const { fiatCurrencyCode, isoFiatCurrencyCode } = getWalletFiat(wallet)
     const { pluginId } = wallet.currencyInfo
+    const tokenId = getTokenId(state.core.account, wallet.currencyInfo.pluginId, currencyCode)
 
     // Denominations
     const cryptoDenomination = getDisplayDenomination(state, pluginId, currencyCode)
@@ -324,6 +325,7 @@ export const FlipInputModal = connect<StateProps, DispatchProps, OwnProps>(
 
     const primaryInfo = {
       walletId: walletId,
+      tokenId,
       displayCurrencyCode: currencyCode,
       displayDenomination: cryptoDenomination,
       exchangeCurrencyCode: cryptoExchangeDenomination.name,
@@ -374,7 +376,6 @@ export const FlipInputModal = connect<StateProps, DispatchProps, OwnProps>(
       wallet,
 
       // Fees
-      feeCurrencyCode: wallet.currencyInfo.currencyCode,
       feeDisplayDenomination,
       feeExchangeDenomination,
       feeNativeAmount: transactionFee.nativeCryptoAmount,

--- a/src/components/modals/WcSmartContractModal.js
+++ b/src/components/modals/WcSmartContractModal.js
@@ -119,6 +119,9 @@ export const WcSmartContractModal = (props: Props) => {
     <Slider parentStyle={styles.slider} onSlidingComplete={handleSubmit} disabledText={s.strings.send_confirmation_slide_to_confirm} />
   )
 
+  // FIXME: HACK!!1! This is a shortcut so we can remove currency code from the fiat text component without completely refactoring this file
+  const tokenId = contractAddress != null ? contractAddress.toLowerCase().replace('0x', '') : undefined
+
   return (
     <ThemedModal
       bridge={bridge}
@@ -139,7 +142,7 @@ export const WcSmartContractModal = (props: Props) => {
             nativeCryptoAmount={amountCrypto}
             denomination={amountDenom}
             walletId={walletId}
-            currencyCode={amountCurrencyCode}
+            tokenId={tokenId}
           />
         )}
         {walletName != null && (
@@ -156,16 +159,10 @@ export const WcSmartContractModal = (props: Props) => {
             nativeCryptoAmount={networkFeeCrypto}
             denomination={feeDenom}
             walletId={walletId}
-            currencyCode={feeCurrencyCode}
           />
         )}
         {!zeroString(totalNativeCrypto) && (
-          <FiatAmountTile
-            title={s.strings.wc_smartcontract_max_total}
-            nativeCryptoAmount={totalNativeCrypto}
-            wallet={wallet}
-            currencyCode={amountCurrencyCode}
-          />
+          <FiatAmountTile title={s.strings.wc_smartcontract_max_total} nativeCryptoAmount={totalNativeCrypto} wallet={wallet} />
         )}
         {slider}
       </ScrollView>

--- a/src/components/scenes/RequestScene.js
+++ b/src/components/scenes/RequestScene.js
@@ -20,6 +20,7 @@ import { config } from '../../theme/appConfig.js'
 import { connect } from '../../types/reactRedux.js'
 import { type NavigationProp } from '../../types/routerTypes.js'
 import type { GuiCurrencyInfo, GuiDenomination } from '../../types/types.js'
+import { getTokenId } from '../../util/CurrencyInfoHelpers.js'
 import { getAvailableBalance, getWalletName } from '../../util/CurrencyWalletHelpers.js'
 import { convertNativeToDenomination, getDenomFromIsoCode, getObjectDiff, truncateDecimals } from '../../util/utils.js'
 import { SceneWrapper } from '../common/SceneWrapper.js'
@@ -313,7 +314,7 @@ export class RequestComponent extends React.Component<Props, State> {
                 <FiatText
                   appendFiatCurrencyCode
                   nativeCryptoAmount={primaryCurrencyInfo.displayDenomination.multiplier}
-                  currencyCode={primaryCurrencyInfo.displayCurrencyCode}
+                  tokenId={primaryCurrencyInfo.tokenId}
                   wallet={wallet}
                 />
               </EdgeText>
@@ -591,10 +592,12 @@ export const Request = connect<StateProps, DispatchProps, OwnProps>(
     const secondaryDisplayDenomination: GuiDenomination = secondaryExchangeDenomination
     const primaryExchangeCurrencyCode: string = primaryExchangeDenomination.name
     const secondaryExchangeCurrencyCode: string = secondaryExchangeDenomination.name ? secondaryExchangeDenomination.name : ''
+    const tokenId = getTokenId(state.core.account, pluginId, currencyCode)
 
     const primaryCurrencyInfo: GuiCurrencyInfo = {
       walletId: walletId,
       pluginId,
+      tokenId,
       displayCurrencyCode: currencyCode,
       displayDenomination: primaryDisplayDenomination,
       exchangeCurrencyCode: primaryExchangeCurrencyCode,

--- a/src/components/text/FiatText.js
+++ b/src/components/text/FiatText.js
@@ -14,22 +14,15 @@ type Props = {|
   // Amount to show:
   nativeCryptoAmount: string,
   tokenId?: string,
-  wallet: EdgeCurrencyWallet,
-
-  // Deprecated. Use `tokenId` instead:
-  currencyCode?: string
+  wallet: EdgeCurrencyWallet
 |}
 
 /**
  * Return a formatted fiat text string representing the exchange rate of a
  * specific crypto asset and native amount.
  **/
-export const FiatText = ({ appendFiatCurrencyCode, autoPrecision, currencyCode, fiatSymbolSpace, nativeCryptoAmount, tokenId, wallet }: Props) => {
-  const {
-    currencyCode: derivedCurrencyCode,
-    denomination,
-    isoFiatCurrencyCode
-  } = useTokenDisplayData({
+export const FiatText = ({ appendFiatCurrencyCode, autoPrecision, fiatSymbolSpace, nativeCryptoAmount, tokenId, wallet }: Props) => {
+  const { currencyCode, denomination, isoFiatCurrencyCode } = useTokenDisplayData({
     tokenId,
     wallet
   })
@@ -37,7 +30,7 @@ export const FiatText = ({ appendFiatCurrencyCode, autoPrecision, currencyCode, 
   return useFiatText({
     appendFiatCurrencyCode,
     autoPrecision,
-    cryptoCurrencyCode: currencyCode ?? derivedCurrencyCode,
+    cryptoCurrencyCode: currencyCode,
     cryptoExchangeMultiplier: denomination.multiplier,
     fiatSymbolSpace,
     isoFiatCurrencyCode,

--- a/src/components/tiles/FiatAmountTile.js
+++ b/src/components/tiles/FiatAmountTile.js
@@ -13,21 +13,18 @@ type Props = {
   // The amount to show:
   nativeCryptoAmount: string,
   tokenId?: string,
-  wallet: EdgeCurrencyWallet,
-
-  // Deprecated. Use `tokenId` instead:
-  currencyCode?: string
+  wallet: EdgeCurrencyWallet
 }
 
 export const FiatAmountTile = (props: Props) => {
-  const { currencyCode, nativeCryptoAmount, title, tokenId, wallet } = props
+  const { nativeCryptoAmount, title, tokenId, wallet } = props
   const theme = useTheme()
   const styles = getStyles(theme)
 
   return (
     <Tile type="static" title={title} contentPadding={false} style={styles.tileContainer}>
       <EdgeText style={styles.tileBodyText}>
-        <FiatText currencyCode={currencyCode} tokenId={tokenId} nativeCryptoAmount={nativeCryptoAmount} wallet={wallet} />
+        <FiatText tokenId={tokenId} nativeCryptoAmount={nativeCryptoAmount} wallet={wallet} />
       </EdgeText>
     </Tile>
   )

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -50,6 +50,7 @@ export type GuiDenomination = EdgeDenomination
 export type GuiCurrencyInfo = {
   walletId: string,
   pluginId?: string,
+  tokenId?: string,
   displayCurrencyCode: string,
   exchangeCurrencyCode: string,
   displayDenomination: GuiDenomination,


### PR DESCRIPTION
New hooks have forced the deprecation of this prop in favor tokenId

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202312168060953