### PR TITLE
Enable MATIC/USDC sell on Wyre

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "edge-login-ui-rn": "^0.10.6",
     "edge-plugin-bity": "https://github.com/EdgeApp/edge-plugin-bity.git#2a52e6cb86512b98f69f8f5dd3105cdf6d0c2d8a",
     "edge-plugin-simplex": "https://github.com/EdgeApp/edge-plugin-simplex.git#b11def82d84f2735b91f4b8104a9e0d3e8c3600d",
-    "edge-plugin-wyre": "https://github.com/EdgeApp/edge-plugin-wyre.git#6412ad28462278b84313537f21a53d307633c5d0",
+    "edge-plugin-wyre": "https://github.com/EdgeApp/edge-plugin-wyre.git#de269abc6999a7f8bf492f58a800dfd248d913d3",
     "ethers": "^5.6.0",
     "qrcode-generator": "^1.4.4",
     "react": "17.0.2",

--- a/src/modules/UI/scenes/Plugins/EdgeProvider.js
+++ b/src/modules/UI/scenes/Plugins/EdgeProvider.js
@@ -43,6 +43,7 @@ type WalletDetails = {
   receiveAddress: {
     publicAddress: string
   },
+  chainCode: string,
   currencyCode: string,
   fiatCurrencyCode: string
 }
@@ -239,6 +240,7 @@ export class EdgeProvider extends Bridgeable {
       name: walletName,
       pluginId: edgeWallet.currencyInfo.pluginId,
       receiveAddress,
+      chainCode: this.selectedChainCode,
       currencyCode,
       fiatCurrencyCode: edgeWallet.fiatCurrencyCode.replace('iso:', ''),
       currencyIcon: icons.symbolImage,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4921,12 +4921,17 @@ cleaner-config@^0.1.8:
     minimist "^1.2.5"
     sucrase "^3.17.1"
 
-cleaners@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/cleaners/-/cleaners-0.2.1.tgz#535849cfabc91e3ae1fc872b43d450446cd1a1a1"
-  integrity sha512-DSz39+aAcvfqwruSz7H7xY9kE3tRbMTiq2GQtZHpNWox2npyoQGdMUYR7pYgApJNSDY5Q9GNRo+JyncxI5USIA==
+cleaners@^0.3.1, cleaners@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/cleaners/-/cleaners-0.3.9.tgz#e9d2b7ebbbf62c0ae9f7bf1f1cf0aa5544acb3fa"
+  integrity sha512-DAddE949KDyTFcb6LdVpEd4BBHa55wNfm63tE0AYT2hDZyg0IR6lwOqjPhP/6GwF1z9FWeKqjw20T27/UHjM+Q==
 
-cleaners@^0.3.1, cleaners@^0.3.11, cleaners@^0.3.12, cleaners@^0.3.8, cleaners@^0.3.9:
+cleaners@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/cleaners/-/cleaners-0.3.11.tgz#7168178df8223965acfea1b81883250c574fedfe"
+  integrity sha512-Iq/spAHw/Ca2O8+kRaYy60+XWQrnqYa7KuuHM7z+RV8wvrN2JTWtBpY0uZWfhVuooGY7SoaY6Cwvbqo8oE4OYQ==
+
+cleaners@^0.3.12, cleaners@^0.3.8:
   version "0.3.12"
   resolved "https://registry.yarnpkg.com/cleaners/-/cleaners-0.3.12.tgz#0e99ef2460a59ed87550a60bdfc441b1696ff9cb"
   integrity sha512-bK7IvvYyhfy30S3VKmWi/YVWp0MUH1pEYfdtbjCpQiIzy8gmP9GCXv6AVZENDHbpcRHqMnZONs3ieyJMh3zvVw==
@@ -6208,11 +6213,11 @@ edge-login-ui-rn@^0.10.6:
   dependencies:
     moment "^2.22.2"
 
-"edge-plugin-wyre@https://github.com/EdgeApp/edge-plugin-wyre.git#6412ad28462278b84313537f21a53d307633c5d0":
+"edge-plugin-wyre@https://github.com/EdgeApp/edge-plugin-wyre.git#de269abc6999a7f8bf492f58a800dfd248d913d3":
   version "0.1.2"
-  resolved "https://github.com/EdgeApp/edge-plugin-wyre.git#6412ad28462278b84313537f21a53d307633c5d0"
+  resolved "https://github.com/EdgeApp/edge-plugin-wyre.git#de269abc6999a7f8bf492f58a800dfd248d913d3"
   dependencies:
-    cleaners "^0.2.0"
+    cleaners "^0.3.12"
     js-sha256 "^0.9.0"
     moment "^2.22.2"
 


### PR DESCRIPTION
This PR cleans up token handling in EdgeProvider and updates to the latest edge-plugin-wyre which requires the newer EdgeProvider to properly handle MATIC and MATIC-USDC tokens. 

This is pretty valuable as many AAVE users borrow MATIC-USDC and need to sell it to their bank.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202542030026805