### PR TITLE
Add supportEmail to AppConfig

### DIFF
--- a/src/actions/CreateWalletActions.js
+++ b/src/actions/CreateWalletActions.js
@@ -11,6 +11,7 @@ import { Airship, showError } from '../components/services/AirshipInstance.js'
 import { getPluginId } from '../constants/WalletAndCurrencyConstants.js'
 import s from '../locales/strings.js'
 import { getExchangeDenomination } from '../selectors/DenominationSelectors.js'
+import { config } from '../theme/appConfig.js'
 import type { Dispatch, GetState } from '../types/reduxTypes.js'
 import { Actions } from '../types/routerTypes.js'
 import { logEvent } from '../util/tracking.js'
@@ -156,7 +157,7 @@ export const createAccountTransaction =
             const edgeMetadata: EdgeMetadata = {
               name: sprintf(s.strings.create_wallet_account_metadata_name, createdWalletCurrencyCode),
               category: 'Expense:' + sprintf(s.strings.create_wallet_account_metadata_category, createdWalletCurrencyCode),
-              notes: sprintf(s.strings.create_wallet_account_metadata_notes, createdWalletCurrencyCode, createdWalletCurrencyCode, 'support@edge.app')
+              notes: sprintf(s.strings.create_wallet_account_metadata_notes, createdWalletCurrencyCode, createdWalletCurrencyCode, config.supportEmail)
             }
             paymentWallet.saveTxMetadata(edgeTransaction.txid, currencyCode, edgeMetadata).then(() => {
               Actions.popTo('walletListScene')

--- a/src/components/scenes/CrashScene.js
+++ b/src/components/scenes/CrashScene.js
@@ -3,8 +3,10 @@
 import * as React from 'react'
 import { Text } from 'react-native'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
+import { sprintf } from 'sprintf-js'
 
 import s from '../../locales/strings.js'
+import { config } from '../../theme/appConfig.js'
 import { SceneWrapper } from '../common/SceneWrapper.js'
 import { type Theme, type ThemeProps, cacheStyles, withTheme } from '../services/ThemeContext.js'
 
@@ -19,7 +21,7 @@ function CrashSceneComponent(props: ThemeProps): React.Node {
     <SceneWrapper background="theme" padding={theme.rem(0.5)} scroll>
       <AntDesignIcon name="frowno" style={styles.icon} />
       <Text style={styles.titleText}>{s.strings.error_boundary_title}</Text>
-      <Text style={styles.messageText}>{s.strings.error_boundary_message}</Text>
+      <Text style={styles.messageText}>{sprintf(s.strings.error_boundary_message_s, config.supportEmail)}</Text>
     </SceneWrapper>
   )
 }

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -799,8 +799,8 @@ const strings = {
     'NOTE: If you had custom nodes enabled, those wallets will not sync until corrected.',
 
   error_boundary_title: 'Oops!',
-  error_boundary_message:
-    "We're sorry but something went wrong. Please kill and restart the app to continue.\n\nIf the problem persists, contact us at support@edge.app, and we'll do our best to fix the problem.",
+  error_boundary_message_s:
+    "We're sorry but something went wrong. Please kill and restart the app to continue.\n\nIf the problem persists, contact us at %1$s, and we'll do our best to fix the problem.",
 
   export_transaction_date_range: 'Date Range',
   export_transaction_export_type: 'Export Type',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -731,7 +731,7 @@
   "update_notice_deprecate_electrum_servers_title": "Blockbook Upgrade",
   "update_notice_deprecate_electrum_servers_message": "%s no longer uses Electrum Servers. If you would like to continue to use CUSTOM NODES, please input Blockbook compatible addresses.\n\nNOTE: If you had custom nodes enabled, those wallets will not sync until corrected.",
   "error_boundary_title": "Oops!",
-  "error_boundary_message": "We're sorry but something went wrong. Please kill and restart the app to continue.\n\nIf the problem persists, contact us at support@edge.app, and we'll do our best to fix the problem.",
+  "error_boundary_message_s": "We're sorry but something went wrong. Please kill and restart the app to continue.\n\nIf the problem persists, contact us at %1$s, and we'll do our best to fix the problem.",
   "export_transaction_date_range": "Date Range",
   "export_transaction_export_type": "Export Type",
   "export_transaction_this_month": "This Month",

--- a/src/theme/edgeConfig.js
+++ b/src/theme/edgeConfig.js
@@ -5,20 +5,20 @@ import { edgeDark } from './variables/edgeDark.js'
 import { edgeLight } from './variables/edgeLight.js'
 
 export const edgeConfig: AppConfig = {
-  configName: 'edge',
   appId: undefined,
   appName: 'Edge',
   appNameShort: 'Edge',
-  darkTheme: edgeDark,
-  lightTheme: edgeLight,
-  supportsEdgeLogin: true,
-  referralServers: ['https://referral1.edge.app'],
-  notificationServers: ['https://notif1.edge.app'],
-  knowledgeBase: 'https://support.edge.app/support/home',
-  supportSite: 'https://support.edge.app/support/tickets/new',
-  phoneNumber: '+1-619-777-5688',
-  website: 'https://edge.app',
-  termsOfServiceSite: 'https://edge.app/tos/',
   appStore: 'https://itunes.apple.com/app/id1344400091',
-  defaultWallets: ['BTC', 'ETH', 'LTC', 'BCH', 'DASH']
+  configName: 'edge',
+  darkTheme: edgeDark,
+  defaultWallets: ['BTC', 'ETH', 'LTC', 'BCH', 'DASH'],
+  knowledgeBase: 'https://support.edge.app/support/home',
+  lightTheme: edgeLight,
+  notificationServers: ['https://notif1.edge.app'],
+  phoneNumber: '+1-619-777-5688',
+  referralServers: ['https://referral1.edge.app'],
+  supportsEdgeLogin: true,
+  supportSite: 'https://support.edge.app/support/tickets/new',
+  termsOfServiceSite: 'https://edge.app/tos/',
+  website: 'https://edge.app'
 }

--- a/src/theme/edgeConfig.js
+++ b/src/theme/edgeConfig.js
@@ -18,6 +18,7 @@ export const edgeConfig: AppConfig = {
   phoneNumber: '+1-619-777-5688',
   referralServers: ['https://referral1.edge.app'],
   supportsEdgeLogin: true,
+  supportEmail: 'support@edge.app',
   supportSite: 'https://support.edge.app/support/tickets/new',
   termsOfServiceSite: 'https://edge.app/tos/',
   website: 'https://edge.app'

--- a/src/theme/testConfig.js
+++ b/src/theme/testConfig.js
@@ -18,6 +18,7 @@ export const testConfig: AppConfig = {
   phoneNumber: '+1-800-100-1000',
   referralServers: ['https://referral1.testy.com'],
   supportsEdgeLogin: false,
+  supportEmail: 'support@testy.com',
   supportSite: 'https://support.testy.com',
   termsOfServiceSite: 'https://testy.com/tos/',
   website: 'https://testy.com'

--- a/src/theme/testConfig.js
+++ b/src/theme/testConfig.js
@@ -5,20 +5,20 @@ import { testDark } from './variables/testDark.js'
 import { testLight } from './variables/testLight.js'
 
 export const testConfig: AppConfig = {
-  configName: 'test',
   appId: 'com.testy.wallet',
   appName: 'Testy Wallet',
   appNameShort: 'Testy',
-  darkTheme: testDark,
-  lightTheme: testLight,
-  supportsEdgeLogin: false,
-  referralServers: ['https://referral1.testy.com'],
-  notificationServers: ['https://notif1.edge.app'],
-  knowledgeBase: 'https://support.testy.com/knowledge',
-  supportSite: 'https://support.testy.com',
-  phoneNumber: '+1-800-100-1000',
-  website: 'https://testy.com',
-  termsOfServiceSite: 'https://testy.com/tos/',
   appStore: 'https://itunes.apple.com/app/id1344400092',
-  defaultWallets: ['BTC', 'FTM:TOMB', 'ETH:USDC']
+  configName: 'test',
+  darkTheme: testDark,
+  defaultWallets: ['BTC', 'FTM:TOMB', 'ETH:USDC'],
+  knowledgeBase: 'https://support.testy.com/knowledge',
+  lightTheme: testLight,
+  notificationServers: ['https://notif1.edge.app'],
+  phoneNumber: '+1-800-100-1000',
+  referralServers: ['https://referral1.testy.com'],
+  supportsEdgeLogin: false,
+  supportSite: 'https://support.testy.com',
+  termsOfServiceSite: 'https://testy.com/tos/',
+  website: 'https://testy.com'
 }

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -326,7 +326,7 @@ export type AppConfig = {
   phoneNumber: string,
   referralServers?: string[],
   supportsEdgeLogin: boolean,
-  knowledgeBase: string,
+  supportEmail: string,
   supportSite: string,
   termsOfServiceSite: string,
   website: string

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -313,22 +313,23 @@ export type wcGetConnection = {
   timeConnected: number
 }
 export type AppConfig = {
-  configName: string,
   appId?: string,
   appName: string,
   appNameShort: string,
+  appStore: string,
+  configName: string,
   darkTheme: Theme,
+  defaultWallets: string[],
+  knowledgeBase: string,
   lightTheme: Theme,
-  referralServers?: string[],
   notificationServers: string[],
+  phoneNumber: string,
+  referralServers?: string[],
   supportsEdgeLogin: boolean,
   knowledgeBase: string,
   supportSite: string,
-  phoneNumber: string,
-  website: string,
   termsOfServiceSite: string,
-  appStore: string,
-  defaultWallets: string[]
+  website: string
 }
 
 /**


### PR DESCRIPTION
We currently allow configuration of all aspects of our app that refer to 'Edge' in order to enable white-labeling. 

The support email is not a part of that configuration and is still hard-coded throughout our app.

Update AppConfig to include supportEmail, and update all hard-coded references to 'support@edge.app' to use 'config.supportEmail' instead. 

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
