### PR TITLE
Deprecate Actions for components

### DIFF
--- a/config.js
+++ b/config.js
@@ -28,13 +28,6 @@ const asConfig = asObject({
     }),
     { apiKey: '' }
   ),
-  x_CHANGELLY_INIT: asOptional(
-    asObject({
-      apiKey: asOptional(asString, ''),
-      secret: asOptional(asString, '')
-    }),
-    { apiKey: '', secret: '' }
-  ),
   x_CURRENCYCONVERTERAPI_INIT: asOptional(
     asObject({
       apiKey: asOptional(asString, '')

--- a/env.example.json
+++ b/env.example.json
@@ -15,10 +15,6 @@
   "x_CHANGE_NOW_INIT": {
     "apiKey": ""
   },
-  "x_CHANGELLY_INIT": {
-    "apiKey": "",
-    "secret": ""
-  },
   "x_CURRENCYCONVERTERAPI_INIT": {
     "apiKey": ""
   },

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "edge-core-js": "^0.19.19",
     "edge-currency-accountbased": "^0.16.1",
     "edge-currency-monero": "^0.4.1",
-    "edge-currency-plugins": "^1.0.0-rc.4",
+    "edge-currency-plugins": "^1.0.0-rc.5",
     "edge-exchange-plugins": "^0.13.1",
     "edge-login-ui-rn": "^0.10.2",
     "edge-plugin-bity": "https://github.com/EdgeApp/edge-plugin-bity.git#2a52e6cb86512b98f69f8f5dd3105cdf6d0c2d8a",

--- a/src/__tests__/TransactionDetails.ui.test.js
+++ b/src/__tests__/TransactionDetails.ui.test.js
@@ -6,6 +6,7 @@ import ShallowRenderer from 'react-test-renderer/shallow'
 
 import { TransactionDetailsComponent } from '../components/scenes/TransactionDetailsScene.js'
 import { getTheme } from '../components/services/ThemeContext.js'
+import { type NavigationProp, getNavigation } from '../types/routerTypes.js'
 import { type GuiWallet } from '../types/types.js'
 
 const fakeGuiWallet: GuiWallet = {
@@ -61,6 +62,7 @@ describe('TransactionDetails.ui', () => {
           thumbnailPath: 'thumb/nail/path'
         }
       },
+
       contacts: [],
       subcategoriesList: [],
       currencyCode: 'BTC',
@@ -73,7 +75,8 @@ describe('TransactionDetails.ui', () => {
       displayDropdownAlert: jest.fn(),
       theme: getTheme()
     }
-    const actual = renderer.render(<TransactionDetailsComponent {...props} />)
+    const navigation: NavigationProp<'transactionDetailsComponent'> = getNavigation()
+    const actual = renderer.render(<TransactionDetailsComponent navigation={navigation} {...props} />)
 
     expect(actual).toMatchSnapshot()
   })
@@ -111,7 +114,9 @@ describe('TransactionDetails.ui', () => {
       displayDropdownAlert: jest.fn(),
       theme: getTheme()
     }
-    const actual = renderer.render(<TransactionDetailsComponent {...props} />)
+    const navigation: NavigationProp<'transactionDetailsComponent'> = getNavigation()
+
+    const actual = renderer.render(<TransactionDetailsComponent navigation={navigation} {...props} />)
 
     expect(actual).toMatchSnapshot()
   })
@@ -150,7 +155,9 @@ describe('TransactionDetails.ui', () => {
       displayDropdownAlert: jest.fn(),
       theme: getTheme()
     }
-    const actual = renderer.render(<TransactionDetailsComponent {...props} />)
+    const navigation: NavigationProp<'transactionDetailsComponent'> = getNavigation()
+
+    const actual = renderer.render(<TransactionDetailsComponent navigation={navigation} {...props} />)
 
     expect(actual).toMatchSnapshot()
   })
@@ -191,8 +198,9 @@ describe('TransactionDetails.ui', () => {
       displayDropdownAlert: jest.fn(),
       theme: getTheme()
     }
-    const actual = renderer.render(<TransactionDetailsComponent {...props} />)
+    const navigation: NavigationProp<'transactionDetailsComponent'> = getNavigation()
 
+    const actual = renderer.render(<TransactionDetailsComponent navigation={navigation} {...props} />)
     expect(actual).toMatchSnapshot()
   })
 })

