### PR TITLE
Jon/patch/loan-create-disps

### DIFF
--- a/src/components/data/row/CryptoFiatAmountRow.js
+++ b/src/components/data/row/CryptoFiatAmountRow.js
@@ -5,6 +5,7 @@ import * as React from 'react'
 import { View } from 'react-native'
 
 import { memo } from '../../../types/reactHooks'
+import { fixSides, mapSides, sidesToMargin } from '../../../util/sides'
 import { CryptoIcon } from '../../icons/CryptoIcon'
 import { FiatIcon } from '../../icons/FiatIcon'
 import { type Theme, cacheStyles, useTheme } from '../../services/ThemeContext.js'
@@ -13,6 +14,7 @@ import { FiatText } from '../../text/FiatText.js'
 import { EdgeText } from '../../themed/EdgeText.js'
 
 type Props = {|
+  marginRem?: number[] | number,
   nativeAmount: string,
   tokenId?: string,
   wallet: EdgeCurrencyWallet
@@ -23,14 +25,15 @@ type Props = {|
 // supports only an input amount of native fiat and a conversion to some token.
 // -----------------------------------------------------------------------------
 const CryptoFiatAmountRowComponent = (props: Props) => {
-  const { nativeAmount, tokenId, wallet } = props
+  const { marginRem, nativeAmount, tokenId, wallet } = props
   const theme = useTheme()
   const styles = getStyles(theme)
+  const margin = sidesToMargin(mapSides(fixSides(marginRem, 1), theme.rem))
   const { pluginId } = wallet.currencyInfo
 
   // Use nativeAmount in both fiat and crypto display fields because they properly handle any user/locale settings.
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, margin]}>
       <View style={styles.columnLeft}>
         <CryptoIcon sizeRem={1.5} tokenId={tokenId} pluginId={pluginId} hideSecondary />
         <EdgeText style={styles.text}>

--- a/src/components/data/row/CurrencyRow.js
+++ b/src/components/data/row/CurrencyRow.js
@@ -7,6 +7,7 @@ import { useWalletBalance } from '../../../hooks/useWalletBalance.js'
 import { useWalletName } from '../../../hooks/useWalletName.js'
 import { memo } from '../../../types/reactHooks.js'
 import { useSelector } from '../../../types/reactRedux.js'
+import { fixSides, mapSides, sidesToMargin } from '../../../util/sides'
 import { CryptoIcon } from '../../icons/CryptoIcon'
 import { type Theme, cacheStyles, useTheme } from '../../services/ThemeContext.js'
 import { CryptoText } from '../../text/CryptoText'
@@ -15,6 +16,7 @@ import { TickerText } from '../../text/TickerText.js'
 import { EdgeText } from '../../themed/EdgeText.js'
 
 type Props = {|
+  marginRem?: number[] | number,
   showRate?: boolean,
   token?: EdgeToken,
   tokenId?: string,
@@ -25,9 +27,10 @@ type Props = {|
 // A view representing the data from a wallet, used for rows, cards, etc.
 // -----------------------------------------------------------------------------
 const CurrencyRowComponent = (props: Props) => {
-  const { showRate = false, token, tokenId, wallet } = props
+  const { marginRem, showRate = false, token, tokenId, wallet } = props
   const theme = useTheme()
   const styles = getStyles(theme)
+  const margin = sidesToMargin(mapSides(fixSides(marginRem, 1), theme.rem))
 
   // Currency code and wallet name for display:
   const allTokens = wallet.currencyConfig.allTokens
@@ -40,7 +43,7 @@ const CurrencyRowComponent = (props: Props) => {
   const balance = useWalletBalance(wallet, tokenId)
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, margin]}>
       <CryptoIcon sizeRem={2} tokenId={tokenId} walletId={wallet.id} />
       <View style={styles.nameColumn}>
         <View style={styles.currencyRow}>

--- a/src/components/scenes/Loans/LoanCreateConfirmationScene.js
+++ b/src/components/scenes/Loans/LoanCreateConfirmationScene.js
@@ -119,11 +119,11 @@ export const LoanCreateConfirmationScene = (props: Props) => {
       </Tile>
 
       <Tile type="static" title={s.strings.loan_collateral_source}>
-        <CurrencyRow tokenId={srcTokenId} wallet={srcWallet} />
+        <CurrencyRow tokenId={srcTokenId} wallet={srcWallet} marginRem={0} />
       </Tile>
 
       <Tile type="static" title={s.strings.loan_destination}>
-        <CurrencyRow tokenId={destTokenId} wallet={destWallet} />
+        <CurrencyRow tokenId={destTokenId} wallet={destWallet} marginRem={0} />
       </Tile>
 
       {renderFeeTile}

--- a/src/components/scenes/Loans/LoanCreateConfirmationScene.js
+++ b/src/components/scenes/Loans/LoanCreateConfirmationScene.js
@@ -13,6 +13,7 @@ import { useDispatch } from '../../../types/reactRedux'
 import { type NavigationProp, type RouteProp } from '../../../types/routerTypes'
 import { makeAaveBorrowAction, makeAaveDepositAction, makeActionProgram } from '../../../util/ActionProgramUtils'
 import { NetworkFeeTile } from '../../cards/LoanDebtsAndCollateralComponents'
+import { CryptoFiatAmountRow } from '../../data/row/CryptoFiatAmountRow'
 import { CurrencyRow } from '../../data/row/CurrencyRow'
 import { showError } from '../../services/AirshipInstance'
 import { FiatText } from '../../text/FiatText'
@@ -124,6 +125,9 @@ export const LoanCreateConfirmationScene = (props: Props) => {
         <EdgeText>
           <FiatText appendFiatCurrencyCode autoPrecision hideFiatSymbol nativeCryptoAmount={nativeDestAmount} tokenId={destTokenId} wallet={destWallet} />
         </EdgeText>
+      </Tile>
+      <Tile type="static" title={s.strings.loan_collateral_amount}>
+        <CryptoFiatAmountRow nativeAmount={nativeSrcAmount} tokenId={srcTokenId} wallet={srcWallet} marginRem={[0.25, 0, 0, 0]} />
       </Tile>
 
       <Tile type="static" title={s.strings.loan_collateral_source}>

--- a/src/components/scenes/Loans/LoanCreateConfirmationScene.js
+++ b/src/components/scenes/Loans/LoanCreateConfirmationScene.js
@@ -93,9 +93,17 @@ export const LoanCreateConfirmationScene = (props: Props) => {
   }, [destTokenId, nativeDestAmount, borrowEngine])
 
   const renderFeeTile = useMemo(() => {
-    if (depositApprovalAction == null || borrowApprovalAction == null) return
-    return <NetworkFeeTile wallet={srcWallet} nativeAmount={add(depositApprovalAction.networkFee.nativeAmount, borrowApprovalAction.networkFee.nativeAmount)} />
-  }, [borrowApprovalAction, depositApprovalAction, srcWallet])
+    return (
+      <NetworkFeeTile
+        wallet={borrowEngineWallet}
+        nativeAmount={
+          depositApprovalAction == null || borrowApprovalAction == null
+            ? '0'
+            : add(depositApprovalAction.networkFee.nativeAmount, borrowApprovalAction.networkFee.nativeAmount)
+        }
+      />
+    )
+  }, [borrowApprovalAction, depositApprovalAction, borrowEngineWallet])
 
   const onSliderComplete = async (resetSlider: () => void) => {
     if (actionProgram != null) {

--- a/src/components/scenes/Loans/LoanCreateScene.js
+++ b/src/components/scenes/Loans/LoanCreateScene.js
@@ -187,7 +187,7 @@ export const LoanCreateScene = (props: Props) => {
           <EdgeText style={disabled ? styles.textInitialDisabled : styles.textInitial}>{emptyLabel}</EdgeText>
         ) : (
           <View style={styles.currencyRow}>
-            <CurrencyRow tokenId={tokenId} wallet={wallet} />
+            <CurrencyRow tokenId={tokenId} wallet={wallet} marginRem={[0, 0.5, 0, 0.5]} />
           </View>
         )}
       </TappableCard>
@@ -343,13 +343,13 @@ export const LoanCreateScene = (props: Props) => {
 
           {/* Collateral Amount Required / Collateral Amount */}
           <EdgeText style={styles.textTitle}>{s.strings.loan_collateral_required}</EdgeText>
-          <Card marginRem={[0.5, 0.5, 0.5, 0.5]} paddingRem={1}>
+          <Card marginRem={[0.5, 0.5, 0.5, 0.5]}>
             {srcWallet == null || destWallet == null ? (
-              <EdgeText style={styles.textInitial}>
+              <EdgeText style={[styles.textInitial, { margin: theme.rem(0.5) }]}>
                 {srcWallet == null ? s.strings.loan_select_source_collateral : s.strings.loan_select_receiving_wallet}
               </EdgeText>
             ) : (
-              <CryptoFiatAmountRow nativeAmount={nativeRequiredCrypto} tokenId={srcTokenId} wallet={srcWallet} />
+              <CryptoFiatAmountRow nativeAmount={nativeRequiredCrypto} tokenId={srcTokenId} wallet={srcWallet} marginRem={0.25} />
             )}
           </Card>
 
@@ -410,7 +410,7 @@ const getStyles = cacheStyles(theme => {
       alignSelf: 'flex-start',
       fontSize: theme.rem(0.75),
       fontFamily: theme.fontFaceMedium,
-      margin: theme.rem(0.5)
+      margin: theme.rem(1)
     },
     textInitialDisabled: {
       alignSelf: 'center',

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -930,7 +930,7 @@ const strings = {
   loan_details_title: 'Loan Details',
   loan_enter_loan_amount_s: 'Enter Loan Amount (%1$s)',
   loan_error_title: 'Unexpected Error',
-  loan_estimate_fee: 'Estimate Fee',
+  loan_estimate_fee: 'Estimated Fee',
   loan_exchange_rate: 'Exchange Rate',
   loan_failed_loan: 'Failed to load loan data',
   loan_fiat_value: 'Fiat Value',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -833,7 +833,7 @@
   "loan_details_title": "Loan Details",
   "loan_enter_loan_amount_s": "Enter Loan Amount (%1$s)",
   "loan_error_title": "Unexpected Error",
-  "loan_estimate_fee": "Estimate Fee",
+  "loan_estimate_fee": "Estimated Fee",
   "loan_exchange_rate": "Exchange Rate",
   "loan_failed_loan": "Failed to load loan data",
   "loan_fiat_value": "Fiat Value",


### PR DESCRIPTION
Adds 'Collateral Amount' tile to LoanCreateConfirmationScene

Other changes:
-Update network fee tile to show an empty value while loading
-Adjust styling alignment in LoanCreate workflow

<img width=300px src=https://user-images.githubusercontent.com/90650827/187813265-16705c6a-5322-4543-b848-328992208af0.png>
<img width=300px src=https://user-images.githubusercontent.com/90650827/187813266-2c0ba0ba-6670-42eb-9295-f94160a7329f.png>
<img width=300px src=https://user-images.githubusercontent.com/90650827/187813270-6e0a73d5-60de-45d9-825e-a1b239962610.png>


#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202895674767128