### PR TITLE
Jon/aave/manage-collateral-ltv

### DIFF
--- a/src/components/scenes/Loans/LoanAddCollateralScene.js
+++ b/src/components/scenes/Loans/LoanAddCollateralScene.js
@@ -14,14 +14,14 @@ export const LoanAddCollateralScene = (props: Props) => {
   const { borrowEngine, borrowPlugin } = route.params
 
   return ManageCollateralScene({
-    borrowEngine,
-    borrowPluginId: borrowPlugin.borrowInfo.borrowPluginId,
-    defaultTokenId: borrowEngine.collaterals[0].tokenId,
     action: async req => await borrowEngine.deposit(req),
     actionOpType: 'loan-deposit',
     actionWallet: 'fromWallet',
+    amountChange: 'increase',
+    borrowEngine,
+    borrowPluginId: borrowPlugin.borrowInfo.pluginId,
+    defaultTokenId: borrowEngine.collaterals[0].tokenId,
     ltvType: 'collaterals',
-    ltvChange: 'decrease',
 
     showExchangeRateTile: true,
     showTotalDebtTile: true,

--- a/src/components/scenes/Loans/LoanBorrowMoreScene.js
+++ b/src/components/scenes/Loans/LoanBorrowMoreScene.js
@@ -14,15 +14,14 @@ export const LoanBorrowMoreScene = (props: Props) => {
   const { borrowEngine, borrowPlugin } = route.params
 
   return ManageCollateralScene({
-    borrowEngine,
-    borrowPluginId: borrowPlugin.borrowInfo.borrowPluginId,
-    defaultTokenId: borrowEngine.debts[0].tokenId,
     action: async req => await borrowEngine.borrow(req),
     actionOpType: 'loan-borrow',
     actionWallet: 'fromWallet',
+    amountChange: 'increase',
+    borrowEngine,
+    borrowPluginId: borrowPlugin.borrowInfo.pluginId,
+    defaultTokenId: borrowEngine.debts[0].tokenId,
     ltvType: 'debts',
-    ltvChange: 'increase',
-    debtChange: 'increase',
 
     showTotalDebtTile: true,
     showNewDebtTile: true,

--- a/src/components/scenes/Loans/LoanRepayScene.js
+++ b/src/components/scenes/Loans/LoanRepayScene.js
@@ -14,14 +14,14 @@ export const LoanMakeLoanPaymentScene = (props: Props) => {
   const { borrowEngine, borrowPlugin } = route.params
 
   return ManageCollateralScene({
-    borrowEngine,
-    borrowPluginId: borrowPlugin.borrowInfo.borrowPluginId,
-    defaultTokenId: borrowEngine.debts[0].tokenId,
     action: async req => await borrowEngine.repay(req),
     actionOpType: 'loan-repay',
     actionWallet: 'fromWallet',
+    amountChange: 'decrease',
+    borrowEngine,
+    borrowPluginId: borrowPlugin.borrowInfo.pluginId,
+    defaultTokenId: borrowEngine.debts[0].tokenId,
     ltvType: 'debts',
-    ltvChange: 'decrease',
 
     showTotalDebtTile: true,
     showNewDebtTile: true,

--- a/src/components/scenes/Loans/LoanWithdrawCollateralScene.js
+++ b/src/components/scenes/Loans/LoanWithdrawCollateralScene.js
@@ -14,14 +14,14 @@ export const LoanWithdrawCollateralScene = (props: Props) => {
   const { borrowEngine, borrowPlugin } = route.params
 
   return ManageCollateralScene({
-    borrowEngine,
-    borrowPluginId: borrowPlugin.borrowInfo.borrowPluginId,
-    defaultTokenId: borrowEngine.collaterals[0].tokenId,
     action: async req => await borrowEngine.withdraw(req),
     actionOpType: 'loan-withdraw',
     actionWallet: 'toWallet',
+    amountChange: 'decrease',
+    borrowEngine,
+    borrowPluginId: borrowPlugin.borrowInfo.pluginId,
+    defaultTokenId: borrowEngine.collaterals[0].tokenId,
     ltvType: 'collaterals',
-    ltvChange: 'increase',
 
     showExchangeRateTile: true,
     showTotalDebtTile: true,

--- a/src/components/scenes/Loans/ManageCollateralScene.js
+++ b/src/components/scenes/Loans/ManageCollateralScene.js
@@ -37,25 +37,23 @@ type ManageCollateralRequest = {
 }
 
 type Props<T: $Keys<ParamList>> = {
-  borrowEngine: BorrowEngine,
-  borrowPluginId: string,
-  defaultTokenId?: string,
   // TODO: Remove use of ApprovableAction to calculate fees. Update ActionQueue to handle fee calcs
   action: (request: ManageCollateralRequest) => Promise<ApprovableAction>,
   actionOpType: 'loan-borrow' | 'loan-deposit' | 'loan-repay' | 'loan-withdraw',
   actionWallet: 'fromWallet' | 'toWallet',
+  amountChange?: 'increase' | 'decrease',
+  borrowEngine: BorrowEngine,
+  borrowPluginId: string,
+  defaultTokenId?: string,
   ltvType: 'debts' | 'collaterals',
-  ltvChange: 'increase' | 'decrease',
-  debtChange?: 'increase' | 'decrease',
 
   showExchangeRateTile?: boolean,
-  showTotalDebtTile?: boolean,
+  showNewDebtAprChange?: true,
   showNewDebtTile?: boolean,
   showTotalCollateralTile?: boolean,
-  showNewDebtAprChange?: true,
+  showTotalDebtTile?: boolean,
 
   headerText: string,
-
   navigation: NavigationProp<T>
 }
 
@@ -64,18 +62,19 @@ export const ManageCollateralScene = <T: $Keys<ParamList>>(props: Props<T>) => {
     action,
     actionOpType,
     actionWallet,
+    amountChange = 'increase',
     borrowEngine,
     borrowPluginId,
     defaultTokenId,
-    headerText,
-    ltvChange,
     ltvType,
+
     showExchangeRateTile,
-    showTotalDebtTile,
-    showNewDebtTile,
-    debtChange = 'increase',
-    showTotalCollateralTile,
     showNewDebtAprChange,
+    showNewDebtTile,
+    showTotalCollateralTile,
+    showTotalDebtTile,
+
+    headerText,
     navigation
   } = props
 
@@ -235,10 +234,12 @@ export const ManageCollateralScene = <T: $Keys<ParamList>>(props: Props<T>) => {
   }, [currencyWallet, borrowEngine, showTotalDebtTile])
 
   const renderNewDebtTile = useMemo(() => {
-    const multiplier = debtChange === 'increase' ? '1' : '-1'
+    const multiplier = amountChange === 'increase' ? '1' : '-1'
     const newDebt = { nativeAmount: mul(actionNativeAmount, multiplier), tokenId: selectedTokenId, apr: 0 } // APR is only present to appease Flow. It does not mean anything.
-    return showNewDebtTile ? <DebtAmountTile title={s.strings.loan_new_principle} wallet={currencyWallet} debts={[...borrowEngine.debts, newDebt]} /> : null
-  }, [currencyWallet, borrowEngine, actionNativeAmount, selectedTokenId, showNewDebtTile])
+    return showNewDebtTile ? (
+      <DebtAmountTile title={s.strings.loan_new_principle} wallet={currencyWallet} debts={[...borrowEngine.debts, newDebt]} key="newDebt" />
+    ) : null
+  }, [amountChange, actionNativeAmount, selectedTokenId, showNewDebtTile, currencyWallet, borrowEngine.debts])
 
   const renderTotalCollateralTile = useMemo(() => {
     return showTotalCollateralTile ? (
@@ -263,9 +264,16 @@ export const ManageCollateralScene = <T: $Keys<ParamList>>(props: Props<T>) => {
 
   const renderLTVRatioTile = useMemo(() => {
     return (
-      <LoanToValueTile borrowEngine={borrowEngine} tokenId={selectedTokenId} nativeAmount={actionNativeAmount} type={ltvType} direction={ltvChange} key="ltv" />
+      <LoanToValueTile
+        borrowEngine={borrowEngine}
+        tokenId={selectedTokenId}
+        nativeAmount={actionNativeAmount}
+        type={ltvType}
+        direction={amountChange}
+        key="ltv"
+      />
     )
-  }, [borrowEngine, ltvChange, ltvType, selectedTokenId, actionNativeAmount])
+  }, [borrowEngine, amountChange, ltvType, selectedTokenId, actionNativeAmount])
 
   const tiles = [
     renderFlipInput,


### PR DESCRIPTION
ltvChange and debtChange props on the ManageCollateralScene are redundant. Combine into a single amountChange prop.

Callers of the ManageCollateralScene were not all properly setting the *change props. Set the correct amountChange prop for the callers of ManageCollateralScene

#### PR Dependencies

#3558 action-queue-integration

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202717370125968