### PR TITLE
Don't display cleaner error for push messages

### DIFF
--- a/src/components/services/DeepLinkingManager.ts
+++ b/src/components/services/DeepLinkingManager.ts
@@ -52,7 +52,12 @@ export function DeepLinkingManager(props: Props) {
 
   const handlePushMessage = (message: FirebaseMessagingTypes.RemoteMessage) => {
     try {
-      handleUrl(pushMessagePayloadToEdgeUri(message))
+      const url = pushMessagePayloadToEdgeUri(message)
+      if (url == null) {
+        // Unhandled push message ie. security alerts
+        return
+      }
+      handleUrl(url)
     } catch (error) {
       showError(error)
     }

--- a/src/controllers/action-queue/types/pushPayloadTypes.ts
+++ b/src/controllers/action-queue/types/pushPayloadTypes.ts
@@ -1,5 +1,5 @@
 import { FirebaseMessagingTypes } from '@react-native-firebase/messaging'
-import { asObject, asString, asValue } from 'cleaners'
+import { asMaybe, asObject, asString, asValue } from 'cleaners'
 import URL from 'url-parse'
 
 //
@@ -17,8 +17,10 @@ const asPriceChangePayloadData = asObject({
   pluginId: asString
 })
 
-export const pushMessagePayloadToEdgeUri = (message: FirebaseMessagingTypes.RemoteMessage): string => {
-  const { type, pluginId } = asPriceChangePayloadData(message.data)
+export const pushMessagePayloadToEdgeUri = (message: FirebaseMessagingTypes.RemoteMessage): string | undefined => {
+  const data = asMaybe(asPriceChangePayloadData)(message.data)
+  if (data == null) return
+  const { type, pluginId } = data
   const body = asString(message.notification?.body)
   return `edge://${type}?${URL.qs.stringify({ body, pluginId })}`
 }


### PR DESCRIPTION
Not all push messages are handled in this path (like security alerts) so an unrecognized message can be ignored instead of throwing.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203145897232074