### PR TITLE
Load the synced settings prior to login

### DIFF
--- a/src/reducers/CoreReducer.js
+++ b/src/reducers/CoreReducer.js
@@ -32,7 +32,7 @@ export const core: Reducer<CoreState, Action> = combineReducers({
   account(state: EdgeAccount = defaultAccount, action: Action): EdgeAccount {
     switch (action.type) {
       case 'LOGIN':
-        return action.data
+        return action.data.account
       case 'LOGOUT':
         return defaultAccount
     }

--- a/src/reducers/scenes/SettingsReducer.js
+++ b/src/reducers/scenes/SettingsReducer.js
@@ -117,13 +117,13 @@ function currencyPluginUtil(state: SettingsState, currencyInfo: EdgeCurrencyInfo
   }
 }
 
-export const settingsLegacy = (state: SettingsState = initialState, action: Action) => {
+export const settingsLegacy = (state: SettingsState = initialState, action: Action): SettingsState => {
   switch (action.type) {
     case 'LOGIN': {
-      const account = action.data
+      const { account, walletSort } = action.data
 
       // Setup default denominations for settings based on currencyInfo
-      const newState = { ...state }
+      const newState = { ...state, walletSort }
       for (const pluginId of Object.keys(account.currencyConfig)) {
         const { currencyInfo } = account.currencyConfig[pluginId]
         const { currencyCode } = currencyInfo
@@ -278,7 +278,7 @@ export const settingsLegacy = (state: SettingsState = initialState, action: Acti
   }
 }
 
-export const settings = (state: SettingsState = initialState, action: Action) => {
+export const settings = (state: SettingsState = initialState, action: Action): SettingsState => {
   let result = state
   const legacy = settingsLegacy(state, action)
 

--- a/src/types/reduxActions.js
+++ b/src/types/reduxActions.js
@@ -95,7 +95,7 @@ export type Action =
       data: { activeWalletIds: string[] }
     }
   | { type: 'IS_CHECKING_HANDLE_AVAILABILITY', data: boolean }
-  | { type: 'LOGIN', data: EdgeAccount }
+  | { type: 'LOGIN', data: { account: EdgeAccount, walletSort: SortOption } }
   | { type: 'LOGOUT', data: { username?: string } }
   | { type: 'MESSAGE_TWEAK_HIDDEN', data: { messageId: string, source: TweakSource } }
   | { type: 'PERMISSIONS/UPDATE', data: PermissionsState }


### PR DESCRIPTION
This means we will show the correct sort order immediately, and not have to wait for the complicated settings processing to take place.

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
