### PR TITLE
Refactor CurrencyRow out from WalletListCurrencyRow

### DIFF
--- a/src/__tests__/components/CurrencyIcon.test.js
+++ b/src/__tests__/components/CurrencyIcon.test.js
@@ -5,7 +5,7 @@ import * as React from 'react'
 import * as reactRedux from 'react-redux'
 import ShallowRenderer from 'react-test-renderer/shallow'
 
-import { CryptoIconComponent } from '../../components/icons/CryptoIcon.js'
+import { CryptoIcon } from '../../components/icons/CryptoIcon.js'
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -51,7 +51,7 @@ describe('CryptoIcon', () => {
       marginRem: 1,
       paddingRem: [1, 2]
     }
-    const actual = renderer.render(<CryptoIconComponent {...props} />)
+    const actual = renderer.render(<CryptoIcon {...props} />)
 
     expect(actual).toMatchSnapshot()
   })

--- a/src/components/data/row/CurrencyRow.js
+++ b/src/components/data/row/CurrencyRow.js
@@ -3,16 +3,16 @@ import { type EdgeCurrencyWallet, type EdgeToken } from 'edge-core-js'
 import * as React from 'react'
 import { View } from 'react-native'
 
-import { useWalletBalance } from '../../hooks/useWalletBalance.js'
-import { useWalletName } from '../../hooks/useWalletName.js'
-import { memo } from '../../types/reactHooks.js'
-import { useSelector } from '../../types/reactRedux.js'
-import { CryptoIcon } from '../icons/CryptoIcon'
-import { type Theme, cacheStyles, useTheme } from '../services/ThemeContext.js'
-import { CryptoText } from '../text/CryptoText'
-import { FiatText } from '../text/FiatText.js'
-import { TickerText } from '../text/TickerText.js'
-import { EdgeText } from '../themed/EdgeText.js'
+import { useWalletBalance } from '../../../hooks/useWalletBalance.js'
+import { useWalletName } from '../../../hooks/useWalletName.js'
+import { memo } from '../../../types/reactHooks.js'
+import { useSelector } from '../../../types/reactRedux.js'
+import { CryptoIcon } from '../../icons/CryptoIcon'
+import { type Theme, cacheStyles, useTheme } from '../../services/ThemeContext.js'
+import { CryptoText } from '../../text/CryptoText'
+import { FiatText } from '../../text/FiatText.js'
+import { TickerText } from '../../text/TickerText.js'
+import { EdgeText } from '../../themed/EdgeText.js'
 
 type Props = {|
   showRate?: boolean,
@@ -24,7 +24,7 @@ type Props = {|
 // -----------------------------------------------------------------------------
 // A view representing the data from a wallet, used for rows, cards, etc.
 // -----------------------------------------------------------------------------
-const CurrencyGroupComponent = (props: Props) => {
+const CurrencyRowComponent = (props: Props) => {
   const { showRate = false, token, tokenId, wallet } = props
   const theme = useTheme()
   const styles = getStyles(theme)
@@ -38,8 +38,8 @@ const CurrencyGroupComponent = (props: Props) => {
   const balance = useWalletBalance(wallet, tokenId)
 
   return (
-    <>
-      <CryptoIcon marginRem={1} sizeRem={2} tokenId={tokenId} walletId={wallet.id} />
+    <View style={styles.container}>
+      <CryptoIcon sizeRem={2} tokenId={tokenId} walletId={wallet.id} />
       <View style={styles.nameColumn}>
         <View style={styles.currencyRow}>
           <EdgeText style={styles.currencyText}>{currencyCode}</EdgeText>
@@ -61,7 +61,7 @@ const CurrencyGroupComponent = (props: Props) => {
           </EdgeText>
         </View>
       ) : null}
-    </>
+    </View>
   )
 }
 
@@ -76,7 +76,14 @@ const getStyles = cacheStyles((theme: Theme) => ({
     flexDirection: 'column',
     flexGrow: 1,
     flexShrink: 1,
-    marginRight: theme.rem(0.5)
+    marginRight: theme.rem(0.5),
+    marginLeft: theme.rem(1)
+  },
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginLeft: theme.rem(0.5)
   },
   currencyRow: {
     flexDirection: 'row',
@@ -106,4 +113,4 @@ const getStyles = cacheStyles((theme: Theme) => ({
   }
 }))
 
-export const CurrencyGroup = memo(CurrencyGroupComponent)
+export const CurrencyRow = memo(CurrencyRowComponent)

--- a/src/components/icons/CryptoIcon.js
+++ b/src/components/icons/CryptoIcon.js
@@ -25,7 +25,7 @@ type Props = {
   currencyCode?: string
 }
 
-export const CryptoIconComponent = (props: Props) => {
+const CryptoIconComponent = (props: Props) => {
   let { pluginId, tokenId } = props
   const { walletId, mono = false, sizeRem, marginRem, currencyCode } = props
 

--- a/src/components/shared/CurrencyGroup.js
+++ b/src/components/shared/CurrencyGroup.js
@@ -1,0 +1,109 @@
+// @flow
+import { type EdgeCurrencyWallet, type EdgeToken } from 'edge-core-js'
+import * as React from 'react'
+import { View } from 'react-native'
+
+import { useWalletBalance } from '../../hooks/useWalletBalance.js'
+import { useWalletName } from '../../hooks/useWalletName.js'
+import { memo } from '../../types/reactHooks.js'
+import { useSelector } from '../../types/reactRedux.js'
+import { CryptoIcon } from '../icons/CryptoIcon'
+import { type Theme, cacheStyles, useTheme } from '../services/ThemeContext.js'
+import { CryptoText } from '../text/CryptoText'
+import { FiatText } from '../text/FiatText.js'
+import { TickerText } from '../text/TickerText.js'
+import { EdgeText } from '../themed/EdgeText.js'
+
+type Props = {|
+  showRate?: boolean,
+  token?: EdgeToken,
+  tokenId?: string,
+  wallet: EdgeCurrencyWallet
+|}
+
+// -----------------------------------------------------------------------------
+// A view representing the data from a wallet, used for rows, cards, etc.
+// -----------------------------------------------------------------------------
+const CurrencyGroupComponent = (props: Props) => {
+  const { showRate = false, token, tokenId, wallet } = props
+  const theme = useTheme()
+  const styles = getStyles(theme)
+
+  // Currency code and wallet name for display:
+  const { currencyCode } = token == null ? wallet.currencyInfo : token
+  const name = useWalletName(wallet)
+
+  // Balance stuff:
+  const showBalance = useSelector(state => state.ui.settings.isAccountBalanceVisible)
+  const balance = useWalletBalance(wallet, tokenId)
+
+  return (
+    <>
+      <CryptoIcon marginRem={1} sizeRem={2} tokenId={tokenId} walletId={wallet.id} />
+      <View style={styles.nameColumn}>
+        <View style={styles.currencyRow}>
+          <EdgeText style={styles.currencyText}>{currencyCode}</EdgeText>
+          {showRate && wallet != null ? (
+            <EdgeText style={styles.exchangeRateText}>
+              <TickerText wallet={wallet} tokenId={tokenId} />
+            </EdgeText>
+          ) : null}
+        </View>
+        <EdgeText style={styles.nameText}>{name}</EdgeText>
+      </View>
+      {showBalance ? (
+        <View style={styles.balanceColumn}>
+          <EdgeText>
+            <CryptoText wallet={wallet} tokenId={tokenId} nativeAmount={balance} />
+          </EdgeText>
+          <EdgeText style={styles.fiatBalanceText}>
+            <FiatText nativeCryptoAmount={balance} tokenId={tokenId} wallet={wallet} />
+          </EdgeText>
+        </View>
+      ) : null}
+    </>
+  )
+}
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  // Layout:
+  balanceColumn: {
+    alignItems: 'flex-end',
+    flexDirection: 'column',
+    paddingRight: theme.rem(1)
+  },
+  nameColumn: {
+    flexDirection: 'column',
+    flexGrow: 1,
+    flexShrink: 1,
+    marginRight: theme.rem(0.5)
+  },
+  currencyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-start'
+  },
+
+  // Text:
+  fiatBalanceText: {
+    fontSize: theme.rem(0.75),
+    color: theme.secondaryText
+  },
+  currencyText: {
+    flexBasis: 'auto',
+    flexShrink: 1,
+    fontFamily: theme.fontFaceMedium
+  },
+  exchangeRateText: {
+    textAlign: 'left',
+    flexBasis: 'auto',
+    flexShrink: 1,
+    marginLeft: theme.rem(0.75)
+  },
+  nameText: {
+    fontSize: theme.rem(0.75),
+    color: theme.secondaryText
+  }
+}))
+
+export const CurrencyGroup = memo(CurrencyGroupComponent)

--- a/src/components/themed/WalletListCurrencyRow.js
+++ b/src/components/themed/WalletListCurrencyRow.js
@@ -5,8 +5,8 @@ import { TouchableOpacity } from 'react-native'
 
 import { useHandler } from '../../hooks/useHandler.js'
 import { memo } from '../../types/reactHooks.js'
+import { CurrencyRow } from '../data/row/CurrencyRow.js'
 import { type Theme, cacheStyles, useTheme } from '../services/ThemeContext.js'
-import { CurrencyGroup } from '../shared/CurrencyGroup.js'
 
 type Props = {|
   showRate?: boolean,
@@ -42,7 +42,7 @@ const WalletListCurrencyRowComponent = (props: Props) => {
 
   return (
     <TouchableOpacity style={styles.row} onLongPress={onLongPress} onPress={handlePress}>
-      <CurrencyGroup showRate={showRate} token={token} tokenId={tokenId} wallet={wallet} />
+      <CurrencyRow showRate={showRate} token={token} tokenId={tokenId} wallet={wallet} />
     </TouchableOpacity>
   )
 }
@@ -53,7 +53,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     alignItems: 'center',
     flexDirection: 'row',
     justifyContent: 'center',
-    minHeight: theme.rem(4.25)
+    minHeight: theme.rem(4.25),
+    marginLeft: theme.rem(0.5)
   }
 }))
 

