### PR TITLE
Refactor TransactionListRow to no longer use GuiWallet

### DIFF
--- a/src/__tests__/components/TransactionRow.test.js
+++ b/src/__tests__/components/TransactionRow.test.js
@@ -7,7 +7,7 @@ import * as React from 'react'
 import ShallowRenderer from 'react-test-renderer/shallow'
 
 import { getTheme } from '../../components/services/ThemeContext.js'
-import { TransactionListRowComponent } from '../../components/themed/TransactionListRow.js'
+import { TransactionListRow } from '../../components/themed/TransactionListRow.js'
 import { getSymbolFromCurrency } from '../../constants/WalletAndCurrencyConstants.js'
 import { formatNumber } from '../../locales/intl.js'
 import { type GuiWallet } from '../../types/types.js'
@@ -76,7 +76,7 @@ describe('Transaction List Row', () => {
       transaction: transaction,
       theme: getTheme()
     }
-    const actual = renderer.render(<TransactionListRowComponent {...props} />)
+    const actual = renderer.render(<TransactionListRow {...props} />)
 
     expect(actual).toMatchSnapshot()
   })

--- a/src/components/themed/TransactionListRow.js
+++ b/src/components/themed/TransactionListRow.js
@@ -1,16 +1,18 @@
 // @flow
 
 import { abs, div, log10 } from 'biggystring'
-import type { EdgeCurrencyInfo, EdgeCurrencyWallet } from 'edge-core-js'
 import * as React from 'react'
 
 import { getSymbolFromCurrency } from '../../constants/WalletAndCurrencyConstants.js'
 import { displayFiatAmount } from '../../hooks/useFiatText.js'
+import { useHandler } from '../../hooks/useHandler.js'
+import { useWatch } from '../../hooks/useWatch.js'
 import { formatNumber } from '../../locales/intl.js'
 import s from '../../locales/strings'
 import { getDisplayDenomination, getExchangeDenomination } from '../../selectors/DenominationSelectors.js'
-import { connect } from '../../types/reactRedux.js'
+import { useSelector } from '../../types/reactRedux'
 import { Actions } from '../../types/routerTypes.js'
