### PR TITLE
Fix showing metadata notes

### DIFF
--- a/src/__tests__/__snapshots__/sendConfirmationReducer.test.js.snap
+++ b/src/__tests__/__snapshots__/sendConfirmationReducer.test.js.snap
@@ -271,7 +271,7 @@ Object {
     "signedTx": "",
     "txid": "",
   },
-  "transactionMetadata": null,
+  "transactionMetadata": Object {},
 }
 `;
 

--- a/src/components/scenes/SendScene.js
+++ b/src/components/scenes/SendScene.js
@@ -444,13 +444,13 @@ class SendComponent extends React.PureComponent<Props, State> {
     return null
   }
 
-  renderMetadata() {
+  renderMetadataNotes() {
     const { transactionMetadata } = this.props
 
-    if (transactionMetadata && transactionMetadata.name) {
+    if (transactionMetadata && transactionMetadata.notes) {
       return (
         <Tile type="static" title={s.strings.send_scene_metadata_name_title}>
-          <EdgeText>{transactionMetadata.name}</EdgeText>
+          <EdgeText>{transactionMetadata.notes}</EdgeText>
         </Tile>
       )
     }
@@ -570,7 +570,7 @@ class SendComponent extends React.PureComponent<Props, State> {
           {this.renderAmount()}
           {this.renderError()}
           {this.renderFees()}
-          {this.renderMetadata()}
+          {this.renderMetadataNotes()}
           {this.renderSelectFioAddress()}
           {this.renderUniqueIdentifier()}
           {this.renderInfoTiles()}

--- a/src/reducers/scenes/SendConfirmationReducer.js
+++ b/src/reducers/scenes/SendConfirmationReducer.js
@@ -140,7 +140,7 @@ const authRequired = (state: 'none' | 'pin' = 'none', action: Action): 'none' | 
 const transactionMetadata = (state: EdgeMetadata | null = null, action: Action): EdgeMetadata | null => {
   switch (action.type) {
     case 'UI/SEND_CONFIRMATION/UPDATE_TRANSACTION': {
-      if (!action.data.guiMakeSpendInfo || !action.data.guiMakeSpendInfo.metadata || !action.data.guiMakeSpendInfo.metadata.name) return state
+      if (!action.data.guiMakeSpendInfo || !action.data.guiMakeSpendInfo.metadata) return state
 
       return action.data.guiMakeSpendInfo.metadata || null
     }


### PR DESCRIPTION
This has been broken for a LONG time and was incorrectly showing metadata.name. The JSON payment protocol was also incorrectly putting notes into the name which hid this bug.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
