### PR TITLE
Add SceneWrapper around FillLoader

### DIFF
--- a/src/components/scenes/Loans/LoanCreateConfirmationScene.js
+++ b/src/components/scenes/Loans/LoanCreateConfirmationScene.js
@@ -16,6 +16,7 @@ import { type NavigationProp, type RouteProp } from '../../../types/routerTypes'
 import { makeAaveBorrowAction, makeAaveDepositAction } from '../../../util/ActionProgramUtils'
 import { translateError } from '../../../util/translateError'
 import { NetworkFeeTile } from '../../cards/LoanDebtsAndCollateralComponents'
+import { SceneWrapper } from '../../common/SceneWrapper'
 import { CryptoFiatAmountRow } from '../../data/row/CryptoFiatAmountRow'
 import { CurrencyRow } from '../../data/row/CurrencyRow'
 import { FillLoader } from '../../progress-indicators/FillLoader'
@@ -126,7 +127,9 @@ export const LoanCreateConfirmationScene = (props: Props) => {
   if (loanAccountError != null) return <Alert title={s.strings.error_unexpected_title} type="error" message={translateError(loanAccountError)} />
 
   return loanAccount == null ? (
-    <FillLoader />
+    <SceneWrapper background="theme">
+      <FillLoader />
+    </SceneWrapper>
   ) : (
     <FormScene headerText={s.strings.loan_create_confirmation_title} sliderDisabled={false} onSliderComplete={onSliderComplete}>
       <Tile type="static" title={s.strings.loan_amount_borrow}>


### PR DESCRIPTION
A plain FillLoader was used while waiting for LoanCreateConfirmationScene to load, showing up as white since there was no background.
 
Add SceneWrapper around FillLoader during LoanCreateConfirmationScene init so there's a background.

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202925555994050