### PR TITLE
Remove state from SwapSettingsScene

### DIFF
--- a/src/components/scenes/SwapSettingsScene.js
+++ b/src/components/scenes/SwapSettingsScene.js
@@ -42,7 +42,6 @@ type State = {
 }
 
 export class SwapSettings extends React.Component<Props, State> {
-  cleanups: Array<() => mixed> = []
   sortedIds: string[]
 
   constructor(props: Props) {
@@ -53,14 +52,6 @@ export class SwapSettings extends React.Component<Props, State> {
     for (const pluginId of Object.keys(exchanges)) {
       const exchange = exchanges[pluginId]
       this.state.enabled[pluginId] = exchange.enabled
-
-      this.cleanups.push(
-        exchange.watch('enabled', enabled =>
-          this.setState(state => ({
-            enabled: { ...state.enabled, [pluginId]: enabled }
-          }))
-        )
-      )
     }
 
     const exchangeIds = Object.keys(exchanges).filter(id => id !== 'transfer')
@@ -68,7 +59,8 @@ export class SwapSettings extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    for (const cleanup of this.cleanups) cleanup()
+    const { exchanges } = this.props
+    Promise.all(Object.keys(exchanges).map(pluginId => exchanges[pluginId].changeEnabled(this.state.enabled[pluginId])))
   }
 
   handlePreferredModal = () => {
@@ -124,15 +116,15 @@ export class SwapSettings extends React.Component<Props, State> {
   renderPlugin(pluginId: string) {
     const { exchanges } = this.props
     const { displayName } = exchanges[pluginId].swapInfo
+    const pluginEnabled = this.state.enabled[pluginId]
 
     return (
       <SettingsSwitchRow
         key={pluginId}
         label={displayName}
-        value={this.state.enabled[pluginId]}
+        value={pluginEnabled}
         onPress={async () => {
-          const newValue = !exchanges[pluginId].enabled
-          await exchanges[pluginId].changeEnabled(newValue)
+          this.setState({ enabled: { ...this.state.enabled, [pluginId]: !pluginEnabled } })
         }}
       >
         {this.renderPluginIcon(pluginId)}

--- a/src/components/scenes/SwapSettingsScene.js
+++ b/src/components/scenes/SwapSettingsScene.js
@@ -38,8 +38,7 @@ type StateProps = {
 type Props = StateProps & DispatchProps & ThemeProps
 
 type State = {
-  enabled: { [pluginId: string]: boolean },
-  needsActivation: { [pluginId: string]: boolean }
+  enabled: { [pluginId: string]: boolean }
 }
 
 export class SwapSettings extends React.Component<Props, State> {
@@ -50,23 +49,15 @@ export class SwapSettings extends React.Component<Props, State> {
     super(props)
     const { exchanges } = props
 
-    this.state = { enabled: {}, needsActivation: {} }
+    this.state = { enabled: {} }
     for (const pluginId of Object.keys(exchanges)) {
       const exchange = exchanges[pluginId]
       this.state.enabled[pluginId] = exchange.enabled
-      this.state.needsActivation[pluginId] = exchange.needsActivation
 
       this.cleanups.push(
         exchange.watch('enabled', enabled =>
           this.setState(state => ({
             enabled: { ...state.enabled, [pluginId]: enabled }
-          }))
-        )
-      )
-      this.cleanups.push(
-        exchange.watch('needsActivation', needsActivation =>
-          this.setState(state => ({
-            needsActivation: { ...state.needsActivation, [pluginId]: needsActivation }
           }))
         )
       )


### PR DESCRIPTION
This removes the state from the swap settings scene where there was a theoretical race condition could make the state out of sync with the actual plugin settings. This also removes reference to needsActivation which isn't used.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202604584900504