### PR TITLE
Fix track link bank promo cards

### DIFF
--- a/src/plugins/gui/fiatPlugin.js
+++ b/src/plugins/gui/fiatPlugin.js
@@ -128,10 +128,14 @@ export const checkWyreHasLinkedBank = async (dataStore: EdgeDataStore): Promise<
     }
     if (key == null) return false
     const paymentMethods = await getWyrePaymentMethods(key)
+    if (paymentMethods.data.length < 1) return false
     const accountName = paymentMethods.data[0].owner.substring(8)
     const wyreAccount = await getWyreAccount(accountName, key)
     return checkWyreActive(wyreAccount, paymentMethods)
   } catch (e) {
+    if (typeof e.message === 'string' && e.message.includes('No item named')) {
+      return false
+    }
     console.error(e.message)
   }
 }
@@ -189,7 +193,5 @@ async function getWyrePaymentMethods(token: string): Promise<GetPaymentMethods> 
   const result = await fetch(url, request)
   if (!result.ok) throw new Error('fetchError')
   if (result.status === 204) throw new Error('emptyResponse')
-  const newData = asGetPaymentMethods(await result.json())
-  if (newData.data.length < 1) throw new Error('emptyResponse')
-  return newData
+  return asGetPaymentMethods(await result.json())
 }


### PR DESCRIPTION
In the case of no payment methods, don't throw but return false for linked bank accounts

Also return false if wyreAccountId or wyreSecret don't exist

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
