### PR TITLE
Don't bother rounding yesterday's date

### DIFF
--- a/src/actions/ExchangeRateActions.js
+++ b/src/actions/ExchangeRateActions.js
@@ -5,7 +5,7 @@ import { asArray, asEither, asNull, asObject, asString } from 'cleaners'
 
 import { type Dispatch, type GetState, type RootState } from '../types/reduxTypes.js'
 import { type GuiExchangeRates } from '../types/types.js'
-import { DECIMAL_PRECISION, getYesterdayDateRoundDownHour, pickRandom } from '../util/utils.js'
+import { DECIMAL_PRECISION, getYesterdayDate, pickRandom } from '../util/utils.js'
 
 const RATES_SERVERS = ['https://rates2.edge.app']
 const RATES_SERVER_MAX_QUERY_SIZE = 100
@@ -37,7 +37,7 @@ async function buildExchangeRates(state: RootState): GuiExchangeRates {
   const accountIsoFiat = state.ui.settings.defaultIsoFiat
 
   const exchangeRates: Array<{ currency_pair: string, date?: string }> = []
-  const yesterdayDate = getYesterdayDateRoundDownHour()
+  const yesterdayDate = getYesterdayDate()
   if (accountIsoFiat !== 'iso:USD') {
     exchangeRates.push({ currency_pair: `iso:USD_${accountIsoFiat}` })
   }

--- a/src/hooks/useTokenDisplayData.js
+++ b/src/hooks/useTokenDisplayData.js
@@ -3,7 +3,7 @@
 import { type EdgeCurrencyWallet } from 'edge-core-js'
 
 import { useSelector } from '../types/reactRedux'
-import { fixFiatCurrencyCode, getDenomFromIsoCode, getYesterdayDateRoundDownHour, zeroString } from '../util/utils'
+import { fixFiatCurrencyCode, getDenomFromIsoCode, zeroString } from '../util/utils'
 
 /**
  * Returns data from tokens relevant for display
@@ -30,7 +30,12 @@ export const useTokenDisplayData = (props: {| tokenId?: string, wallet: EdgeCurr
   // - 'Yest' is an index for a historical price from 24 hours ago.
   const usdFiatPrice = useSelector(state => state.exchangeRates[`iso:USD_${isoFiatCurrencyCode}`])
   const assetFiatPrice = useSelector(state => state.exchangeRates[`${currencyCode}_${isoFiatCurrencyCode}`])
-  const assetFiatYestPrice = useSelector(state => state.exchangeRates[`${currencyCode}_iso:USD_${getYesterdayDateRoundDownHour()}`])
+  const assetFiatYestPrice = useSelector(state => {
+    // The extra _ at the end means there is yesterday's date string at the end of the key
+    const pair = Object.keys(state.exchangeRates).find(pair => pair.includes(`${currencyCode}_iso:USD_`))
+    if (pair != null) return state.exchangeRates[pair]
+    return '0'
+  })
 
   return {
     currencyCode,

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -366,11 +366,8 @@ export const autoCorrectDate = (dateInSeconds: number, currentDateInSeconds: num
   return dateInSeconds
 }
 
-export const getYesterdayDateRoundDownHour = () => {
+export const getYesterdayDate = () => {
   const date = new Date()
-  date.setMinutes(0)
-  date.setSeconds(0)
-  date.setMilliseconds(0)
   const yesterday = date.setDate(date.getDate() - 1)
   return new Date(yesterday).toISOString()
 }


### PR DESCRIPTION
We can use the date as-is and let the server normalize. This change uncovered the (small and infrequent) possibility in useTokenDisplayData where the calculated yesterday date string might not exist in the exchange rate cache so the check is more general and just looks for a key with a date. We could get fancier with an actual date string regex but the extra underscore check is sufficient for how the cache is filled up and used.