### PR TITLE
Do not require FIO plugin in order to sweep keys

### DIFF
--- a/src/actions/ScanActions.js
+++ b/src/actions/ScanActions.js
@@ -185,14 +185,16 @@ export const parseScannedUri = (data: string, customErrorTitle?: string, customE
   let fioAddress
   if (account && account.currencyConfig) {
     const fioPlugin = account.currencyConfig.fio
-    const currencyCode: string = state.ui.wallets.selectedCurrencyCode
-    try {
-      const publicAddress = await checkPubAddress(fioPlugin, data.toLowerCase(), edgeWallet.currencyInfo.currencyCode, currencyCode)
-      fioAddress = data.toLowerCase()
-      data = publicAddress
-    } catch (e) {
-      if (!e.code || e.code !== fioPlugin.currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS) {
-        return showError(e)
+    if (fioPlugin != null) {
+      const currencyCode: string = state.ui.wallets.selectedCurrencyCode
+      try {
+        const publicAddress = await checkPubAddress(fioPlugin, data.toLowerCase(), edgeWallet.currencyInfo.currencyCode, currencyCode)
+        fioAddress = data.toLowerCase()
+        data = publicAddress
+      } catch (e) {
+        if (!e.code || e.code !== fioPlugin.currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS) {
+          return showError(e)
+        }
       }
     }
   }


### PR DESCRIPTION
If FIO plugin is disabled, the sweep private keys feature should still
work.
This is particularly useful when developing because devs may disable
plugins.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