+import { type GuiContact } from '../../types/types'
 import type { TransactionListTx } from '../../types/types.js'
 import {
   DECIMAL_PRECISION,
@@ -26,30 +28,64 @@ import {
 import { showError } from '../services/AirshipInstance.js'
 import { TransactionRow } from './TransactionRow.js'
 
-type StateProps = {
-  cryptoAmount: string,
-  denominationSymbol?: string,
-  fiatAmount: string,
-  fiatSymbol: string,
-  isSentTransaction: boolean,
-  requiredConfirmations: number,
-  selectedCurrencyName: string,
-  thumbnailPath?: string
-}
-
-type OwnProps = {
-  // eslint-disable-next-line react/no-unused-prop-types
+type Props = {
   walletId: string,
-  // eslint-disable-next-line react/no-unused-prop-types
   currencyCode: string,
   transaction: TransactionListTx
 }
 
-type Props = OwnProps & StateProps
+export function TransactionListRow(props: Props) {
+  const { currencyCode, walletId, transaction } = props
+  const { metadata } = transaction
+  const { name, amountFiat } = metadata ?? {}
+  const account = useSelector(state => state.core.account)
+  const currencyWallets = useWatch(account, 'currencyWallets')
+  const wallet = currencyWallets[walletId]
+  const fiatCurrencyCode = useWatch(wallet, 'fiatCurrencyCode')
+  const nonIsoFiatCurrencyCode = fiatCurrencyCode.replace('iso:', '')
+  const currencyInfo = wallet.currencyInfo
 
-export class TransactionListRowComponent extends React.PureComponent<Props> {
-  handlePress = () => {
-    const { transaction, thumbnailPath } = this.props
+  const displayDenomination = useSelector(state => getDisplayDenomination(state, currencyInfo.pluginId, currencyCode))
+  const exchangeDenomination = useSelector(state => getExchangeDenomination(state, currencyInfo.pluginId, currencyCode))
+  const fiatDenomination = getDenomFromIsoCode(nonIsoFiatCurrencyCode)
+
+  const currencyName =
+    currencyCode === currencyInfo.currencyCode
+      ? currencyInfo.displayName
+      : currencyInfo.metaTokens.find(metaToken => metaToken.currencyCode === currencyCode)?.currencyName
+
+  // Required Confirmations
+  const requiredConfirmations = currencyInfo.requiredConfirmations || 1 // set default requiredConfirmations to 1, so once the transaction is in a block consider fully confirmed
+
+  // Thumbnail
+  let thumbnailPath
+  const contacts: GuiContact[] = useSelector(state => state.contacts) ?? []
+  const transactionContactName = name != null ? normalizeForSearch(name) : null
+  for (const contact of contacts) {
+    const { givenName, familyName } = contact
+    const fullName = normalizeForSearch(`${givenName}${familyName ?? ''}`)
+    if (contact.thumbnailPath && fullName === transactionContactName) {
+      thumbnailPath = contact.thumbnailPath
+      break
+    }
+  }
+
+  // CryptoAmount
+  const rateKey = `${currencyCode}_${fiatCurrencyCode}`
+  const exchangeRate: string = useSelector(state => state.exchangeRates[rateKey])
+  let maxConversionDecimals = DEFAULT_TRUNCATE_PRECISION
+  if (exchangeRate) {
+    const precisionAdjustValue = precisionAdjust({
+      primaryExchangeMultiplier: exchangeDenomination.multiplier,
+      secondaryExchangeMultiplier: fiatDenomination.multiplier,
+      exchangeSecondaryToPrimaryRatio: exchangeRate
+    })
+    maxConversionDecimals = maxPrimaryCurrencyConversionDecimals(log10(displayDenomination.multiplier), precisionAdjustValue)
+  }
+  const cryptoAmount = div(abs(transaction.nativeAmount ?? '0'), displayDenomination.multiplier, DECIMAL_PRECISION)
+  const cryptoAmountFormat = formatNumber(decimalOrZero(truncateDecimals(cryptoAmount, maxConversionDecimals), maxConversionDecimals))
+
+  const handlePress = useHandler(() => {
     if (transaction == null) {
       return showError(s.strings.transaction_details_error_invalid)
     }
@@ -57,81 +93,20 @@ export class TransactionListRowComponent extends React.PureComponent<Props> {
       edgeTransaction: transaction,
       thumbnailPath
     })
-  }
+  })
 
-  render() {
-    return (
-      <TransactionRow
-        cryptoAmount={this.props.cryptoAmount}
-        denominationSymbol={this.props.denominationSymbol}
-        fiatAmount={this.props.fiatAmount}
-        fiatSymbol={this.props.fiatSymbol}
-        onPress={this.handlePress}
-        isSentTransaction={this.props.isSentTransaction}
-        requiredConfirmations={this.props.requiredConfirmations}
-        selectedCurrencyName={this.props.selectedCurrencyName}
-        thumbnailPath={this.props.thumbnailPath}
-        transaction={this.props.transaction}
-      />
-    )
-  }
+  return (
+    <TransactionRow
+      cryptoAmount={cryptoAmountFormat}
+      denominationSymbol={displayDenomination.symbol}
+      fiatAmount={displayFiatAmount(amountFiat)}
+      fiatSymbol={getSymbolFromCurrency(nonIsoFiatCurrencyCode)}
+      onPress={handlePress}
+      isSentTransaction={isSentTransaction(transaction)}
+      requiredConfirmations={requiredConfirmations}
+      selectedCurrencyName={currencyName || currencyCode}
+      thumbnailPath={thumbnailPath}
+      transaction={transaction}
+    />
+  )
 }
-
-export const TransactionListRow = connect<StateProps, {}, OwnProps>(
-  (state, ownProps) => {
-    const { currencyCode, walletId, transaction } = ownProps
-    const { metadata } = transaction
-    const { name, amountFiat } = metadata ?? {}
-    const guiWallet = state.ui.wallets.byId[walletId]
-    const { fiatCurrencyCode } = guiWallet
-    const { currencyWallets } = state.core.account
-    const coreWallet: EdgeCurrencyWallet = currencyWallets[walletId]
-    const currencyInfo: EdgeCurrencyInfo = coreWallet.currencyInfo
-    const displayDenomination = getDisplayDenomination(state, currencyInfo.pluginId, currencyCode)
-    const exchangeDenomination = getExchangeDenomination(state, currencyInfo.pluginId, currencyCode)
-    const fiatDenomination = getDenomFromIsoCode(guiWallet.fiatCurrencyCode)
-
-    // Required Confirmations
-    const requiredConfirmations = currencyInfo.requiredConfirmations || 1 // set default requiredConfirmations to 1, so once the transaction is in a block consider fully confirmed
-
-    // Thumbnail
-    let thumbnailPath
-    const contacts = state.contacts || []
-    const transactionContactName = name != null ? normalizeForSearch(name) : null
-    for (const contact of contacts) {
-      const { givenName, familyName } = contact
-      const fullName = normalizeForSearch(`${givenName}${familyName ?? ''}`)
-      if (contact.thumbnailPath && fullName === transactionContactName) {
-        thumbnailPath = contact.thumbnailPath
-        break
-      }
-    }
-
-    // CryptoAmount
-    const rateKey = `${currencyCode}_${guiWallet.isoFiatCurrencyCode}`
-    const exchangeRate = state.exchangeRates[rateKey] ? state.exchangeRates[rateKey] : undefined
-    let maxConversionDecimals = DEFAULT_TRUNCATE_PRECISION
-    if (exchangeRate) {
-      const precisionAdjustValue = precisionAdjust({
-        primaryExchangeMultiplier: exchangeDenomination.multiplier,
-        secondaryExchangeMultiplier: fiatDenomination.multiplier,
-        exchangeSecondaryToPrimaryRatio: exchangeRate
-      })
-      maxConversionDecimals = maxPrimaryCurrencyConversionDecimals(log10(displayDenomination.multiplier), precisionAdjustValue)
-    }
-    const cryptoAmount = div(abs(transaction.nativeAmount ?? '0'), displayDenomination.multiplier, DECIMAL_PRECISION)
-    const cryptoAmountFormat = formatNumber(decimalOrZero(truncateDecimals(cryptoAmount, maxConversionDecimals), maxConversionDecimals))
-
-    return {
-      isSentTransaction: isSentTransaction(transaction),
-      cryptoAmount: cryptoAmountFormat,
-      fiatAmount: displayFiatAmount(amountFiat),
-      fiatSymbol: getSymbolFromCurrency(fiatCurrencyCode),
-      denominationSymbol: displayDenomination.symbol,
-      requiredConfirmations,
-      selectedCurrencyName: guiWallet.currencyNames[currencyCode] || currencyCode,
-      thumbnailPath
-    }
-  },
-  dispatch => ({})
-)(TransactionListRowComponent)


### PR DESCRIPTION
This fixes a race condition with the GuiWallet redux loading state.

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202633128622522