### PR TITLE
Add the 'allowKeysOnlyMode' and default to hide the 'keysOnlyMode' plugins in the walletListModal

### DIFF
--- a/src/components/scenes/CryptoExchangeScene.js
+++ b/src/components/scenes/CryptoExchangeScene.js
@@ -8,7 +8,7 @@ import { sprintf } from 'sprintf-js'
 
 import { type SetNativeAmountInfo, exchangeMax, getQuoteForTransaction, selectWalletForExchange } from '../../actions/CryptoExchangeActions'
 import { updateMostRecentWalletsSelected } from '../../actions/WalletActions.js'
-import { getSpecialCurrencyInfo, SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants.js'
+import { getSpecialCurrencyInfo } from '../../constants/WalletAndCurrencyConstants.js'
 import s from '../../locales/strings.js'
 import { getExchangeRate } from '../../selectors/WalletSelectors.js'
 import { connect } from '../../types/reactRedux.js'
@@ -76,11 +76,6 @@ type State = {
   fromAmountNative: string,
   toAmountNative: string
 }
-
-// Prevent currencies that are "watch only" from being allowed to exchange
-const disabledCurrencyCodes = Object.keys(SPECIAL_CURRENCY_INFO)
-  .filter(pluginId => SPECIAL_CURRENCY_INFO[pluginId].keysOnlyMode ?? false)
-  .map(pluginId => SPECIAL_CURRENCY_INFO[pluginId].chainCode)
 
 const defaultFromWalletInfo = {
   fromCurrencyCode: '',
@@ -243,7 +238,7 @@ export class CryptoExchangeComponent extends React.Component<Props, State> {
         bridge={bridge}
         headerTitle={whichWallet === 'to' ? s.strings.select_recv_wallet : s.strings.select_src_wallet}
         showCreateWallet={whichWallet === 'to'}
-        excludeCurrencyCodes={whichWallet === 'to' ? disabledCurrencyCodes : []}
+        allowKeysOnlyMode={whichWallet === 'from'}
         filterActivation
       />
     )).then(({ walletId, currencyCode }: WalletListResult) => {

--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -27,7 +27,6 @@ import { selectWallet } from '../../../../actions/WalletActions'
 import { ButtonsModal } from '../../../../components/modals/ButtonsModal.js'
 import { type WalletListResult, WalletListModal } from '../../../../components/modals/WalletListModal.js'
 import { Airship, showError, showToast } from '../../../../components/services/AirshipInstance.js'
-import { SPECIAL_CURRENCY_INFO } from '../../../../constants/WalletAndCurrencyConstants.js'
 import s from '../../../../locales/strings'
 import { type GuiPlugin } from '../../../../types/GuiPluginTypes.js'
 import { type Dispatch, type RootState } from '../../../../types/reduxTypes.js'
@@ -95,11 +94,6 @@ const asEdgeTokenIdExtended = asObject({
   currencyCode: asOptional(asString)
 })
 
-// Prevent currencies that are "watch only" from being allowed to exchange
-const excludeAssets = Object.keys(SPECIAL_CURRENCY_INFO)
-  .filter(pluginId => SPECIAL_CURRENCY_INFO[pluginId].keysOnlyMode ?? false)
-  .map(pluginId => ({ pluginId }))
-
 const asCurrencyCodesArray = asOptional(asArray(asEither(asString, asEdgeTokenIdExtended)))
 type ExtendedCurrencyCode = string | $Call<typeof asEdgeTokenIdExtended>
 
@@ -155,7 +149,6 @@ export class EdgeProvider extends Bridgeable {
         bridge={bridge}
         showCreateWallet
         allowedAssets={upgradeExtendedCurrencyCodes(this._state.core.account, this._plugin.fixCurrencyCodes, allowedCurrencyCodes)}
-        excludeAssets={excludeAssets}
         headerTitle={s.strings.choose_your_wallet}
       />
     ))


### PR DESCRIPTION
In the pictures you can see I have a keysOnlyMode wallet (smartcash) which doesn't appear in any list other then the exchange-from and the main wallet list

![Simulator Screen Shot - iPhone 13 Pro - 2022-06-21 at 18 08 44](https://user-images.githubusercontent.com/4012041/174922087-3edd2982-aeb3-46be-83a4-4e44337f838e.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-06-21 at 18 09 30](https://user-images.githubusercontent.com/4012041/174922174-78bbd836-f6ae-4f3b-978e-d50252d6b2b0.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-06-21 at 18 09 16](https://user-images.githubusercontent.com/4012041/174922176-44e9823d-f816-4fd6-bae2-ba922b9ac91b.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-06-21 at 18 09 07](https://user-images.githubusercontent.com/4012041/174922182-4d612b8b-8f55-4966-be5a-c204568a2d7d.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-06-21 at 18 08 44](https://user-images.githubusercontent.com/4012041/174922183-c2904664-00a4-4885-aabf-7887d6b52545.png)

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202475595731510