### PR TITLE
Fix missing Done row on iOS devices in Request scene

### DIFF
--- a/src/__tests__/__snapshots__/Request.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Request.test.tsx.snap
@@ -87,7 +87,6 @@ exports[`Request should render with loaded props 1`] = `
         forceUpdateGuiCounter={0}
         headerCallback={[Function]}
         headerText="Receive to No name"
-        inputAccessoryViewID=""
         isEditable={true}
         isFiatOnTop={true}
         isFocus={false}

--- a/src/components/scenes/RequestScene.tsx
+++ b/src/components/scenes/RequestScene.tsx
@@ -359,7 +359,7 @@ export class RequestComponent extends React.Component<Props, State> {
               isFocus={false}
               onNext={this.onNext}
               topReturnKeyType={this.state.isFioMode ? 'next' : 'done'}
-              inputAccessoryViewID={this.state.isFioMode ? inputAccessoryViewID : ''}
+              inputAccessoryViewID={this.state.isFioMode ? inputAccessoryViewID : undefined}
               headerCallback={this.handleOpenWalletListModal}
               onError={this.onError}
             />


### PR DESCRIPTION
The flip input used to check for an empty string inputAccessoryViewID but that was changed recently to just accept the prop as passed in (which is correct). Therefore the fix needs to be in the request scene which created the prop.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203028877160239