### PR TITLE
Tighten filtering for sweep private key

### DIFF
--- a/src/components/themed/ControlPanel.js
+++ b/src/components/themed/ControlPanel.js
@@ -38,6 +38,10 @@ import { DividerLine } from './DividerLine'
 
 type Props = { navigation: NavigationProp<'controlPanel'> }
 
+const SWEEPABLE_CURRENCY_CODES = Object.keys(SPECIAL_CURRENCY_INFO)
+  .filter(pluginId => SPECIAL_CURRENCY_INFO[pluginId].isPrivateKeySweepable)
+  .map(pluginId => SPECIAL_CURRENCY_INFO[pluginId].chainCode)
+
 export function ControlPanel(props: Props) {
   const { navigation } = props
   const state: any = navigation.state
@@ -48,7 +52,8 @@ export function ControlPanel(props: Props) {
 
   // ---- Redux State ----
 
-  const wallets = useSelector(state => state.core.account.currencyWallets)
+  const account = useSelector(state => state.core.account)
+  const wallets = useWatch(account, 'currencyWallets')
   const activeUsername = useSelector(state => state.core.account.username)
   const context = useSelector(state => state.core.context)
   const selectedWallet = useSelectedWallet()
@@ -101,18 +106,15 @@ export function ControlPanel(props: Props) {
   }
 
   const handleSweep = () => {
-    const sweepableCurrencyCodes = Object.keys(SPECIAL_CURRENCY_INFO)
-      .filter(pluginId => SPECIAL_CURRENCY_INFO[pluginId].isPrivateKeySweepable)
-      .map(pluginId => SPECIAL_CURRENCY_INFO[pluginId].chainCode)
     const excludeWalletIds = Object.keys(wallets).filter(
-      walletId => !sweepableCurrencyCodes.some(currencyCode => currencyCode === wallets[walletId].currencyInfo.currencyCode)
+      walletId => !SWEEPABLE_CURRENCY_CODES.some(currencyCode => currencyCode === wallets[walletId].currencyInfo.currencyCode)
     )
 
     Airship.show(bridge => (
       <WalletListModal
         bridge={bridge}
         headerTitle={s.strings.select_wallet}
-        allowedCurrencyCodes={sweepableCurrencyCodes}
+        allowedCurrencyCodes={SWEEPABLE_CURRENCY_CODES}
         excludeWalletIds={excludeWalletIds}
         showCreateWallet
       />


### PR DESCRIPTION
Sweep private key filters only by currency code.

Tighten filtering so that the wallet's native currency is taken into account in the wallet picker for sweep private key.

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202647424989390
  - https://app.asana.com/0/0/1202648122272329