### PR TITLE
Use enabledTokenIds instead of balance keys

### DIFF
--- a/src/actions/ExchangeRateActions.js
+++ b/src/actions/ExchangeRateActions.js
@@ -53,7 +53,8 @@ async function buildExchangeRates(state: RootState): GuiExchangeRates {
     if (walletIsoFiat !== 'iso:USD') {
       exchangeRates.push({ currency_pair: `iso:USD_${walletIsoFiat}` })
     }
-    for (const tokenCode of Object.keys(wallet.balances)) {
+    for (const tokenId of wallet.enabledTokenIds) {
+      const { currencyCode: tokenCode } = wallet.currencyConfig.allTokens[tokenId]
       if (tokenCode !== currencyCode) {
         exchangeRates.push({ currency_pair: `${tokenCode}_${walletIsoFiat}` })
         exchangeRates.push({ currency_pair: `${tokenCode}_${accountIsoFiat}` })


### PR DESCRIPTION
The balances object contains other stuff like FIO:STAKED keys that don't need an exchange rate and won't ever find them

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202342403689844