### PR TITLE
Jon/fix/aave/ltv-limit

### DIFF
--- a/src/components/scenes/Loans/LoanCreateScene.tsx
+++ b/src/components/scenes/Loans/LoanCreateScene.tsx
@@ -275,7 +275,7 @@ export const LoanCreateScene = (props: Props) => {
           numberOfLines={0}
           marginRem={[0.5, 0.5, 0.5, 0.5]}
           title={s.strings.exchange_insufficient_funds_title}
-          message={sprintf(s.strings.loan_amount_exceeds_s_collateral, displayLtvLimit, srcCurrencyCode)}
+          message={sprintf(s.strings.loan_amount_exceeds_s_collateral, displayLtvLimit)}
           type="error"
         />
       )

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -924,7 +924,7 @@ const strings = {
   loan_add_collateral: 'Add Collateral',
   loan_add_from: 'Add from %s',
   loan_amount_borrow: 'Amount to Borrow',
-  loan_amount_exceeds_s_collateral: 'Loan exceeds %1$s of collateral value in your %2$s wallet',
+  loan_amount_exceeds_s_collateral: 'Total loan value exceeds %1$s of total collateral value.',
   loan_available_equity: 'Available Equity',
   loan_borrow_details_title: 'Borrow Details',
   loan_borrow_more: 'Borrow More',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -826,7 +826,7 @@
   "loan_add_collateral": "Add Collateral",
   "loan_add_from": "Add from %s",
   "loan_amount_borrow": "Amount to Borrow",
-  "loan_amount_exceeds_s_collateral": "Loan exceeds %1$s of collateral value in your %2$s wallet",
+  "loan_amount_exceeds_s_collateral": "Total loan value exceeds %1$s of total collateral value.",
   "loan_available_equity": "Available Equity",
   "loan_borrow_details_title": "Borrow Details",
   "loan_borrow_more": "Borrow More",


### PR DESCRIPTION
Adds an LTV check hard-coded to 74% to the Borrow and Withdraw scenes. Shows an error card and disables the confirm slider if LTV liquidation threshold is exceeded.

<img width="300" alt="Screen Shot 2022-09-26 at 6 06 46 PM" src="https://user-images.githubusercontent.com/90650827/192409305-e9019db0-c0c7-4555-a844-184fa25ed139.png">

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203015146283993