### PR TITLE
Implement CryptoFiatAmountGroup

### DIFF
--- a/src/components/data/row/CryptoFiatAmountRow.js
+++ b/src/components/data/row/CryptoFiatAmountRow.js
@@ -1,0 +1,96 @@
+// @flow
+
+import { div, mul } from 'biggystring'
+import { type EdgeCurrencyWallet } from 'edge-core-js'
+import * as React from 'react'
+import { View } from 'react-native'
+
+import { useTokenDisplayData } from '../../../hooks/useTokenDisplayData'
+import { memo, useMemo } from '../../../types/reactHooks'
+import { DECIMAL_PRECISION } from '../../../util/utils'
+import { CryptoIcon } from '../../icons/CryptoIcon'
+import { FiatIcon } from '../../icons/FiatIcon'
+import { type Theme, cacheStyles, useTheme } from '../../services/ThemeContext.js'
+import { CryptoText } from '../../text/CryptoText'
+import { FiatText } from '../../text/FiatText.js'
+import { EdgeText } from '../../themed/EdgeText.js'
+
+type Props = {|
+  nativeFiatAmount: string,
+  tokenId: string,
+  wallet: EdgeCurrencyWallet
+|}
+
+// -----------------------------------------------------------------------------
+// A row of data with crypto on the left and fiat on the right. Currently
+// supports only an input amount of native fiat and a conversion to some token.
+// -----------------------------------------------------------------------------
+const CryptoFiatAmountRowComponent = (props: Props) => {
+  const { nativeFiatAmount, tokenId, wallet } = props
+  const theme = useTheme()
+  const styles = getStyles(theme)
+  const walletId = wallet.id
+  const token = wallet.currencyConfig.allTokens[tokenId]
+  const { currencyCode, denominations } = token
+  const tokenExchangeMultiplier = denominations[0].multiplier
+
+  const { assetToFiatRate: tokenFiatRate } = useTokenDisplayData({
+    tokenId,
+    wallet
+  })
+
+  /**
+   * Convert between native fiat amount and native crypto amount:
+   *   nativeFiatAmount = (nativeCryptoAmount / cryptoExchangeMultiplier) * tokenFiatRate
+   *   nativeCryptoAmount = cryptoExchangeMultiplier * (nativeFiatAmount / tokenFiatRate)
+   */
+  const nativeTokenAmount = useMemo(() => {
+    const ret = mul(tokenExchangeMultiplier, div(nativeFiatAmount, tokenFiatRate, DECIMAL_PRECISION))
+    return ret
+  }, [tokenExchangeMultiplier, nativeFiatAmount, tokenFiatRate])
+
+  // Use nativeTokenAmount in both fiat and crypto display fields because they properly handle any user/locale settings.
+  return (
+    <View style={styles.spacedContainer}>
+      <View style={styles.halfContainer}>
+        <CryptoIcon sizeRem={1.5} marginRem={[0.5, 0.25, 0.5, 0.5]} tokenId={tokenId} walletId={walletId} />
+        {/* Extra view to make text respect bounds of outer halfContainer */}
+        <View style={styles.halfContainer}>
+          <EdgeText style={styles.text}>
+            <CryptoText wallet={wallet} tokenId={tokenId} nativeAmount={nativeTokenAmount} />
+            {' ' + currencyCode}
+          </EdgeText>
+        </View>
+      </View>
+
+      <View style={styles.halfContainer}>
+        <FiatIcon sizeRem={1.5} marginRem={[0.5, 0.25, 0.5, 0.5]} fiatCurrencyCode={wallet.fiatCurrencyCode} />
+        {/* Make text respect bounds of outer half container */}
+        <View style={styles.halfContainer}>
+          <EdgeText style={styles.text}>
+            <FiatText appendFiatCurrencyCode autoPrecision hideFiatSymbol nativeCryptoAmount={nativeTokenAmount} tokenId={tokenId} wallet={wallet} />
+          </EdgeText>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  spacedContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    flex: 1
+  },
+  halfContainer: {
+    flex: 1,
+    alignItems: 'center',
+    flexDirection: 'row'
+  },
+  text: {
+    fontFamily: theme.fontFaceMedium,
+    marginLeft: theme.rem(0.25)
+  }
+}))
+
+export const CryptoFiatAmountRow = memo(CryptoFiatAmountRowComponent)

