### PR TITLE
Fixed alignment of 'Invalid Password' error text

### DIFF
--- a/src/__tests__/components/__snapshots__/OutlinedTextInput.test.js.snap
+++ b/src/__tests__/components/__snapshots__/OutlinedTextInput.test.js.snap
@@ -137,11 +137,11 @@ exports[`OutlinedTextInput should render with some props 1`] = `
       style={
         Array [
           Object {
-            "bottom": -20,
+            "bottom": -28,
             "color": "#E85466",
             "fontFamily": "Quicksand-Regular",
             "fontSize": 17,
-            "left": 17,
+            "left": 28,
             "position": "absolute",
           },
           [MockFunction],

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.js.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.js.snap
@@ -257,11 +257,11 @@ Array [
         style={
           Array [
             Object {
-              "bottom": -20,
+              "bottom": -28,
               "color": "#E85466",
               "fontFamily": "Quicksand-Regular",
               "fontSize": 17,
-              "left": 17,
+              "left": 28,
               "position": "absolute",
             },
             [MockFunction],

--- a/src/components/modals/TextInputModal.js
+++ b/src/components/modals/TextInputModal.js
@@ -106,7 +106,7 @@ export function TextInputModal(props: Props) {
         multiline={multiline}
         // Our props:
         error={errorMessage}
-        marginRem={[1, 0.5]}
+        marginRem={[1, 0.5, 1.5, 0.5]}
         onChangeText={handleChangeText}
         onSubmitEditing={handleSubmit}
         value={text}

--- a/src/components/themed/OutlinedTextInput.js
+++ b/src/components/themed/OutlinedTextInput.js
@@ -449,8 +449,8 @@ const getStyles = cacheStyles(theme => {
     errorText: {
       ...footerCommon,
       color: theme.dangerText,
-      left: theme.rem(0.75),
-      bottom: -theme.rem(0.875)
+      left: theme.rem(1.25),
+      bottom: -theme.rem(1.25)
     },
 
     // The counter text splits the bottom right border line:


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS Tablet
- [ ] Tested on small Android
- [ ] n/a
![incorrect-pw](https://user-images.githubusercontent.com/4023066/171467576-83104e77-c1b4-43d0-85a9-9eb016fc36d8.png)

