### PR TITLE
Revert change to yesterdate rounding

### DIFF
--- a/src/actions/ExchangeRateActions.js
+++ b/src/actions/ExchangeRateActions.js
@@ -5,7 +5,7 @@ import { asArray, asEither, asNull, asObject, asString } from 'cleaners'
 
 import { type Dispatch, type GetState, type RootState } from '../types/reduxTypes.js'
 import { type GuiExchangeRates } from '../types/types.js'
-import { DECIMAL_PRECISION, getYesterdayDate, pickRandom } from '../util/utils.js'
+import { DECIMAL_PRECISION, getYesterdayDateRoundDownHour, pickRandom } from '../util/utils.js'
 
 const RATES_SERVERS = ['https://rates2.edge.app']
 const RATES_SERVER_MAX_QUERY_SIZE = 100
@@ -37,7 +37,7 @@ async function buildExchangeRates(state: RootState): GuiExchangeRates {
   const accountIsoFiat = state.ui.settings.defaultIsoFiat
 
   const exchangeRates: Array<{ currency_pair: string, date?: string }> = []
-  const yesterdayDate = getYesterdayDate()
+  const yesterdayDate = getYesterdayDateRoundDownHour()
   if (accountIsoFiat !== 'iso:USD') {
     exchangeRates.push({ currency_pair: `iso:USD_${accountIsoFiat}` })
   }

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -368,8 +368,11 @@ export const autoCorrectDate = (dateInSeconds: number, currentDateInSeconds: num
   return dateInSeconds
 }
 
-export const getYesterdayDate = () => {
+export const getYesterdayDateRoundDownHour = () => {
   const date = new Date()
+  date.setMinutes(0)
+  date.setSeconds(0)
+  date.setMilliseconds(0)
   const yesterday = date.setDate(date.getDate() - 1)
   return new Date(yesterday).toISOString()
 }


### PR DESCRIPTION
The rates server providers are too rate limited to reliably serve historical rates at 30 second accuracy.