### PR TITLE
Jon/fix/aave/swap-status-display

### DIFF
--- a/src/controllers/action-queue/cleaners.ts
+++ b/src/controllers/action-queue/cleaners.ts
@@ -119,12 +119,13 @@ const asLoanWithdrawActionOp = asObject<LoanWithdrawActionOp>({
 })
 const asSwapActionOp = asObject<SwapActionOp>({
   type: asValue('swap'),
-  fromWalletId: asString,
-  toWalletId: asString,
+  amountFor: asValue('from', 'to'),
+  walletId: asString,
   fromTokenId: asOptional(asString),
-  toTokenId: asOptional(asString),
+  fromWalletId: asString,
   nativeAmount: asString,
-  amountFor: asValue('from', 'to')
+  toTokenId: asOptional(asString),
+  toWalletId: asString
 })
 export const asActionOp: Cleaner<ActionOp> = asEither(
   asSeqActionOp,

--- a/src/controllers/action-queue/types.ts
+++ b/src/controllers/action-queue/types.ts
@@ -74,12 +74,13 @@ export type LoanWithdrawActionOp = {
 }
 export type SwapActionOp = {
   type: 'swap'
-  fromWalletId: string
-  toWalletId: string
-  fromTokenId?: string
-  toTokenId?: string
-  nativeAmount: string
   amountFor: 'from' | 'to'
+  walletId: string
+  fromTokenId?: string
+  fromWalletId: string
+  nativeAmount: string
+  toTokenId?: string
+  toWalletId: string
 }
 export type ActionOp =
   | SeqActionOp

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -976,7 +976,7 @@ const strings = {
   loan_select_source_collateral: 'Please select a source of collateral',
   loan_withdraw_collateral: 'Withdraw Collateral',
 
-  loan_aave: 'AAVE',
+  loan_aave_fragment: 'AAVE',
   loan_status_cancel_txs: 'Cancel Transactions',
   loan_status_cancel_txs_modal_msg:
     "Canceling transactions will stop the current process, but cannot reverse the steps that have already been done. If you'd like to revert the actions, those steps will have to be taken manually.\n\nIf you have any questions, please contact us or email %1$s",

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -29,7 +29,7 @@ const strings = {
   action_queue_display_loan_withdraw_message: `Withdraw %1$s from loan.`,
   // swap
   action_queue_display_swap_title: `Swap %1$s into %2$s`,
-  action_queue_display_swap_message: `To use %1$s as collateral, %2$s must swap %1$s into %3$s to put it on the same network as %4$s.`,
+  action_queue_display_swap_message: `To use %1$s as collateral, %2$s must swap %1$s into %3$s to put it on the same network as %4$s (%5$s).`,
 
   // Action Queue Push Notifications
   action_queue_push_notification_title: `Action Complete`,

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -18,7 +18,7 @@
   "action_queue_display_loan_withdraw_title": "Withdraw collateral from loan",
   "action_queue_display_loan_withdraw_message": "Withdraw %1$s from loan.",
   "action_queue_display_swap_title": "Swap %1$s into %2$s",
-  "action_queue_display_swap_message": "To use %1$s as collateral, %2$s must swap %1$s into %3$s to put it on the same network as %4$s.",
+  "action_queue_display_swap_message": "To use %1$s as collateral, %2$s must swap %1$s into %3$s to put it on the same network as %4$s (%5$s).",
   "action_queue_push_notification_title": "Action Complete",
   "action_queue_push_notification_body": "Edge has finished working on your behalf.",
   "bitpay_metadata_name": "Invoice ID: %s",

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -875,7 +875,7 @@
   "loan_select_receiving_wallet": "Please select a receiving wallet",
   "loan_select_source_collateral": "Please select a source of collateral",
   "loan_withdraw_collateral": "Withdraw Collateral",
-  "loan_aave": "AAVE",
+  "loan_aave_fragment": "AAVE",
   "loan_status_cancel_txs": "Cancel Transactions",
   "loan_status_cancel_txs_modal_msg": "Canceling transactions will stop the current process, but cannot reverse the steps that have already been done. If you'd like to revert the actions, those steps will have to be taken manually.\n\nIf you have any questions, please contact us or email %1$s",
   "loan_status_complete": "Your loan has completed successfully!\nPlease allow time for your account to be credited.",


### PR DESCRIPTION
- Update SwapActionOp type
- Update swap description to be more descriptive about the WBTC network being swapped into.
- Fix sprintf call

![Screen Shot 2022-09-23 at 12 40 27 PM](https://user-images.githubusercontent.com/90650827/192046235-260c41ba-cde7-4aac-8d43-92919a2b104b.png)

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203020953556924