### PR TITLE
Jon/aave/fixes/req-collateral-precision

### DIFF
--- a/src/components/scenes/Loans/LoanCreateScene.js
+++ b/src/components/scenes/Loans/LoanCreateScene.js
@@ -183,7 +183,7 @@ export const LoanCreateScene = (props: Props) => {
 
   // Required Collateral
   // TODO: LTV is calculated in equivalent ETH value, NOT USD! These calcs/limits/texts might need to be updated...
-  const requiredFiat = useMemo(() => div(borrowAmountFiat, ltvRatio), [borrowAmountFiat, ltvRatio])
+  const requiredFiat = useMemo(() => div(borrowAmountFiat, ltvRatio, DECIMAL_PRECISION), [borrowAmountFiat, ltvRatio])
 
   // Deposit + Borrow Request Data
   // Convert collateral in fiat -> collateral crypto

--- a/src/plugins/borrow-plugins/plugins/aave/BorrowEngineFactory.js
+++ b/src/plugins/borrow-plugins/plugins/aave/BorrowEngineFactory.js
@@ -4,6 +4,7 @@ import { type Cleaner, asMaybe } from 'cleaners'
 import { type EdgeCurrencyWallet, type EdgeToken } from 'edge-core-js'
 import { BigNumber, ethers } from 'ethers'
 
+import { zeroString } from '../../../../util/utils'
 import { type CallInfo, asTxInfo, makeApprovableCall, makeTxCalls } from '../../common/ApprovableCall'
 import { asGraceful } from '../../common/cleaners/asGraceful'
 import { composeApprovableActions } from '../../common/util/composeApprovableActions'
@@ -124,6 +125,8 @@ export const makeBorrowEngineFactory = (blueprint: BorrowEngineBlueprint) => {
 
       async deposit(request: DepositRequest): Promise<ApprovableAction> {
         const { nativeAmount, tokenId, fromWallet = wallet } = request
+        if (zeroString(nativeAmount)) throw new Error('BorrowEngine: withdraw request contains no nativeAmount.')
+
         validateWalletParam(fromWallet)
 
         const token = getToken(tokenId)
@@ -188,6 +191,8 @@ export const makeBorrowEngineFactory = (blueprint: BorrowEngineBlueprint) => {
       },
       async withdraw(request: WithdrawRequest): Promise<ApprovableAction> {
         const { nativeAmount, tokenId, toWallet = wallet } = request
+        if (zeroString(nativeAmount)) throw new Error('BorrowEngine: withdraw request contains no nativeAmount.')
+
         validateWalletParam(toWallet)
 
         const token = getToken(tokenId)
@@ -213,6 +218,7 @@ export const makeBorrowEngineFactory = (blueprint: BorrowEngineBlueprint) => {
       },
       async borrow(request: BorrowRequest): Promise<ApprovableAction> {
         const { nativeAmount, tokenId, fromWallet = wallet } = request
+        if (zeroString(nativeAmount)) throw new Error('BorrowEngine: borrow request contains no nativeAmount.')
 
         const token = getToken(tokenId)
         const tokenAddress = getTokenAddress(token)
@@ -242,6 +248,7 @@ export const makeBorrowEngineFactory = (blueprint: BorrowEngineBlueprint) => {
       },
       async repay(request: RepayRequest): Promise<ApprovableAction> {
         const { nativeAmount, tokenId, fromWallet = wallet } = request
+        if (zeroString(nativeAmount)) throw new Error('BorrowEngine: repay request contains no nativeAmount.')
 
         const token = getToken(tokenId)
         const tokenAddress = getTokenAddress(token)


### PR DESCRIPTION
Small borrow amounts were failing due to whole number decimal precision rounding request values to 0. Update calculation such that normal DECIMAL_PRECISION is used.

For borrow engine requests, check nativeAmount is nonzero for borrow, repay, deposit, and withdraw.

#### PR Dependencies

#3558 action-queue-integration

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202717370125930