### PR TITLE
Add the a missing walletId to the currencyIcon in the Exchange Quote Scene

### DIFF
--- a/src/__tests__/components/ExchangeQuoteComponent.test.js
+++ b/src/__tests__/components/ExchangeQuoteComponent.test.js
@@ -18,6 +18,7 @@ describe('ExchangeQuote', () => {
       currencyCode: 'BTC',
       fiatCurrencyCode: 'USD',
       fiatCurrencyAmount: '40000',
+      walletId: '123456789',
       walletName: 'myWallet',
       total: '40001',
       miningFee: '1',

--- a/src/__tests__/components/__snapshots__/ExchangeQuoteComponent.test.js.snap
+++ b/src/__tests__/components/__snapshots__/ExchangeQuoteComponent.test.js.snap
@@ -14,6 +14,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
       <Memo(CurrencyIconComponent)
         currencyCode="BTC"
         sizeRem={1.5}
+        walletId="123456789"
       />
     }
     subTitle="myWallet"

--- a/src/components/scenes/CryptoExchangeQuoteScene.js
+++ b/src/components/scenes/CryptoExchangeQuoteScene.js
@@ -118,6 +118,7 @@ export class CryptoExchangeQuoteScreenComponent extends React.Component<Props, S
             isTop
             miningFee={fee}
             total={fromTotalFiat}
+            walletId={request.fromWallet.id}
             walletName={request.fromWallet.name || ''}
           />
           <LineTextDivider title={s.strings.string_to_capitalize} lowerCased />
@@ -127,6 +128,7 @@ export class CryptoExchangeQuoteScreenComponent extends React.Component<Props, S
             currencyCode={toDenomination}
             fiatCurrencyAmount={toFiat}
             fiatCurrencyCode={request.toWallet.fiatCurrencyCode.replace('iso:', '')}
+            walletId={request.toWallet.id}
             walletName={request.toWallet.name || ''}
           />
           <View style={styles.pluginRowPoweredByRow}>

--- a/src/components/themed/ExchangeQuoteComponent.js
+++ b/src/components/themed/ExchangeQuoteComponent.js
@@ -17,6 +17,7 @@ type Props = {
   currencyCode: string,
   fiatCurrencyCode: string,
   fiatCurrencyAmount: string,
+  walletId: string,
   walletName: string,
   total?: string,
   miningFee?: string | null
@@ -49,7 +50,7 @@ export class ExchangeQuoteComponent extends React.PureComponent<Props & ThemePro
     return (
       <Card marginRem={[0, 1]}>
         <CardContent
-          image={<CurrencyIcon currencyCode={this.props.currencyCode} sizeRem={1.5} />}
+          image={<CurrencyIcon walletId={this.props.walletId} currencyCode={this.props.currencyCode} sizeRem={1.5} />}
           title={this.props.currency}
           subTitle={this.props.walletName}
           value={`${this.props.cryptoAmount} ${this.props.currencyCode}`}


### PR DESCRIPTION
Fixed the issue where for tokens it would use the wrong parent code

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a