### PR TITLE
Allow new user to select initial wallets

### DIFF
--- a/src/__tests__/scenes/CreateWalletSelectCryptoScene.test.tsx
+++ b/src/__tests__/scenes/CreateWalletSelectCryptoScene.test.tsx
@@ -6,6 +6,7 @@ import { createStore } from 'redux'
 
 import { CreateWalletSelectCryptoScene } from '../../components/scenes/CreateWalletSelectCryptoScene'
 import { rootReducer } from '../../reducers/RootReducer'
+import { RouteProp } from '../../types/routerTypes'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
 
 describe('CreateWalletSelectCrypto', () => {
@@ -63,10 +64,14 @@ describe('CreateWalletSelectCrypto', () => {
 
   it('should render with loading props', () => {
     const navigation = fakeNavigation
+    const route: RouteProp<'createWalletSelectCrypto'> = {
+      name: 'createWalletSelectCrypto',
+      params: {}
+    }
 
     const actual = renderer.create(
       <Provider store={store}>
-        <CreateWalletSelectCryptoScene navigation={navigation} />
+        <CreateWalletSelectCryptoScene navigation={navigation} route={route} />
       </Provider>
     )
 

--- a/src/actions/LoginActions.tsx
+++ b/src/actions/LoginActions.tsx
@@ -56,8 +56,8 @@ export function initializeAccount(account: EdgeAccount, touchIdInfo: GuiTouchIdI
   return async (dispatch, getState) => {
     // Log in as quickly as possible, but we do need the sort order:
     const syncedSettings = await getSyncedSettings(account)
-    const { walletSort } = syncedSettings
-    dispatch({ type: 'LOGIN', data: { account, walletSort } })
+    const { walletsSort } = syncedSettings
+    dispatch({ type: 'LOGIN', data: { account, walletSort: walletsSort } })
     Actions.push('edge', {})
 
     // Show a notice for deprecated electrum server settings
@@ -160,11 +160,6 @@ export function initializeAccount(account: EdgeAccount, touchIdInfo: GuiTouchIdI
       accountInitObject = { ...accountInitObject, ...mergedLocalSettings.finalSettings }
 
       accountInitObject.pinLoginEnabled = await context.pinLoginEnabled(account.username)
-
-      if (newAccount) {
-        accountInitObject.defaultFiat = defaultFiat
-        accountInitObject.defaultIsoFiat = 'iso:' + defaultFiat
-      }
 
       const defaultDenominationSettings = state.ui.settings.denominationSettings
       const syncedDenominationSettings = syncedSettings?.denominationSettings ?? {}

--- a/src/actions/LoginActions.tsx
+++ b/src/actions/LoginActions.tsx
@@ -291,10 +291,14 @@ async function safeCreateWallet(account: EdgeAccount, walletType: string, wallet
 
 // The `currencyCodes` are in the format "ETH:DAI",
 const currencyCodesToEdgeTokenIds = (account: EdgeAccount, currencyCodes: string[]): EdgeTokenId[] => {
-  const chainCodePluginIdMap = Object.keys(account.currencyConfig).reduce((map: { [chainCode: string]: string }, pluginId) => {
-    map[account.currencyConfig[pluginId].currencyInfo.currencyCode] = pluginId
-    return map
-  }, {})
+  const chainCodePluginIdMap = Object.keys(account.currencyConfig).reduce(
+    (map: { [chainCode: string]: string }, pluginId) => {
+      const chainCode = account.currencyConfig[pluginId].currencyInfo.currencyCode
+      if (map[chainCode] == null) map[chainCode] = pluginId
+      return map
+    },
+    { BNB: 'binancesmartchain' } // HACK: Prefer BNB Smart Chain over Beacon Chain if provided a BNB currency code)
+  )
 
   const edgeTokenIds: EdgeTokenId[] = []
 

--- a/src/actions/RecoveryReminderActions.tsx
+++ b/src/actions/RecoveryReminderActions.tsx
@@ -1,4 +1,3 @@
-import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
 
 import { ButtonsModal } from '../components/modals/ButtonsModal'
@@ -9,7 +8,7 @@ import { ThunkAction } from '../types/reduxTypes'
 import { Actions } from '../types/routerTypes'
 import { getTotalFiatAmountFromExchangeRates } from '../util/utils'
 
-const levels = [20, 200, 2000, 20000, 200000]
+const levels = ['20', '200', '2000', '20000', '200000'] as const
 
 /**
  * Show a modal if the user's balance is over one of the limits &
@@ -26,14 +25,13 @@ export function checkPasswordRecovery(): ThunkAction<void> {
 
     // Loop towards the highest non-shown level less than our balance:
     for (const level of levels) {
-      // @ts-expect-error
       if (passwordRecoveryRemindersShown[level]) continue
-      if (totalDollars < level) return
+      if (totalDollars < parseInt(level)) return
 
       // Mark this level as shown:
       dispatch({ type: 'UPDATE_SHOW_PASSWORD_RECOVERY_REMINDER_MODAL', data: level })
       setPasswordRecoveryRemindersAsync(account, level).catch(showError)
-      showReminderModal(level, account).catch(showError)
+      showReminderModal().catch(showError)
       return
     }
   }
@@ -41,7 +39,7 @@ export function checkPasswordRecovery(): ThunkAction<void> {
 /**
  * Actually show the password reminder modal.
  */
-async function showReminderModal(level: number, account: EdgeAccount) {
+async function showReminderModal() {
   const reply = await Airship.show<'ok' | 'cancel' | undefined>(bridge => (
     <ButtonsModal
       bridge={bridge}

--- a/src/components/Main.ui.tsx
+++ b/src/components/Main.ui.tsx
@@ -157,6 +157,7 @@ export class MainComponent extends React.Component<Props> {
               // @ts-expect-error
               renderRightButton={<HeaderTextButton type="help" placement="right" />}
             />
+            <Scene key="createWalletSelectCrypto" component={withNavigation(CreateWalletSelectCryptoScene)} navTransparent />
             {this.renderTransactionDetailsView()}
             {this.renderTabView()}
           </Stack>

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -68,6 +68,7 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
     return createWalletList.reduce((map: { [key: string]: boolean }, item) => {
       const { key, pluginId, tokenId } = item
       map[key] = defaultSelection.find(edgeTokenId => edgeTokenId.pluginId === pluginId && edgeTokenId.tokenId === tokenId) != null
+      if (item.walletType === 'wallet:bitcoin-bip44') map[key] = false // HACK: Make sure we don't select both bitcoin wallet choices
       return map
     }, {})
   })

--- a/src/modules/Core/Account/settings.ts
+++ b/src/modules/Core/Account/settings.ts
@@ -17,6 +17,8 @@ export const PASSWORD_RECOVERY_REMINDERS_SHOWN = {
   '200000': false
 }
 
+export type PasswordReminderTime = keyof typeof PASSWORD_RECOVERY_REMINDERS_SHOWN
+
 export const asCurrencyCodeDenom = asObject({
   name: asString,
   multiplier: asString,
@@ -149,7 +151,7 @@ export const setSpendingLimits = async (account: EdgeAccount, spendingLimits: Sp
     return out
   })
 }
-export async function setPasswordRecoveryRemindersAsync(account: EdgeAccount, level: number) {
+export async function setPasswordRecoveryRemindersAsync(account: EdgeAccount, level: PasswordReminderTime) {
   const settings = await getSyncedSettings(account)
   const passwordRecoveryRemindersShown = { ...settings.passwordRecoveryRemindersShown }
   passwordRecoveryRemindersShown[level] = true
@@ -165,7 +167,7 @@ export const setDenominationKeyRequest = async (account: EdgeAccount, pluginId: 
   })
 
 // Helper Functions
-export async function getSyncedSettings(account: EdgeAccount): Promise<any> {
+export async function getSyncedSettings(account: EdgeAccount): Promise<ReturnType<typeof asSyncedAccountSettings>> {
   try {
     const text = await account.disklet.getText(SYNCED_SETTINGS_FILENAME)
     const settingsFromFile = JSON.parse(text)

--- a/src/reducers/scenes/SettingsReducer.ts
+++ b/src/reducers/scenes/SettingsReducer.ts
@@ -280,7 +280,6 @@ export const settingsLegacy = (state: SettingsState = initialState, action: Acti
     case 'UPDATE_SHOW_PASSWORD_RECOVERY_REMINDER_MODAL': {
       const level = action.data
       const passwordRecoveryRemindersShown = { ...state.passwordRecoveryRemindersShown }
-      // @ts-expect-error
       passwordRecoveryRemindersShown[level] = true
       return { ...state, passwordRecoveryRemindersShown }
     }

--- a/src/types/reduxActions.ts
+++ b/src/types/reduxActions.ts
@@ -15,6 +15,7 @@ import { PriceChangeNotificationSettings } from '../actions/NotificationActions'
 import { SortOption } from '../components/modals/WalletListSortModal'
 import { ActionQueueAction } from '../controllers/action-queue/redux/actions'
 import { LoanManagerActions } from '../controllers/loan-manager/redux/actions'
+import { PasswordReminderTime } from '../modules/Core/Account/settings'
 import { CcWalletMap } from '../reducers/FioReducer'
 import { PermissionsState } from '../reducers/PermissionsReducer'
 import { AccountActivationPaymentInfo, HandleActivationInfo, HandleAvailableStatus } from '../reducers/scenes/CreateWalletReducer'
@@ -172,7 +173,7 @@ export type Action =
   | { type: 'UI/WALLETS/UPSERT_WALLETS'; data: { wallets: EdgeCurrencyWallet[] } }
   | { type: 'UPDATE_SORTED_WALLET_LIST'; data: WalletListItem[] }
   | { type: 'UPDATE_SWAP_QUOTE'; data: GuiSwapInfo }
-  | { type: 'UPDATE_SHOW_PASSWORD_RECOVERY_REMINDER_MODAL'; data: number }
+  | { type: 'UPDATE_SHOW_PASSWORD_RECOVERY_REMINDER_MODAL'; data: PasswordReminderTime }
   | { type: 'UPDATE_WALLET_LOADING_PROGRESS'; data: { walletId: string; addressLoadingProgress: number } }
   | { type: 'WALLET_ACCOUNT_ACTIVATION_ESTIMATE_ERROR'; data: string }
   | { type: 'NETWORK/NETWORK_STATUS'; data: { isConnected: boolean } }

--- a/src/types/routerTypes.tsx
+++ b/src/types/routerTypes.tsx
@@ -12,6 +12,7 @@ import { ChangeQuoteRequest, StakePolicy, StakePosition } from '../plugins/stake
 import { GuiPlugin } from './GuiPluginTypes'
 import {
   CreateWalletType,
+  EdgeTokenId,
   FeeOption,
   FioConnectionWalletItem,
   FioDomain,
@@ -74,7 +75,10 @@ export interface ParamList {
     walletNames: { [key: string]: string }
     fiatCode: string
   }
-  createWalletSelectCrypto: {}
+  createWalletSelectCrypto: {
+    newAccountFlow?: (items: WalletCreateItem[]) => Promise<void>
+    defaultSelection?: EdgeTokenId[]
+  }
   createWalletSelectFiat: {
     createWalletList: WalletCreateItem[]
   }


### PR DESCRIPTION
Reuse the CreateWalletSelectCryptoScene component after the account is created and before the wallet list loads for the first time.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203152643001448