### PR TITLE
Refactored ScamWarningCard to a generic WarningCard

### DIFF
--- a/src/components/cards/WarningCard.tsx
+++ b/src/components/cards/WarningCard.tsx
@@ -2,16 +2,35 @@ import * as React from 'react'
 import { Platform, View } from 'react-native'
 import IonIcon from 'react-native-vector-icons/Ionicons'
 
-import s from '../../locales/strings'
 import { fixSides, mapSides, sidesToMargin, sidesToPadding } from '../../util/sides'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 
 type Props = {
+  title: string
+  header?: string | null
+  points?: string[] | null
+  footer?: string | null
   marginRem?: number[] | number
   paddingRem?: number[] | number
 }
-export function ScamWarningCard({ marginRem, paddingRem }: Props) {
+/**
+ * A warning card that accepts a title, header, bullet points and a footer,
+ * rendering the bullet points with the correct vertical alignment when
+ * the messages overflow.
+ *  .___________________________.
+ *  | ⚠ Warning                 |
+ *  |                           |
+ *  | This is the header text   |
+ *  |                           |
+ *  | • This is an overflowing  |
+ *  |   bulletpoint message     |
+ *  | • This one's short        |
+ *  |                           |
+ *  | This is the footer text   |
+ *  |___________________________|
+ */
+export function WarningCard({ title, header, points, footer, marginRem, paddingRem }: Props) {
   const theme = useTheme()
   const margin = sidesToMargin(mapSides(fixSides(marginRem, 1), theme.rem))
   const padding = sidesToPadding(mapSides(fixSides(paddingRem, 1), theme.rem))
@@ -30,23 +49,26 @@ export function ScamWarningCard({ marginRem, paddingRem }: Props) {
   }
   return (
     <View style={[styles.warning, margin, padding]}>
-      <View style={styles.header}>
+      <View style={styles.titleContainer}>
         <IonIcon
           name={Platform.OS === 'ios' ? 'ios-warning-outline' : 'md-warning-outline'}
           style={styles.icon}
           color={theme.warningText}
           size={theme.rem(0.8)}
         />
-        <EdgeText style={styles.title}>{s.strings.warning_scam_title}</EdgeText>
+        <EdgeText style={styles.title}>{title}</EdgeText>
       </View>
-      <View style={styles.bulletpoints}>
-        {renderBulletpoint(s.strings.warning_scam_message_financial_advice)}
-        {renderBulletpoint(s.strings.warning_scam_message_irreversibility)}
-        {renderBulletpoint(s.strings.warning_scam_message_unknown_recipients)}
-      </View>
-      <EdgeText style={styles.footer} numberOfLines={0}>
-        {s.strings.warning_scam_footer}
-      </EdgeText>
+      {header != null && (
+        <EdgeText style={styles.text} numberOfLines={0}>
+          {header}
+        </EdgeText>
+      )}
+      {points != null && points.length > 0 && <View style={styles.bulletpoints}>{points?.map(point => renderBulletpoint(point))}</View>}
+      {footer != null && (
+        <EdgeText style={styles.text} numberOfLines={0}>
+          {footer}
+        </EdgeText>
+      )}
     </View>
   )
 }
@@ -60,7 +82,7 @@ const getStyles = (theme: Theme) =>
       margin: theme.rem(1),
       alignSelf: 'stretch'
     },
-    header: {
+    titleContainer: {
       display: 'flex',
       flexDirection: 'row',
       alignItems: 'center'
@@ -74,7 +96,7 @@ const getStyles = (theme: Theme) =>
     icon: {
       marginRight: theme.rem(0.5)
     },
-    footer: {
+    text: {
       fontSize: theme.rem(0.75),
       marginTop: theme.rem(1),
       fontFamily: theme.fontFaceDefault,

--- a/src/components/scenes/SendScene.tsx
+++ b/src/components/scenes/SendScene.tsx
@@ -24,7 +24,7 @@ import { NavigationProp, RouteProp } from '../../types/routerTypes'
 import { GuiExchangeRates, GuiMakeSpendInfo } from '../../types/types'
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import { convertTransactionFeeToDisplayFee } from '../../util/utils'
-import { ScamWarningCard } from '../cards/ScamWarningCard'
+import { WarningCard } from '../cards/WarningCard'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { FlipInputModal, FlipInputModalResult } from '../modals/FlipInputModal'
@@ -386,8 +386,13 @@ class SendComponent extends React.PureComponent<Props, State> {
 
   renderScamWarning() {
     const { recipientAddress } = this.state
+    const points = [
+      s.strings.warning_scam_message_financial_advice,
+      s.strings.warning_scam_message_irreversibility,
+      s.strings.warning_scam_message_unknown_recipients
+    ]
     if (recipientAddress === '') {
-      return <ScamWarningCard marginRem={[1.5, 1]} />
+      return <WarningCard title={s.strings.warning_scam_title} points={points} footer={s.strings.warning_scam_footer} marginRem={[1.5, 1]} />
     }
     return null
   }


### PR DESCRIPTION
ScamWarningCard is now a generic warning card that accepts a list of bullet points (as well as a title/header/footer) and will render the bullet points with correct vertical alignment. 

Should be visually identical to the [original ScamWarningCard](https://github.com/EdgeApp/edge-react-gui/pull/3682)

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

![image](https://user-images.githubusercontent.com/4023066/195758218-72db601d-6daa-4dc9-8b4c-38a862453010.png)
