### PR TITLE
Resync the wallet after sweeping keys

### DIFF
--- a/src/actions/ScanActions.js
+++ b/src/actions/ScanActions.js
@@ -354,6 +354,7 @@ async function sweepPrivateKeys(wallet: EdgeCurrencyWallet, privateKeys: string[
   })
   const signedTx = await wallet.signTx(unsignedTx)
   await wallet.broadcastTx(signedTx)
+  await wallet.resyncBlockchain()
 }
 
 const shownWalletGetCryptoModals = []


### PR DESCRIPTION
When scanning to sweep private keys, funds not showing up until after resync, so just force a resync after the sweep.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202491251474019