### PR TITLE
Jon/aave/fix/swapuz-to-from-quote

### DIFF
--- a/src/components/scenes/Loans/LoanCreateScene.tsx
+++ b/src/components/scenes/Loans/LoanCreateScene.tsx
@@ -159,7 +159,7 @@ export const LoanCreateScene = (props: Props) => {
     const initRequiredFiat = div(borrowAmountFiat, ltvRatio, DECIMAL_PRECISION)
 
     // HACK: Special case for handling new loans on polygon since minimums can easily be exceeded
-    return borrowPlugin.borrowInfo.currencyPluginId === 'polygon' ? max(initRequiredFiat, '105') : initRequiredFiat
+    return borrowPlugin.borrowInfo.currencyPluginId === 'polygon' ? max(initRequiredFiat, '110') : initRequiredFiat
   }, [borrowAmountFiat, borrowPlugin.borrowInfo.currencyPluginId, ltvRatio])
 
   // Convert collateral in fiat -> collateral crypto

--- a/src/controllers/action-queue/runtime/evaluateAction.ts
+++ b/src/controllers/action-queue/runtime/evaluateAction.ts
@@ -1,4 +1,4 @@
-import { add } from 'biggystring'
+import { add, mul } from 'biggystring'
 
 import { ApprovableAction, BorrowEngine, BorrowPlugin } from '../../../plugins/borrow-plugins/types'
 import { queryBorrowPlugins } from '../../../plugins/helpers/borrowPluginHelpers'
@@ -314,8 +314,11 @@ export async function evaluateAction(context: ExecutionContext, program: ActionP
         const aboveAmount = add(currentAddressBalance, swapData.payoutNativeAmount)
         */
 
+        // Add a buffer for margin of error when requesting 'from' quotes since
+        // the swap payout amount is not guaranteed
+        const swapPayoutNativeAmount = amountFor === 'from' ? mul(swapData.payoutNativeAmount, '0.9') : swapData.payoutNativeAmount
         const walletBalance = toWallet.balances[toCurrencyCode] ?? '0'
-        const aboveAmount = add(walletBalance, swapData.payoutNativeAmount)
+        const aboveAmount = add(walletBalance, swapPayoutNativeAmount)
 
         const broadcastTxs: BroadcastTx[] = [
           {

--- a/src/util/ActionProgramUtils.ts
+++ b/src/util/ActionProgramUtils.ts
@@ -61,6 +61,8 @@ export const makeAaveCreateActionProgram = async (params: AaveCreateActionParams
   const toTokenId = source.tokenId ?? Object.keys(allTokens).find(tokenId => allTokens[tokenId].currencyCode === 'WBTC')
 
   // If deposit source wallet is not the borrowEngineWallet, swap first into the borrow engine wallet + deposit token before depositing.
+
+  // Only from quotes supported for Polygon
   if (source.wallet.id !== borrowEngineWallet.id) {
     sequenceActions.push({
       type: 'swap',


### PR DESCRIPTION
Swapuz only supports 'from' quotes.

- Update the ‘swap’ in evaluateAction to undershoot its isEffective amount check in the case of using ‘from’ quoted swaps
- Update the makeAaveCreateActionProgram to undershoot the deposit amount step if it has to use a ‘from’ quote


#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203264158167694