### PR TITLE
Jon/aave/prevent-excess-action-amount

### DIFF
--- a/src/components/tiles/LtvRatioTile.tsx
+++ b/src/components/tiles/LtvRatioTile.tsx
@@ -1,4 +1,4 @@
-import { add, div, mul } from 'biggystring'
+import { add, div, max, mul } from 'biggystring'
 import * as React from 'react'
 
 import { useWatch } from '../../hooks/useWatch'
@@ -45,7 +45,8 @@ export const LtvRatioTile = (props: {
     totalCollateralFiatValue = add(totalCollateralFiatValue, changeAmount)
   }
 
-  const futureValue = zeroString(totalCollateralFiatValue) ? '0' : div(totalDebtFiatValue, totalCollateralFiatValue, 2)
+  // Floor the futureValue at '0'
+  const futureValue = max('0', zeroString(totalCollateralFiatValue) ? '0' : div(totalDebtFiatValue, totalCollateralFiatValue, 2))
 
   return <PercentageChangeArrowTile title={s.strings.loan_loan_to_value_ratio} currentValue={currentValue} futureValue={futureValue} />
 }

--- a/src/components/tiles/TotalDebtCollateralTile.tsx
+++ b/src/components/tiles/TotalDebtCollateralTile.tsx
@@ -1,3 +1,4 @@
+import { max } from 'biggystring'
 import { EdgeCurrencyWallet } from 'edge-core-js'
 import * as React from 'react'
 
@@ -6,7 +7,9 @@ import { FiatAmountTile } from './FiatAmountTile'
 
 export const TotalDebtCollateralTile = (props: { title: string; wallet: EdgeCurrencyWallet; debtsOrCollaterals: any[] }) => {
   const { title, wallet, debtsOrCollaterals } = props
-  const totalFiatAmount = useTotalFiatAmount(wallet, debtsOrCollaterals)
+
+  // Floor totalFiatAmount value at '0'
+  const totalFiatAmount = max('0', useTotalFiatAmount(wallet, debtsOrCollaterals))
 
   return <FiatAmountTile title={title} fiatAmount={totalFiatAmount} wallet={wallet} />
 }


### PR DESCRIPTION
- Cap tile display amounts to handle negative inputs
- Prevent over withdraws/repays with capped values

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203169636825094