### PR TITLE
Limit reserve tokens by configuration

### DIFF
--- a/src/plugins/borrow-plugins/plugins/aave/AaveNetwork.js
+++ b/src/plugins/borrow-plugins/plugins/aave/AaveNetwork.js
@@ -15,7 +15,8 @@ export type AaveNetworkBlueprint = {
   contractAddresses: {
     lendingPool: string,
     protocolDataProvider: string
-  }
+  },
+  enabledTokens: { [currencyCode: string]: boolean }
 }
 
 export type AaveNetwork = {
@@ -34,7 +35,7 @@ export type AaveNetwork = {
 }
 
 export const makeAaveNetworkFactory = (blueprint: AaveNetworkBlueprint): AaveNetwork => {
-  const { provider, contractAddresses } = blueprint
+  const { provider, contractAddresses, enabledTokens } = blueprint
 
   const lendingPool = new ethers.Contract(contractAddresses.lendingPool, LENDING_POOL_ABI, provider)
   const protocolDataProvider = new ethers.Contract(contractAddresses.protocolDataProvider, PROTOCOL_DATA_PROVIDER_ABI, provider)
@@ -51,7 +52,7 @@ export const makeAaveNetworkFactory = (blueprint: AaveNetworkBlueprint): AaveNet
     async getAllReservesTokens() {
       const reserveTokens: Array<[string, string]> = await protocolDataProvider.getAllReservesTokens()
       const out: Array<{ symbol: string, address: string }> = reserveTokens.map(([symbol, address]) => ({ symbol, address }))
-      return out
+      return out.filter(reserveToken => enabledTokens[reserveToken.symbol])
     },
 
     // TODO: Cache the response for this function

--- a/src/plugins/borrow-plugins/plugins/aave/index.js
+++ b/src/plugins/borrow-plugins/plugins/aave/index.js
@@ -17,6 +17,10 @@ const aaveNetwork = makeAaveNetworkFactory({
   contractAddresses: {
     lendingPool: '0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9',
     protocolDataProvider: '0x057835ad21a177dbdd3090bb1cae03eacf78fc6d'
+  },
+  enabledTokens: {
+    DAI: true,
+    WBTC: true
   }
 })
 
@@ -45,6 +49,12 @@ const aaveKovanNetwork = makeAaveNetworkFactory({
   contractAddresses: {
     lendingPool: '0xE0fBa4Fc209b4948668006B2bE61711b7f465bAe',
     protocolDataProvider: '0x3c73a5e5785cac854d468f727c606c07488a29d6'
+  },
+  enabledTokens: {
+    DAI: true,
+    WETH: true,
+    WBTC: true,
+    USDC: true
   }
 })
 
@@ -83,6 +93,12 @@ const aaveLocalhostNetwork = makeAaveNetworkFactory({
   contractAddresses: {
     lendingPool: '0xE0fBa4Fc209b4948668006B2bE61711b7f465bAe',
     protocolDataProvider: '0x3c73a5e5785cac854d468f727c606c07488a29d6'
+  },
+  enabledTokens: {
+    DAI: true,
+    WETH: true,
+    WBTC: true,
+    USDC: true
   }
 })
 


### PR DESCRIPTION
Fix the performance issue caused by fetching all the token balances for all supported AAVE reserver tokens for v1. Solution is to limit which tokens are enabled for the network until some caching/persistence is implemented to improve the loading performance post initialization.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202369707618481