### PR TITLE
Create account infinite loading fix

### DIFF
--- a/src/actions/LoginActions.js
+++ b/src/actions/LoginActions.js
@@ -85,11 +85,6 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: GuiTouchIdI
 
   dispatch({ type: 'LOGIN', data: account })
 
-  navigation.push('edge')
-  if (hasSecurityAlerts(account)) {
-    navigation.push('securityAlerts')
-  }
-
   const state = getState()
   const { context } = state.core
 
@@ -196,6 +191,11 @@ export const initializeAccount = (account: EdgeAccount, touchIdInfo: GuiTouchIdI
     }
 
     dispatch(expiredFioNamesCheckDates())
+
+    navigation.push('edge')
+    if (hasSecurityAlerts(account)) {
+      navigation.push('securityAlerts')
+    }
     await updateWalletsRequest()(dispatch, getState)
   } catch (error) {
     showError(error)


### PR DESCRIPTION
Somehow, the changes from Action->navigation (5d7ae1a172d0cc5e6508c0fb017f58c2006775cd) caused a failure to properly navigate to the wallet list scene after login, upon creating a new account.

Move the transition to the wallet list scene to the end of account initialization.

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202731925884272