### PR TITLE
Fixed incorrect icon spacing in SettingsScene currency rows

### DIFF
--- a/src/components/scenes/SettingsScene.js
+++ b/src/components/scenes/SettingsScene.js
@@ -305,7 +305,7 @@ export class SettingsSceneComponent extends React.Component<Props, State> {
 
             return (
               <SettingsTappableRow key={pluginId} label={displayName} onPress={onPress}>
-                <CryptoIcon marginRem={[0.5, 0]} pluginId={pluginId} sizeRem={1.25} />
+                <CryptoIcon marginRem={[0.5, 0, 0.5, 0.5]} pluginId={pluginId} sizeRem={1.25} />
               </SettingsTappableRow>
             )
           })}


### PR DESCRIPTION
#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

![Simulator Screen Shot - iPhone 8 - 2022-08-02 at 22 52 36](https://user-images.githubusercontent.com/4023066/182379377-8bcc44d2-b51d-44e8-9bae-10147fe72c3e.png)

