### PR TITLE
Only search pluginIds for mainnet wallet create items

### DIFF
--- a/src/components/themed/WalletList.tsx
+++ b/src/components/themed/WalletList.tsx
@@ -287,12 +287,13 @@ export const filterWalletCreateItemListBySearchText = (createWalletList: WalletC
   const out: WalletCreateItem[] = []
   const searchTarget = normalizeForSearch(searchText)
   for (const item of createWalletList) {
-    const { currencyCode, displayName, pluginId } = item
-    if (
-      normalizeForSearch(currencyCode).includes(searchTarget) ||
-      normalizeForSearch(displayName).includes(searchTarget) ||
-      normalizeForSearch(pluginId).includes(searchTarget)
-    ) {
+    const { currencyCode, displayName, pluginId, walletType } = item
+    if (normalizeForSearch(currencyCode).includes(searchTarget) || normalizeForSearch(displayName).includes(searchTarget)) {
+      out.push(item)
+      continue
+    }
+    // Do an additional search for pluginId for mainnet create items
+    if (walletType != null && normalizeForSearch(pluginId).includes(searchTarget)) {
       out.push(item)
     }
   }


### PR DESCRIPTION
Did not want to get rid of pluginId searching completely (for cases like zcoin/firo) but also need to prevent tokens from appearing in the results when search for the mainnet currency.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203162131822926