### PR TITLE
Add optional `poweredBy` field to GuiPlugin

### DIFF
--- a/src/components/scenes/GuiPluginListScene.js
+++ b/src/components/scenes/GuiPluginListScene.js
@@ -220,6 +220,7 @@ class GuiPluginList extends React.PureComponent<Props, State> {
     const plugin = guiPlugins[pluginId]
     const styles = getStyles(this.props.theme)
     const pluginPartnerLogo = pluginPartnerLogos[pluginId] ? theme[pluginPartnerLogos[pluginId]] : { uri: getPartnerIconUri(item.partnerIconPath) }
+    const poweredBy = plugin.poweredBy ?? plugin.displayName
 
     return (
       <View style={styles.pluginRowContainer}>
@@ -237,7 +238,7 @@ class GuiPluginList extends React.PureComponent<Props, State> {
           <View style={styles.pluginRowPoweredByRow}>
             <EdgeText style={styles.footerText}>{s.strings.plugin_powered_by + ' '}</EdgeText>
             <Image style={styles.partnerIconImage} source={pluginPartnerLogo} />
-            <EdgeText style={styles.footerText}>{' ' + plugin.displayName}</EdgeText>
+            <EdgeText style={styles.footerText}>{' ' + poweredBy}</EdgeText>
           </View>
         </TouchableOpacity>
       </View>

--- a/src/constants/plugins/GuiPlugins.js
+++ b/src/constants/plugins/GuiPlugins.js
@@ -135,6 +135,7 @@ export const guiPlugins: { [pluginId: string]: GuiPlugin } = {
     pluginId: 'ionia',
     storeId: 'ionia',
     baseUri: 'https://ioniaedge.web.app',
+    poweredBy: 'Ionia',
     displayName: 'Edge Mastercard'
   },
   custom: {

--- a/src/types/GuiPluginTypes.js
+++ b/src/types/GuiPluginTypes.js
@@ -41,6 +41,9 @@ export type GuiPlugin = {
   // Scene title to display when inside the plugin:
   displayName: string,
 
+  // Name to show next to Powered by. Uses displayName if missing
+  poweredBy?: string,
+
   // The WebView won't navigate to hostnames outside of this list:
   originWhitelist?: string[],
 


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