--- a/src/components/themed/WalletListCurrencyRow.js
+++ b/src/components/themed/WalletListCurrencyRow.js
@@ -1,19 +1,12 @@
 // @flow
 import { type EdgeCurrencyWallet, type EdgeToken } from 'edge-core-js'
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity } from 'react-native'
 
 import { useHandler } from '../../hooks/useHandler.js'
-import { useWalletBalance } from '../../hooks/useWalletBalance.js'
-import { useWalletName } from '../../hooks/useWalletName.js'
 import { memo } from '../../types/reactHooks.js'
-import { useSelector } from '../../types/reactRedux.js'
-import { CryptoIcon } from '../icons/CryptoIcon.js'
 import { type Theme, cacheStyles, useTheme } from '../services/ThemeContext.js'
-import { CryptoText } from '../text/CryptoText'
-import { FiatText } from '../text/FiatText.js'
-import { TickerText } from '../text/TickerText.js'
-import { EdgeText } from './EdgeText.js'
+import { CurrencyGroup } from '../shared/CurrencyGroup.js'
 
 type Props = {|
   showRate?: boolean,
@@ -26,7 +19,7 @@ type Props = {|
   onPress?: (walletId: string, currencyCode: string) => void
 |}
 
-export const WalletListCurrencyRowComponent = (props: Props) => {
+const WalletListCurrencyRowComponent = (props: Props) => {
   const {
     showRate = false,
     token,
@@ -42,11 +35,6 @@ export const WalletListCurrencyRowComponent = (props: Props) => {
 
   // Currency code and wallet name for display:
   const { currencyCode } = token == null ? wallet.currencyInfo : token
-  const name = useWalletName(wallet)
-
-  // Balance stuff:
-  const showBalance = useSelector(state => state.ui.settings.isAccountBalanceVisible)
-  const balance = useWalletBalance(wallet, tokenId)
 
   const handlePress = useHandler(() => {
     if (onPress != null) onPress(wallet.id, currencyCode)
@@ -54,28 +42,7 @@ export const WalletListCurrencyRowComponent = (props: Props) => {
 
   return (
     <TouchableOpacity style={styles.row} onLongPress={onLongPress} onPress={handlePress}>
-      <CryptoIcon marginRem={1} sizeRem={2} tokenId={tokenId} walletId={wallet.id} />
-      <View style={styles.nameColumn}>
-        <View style={styles.currencyRow}>
-          <EdgeText style={styles.currencyText}>{currencyCode}</EdgeText>
-          {showRate && wallet != null ? (
-            <EdgeText style={styles.exchangeRateText}>
-              <TickerText wallet={wallet} tokenId={tokenId} />
-            </EdgeText>
-          ) : null}
-        </View>
-        <EdgeText style={styles.nameText}>{name}</EdgeText>
-      </View>
-      {showBalance ? (
-        <View style={styles.balanceColumn}>
-          <EdgeText>
-            <CryptoText wallet={wallet} tokenId={tokenId} nativeAmount={balance} />
-          </EdgeText>
-          <EdgeText style={styles.fiatBalanceText}>
-            <FiatText nativeCryptoAmount={balance} tokenId={tokenId} wallet={wallet} />
-          </EdgeText>
-        </View>
-      ) : null}
+      <CurrencyGroup showRate={showRate} token={token} tokenId={tokenId} wallet={wallet} />
     </TouchableOpacity>
   )
 }
@@ -87,43 +54,6 @@ const getStyles = cacheStyles((theme: Theme) => ({
     flexDirection: 'row',
     justifyContent: 'center',
     minHeight: theme.rem(4.25)
-  },
-  balanceColumn: {
-    alignItems: 'flex-end',
-    flexDirection: 'column',
-    paddingRight: theme.rem(1)
-  },
-  nameColumn: {
-    flexDirection: 'column',
-    flexGrow: 1,
-    flexShrink: 1,
-    marginRight: theme.rem(0.5)
-  },
-  currencyRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'flex-start'
-  },
-
-  // Text:
-  fiatBalanceText: {
-    fontSize: theme.rem(0.75),
-    color: theme.secondaryText
-  },
-  currencyText: {
-    flexBasis: 'auto',
-    flexShrink: 1,
-    fontFamily: theme.fontFaceMedium
-  },
-  exchangeRateText: {
-    textAlign: 'left',
-    flexBasis: 'auto',
-    flexShrink: 1,
-    marginLeft: theme.rem(0.75)
-  },
-  nameText: {
-    fontSize: theme.rem(0.75),
-    color: theme.secondaryText
   }
 }))
 


### PR DESCRIPTION
The contents of WalletListCurrencyRow is reused across several places in the AAVE feature.

Refactor the contents of the WalletListCurrencyRow into CurrencyRow for reuse.

<img width="641" alt="Screen Shot 2022-06-23 at 10 49 55 PM" src="https://user-images.githubusercontent.com/90650827/175471049-a010d66b-2ade-44d2-89f9-07e6d5f4e827.png">


#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202491779403706