--- a/src/components/text/FiatText.js
+++ b/src/components/text/FiatText.js
@@ -10,6 +10,7 @@ type Props = {|
   appendFiatCurrencyCode?: boolean,
   autoPrecision?: boolean,
   fiatSymbolSpace?: boolean,
+  hideFiatSymbol?: boolean,
 
   // Amount to show:
   nativeCryptoAmount: string,
@@ -21,7 +22,7 @@ type Props = {|
  * Return a formatted fiat text string representing the exchange rate of a
  * specific crypto asset and native amount.
  **/
-export const FiatText = ({ appendFiatCurrencyCode, autoPrecision, fiatSymbolSpace, nativeCryptoAmount, tokenId, wallet }: Props) => {
+export const FiatText = ({ appendFiatCurrencyCode, autoPrecision, hideFiatSymbol, fiatSymbolSpace, nativeCryptoAmount, tokenId, wallet }: Props) => {
   const { currencyCode, denomination, isoFiatCurrencyCode } = useTokenDisplayData({
     tokenId,
     wallet
@@ -33,6 +34,7 @@ export const FiatText = ({ appendFiatCurrencyCode, autoPrecision, fiatSymbolSpac
     cryptoCurrencyCode: currencyCode,
     cryptoExchangeMultiplier: denomination.multiplier,
     fiatSymbolSpace,
+    hideFiatSymbol,
     isoFiatCurrencyCode,
     nativeCryptoAmount
   })

--- a/src/hooks/useFiatText.js
+++ b/src/hooks/useFiatText.js
@@ -14,6 +14,7 @@ type Props = {
   cryptoCurrencyCode: string,
   cryptoExchangeMultiplier?: string,
   fiatSymbolSpace?: boolean,
+  hideFiatSymbol?: boolean,
   isoFiatCurrencyCode?: string,
   nativeCryptoAmount?: string,
   noGrouping?: boolean
@@ -26,6 +27,7 @@ export const useFiatText = (props: Props): string => {
     cryptoCurrencyCode,
     cryptoExchangeMultiplier = defaultMultiplier,
     fiatSymbolSpace,
+    hideFiatSymbol,
     isoFiatCurrencyCode = USD_FIAT,
     nativeCryptoAmount = cryptoExchangeMultiplier,
     noGrouping = false
@@ -49,7 +51,7 @@ export const useFiatText = (props: Props): string => {
         })
       : '0'
 
-  const fiatSymbol = `${getSymbolFromCurrency(isoFiatCurrencyCode)}${fiatSymbolSpace ? ' ' : ''}`
+  const fiatSymbol = hideFiatSymbol ? '' : `${getSymbolFromCurrency(isoFiatCurrencyCode)}${fiatSymbolSpace ? ' ' : ''}`
   const fiatCurrencyCode = appendFiatCurrencyCode ? ` ${isoFiatCurrencyCode.replace('iso:', '')}` : ''
   return `${fiatSymbol}${fiatString}${fiatCurrencyCode}`
 }


### PR DESCRIPTION
Based on an input native fiat amount, wallet, and token, return a row showing:
- Crypto icon,
- The equivalent formatted/localized crypto amount
- Fiat icon
- Fiat (display) amount

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
- [ ] 
<img width="477" alt="Screen Shot 2022-06-23 at 6 46 29 PM" src="https://user-images.githubusercontent.com/90650827/175445868-e244b4c1-c82a-4c10-8e08-0ed55bc26eba.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202491779403713