### PR TITLE
Wallet Picker Fixes

### DIFF
--- a/src/components/scenes/CreateWalletSelectCryptoScene.js
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.js
@@ -4,7 +4,7 @@ import { type EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
 import { Alert, FlatList, View } from 'react-native'
 
-import { getSpecialCurrencyInfo, SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants.js'
+import { getSpecialCurrencyInfo } from '../../constants/WalletAndCurrencyConstants.js'
 import s from '../../locales/strings.js'
 import { connect } from '../../types/reactRedux.js'
 import { type NavigationProp } from '../../types/routerTypes.js'
@@ -109,9 +109,7 @@ export class CreateWalletSelectCryptoComponent extends React.Component<Props, St
     // Sort and filter the available types:
     const sortedArray = getCreateWalletTypes(account)
     const filteredArray = sortedArray.filter(
-      entry =>
-        !SPECIAL_CURRENCY_INFO[entry.pluginId]?.keysOnlyMode &&
-        (entry.currencyName.toLowerCase().indexOf(lowerSearch) >= 0 || entry.currencyCode.toLowerCase().indexOf(lowerSearch) >= 0)
+      entry => entry.currencyName.toLowerCase().indexOf(lowerSearch) >= 0 || entry.currencyCode.toLowerCase().indexOf(lowerSearch) >= 0
     )
 
     return (

--- a/src/components/themed/WalletList.js
+++ b/src/components/themed/WalletList.js
@@ -141,7 +141,7 @@ export function WalletList(props: Props) {
     for (const createWalletCurrency of createWalletCurrencies) {
       const { currencyCode, currencyName, pluginId, walletType } = createWalletCurrency
       out.push({
-        key: `create-${currencyCode}`,
+        key: `create-${pluginId}`,
         currencyCode,
         displayName: currencyName,
         pluginId,
@@ -161,7 +161,7 @@ export function WalletList(props: Props) {
         if (currencyCode === currencyInfo.currencyCode) continue
 
         out.push({
-          key: `create-${currencyInfo.currencyCode}-${tokenId}`,
+          key: `create-${currencyInfo.pluginId}-${tokenId}`,
           currencyCode,
           displayName,
           pluginId,

--- a/src/components/themed/WalletListFooter.js
+++ b/src/components/themed/WalletListFooter.js
@@ -34,7 +34,7 @@ export const WalletListFooter = (props: Props) => {
       .filter(pluginId => SPECIAL_CURRENCY_INFO[pluginId]?.isCustomTokensSupported)
       .map(pluginId => ({ pluginId }))
 
-    Airship.show(bridge => <WalletListModal allowedAssets={allowedAssets} bridge={bridge} headerTitle={s.strings.select_wallet} />)
+    Airship.show(bridge => <WalletListModal allowedAssets={allowedAssets} bridge={bridge} headerTitle={s.strings.select_wallet} showCreateWallet />)
       .then(({ walletId, currencyCode }) => {
         if (walletId != null && currencyCode != null) {
           navigation.navigate('manageTokens', { walletId })

--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -28,6 +28,7 @@ import { ButtonsModal } from '../../../../components/modals/ButtonsModal.js'
 import { type WalletListResult, WalletListModal } from '../../../../components/modals/WalletListModal.js'
 import { Airship, showError, showToast } from '../../../../components/services/AirshipInstance.js'
 import { SEND } from '../../../../constants/SceneKeys.js'
+import { SPECIAL_CURRENCY_INFO } from '../../../../constants/WalletAndCurrencyConstants.js'
 import s from '../../../../locales/strings'
 import { type GuiPlugin } from '../../../../types/GuiPluginTypes.js'
 import { type Dispatch, type RootState } from '../../../../types/reduxTypes.js'
@@ -95,6 +96,11 @@ const asEdgeTokenIdExtended = asObject({
   currencyCode: asOptional(asString)
 })
 
+// Prevent currencies that are "watch only" from being allowed to exchange
+const excludeAssets = Object.keys(SPECIAL_CURRENCY_INFO)
+  .filter(pluginId => SPECIAL_CURRENCY_INFO[pluginId].keysOnlyMode ?? false)
+  .map(pluginId => ({ pluginId }))
+
 const asCurrencyCodesArray = asOptional(asArray(asEither(asString, asEdgeTokenIdExtended)))
 type ExtendedCurrencyCode = string | $Call<typeof asEdgeTokenIdExtended>
 
@@ -150,6 +156,7 @@ export class EdgeProvider extends Bridgeable {
         bridge={bridge}
         showCreateWallet
         allowedAssets={upgradeExtendedCurrencyCodes(this._state.core.account, this._plugin.fixCurrencyCodes, allowedCurrencyCodes)}
+        excludeAssets={excludeAssets}
         headerTitle={s.strings.choose_your_wallet}
       />
     ))

--- a/src/util/CurrencyInfoHelpers.js
+++ b/src/util/CurrencyInfoHelpers.js
@@ -8,6 +8,7 @@ import { type CreateWalletType } from '../types/types.js'
 const activationRequiredCurrencyCodes = Object.keys(SPECIAL_CURRENCY_INFO)
   .filter(pluginId => SPECIAL_CURRENCY_INFO[pluginId].isAccountActivationRequired ?? false)
   .map(pluginId => SPECIAL_CURRENCY_INFO[pluginId].chainCode)
+const keysOnlyModePlugins = Object.keys(SPECIAL_CURRENCY_INFO).filter(pluginId => SPECIAL_CURRENCY_INFO[pluginId].keysOnlyMode ?? false)
 
 /**
  * Grab all the EdgeCurrencyInfo objects in an account.
@@ -62,6 +63,8 @@ export function getCreateWalletTypes(account: EdgeAccount, filterActivation: boo
   const out: CreateWalletType[] = []
   for (const currencyInfo of infos) {
     const { currencyCode, pluginId } = currencyInfo
+    // Prevent plugins that are "watch only" from being allowed to create new wallets
+    if (keysOnlyModePlugins.includes(pluginId)) continue
     // Prevent currencies that needs activation from being created from a modal
     if (filterActivation && activationRequiredCurrencyCodes.includes(currencyCode.toUpperCase())) continue
     // FIO disable changes


### PR DESCRIPTION
1. Adds the 'create wallet' rows back to "Add Token" wallet picker
2. Disable a WAX (or any keysOnlyMode) Wallet from being created
3. Disable a WAX (or any keysOnlyMode) Wallet from being used in an edgeProvider

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [x] n/a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202319717091534
  - https://app.asana.com/0/0/1202326792172978