### PR TITLE
fix React Native doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Edge Wallet is:
 
 ### Prepare React Native Development Tools
 
-The React Native documentation contains [detailed instructions on how to prepare your computer for React Native development](https://reactnative.dev/docs/0.64/environment-setup). Follow the instructions in the "React Native CLI Quickstart" for your specific platform.
+The React Native documentation contains [detailed instructions on how to prepare your computer for React Native development](https://reactnative.dev/docs/0.67/environment-setup). Follow the instructions in the "React Native CLI Quickstart" for your specific platform.
 
 If you are using a Mac, follow both the iOS and Android target instructions. Otherwise, you only need the Android target instructions.
 


### PR DESCRIPTION
The link in the README was outdated as it pointed to React Native v6.4.

Fixed the link so that it points to v6.7.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
- [x]  N/A
