### PR TITLE
Patch ansi-styles package for Hermes runtime compatibility

### DIFF
--- a/patches/pretty-format++ansi-styles+5.2.0.patch
+++ b/patches/pretty-format++ansi-styles+5.2.0.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/pretty-format/node_modules/ansi-styles/index.js b/node_modules/pretty-format/node_modules/ansi-styles/index.js
+index a9eac58..34292cb 100644
+--- a/node_modules/pretty-format/node_modules/ansi-styles/index.js
++++ b/node_modules/pretty-format/node_modules/ansi-styles/index.js
+@@ -127,12 +127,12 @@ function assembleStyles() {
+ 		},
+ 		hexToRgb: {
+ 			value: hex => {
+-				const matches = /(?<colorString>[a-f\d]{6}|[a-f\d]{3})/i.exec(hex.toString(16));
++				const matches = /([a-f\d]{6}|[a-f\d]{3})/i.exec(hex.toString(16));
+ 				if (!matches) {
+ 					return [0, 0, 0];
+ 				}
+ 
+-				let {colorString} = matches.groups;
++				let colorString = matches[1];
+ 
+ 				if (colorString.length === 3) {
+ 					colorString = colorString.split('').map(character => character + character).join('');


### PR DESCRIPTION
This patches the ansi-styles package removing the unsupported named-group in a regex.

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
