### PR TITLE
Update Scam Warning

### DIFF
--- a/src/actions/ScamWarningActions.tsx
+++ b/src/actions/ScamWarningActions.tsx
@@ -1,0 +1,32 @@
+import { Disklet } from 'disklet'
+import * as React from 'react'
+
+import { ConfirmContinueModal } from '../components/modals/ConfirmContinueModal'
+import { Airship } from '../components/services/AirshipInstance'
+import { ModalMessage } from '../components/themed/ModalParts'
+import { SCAM_WARNING } from '../constants/constantSettings'
+import s from '../locales/strings'
+
+let isWarningChecked = false
+
+export const dismissScamWarning = async (disklet: Disklet) => {
+  if (isWarningChecked) return
+
+  try {
+    await disklet.getText(SCAM_WARNING)
+  } catch (error: any) {
+    Airship.show<boolean>(bridge => {
+      const warningMessage = `\u2022 ${s.strings.warning_scam_message_financial_advice}\n\n\u2022 ${s.strings.warning_scam_message_irreversibility}\n\n\u2022 ${s.strings.warning_scam_message_unknown_recipients}`
+
+      return (
+        <ConfirmContinueModal bridge={bridge} title={s.strings.warning_scam_title}>
+          <ModalMessage isWarning>{warningMessage}</ModalMessage>
+        </ConfirmContinueModal>
+      )
+    }).then(async () => {
+      await disklet.setText(SCAM_WARNING, '')
+
+      isWarningChecked = true
+    })
+  }
+}

--- a/src/components/cards/WarningCard.tsx
+++ b/src/components/cards/WarningCard.tsx
@@ -39,7 +39,7 @@ export function WarningCard({ title, header, points, footer, marginRem, paddingR
 
   const renderBulletpoint = (message: string) => {
     return (
-      <View style={styles.bulletpointRow}>
+      <View style={styles.bulletpointRow} key={message}>
         <EdgeText style={styles.bulletpointText}>{'\u2022 '}</EdgeText>
         <EdgeText style={styles.bulletpointText} numberOfLines={0}>
           {message}

--- a/src/constants/constantSettings.ts
+++ b/src/constants/constantSettings.ts
@@ -2,5 +2,6 @@ export const SETTINGS_PERMISSION_LIMITS = 'SETTINGS_PERMISSION_LIMIT'
 export const SETTINGS_PERMISSION_QUANTITY = 3
 export const EDGE_URL = 'https://edge.app'
 export const TUTORIAL = 'tutorial.json'
+export const SCAM_WARNING = 'scamWarning.json'
 export const TOKEN_TERMS_AGREEMENT = 'ttAgreement.json'
 export const MINIMUM_DEVICE_HEIGHT = 580


### PR DESCRIPTION
If the SendScene is opened with a pre-populated address,

1. Either from swiping the wallet list row OR
2. From the ControlPanel (side menu)

Then, show a scam warning in a ConfirmAndContinue modal once.

Subsequent initializations of the SendScene will then never show the scam warning modal.

![Simulator Screen Shot - iPhone 8 Plus - 2022-10-26 at 17 34 13](https://user-images.githubusercontent.com/90650827/198163917-9c101fa6-283e-49bf-a00b-8d29db12dae8.png)

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203082480130376