--- a/src/__tests__/components/__snapshots__/MenuTab.test.js.snap
+++ b/src/__tests__/components/__snapshots__/MenuTab.test.js.snap
@@ -1,11 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MenuTab should render with loading props 1`] = `
-<MenuTabComponent
+<WithNavigation(MenuTabComponent)
   navigation={
     Object {
       "addListener": [Function],
       "closeDrawer": [Function],
+      "currentScene": Object {},
       "goBack": [Function],
       "isFocused": [Function],
       "navigate": [Function],

--- a/src/__tests__/scenes/__snapshots__/CreateWalletNameScene.test.js.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletNameScene.test.js.snap
@@ -6,6 +6,7 @@ exports[`createWalletName should render with loading props 1`] = `
     Object {
       "addListener": [Function],
       "closeDrawer": [Function],
+      "currentScene": Object {},
       "goBack": [Function],
       "isFocused": [Function],
       "navigate": [Function],

--- a/src/components/modals/AccelerateTxModel.js
+++ b/src/components/modals/AccelerateTxModel.js
@@ -10,7 +10,7 @@ import s from '../../locales/strings.js'
 import { Slider } from '../../modules/UI/components/Slider/Slider.js'
 import { getDisplayDenominationFromState, getExchangeDenominationFromState } from '../../selectors/DenominationSelectors.js'
 import { connect } from '../../types/reactRedux.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, withNavigation } from '../../types/routerTypes.js'
 import { type GuiExchangeRates } from '../../types/types.js'
 import { convertTransactionFeeToDisplayFee } from '../../util/utils.js'
 import { showError, showToast, showWarning } from '../services/AirshipInstance.js'
@@ -24,7 +24,8 @@ type Status = 'confirming' | 'sending' | 'sent'
 type OwnProps = {
   bridge: AirshipBridge<Status>,
   edgeTransaction: EdgeTransaction,
-  wallet: EdgeCurrencyWallet
+  wallet: EdgeCurrencyWallet,
+  navigation: NavigationProp<'accelerateTxModelComponent'>
 }
 type StateProps = {
   exchangeRates: GuiExchangeRates
@@ -108,7 +109,7 @@ export class AccelerateTxModelComponent extends PureComponent<Props, State> {
   }
 
   signBroadcastAndSaveRbf = async () => {
-    const { wallet } = this.props
+    const { wallet, navigation } = this.props
     const { edgeUnsignedTransaction } = this.state
 
     if (edgeUnsignedTransaction) {
@@ -129,7 +130,7 @@ export class AccelerateTxModelComponent extends PureComponent<Props, State> {
 
           showToast(s.strings.transaction_success_message)
 
-          Actions.replace('transactionDetails', { edgeTransaction: edgeSignedTransaction })
+          navigation.replace('transactionDetails', { edgeTransaction: edgeSignedTransaction })
         } else {
           showWarning(s.strings.transaction_success_message)
         }
@@ -251,4 +252,4 @@ export const AccelerateTxModel = connect<StateProps, DispatchProps, OwnProps>(
       return dispatch(getExchangeDenominationFromState(pluginId, currencyCode))
     }
   })
-)(withTheme(AccelerateTxModelComponent))
+)(withTheme(withNavigation(AccelerateTxModelComponent)))

--- a/src/components/modals/PasswordReminderModal.js
+++ b/src/components/modals/PasswordReminderModal.js
@@ -8,7 +8,7 @@ import { type AirshipBridge } from 'react-native-airship'
 import { passwordReminderSuccess, postponePasswordReminder, requestChangePassword } from '../../actions/PasswordReminderActions.js'
 import s from '../../locales/strings.js'
 import { connect } from '../../types/reactRedux.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, withNavigation } from '../../types/routerTypes.js'
 import { showToast } from '../services/AirshipInstance.js'
 import { type ThemeProps, withTheme } from '../services/ThemeContext.js'
 import { EdgeTextField } from '../themed/EdgeTextField.js'
@@ -17,7 +17,8 @@ import { ModalCloseArrow, ModalMessage, ModalTitle } from '../themed/ModalParts.
 import { ThemedModal } from '../themed/ThemedModal.js'
 
 type OwnProps = {
-  bridge: AirshipBridge<void>
+  bridge: AirshipBridge<void>,
+  navigation: NavigationProp<'passwordReminderModalComponent'>
 }
 
 type StateProps = {
@@ -55,7 +56,7 @@ export class PasswordReminderModalComponent extends React.PureComponent<Props, S
     if (!this.state.spinning) {
       this.props.bridge.resolve()
       this.props.onRequestChangePassword()
-      setTimeout(() => Actions.jump('changePassword'), 10)
+      setTimeout(() => this.props.navigation.navigate('changePassword'), 10)
     }
   }
 
@@ -128,4 +129,4 @@ export const PasswordReminderModal = connect<StateProps, DispatchProps, OwnProps
       dispatch(postponePasswordReminder())
     }
   })
-)(withTheme(PasswordReminderModalComponent))
+)(withTheme(withNavigation(PasswordReminderModalComponent)))

--- a/src/components/modals/SwapVerifyTermsModal.js
+++ b/src/components/modals/SwapVerifyTermsModal.js
@@ -21,11 +21,6 @@ type TermsUri = {
 }
 
 const pluginData: { [pluginId: string]: TermsUri } = {
-  changelly: {
-    termsUri: 'https://changelly.com/terms-of-use',
-    privacyUri: 'https://changelly.com/privacy-policy',
-    kycUri: 'https://changelly.com/aml-kyc'
-  },
   switchain: {
     termsUri: 'https://www.switchain.com/tos',
     privacyUri: 'https://www.switchain.com/policy',

--- a/src/components/navigation/GuiPluginBackButton.js
+++ b/src/components/navigation/GuiPluginBackButton.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, getNavigation } from '../../types/routerTypes.js'
 import { BackButton } from './BackButton.js'
 
 // The scene holds a ref to the webview:
@@ -18,7 +18,8 @@ export function renderPluginBackButton() {
 }
 
 export function handlePluginBack() {
+  const navigation: NavigationProp<'edge'> = getNavigation()
   if (currentPlugin == null || !currentPlugin.goBack()) {
-    Actions.pop()
+    navigation.pop()
   }
 }

--- a/src/components/navigation/HeaderTextButton.js
+++ b/src/components/navigation/HeaderTextButton.js
@@ -4,14 +4,15 @@ import * as React from 'react'
 import { TouchableOpacity } from 'react-native'
 
 import s from '../../locales/strings.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, withNavigation } from '../../types/routerTypes.js'
 import { showHelpModal } from '../modals/HelpModal.js'
 import { type Theme, type ThemeProps, cacheStyles, withTheme } from '../services/ThemeContext.js'
 import { EdgeText } from '../themed/EdgeText.js'
 
 type Props = {
   type: 'exit' | 'help',
-  placement: 'left' | 'right'
+  placement: 'left' | 'right',
+  navigation: NavigationProp<'headerTextButtonComponent'>
 }
 
 const title = {
@@ -21,9 +22,9 @@ const title = {
 
 class HeaderTextButtonComponent extends React.PureComponent<Props & ThemeProps> {
   handlePress = () => {
-    const { type } = this.props
+    const { type, navigation } = this.props
     if (type === 'exit') {
-      Actions.pop()
+      navigation.pop()
     } else if (type === 'help') {
       showHelpModal()
     }
@@ -57,4 +58,4 @@ const getStyles = cacheStyles((theme: Theme) => ({
   }
 }))
 
-export const HeaderTextButton = withTheme(HeaderTextButtonComponent)
+export const HeaderTextButton = withTheme(withNavigation(HeaderTextButtonComponent))

--- a/src/components/navigation/TransactionDropdown.js
+++ b/src/components/navigation/TransactionDropdown.js
@@ -10,7 +10,7 @@ import { selectWallet } from '../../actions/WalletActions'
 import s from '../../locales/strings.js'
 import { getDisplayDenomination } from '../../selectors/DenominationSelectors.js'
 import { connect } from '../../types/reactRedux.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, useNavigation } from '../../types/routerTypes.js'
 import { convertNativeToDisplay } from '../../util/utils.js'
 import { Airship } from '../services/AirshipInstance.js'
 import { FlashNotification } from './FlashNotification.js'
@@ -45,6 +45,7 @@ type Props = OwnProps & StateProps & DispatchProps
 
 export function TransactionDropdown(props: Props) {
   const { bridge, message, tx, walletId, selectWallet } = props
+  const navigation: NavigationProp<'edge'> = useNavigation()
 
   return (
     <FlashNotification
@@ -52,7 +53,7 @@ export function TransactionDropdown(props: Props) {
       onPress={() => {
         bridge.resolve()
         walletId && selectWallet(walletId, tx.currencyCode)
-        Actions.push('transactionDetails', {
+        navigation.push('transactionDetails', {
           edgeTransaction: tx
         })
       }}

--- a/src/components/scenes/FioStakingOverviewScene.js
+++ b/src/components/scenes/FioStakingOverviewScene.js
@@ -17,7 +17,7 @@ import { convertCurrency } from '../../selectors/WalletSelectors'
 import { useEffect, useState } from '../../types/reactHooks.js'
 import { connect } from '../../types/reactRedux'
 import type { RouteProp } from '../../types/routerTypes'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, useNavigation } from '../../types/routerTypes.js'
 import { convertNativeToDenomination } from '../../util/utils'
 import { SceneWrapper } from '../common/SceneWrapper.js'
 import { type ThemeProps, cacheStyles, withTheme } from '../services/ThemeContext.js'
@@ -65,6 +65,7 @@ export const FioStakingOverviewSceneComponent = (props: Props) => {
   const styles = getStyles(theme)
   const [locks, setLocks] = useState<Lock[]>([])
   const stakingStatus = useWatchWallet(currencyWallet, 'stakingStatus')
+  const navigation: NavigationProp<'edge'> = useNavigation()
 
   useEffect(() => {
     refreshAllFioAddresses()
@@ -85,10 +86,10 @@ export const FioStakingOverviewSceneComponent = (props: Props) => {
   }, [stakingStatus, currencyDenomination])
 
   const handlePressStake = () => {
-    Actions.jump('fioStakingChange', { change: 'add', currencyCode, walletId })
+    navigation.navigate('fioStakingChange', { change: 'add', currencyCode, walletId })
   }
   const handlePressUnstake = () => {
-    Actions.jump('fioStakingChange', { change: 'remove', currencyCode, walletId })
+    navigation.navigate('fioStakingChange', { change: 'remove', currencyCode, walletId })
   }
 
   const renderItems = () =>

--- a/src/components/scenes/SendScene.js
+++ b/src/components/scenes/SendScene.js
@@ -22,7 +22,7 @@ import s from '../../locales/strings.js'
 import { checkRecordSendFee, FIO_NO_BUNDLED_ERR_CODE } from '../../modules/FioAddress/util'
 import { getDisplayDenominationFromState, getExchangeDenominationFromState } from '../../selectors/DenominationSelectors.js'
 import { connect } from '../../types/reactRedux.js'
-import { type NavigationProp, type RouteProp } from '../../types/routerTypes.js'
+import { type NavigationProp, type RouteProp, withNavigation } from '../../types/routerTypes.js'
 import { type GuiExchangeRates, type GuiMakeSpendInfo } from '../../types/types.js'
 import { getWalletName } from '../../util/CurrencyWalletHelpers.js'
 import { convertTransactionFeeToDisplayFee } from '../../util/utils.js'
@@ -75,7 +75,8 @@ type DispatchProps = {
 
 type OwnProps = {
   navigation: NavigationProp<'send'>,
-  route: RouteProp<'send'>
+  route: RouteProp<'send'>,
+  navigation: NavigationProp<'selectFioAddressComponent'>
 }
 type Props = OwnProps & StateProps & DispatchProps & ThemeProps
 
@@ -468,6 +469,7 @@ class SendComponent extends React.PureComponent<Props, State> {
     return (
       <View>
         <SelectFioAddress
+          navigation={this.props.navigation}
           selected={fioSender.fioAddress}
           memo={fioSender.memo}
           memoError={fioSender.memoError}
@@ -653,4 +655,4 @@ export const SendScene = connect<StateProps, DispatchProps, OwnProps>(
       return dispatch(getDisplayDenominationFromState(pluginId, currencyCode))
     }
   })
-)(withTheme(SendComponent))
+)(withTheme(withNavigation(SendComponent)))

--- a/src/components/scenes/TransactionDetailsScene.js
+++ b/src/components/scenes/TransactionDetailsScene.js
@@ -17,7 +17,7 @@ import s from '../../locales/strings.js'
 import { getDisplayDenomination, getExchangeDenomination } from '../../selectors/DenominationSelectors.js'
 import { convertCurrencyFromExchangeRates } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
-import { type RouteProp, Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, type RouteProp, withNavigation } from '../../types/routerTypes.js'
 import type { GuiContact, GuiWallet } from '../../types/types.js'
 import {
   autoCorrectDate,
@@ -42,8 +42,10 @@ import { MainButton } from '../themed/MainButton.js'
 import { Tile } from '../tiles/Tile.js'
 
 type OwnProps = {
-  route: RouteProp<'transactionDetails'>
+  route: RouteProp<'transactionDetails'>,
+  navigation: NavigationProp<'transactionDetailsComponent'> | NavigationProp<'accelerateTxModelComponent'>
 }
+
 type StateProps = {
   contacts: GuiContact[],
   currencyCode: string,
@@ -214,12 +216,12 @@ export class TransactionDetailsComponent extends React.Component<Props, State> {
   }
 
   openAccelerateModel = () => {
-    const { route } = this.props
+    const { route, navigation } = this.props
     const { edgeTransaction } = route.params
     const { wallet } = edgeTransaction
 
     if (wallet) {
-      Airship.show(bridge => <AccelerateTxModel bridge={bridge} edgeTransaction={edgeTransaction} wallet={wallet} />)
+      Airship.show(bridge => <AccelerateTxModel navigation={navigation} bridge={bridge} edgeTransaction={edgeTransaction} wallet={wallet} />)
     } else {
       showError(new Error('Transaction is missing wallet data.'))
     }
@@ -425,7 +427,7 @@ export class TransactionDetailsComponent extends React.Component<Props, State> {
 
   // Render
   render() {
-    const { currencyInfo, guiWallet, theme, route } = this.props
+    const { currencyInfo, guiWallet, theme, route, navigation } = this.props
     const { edgeTransaction } = route.params
     const { direction, amountFiat, contactName, thumbnailPath, notes, category, subCategory } = this.state
     const { fiatCurrencyCode } = guiWallet
@@ -501,7 +503,7 @@ export class TransactionDetailsComponent extends React.Component<Props, State> {
             <TouchableWithoutFeedback onPress={this.openAdvancedDetails}>
               <EdgeText style={styles.textAdvancedTransaction}>{s.strings.transaction_details_view_advanced_data}</EdgeText>
             </TouchableWithoutFeedback>
-            <MainButton onPress={Actions.pop} label={s.strings.string_done_cap} marginRem={[0, 2, 2]} type="secondary" />
+            <MainButton onPress={() => navigation.pop()} label={s.strings.string_done_cap} marginRem={[0, 2, 2]} type="secondary" />
           </View>
         </ScrollView>
       </SceneWrapper>
@@ -614,4 +616,4 @@ export const TransactionDetailsScene = connect<StateProps, DispatchProps, OwnPro
       dispatch(setTransactionDetails(transaction, edgeMetadata))
     }
   })
-)(withTheme(TransactionDetailsComponent))
+)(withTheme(withNavigation(TransactionDetailsComponent)))

--- a/src/components/scenes/TransactionListScene.js
+++ b/src/components/scenes/TransactionListScene.js
@@ -7,6 +7,7 @@ import { RefreshControl, SectionList } from 'react-native'
 import { fetchMoreTransactions } from '../../actions/TransactionListActions'
 import s from '../../locales/strings'
 import { connect } from '../../types/reactRedux.js'
+import { type NavigationProp, withNavigation } from '../../types/routerTypes'
 import type { TransactionListTx } from '../../types/types.js'
 import { getTokenId } from '../../util/CurrencyInfoHelpers'
 import { SceneWrapper } from '../common/SceneWrapper.js'
@@ -33,11 +34,15 @@ type StateProps = {
   transactions: TransactionListTx[]
 }
 
+type OwnProps = {
+  navigation: NavigationProp<'transactionListRowComponent'>
+}
+
 type DispatchProps = {
   fetchMoreTransactions: (walletId: string, currencyCode: string, reset: boolean) => void
 }
 
-type Props = StateProps & DispatchProps & ThemeProps
+type Props = StateProps & DispatchProps & ThemeProps & OwnProps
 
 type State = {
   reset: boolean,
@@ -146,7 +151,9 @@ class TransactionListComponent extends React.PureComponent<Props, State> {
 
   renderTransaction = (transaction: SectionList<TransactionListTx>) => {
     const { selectedWalletId, selectedCurrencyCode } = this.props
-    return <TransactionListRow walletId={selectedWalletId} currencyCode={selectedCurrencyCode} transaction={transaction.item} />
+    return (
+      <TransactionListRow navigation={this.props.navigation} walletId={selectedWalletId} currencyCode={selectedCurrencyCode} transaction={transaction.item} />
+    )
   }
 
   renderTop = () => (
@@ -219,4 +226,4 @@ export const TransactionList = connect<StateProps, DispatchProps, {}>(
       dispatch(fetchMoreTransactions(walletId, currencyCode, reset))
     }
   })
-)(withTheme(TransactionListComponent))
+)(withTheme(withNavigation(TransactionListComponent)))

--- a/src/components/scenes/WalletListScene.js
+++ b/src/components/scenes/WalletListScene.js
@@ -27,7 +27,7 @@ import { WalletListSwipeable } from '../themed/WalletListSwipeable.js'
 import { WiredProgressBar } from '../themed/WiredProgressBar.js'
 
 type Props = {
-  navigation: NavigationProp<'walletList'>
+  navigation: NavigationProp<'walletList'> | NavigationProp<'passwordReminderModalComponent'>
 }
 
 export function WalletListScene(props: Props) {
@@ -68,7 +68,7 @@ export function WalletListScene(props: Props) {
   useAsyncEffect(
     async () => {
       if (needsPasswordCheck) {
-        await Airship.show(bridge => <PasswordReminderModal bridge={bridge} />)
+        await Airship.show(bridge => <PasswordReminderModal navigation={navigation} bridge={bridge} />)
       } else {
         const userTutorialList = await getWalletListSlideTutorial(disklet)
         const tutorialCount = userTutorialList.walletListSlideTutorialCount || 0

--- a/src/components/services/AccountCallbackManager.js
+++ b/src/components/services/AccountCallbackManager.js
@@ -12,7 +12,7 @@ import { useAsyncEffect } from '../../hooks/useAsyncEffect.js'
 import { useWalletsSubscriber } from '../../hooks/useWalletsSubscriber.js'
 import { useEffect, useState } from '../../types/reactHooks.js'
 import { useDispatch } from '../../types/reactRedux.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, useNavigation } from '../../types/routerTypes.js'
 import { isReceivedTransaction, snooze } from '../../util/utils.js'
 import { WcSmartContractModal } from '../modals/WcSmartContractModal.js'
 import { Airship } from './AirshipInstance.js'
@@ -38,6 +38,7 @@ export function AccountCallbackManager(props: Props) {
   const { account } = props
   const dispatch = useDispatch()
   const [dirty, setDirty] = useState<DirtyList>(notDirty)
+  const navigation: NavigationProp<'edge'> = useNavigation()
 
   // Helper for marking wallets dirty:
   function addWallet(wallet: EdgeCurrencyWallet) {
@@ -66,8 +67,8 @@ export function AccountCallbackManager(props: Props) {
       }),
 
       watchSecurityAlerts(account, hasAlerts => {
-        if (hasAlerts && Actions.currentScene !== 'securityAlerts') {
-          Actions.push('securityAlerts')
+        if (hasAlerts && navigation.currentScene !== 'securityAlerts') {
+          navigation.push('securityAlerts')
         }
       }),
 

--- a/src/components/themed/BuyCrypto.js
+++ b/src/components/themed/BuyCrypto.js
@@ -8,7 +8,7 @@ import { sprintf } from 'sprintf-js'
 import { SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants.js'
 import { useHandler } from '../../hooks/useHandler.js'
 import s from '../../locales/strings.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, useNavigation } from '../../types/routerTypes.js'
 import { type Theme, cacheStyles, useTheme } from '../services/ThemeContext.js'
 import { CurrencyIcon } from '../themed/CurrencyIcon.js'
 import { EdgeText } from './EdgeText.js'
@@ -27,9 +27,9 @@ export const BuyCrypto = (props: Props) => {
   const { wallet, tokenId } = props
   const theme = useTheme()
   const styles = getStyles(theme)
-
+  const navigation: NavigationProp<'edge'> = useNavigation()
   const handlePress = useHandler(() => {
-    Actions.push('pluginListBuy', { direction: 'buy' })
+    navigation.push('pluginListBuy', { direction: 'buy' })
   })
 
   const { displayName, pluginId } = wallet.currencyInfo

--- a/src/components/themed/ControlPanel.js
+++ b/src/components/themed/ControlPanel.js
@@ -25,7 +25,7 @@ import { getDisplayDenomination } from '../../selectors/DenominationSelectors'
 import { config } from '../../theme/appConfig.js'
 import { useEffect, useMemo, useState } from '../../types/reactHooks.js'
 import { useDispatch, useSelector } from '../../types/reactRedux'
-import { type NavigationProp, type ParamList, Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, type ParamList, useNavigation } from '../../types/routerTypes.js'
 import { SceneWrapper } from '../common/SceneWrapper.js'
 import { ButtonsModal } from '../modals/ButtonsModal.js'
 import { ScanModal } from '../modals/ScanModal'
@@ -49,7 +49,7 @@ export function ControlPanel(props: Props) {
   const dispatch = useDispatch()
   const theme = useTheme()
   const styles = getStyles(theme)
-
+  const nav: NavigationProp<'controlPanel'> = useNavigation()
   // ---- Redux State ----
 
   const activeUsername = useSelector(state => state.core.account.username)
@@ -121,7 +121,7 @@ export function ControlPanel(props: Props) {
   }
 
   const handleLoginQr = () => {
-    Actions.drawerClose()
+    navigation.closeDrawer()
     Airship.show(bridge => <ScanModal bridge={bridge} title={s.strings.scan_qr_label} />)
       .then((result: string | void) => {
         if (result) {
@@ -142,15 +142,13 @@ export function ControlPanel(props: Props) {
   }
 
   const handleGoToScene = (scene: $Keys<ParamList>, sceneProps: any) => {
-    const { currentScene, drawerClose } = Actions
-
-    if (currentScene !== scene) {
+    if (nav.currentScene !== scene) {
       navigation.navigate(scene, sceneProps)
     } else if (sceneProps) {
       navigation.setParams(sceneProps)
     }
 
-    drawerClose()
+    navigation.closeDrawer()
   }
 
   /// ---- Animation ----

--- a/src/components/themed/MenuTab.js
+++ b/src/components/themed/MenuTab.js
@@ -8,7 +8,7 @@ import Ionicon from 'react-native-vector-icons/Ionicons'
 
 import { Fontello } from '../../assets/vector/index.js'
 import s from '../../locales/strings.js'
-import { type NavigationProp, type ParamList, Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, type ParamList, withNavigation } from '../../types/routerTypes.js'
 import { type Theme, type ThemeProps, cacheStyles, withTheme } from '../services/ThemeContext.js'
 import { DividerLine } from './DividerLine.js'
 import { EdgeText } from './EdgeText.js'
@@ -30,13 +30,13 @@ export class MenuTabComponent extends React.PureComponent<Props> {
   handleOnPress = (route: 'walletList' | 'pluginListBuy' | 'pluginListSell' | 'exchange') => {
     switch (route) {
       case 'walletList':
-        return Actions.jump('walletListScene')
+        return this.props.navigation.navigate('walletListScene')
       case 'pluginListBuy':
-        return Actions.jump('pluginListBuy', { direction: 'buy' })
+        return this.props.navigation.navigate('pluginListBuy', { direction: 'buy' })
       case 'pluginListSell':
-        return Actions.jump('pluginListSell', { direction: 'sell' })
+        return this.props.navigation.navigate('pluginListSell', { direction: 'sell' })
       case 'exchange':
-        return Actions.jump('exchange')
+        return this.props.navigation.navigate('exchange')
     }
   }
 
@@ -93,4 +93,4 @@ const getStyles = cacheStyles((theme: Theme) => ({
   }
 }))
 
-export const MenuTab = withTheme(MenuTabComponent)
+export const MenuTab = withTheme(withNavigation(MenuTabComponent))

--- a/src/components/themed/SelectFioAddress.js
+++ b/src/components/themed/SelectFioAddress.js
@@ -10,7 +10,7 @@ import s from '../../locales/strings.js'
 import { checkRecordSendFee, findWalletByFioAddress, FIO_NO_BUNDLED_ERR_CODE } from '../../modules/FioAddress/util.js'
 import { getSelectedWallet } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, withNavigation } from '../../types/routerTypes.js'
 import type { FioAddress, FioRequest, GuiWallet } from '../../types/types'
 import { AddressModal } from '../modals/AddressModal'
 import { ButtonsModal } from '../modals/ButtonsModal'
@@ -27,6 +27,7 @@ type OwnProps = {
   onSelect: (fioAddress: string, fioWallet: EdgeCurrencyWallet, error: string) => void,
   onMemoChange: (memo: string, memoError: string) => void,
   fioRequest?: FioRequest,
+  navigation: NavigationProp<'selectFioAddressComponent'>,
   isSendUsingFioAddress?: boolean
 }
 
@@ -143,7 +144,7 @@ export class SelectFioAddressComponent extends React.PureComponent<Props, LocalS
   }
 
   setFioAddress = async (fioAddress: string, fioWallet?: EdgeCurrencyWallet | null) => {
-    const { fioWallets, fioAddresses, fioRequest, currencyCode } = this.props
+    const { fioWallets, fioAddresses, fioRequest, currencyCode, navigation } = this.props
     if (!fioWallet) {
       if (fioAddresses && fioAddress.length) {
         const selectedFioAddress = fioAddresses.find(({ name }) => name === fioAddress)
@@ -182,7 +183,7 @@ export class SelectFioAddressComponent extends React.PureComponent<Props, LocalS
           />
         ))
         if (answer === 'ok') {
-          return Actions.push('fioAddressSettings', {
+          return navigation.push('fioAddressSettings', {
             showAddBundledTxs: true,
             fioWallet,
             fioAddressName: fioAddress
@@ -282,4 +283,4 @@ export const SelectFioAddress = connect<StateProps, DispatchProps, OwnProps>(
       dispatch(refreshAllFioAddresses())
     }
   })
-)(withTheme(SelectFioAddressComponent))
+)(withTheme(withNavigation(SelectFioAddressComponent)))

--- a/src/components/themed/TransactionListComponents.js
+++ b/src/components/themed/TransactionListComponents.js
@@ -5,6 +5,7 @@ import { ActivityIndicator, View } from 'react-native'
 
 import { Gradient } from '../../modules/UI/components/Gradient/Gradient.ui.js'
 import { useSelector } from '../../types/reactRedux.js'
+import { type NavigationProp, useNavigation } from '../../types/routerTypes.js'
 import { type Theme, cacheStyles, useTheme } from '../services/ThemeContext.js'
 import { EdgeText } from '../themed/EdgeText.js'
 import { TransactionListTop } from '../themed/TransactionListTop.js'
@@ -19,11 +20,12 @@ type Props = {
 
 export const Top = (props: Props) => {
   const loading = useSelector(state => !state.ui.wallets.byId[props.walletId])
-
+  const navigation: NavigationProp<'transactionListTopComponent'> = useNavigation()
   return loading ? (
     <ActivityIndicator style={{ flex: 1, alignSelf: 'center' }} size="large" />
   ) : (
     <TransactionListTop
+      navigation={navigation}
       walletId={props.walletId}
       isEmpty={props.isEmpty}
       searching={props.searching}

--- a/src/components/themed/TransactionListRow.js
+++ b/src/components/themed/TransactionListRow.js
@@ -10,7 +10,7 @@ import { formatNumber } from '../../locales/intl.js'
 import s from '../../locales/strings'
 import { getDisplayDenomination, getExchangeDenomination } from '../../selectors/DenominationSelectors.js'
 import { connect } from '../../types/reactRedux.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, withNavigation } from '../../types/routerTypes.js'
 import type { TransactionListTx } from '../../types/types.js'
 import {
   DECIMAL_PRECISION,
@@ -42,18 +42,19 @@ type OwnProps = {
   walletId: string,
   // eslint-disable-next-line react/no-unused-prop-types
   currencyCode: string,
-  transaction: TransactionListTx
+  transaction: TransactionListTx,
+  navigation: NavigationProp<'transactionListRowComponent'>
 }
 
 type Props = OwnProps & StateProps
 
 export class TransactionListRowComponent extends React.PureComponent<Props> {
   handlePress = () => {
-    const { transaction, thumbnailPath } = this.props
+    const { transaction, thumbnailPath, navigation } = this.props
     if (transaction == null) {
       return showError(s.strings.transaction_details_error_invalid)
     }
-    Actions.push('transactionDetails', {
+    navigation.push('transactionDetails', {
       edgeTransaction: transaction,
       thumbnailPath
     })
@@ -134,4 +135,4 @@ export const TransactionListRow = connect<StateProps, {}, OwnProps>(
     }
   },
   dispatch => ({})
-)(TransactionListRowComponent)
+)(withNavigation(TransactionListRowComponent))

--- a/src/components/themed/TransactionListTop.js
+++ b/src/components/themed/TransactionListTop.js
@@ -16,7 +16,7 @@ import { type StakePolicy } from '../../plugins/stake-plugins'
 import { getDisplayDenomination, getExchangeDenomination } from '../../selectors/DenominationSelectors.js'
 import { convertCurrency } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, withNavigation } from '../../types/routerTypes.js'
 import { stakePlugin } from '../../util/stakeUtils.js'
 import { convertNativeToDenomination } from '../../util/utils'
 import { type WalletListResult, WalletListModal } from '../modals/WalletListModal.js'
@@ -32,7 +32,8 @@ type OwnProps = {
   isEmpty: boolean,
   searching: boolean,
   onChangeSortingState: (isSearching: boolean) => void,
-  onSearchTransaction: (searchString: string) => void
+  onSearchTransaction: (searchString: string) => void,
+  navigation: NavigationProp<'transactionListTopComponent'>
 }
 
 type StateProps = {
@@ -175,11 +176,11 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
   }
 
   handleRequest = (): void => {
-    Actions.push('request')
+    this.props.navigation.push('request')
   }
 
   handleSend = (): void => {
-    Actions.push('send', {})
+    this.props.navigation.push('send', {})
   }
 
   handleSearchDone = () => {
@@ -190,9 +191,9 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
   }
 
   handleStakePress = () => {
-    const { currencyCode, walletId } = this.props
-    if (currencyCode === 'FIO') Actions.push('fioStakingOverview', { currencyCode, walletId })
-    else Actions.push('stakeOptions', { walletId, currencyCode })
+    const { currencyCode, walletId, navigation } = this.props
+    if (currencyCode === 'FIO') navigation.push('fioStakingOverview', { currencyCode, walletId })
+    else navigation.push('stakeOptions', { walletId, currencyCode })
   }
 
   clearText = () => {
@@ -430,4 +431,4 @@ export const TransactionListTop = connect<StateProps, DispatchProps, OwnProps>(
       dispatch(selectWalletFromModal(walletId, currencyCode))
     }
   })
-)(withTheme(TransactionListTopComponent))
+)(withTheme(withNavigation(TransactionListTopComponent)))

--- a/src/components/themed/WalletListHeader.js
+++ b/src/components/themed/WalletListHeader.js
@@ -6,7 +6,7 @@ import Ionicon from 'react-native-vector-icons/Ionicons'
 
 import { Fontello } from '../../assets/vector/index.js'
 import s from '../../locales/strings.js'
-import { Actions } from '../../types/routerTypes.js'
+import { type NavigationProp, withNavigation } from '../../types/routerTypes.js'
 import { PromoCard } from '../cards/PromoCard.js'
 import { type Theme, type ThemeProps, cacheStyles, withTheme } from '../services/ThemeContext.js'
 import { EdgeText } from '../themed/EdgeText.js'
@@ -19,7 +19,8 @@ type OwnProps = {
   searchText: string,
   openSortModal: () => void,
   onChangeSearchText: (search: string) => void,
-  onChangeSearchingState: (searching: boolean) => void
+  onChangeSearchingState: (searching: boolean) => void,
+  navigation: NavigationProp<'walletListHeaderComponent'>
 }
 
 type Props = OwnProps & ThemeProps
@@ -47,7 +48,7 @@ export class WalletListHeaderComponent extends React.PureComponent<Props> {
   }
 
   render() {
-    const { sorting, searching, searchText, theme } = this.props
+    const { sorting, searching, searchText, theme, navigation } = this.props
     const styles = getStyles(theme)
 
     return (
@@ -76,7 +77,7 @@ export class WalletListHeaderComponent extends React.PureComponent<Props> {
           <View style={styles.headerContainer}>
             <EdgeText style={styles.headerText}>{s.strings.title_wallets}</EdgeText>
             <View key="defaultButtons" style={styles.headerButtonsContainer}>
-              <TouchableOpacity style={styles.addButton} onPress={() => Actions.push('createWalletSelectCrypto')}>
+              <TouchableOpacity style={styles.addButton} onPress={() => navigation.push('createWalletSelectCrypto')}>
                 <Ionicon name="md-add" size={theme.rem(1.5)} color={theme.iconTappable} />
               </TouchableOpacity>
               <TouchableOpacity onPress={this.props.openSortModal}>
@@ -122,4 +123,4 @@ const getStyles = cacheStyles((theme: Theme) => ({
   }
 }))
 
-export const WalletListHeader = withTheme(WalletListHeaderComponent)
+export const WalletListHeader = withTheme(withNavigation(WalletListHeaderComponent))

--- a/src/types/routerTypes.js
+++ b/src/types/routerTypes.js
@@ -175,6 +175,14 @@ export type ParamList = {
     currencyCode: string,
     walletId: string
   },
+  passwordReminderModalComponent: void,
+  accelerateTxModelComponent: void,
+  headerTextButtonComponent: void,
+  transactionDetailsComponent: void,
+  selectFioAddressComponent: void,
+  transactionListRowComponent: void,
+  transactionListTopComponent: void,
+  walletListHeaderComponent: void,
   fioStakingOverview: {
     currencyCode: string,
     walletId: string
@@ -312,7 +320,7 @@ export type NavigationProp<Name: $Keys<ParamList>> = {
   navigate: <Name: $Keys<ParamList>>(name: Name, params: $ElementType<ParamList, Name>) => void,
   push: <Name: $Keys<ParamList>>(name: Name, params: $ElementType<ParamList, Name>) => void,
   replace: <Name: $Keys<ParamList>>(name: Name, params: $ElementType<ParamList, Name>) => void,
-  setParams: (params: $ElementType<ParamList, Name>) => void,
+  setParams: <Name: $Keys<ParamList>>(params: $ElementType<ParamList, Name>) => void,
 
   // Returning:
   goBack: () => void,
@@ -325,7 +333,8 @@ export type NavigationProp<Name: $Keys<ParamList>> = {
   toggleDrawer: () => void,
 
   // Internals nobody should need to touch:
-  state: mixed
+  state: mixed,
+  currentScene: mixed
 }
 
 /**
@@ -385,6 +394,11 @@ export function withNavigation<Props>(Component: React.ComponentType<Props>): Re
 
       get state() {
         return props.navigation.state
+      },
+
+      get currentScene() {
+        // $FlowFixMe
+        return Flux.Actions.currentScene
       }
     }
 
@@ -393,4 +407,96 @@ export function withNavigation<Props>(Component: React.ComponentType<Props>): Re
   const displayName = Component.displayName ?? Component.name ?? 'Component'
   WithNavigation.displayName = `WithNavigation(${displayName})`
   return WithNavigation
+}
+
+export const useNavigation = <Name: $Keys<ParamList>>() => {
+  const navigation: NavigationProp<Name> = {
+    addListener(event, callback) {
+      // TODO
+      return () => {}
+    },
+    isFocused() {
+      // TODO
+      return false
+    },
+
+    navigate(name, params) {
+      // $FlowFixMe
+      Flux.Actions.jump(name, { route: { name, params } })
+    },
+    push(name, params) {
+      // $FlowFixMe
+      Flux.Actions.push(name, { route: { name, params } })
+    },
+    replace(name, params) {
+      // $FlowFixMe
+      Flux.Actions.replace(name, { route: { name, params } })
+    },
+    setParams(params) {},
+    goBack() {},
+    pop() {
+      // $FlowFixMe
+      Flux.Actions.pop()
+    },
+    popToTop() {},
+
+    closeDrawer() {},
+    openDrawer() {},
+    toggleDrawer() {},
+
+    get state() {},
+    get currentScene() {
+      // $FlowFixMe
+      return Flux.Actions.currentScene
+    }
+  }
+  return navigation
+}
+
+/*
+  A non react-hook version of the navigation function
+  To be consumed by normal functions
+*/
+export const getNavigation = <Name: $Keys<ParamList>>() => {
+  const navigation: NavigationProp<Name> = {
+    addListener(event, callback) {
+      // TODO
+      return () => {}
+    },
+    isFocused() {
+      // TODO
+      return false
+    },
+
+    navigate(name, params) {
+      // $FlowFixMe
+      Flux.Actions.jump(name, { route: { name, params } })
+    },
+    push(name, params) {
+      // $FlowFixMe
+      Flux.Actions.push(name, { route: { name, params } })
+    },
+    replace(name, params) {
+      // $FlowFixMe
+      Flux.Actions.replace(name, { route: { name, params } })
+    },
+    setParams(params) {},
+    goBack() {},
+    pop() {
+      // $FlowFixMe
+      Flux.Actions.pop()
+    },
+    popToTop() {},
+
+    closeDrawer() {},
+    openDrawer() {},
+    toggleDrawer() {},
+
+    get state() {},
+    get currentScene() {
+      // $FlowFixMe
+      return Flux.Actions.currentScene
+    }
+  }
+  return navigation
 }

--- a/src/util/corePlugins.js
+++ b/src/util/corePlugins.js
@@ -89,7 +89,6 @@ export const ratePlugins = {
 
 export const swapPlugins = {
   // Centralized Swaps
-  changelly: ENV.CHANGELLY_INIT,
   changenow: ENV.CHANGE_NOW_INIT,
   exolix: ENV.EXOLIX_INIT,
   foxExchange: ENV.FOX_INIT,

--- a/src/util/fake/fakeNavigation.js
+++ b/src/util/fake/fakeNavigation.js
@@ -23,5 +23,6 @@ export const fakeNavigation: NavigationProp<any> = {
   openDrawer() {},
   toggleDrawer() {},
 
-  state: {}
+  state: {},
+  currentScene: {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6423,10 +6423,10 @@ edge-currency-monero@^0.4.1:
     jsonschema "^1.1.1"
     uri-js "^3.0.2"
 
-edge-currency-plugins@^1.0.0-rc.4:
-  version "1.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/edge-currency-plugins/-/edge-currency-plugins-1.0.0-rc.4.tgz#9200c2cf129c365701574a44863972fec907f85a"
-  integrity sha512-N1J8kqIVbNWECuYfDnr06+DJCzdoY5MqWCxXHNYYeRd961QspHICa5Zixy0Am/EA8gsDW7Enw7LvnMgT2wY7xQ==
+edge-currency-plugins@^1.0.0-rc.5:
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/edge-currency-plugins/-/edge-currency-plugins-1.0.0-rc.5.tgz#b41b5f9d8ef86c1af918a957d26fdcaeafb2256d"
+  integrity sha512-lqSF/YdLH35t3JnHRV+jG7NszEbfKshrmNHbLiG6I/2jc+eNIfEke+PfK/i75Mz1U9L9scfWqms5Y89CstuVUw==
   dependencies:
     altcoin-js "https://github.com/EdgeApp/altcoin-js.git#master"
     async-mutex "^0.2.6"


### PR DESCRIPTION
Replace existing `Actions` with the mock version of the React Navigation
lib.

This PR limits the deprecation to files under `src/components` only,
along with some necessary changes for test units.

Note that a `getNavigation` was created for `handlePluginBack()` to
consume. This might not be the best practice since it might not be
replicatable when migrating to React Navigation. Please advise how to
treat the said function with the mock navigation.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201388479070450