### PR TITLE
Fix FIO-specific chain code handling

### DIFF
--- a/src/components/scenes/FioRequestConfirmationScene.tsx
+++ b/src/components/scenes/FioRequestConfirmationScene.tsx
@@ -5,7 +5,7 @@ import { View } from 'react-native'
 
 import { formatNumber } from '../../locales/intl'
 import s from '../../locales/strings'
-import { addToFioAddressCache, checkPubAddress, getRemainingBundles } from '../../modules/FioAddress/util'
+import { addToFioAddressCache, checkPubAddress, convertEdgeToFIOCodes, getRemainingBundles } from '../../modules/FioAddress/util'
 import { Slider } from '../../modules/UI/components/Slider/Slider'
 import { CcWalletMap } from '../../reducers/FioReducer'
 import { getDisplayDenomination, getExchangeDenomination } from '../../selectors/DenominationSelectors'
@@ -166,6 +166,8 @@ export class FioRequestConfirmationConnected extends React.Component<Props, Stat
           console.log(e)
         }
 
+        const { fioChainCode, fioTokenCode } = convertEdgeToFIOCodes(edgeWallet.currencyInfo.pluginId, chainCode, primaryCurrencyInfo.exchangeCurrencyCode)
+
         // send fio request
         await fioWallet.otherMethods.fioAction('requestFunds', {
           payerFioAddress: this.state.fioAddressTo,
@@ -173,8 +175,8 @@ export class FioRequestConfirmationConnected extends React.Component<Props, Stat
           payerFioPublicKey: payerPublicKey,
           payeeTokenPublicAddress: publicAddress,
           amount: val,
-          tokenCode: primaryCurrencyInfo.exchangeCurrencyCode,
-          chainCode: chainCode || primaryCurrencyInfo.exchangeCurrencyCode,
+          tokenCode: fioTokenCode,
+          chainCode: fioChainCode,
           memo: this.state.memo,
           maxFee: 0
         })

--- a/src/components/scenes/FioRequestListScene.tsx
+++ b/src/components/scenes/FioRequestListScene.tsx
@@ -5,6 +5,7 @@ import { ActivityIndicator, SectionList, View } from 'react-native'
 import { sprintf } from 'sprintf-js'
 
 import { refreshAllFioAddresses } from '../../actions/FioAddressActions'
+import { SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import { formatDate } from '../../locales/intl'
 import s from '../../locales/strings'
 import { addToFioAddressCache, cancelFioRequest, convertFIOToEdgeCodes, FIO_NO_BUNDLED_ERR_CODE } from '../../modules/FioAddress/util'
@@ -13,6 +14,7 @@ import { getExchangeDenominationFromState } from '../../selectors/DenominationSe
 import { connect } from '../../types/reactRedux'
 import { NavigationProp } from '../../types/routerTypes'
 import { FioAddress, FioRequest, GuiWallet } from '../../types/types'
+import { getTokenId } from '../../util/CurrencyInfoHelpers'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { WalletListModal, WalletListResult } from '../modals/WalletListModal'
@@ -352,14 +354,22 @@ class FioRequestList extends React.Component<Props, LocalState> {
   }
 
   renderDropUp = async (selectedFioPendingRequest: FioRequest) => {
-    const { onSelectWallet } = this.props
+    const { account, onSelectWallet } = this.props
     const { content } = selectedFioPendingRequest
-    const chainCode = content.chain_code.toUpperCase()
-    const tokenCode = content.token_code.toUpperCase()
-    const allowedFullCurrencyCode: string[] = chainCode !== tokenCode && tokenCode && tokenCode !== '' ? [`${chainCode}-${tokenCode}`] : [chainCode]
+    const pluginId = Object.keys(SPECIAL_CURRENCY_INFO).find(
+      pluginId => (SPECIAL_CURRENCY_INFO[pluginId].fioChainCode ?? SPECIAL_CURRENCY_INFO[pluginId].chainCode) === content.chain_code.toUpperCase()
+    )
+    if (pluginId == null) {
+      showError(sprintf(s.strings.fio_request_unknown_chain_code, content.chain_code.toUpperCase()))
+      return
+    }
+
+    const { tokenCode } = convertFIOToEdgeCodes(pluginId, content.chain_code.toUpperCase(), content.token_code.toUpperCase())
+    const tokenId = getTokenId(account, pluginId, tokenCode)
+    const allowedAssets = [{ pluginId, tokenId }]
 
     const { walletId, currencyCode } = await Airship.show<WalletListResult>(bridge => (
-      <WalletListModal bridge={bridge} headerTitle={s.strings.fio_src_wallet} allowedCurrencyCodes={allowedFullCurrencyCode} />
+      <WalletListModal bridge={bridge} headerTitle={s.strings.fio_src_wallet} allowedAssets={allowedAssets} />
     ))
     if (walletId && currencyCode) {
       onSelectWallet(walletId, currencyCode)

--- a/src/components/scenes/FioRequestListScene.tsx
+++ b/src/components/scenes/FioRequestListScene.tsx
@@ -7,7 +7,7 @@ import { sprintf } from 'sprintf-js'
 import { refreshAllFioAddresses } from '../../actions/FioAddressActions'
 import { formatDate } from '../../locales/intl'
 import s from '../../locales/strings'
-import { addToFioAddressCache, cancelFioRequest, FIO_NO_BUNDLED_ERR_CODE } from '../../modules/FioAddress/util'
+import { addToFioAddressCache, cancelFioRequest, convertFIOToEdgeCodes, FIO_NO_BUNDLED_ERR_CODE } from '../../modules/FioAddress/util'
 import { Gradient } from '../../modules/UI/components/Gradient/Gradient.ui'
 import { getExchangeDenominationFromState } from '../../selectors/DenominationSelectors'
 import { connect } from '../../types/reactRedux'
@@ -316,18 +316,20 @@ class FioRequestList extends React.Component<Props, LocalState> {
     const { wallets = {}, onSelectWallet } = this.props
     const availableWallets: Array<{ id: string; currencyCode: string }> = []
     for (const walletKey of Object.keys(wallets)) {
-      if (wallets[walletKey].currencyCode.toUpperCase() === fioRequest.content.token_code.toUpperCase()) {
-        availableWallets.push({ id: wallets[walletKey].id, currencyCode: wallets[walletKey].currencyCode })
+      const { chainCode, tokenCode } = convertFIOToEdgeCodes(
+        wallets[walletKey].pluginId,
+        fioRequest.content.chain_code.toUpperCase(),
+        fioRequest.content.token_code.toUpperCase()
+      )
+      if (wallets[walletKey].currencyCode.toUpperCase() === tokenCode) {
+        availableWallets.push({ id: walletKey, currencyCode: tokenCode })
         if (availableWallets.length > 1) {
           this.renderDropUp(fioRequest)
           return
         }
       }
-      if (
-        wallets[walletKey].currencyCode.toUpperCase() === fioRequest.content.chain_code.toUpperCase() &&
-        wallets[walletKey].enabledTokens.includes(fioRequest.content.token_code.toUpperCase())
-      ) {
-        availableWallets.push({ id: wallets[walletKey].id, currencyCode: fioRequest.content.token_code.toUpperCase() })
+      if (wallets[walletKey].currencyCode.toUpperCase() === chainCode && wallets[walletKey].enabledTokens.includes(tokenCode)) {
+        availableWallets.push({ id: walletKey, currencyCode: tokenCode })
         if (availableWallets.length > 1) {
           this.renderDropUp(fioRequest)
           return

--- a/src/components/themed/FioRequestRow.tsx
+++ b/src/components/themed/FioRequestRow.tsx
@@ -8,6 +8,7 @@ import FontAwesome from 'react-native-vector-icons/FontAwesome'
 import { getSymbolFromCurrency } from '../../constants/WalletAndCurrencyConstants'
 import { formatNumber, formatTime } from '../../locales/intl'
 import s from '../../locales/strings'
+import { convertEdgeToFIOCodes, convertFIOToEdgeCodes } from '../../modules/FioAddress/util'
 import { isRejectedFioRequest, isSentFioRequest } from '../../modules/FioRequest/util'
 import { getDisplayDenomination } from '../../selectors/DenominationSelectors'
 import { getSelectedWallet } from '../../selectors/WalletSelectors'
@@ -199,17 +200,20 @@ export const FioRequestRow = connect<StateProps, {}, OwnProps>(
         fiatAmount: ''
       }
     }
-    const tokenCode = fioRequest.content.token_code.toUpperCase()
+    let tokenCode = fioRequest.content.token_code.toUpperCase()
     try {
-      const { allCurrencyInfos } = state.ui.settings.plugins
-      const plugin = allCurrencyInfos.find(plugin => {
-        const { currencyCode: pluginCurrencyCode } = plugin
+      const { currencyConfig } = state.core.account
+      const pluginId = Object.keys(currencyConfig).find(pluginId => {
+        const { currencyCode: pluginCurrencyCode } = currencyConfig[pluginId].currencyInfo
         if (pluginCurrencyCode == null) return false
-        return pluginCurrencyCode.toUpperCase() === fioRequest.content.chain_code.toUpperCase()
+        const { fioChainCode } = convertEdgeToFIOCodes(pluginId, pluginCurrencyCode, tokenCode)
+        return fioChainCode === fioRequest.content.chain_code.toUpperCase()
       })
 
-      if (plugin == null) throw new Error(`No plugin match for this chain code - ${fioRequest.content.chain_code.toUpperCase()}`)
-      displayDenomination = getDisplayDenomination(state, plugin.pluginId, tokenCode)
+      if (pluginId == null) throw new Error(`No plugin match for this chain code - ${fioRequest.content.chain_code.toUpperCase()}`)
+      const { tokenCode: edgeTokenCode } = convertFIOToEdgeCodes(pluginId, fioRequest.content.chain_code.toUpperCase(), tokenCode)
+      tokenCode = edgeTokenCode
+      displayDenomination = getDisplayDenomination(state, pluginId, tokenCode)
     } catch (e: any) {
       console.log('No denomination for this Token Code -', tokenCode)
     }

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -820,6 +820,7 @@ const strings = {
   fio_request_renew_domain_ok_text: 'Your domain has been successfully renewed',
   fio_request_sent_details_to: 'Request sent to',
   fio_request_sent_details_from: 'Request sent from',
+  fio_request_unknown_chain_code: 'Unknown chain code: %s',
   fio_get_requests_error: 'There was an issue fetching requests',
   fio_confirm_request_error: 'There was an issue during request send',
   fio_reject_request_error: 'There was an issue during request rejection',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -731,6 +731,7 @@
   "fio_request_renew_domain_ok_text": "Your domain has been successfully renewed",
   "fio_request_sent_details_to": "Request sent to",
   "fio_request_sent_details_from": "Request sent from",
+  "fio_request_unknown_chain_code": "Unknown chain code: %s",
   "fio_get_requests_error": "There was an issue fetching requests",
   "fio_confirm_request_error": "There was an issue during request send",
   "fio_reject_request_error": "There was an issue during request rejection",

--- a/src/modules/FioAddress/components/ConnectWallets.tsx
+++ b/src/modules/FioAddress/components/ConnectWallets.tsx
@@ -7,12 +7,11 @@ import { showError } from '../../../components/services/AirshipInstance'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../../../components/services/ThemeContext'
 import { EdgeText } from '../../../components/themed/EdgeText'
 import { MainButton } from '../../../components/themed/MainButton'
-import { getSpecialCurrencyInfo } from '../../../constants/WalletAndCurrencyConstants'
 import s from '../../../locales/strings'
 import { connect } from '../../../types/reactRedux'
 import { Actions } from '../../../types/routerTypes'
 import { FioConnectionWalletItem } from '../../../types/types'
-import { makeConnectWallets } from '../util'
+import { convertFIOToEdgeCodes, makeConnectWallets } from '../util'
 
 interface LocalState {
   connectWalletsMap: { [walletId: string]: FioConnectionWalletItem }
@@ -150,13 +149,15 @@ class ConnectWallets extends React.Component<Props, LocalState> {
       const noWalletSymbol = '-'
 
       // Convert back to Edge currency code to display the icon
-      const info = getSpecialCurrencyInfo(wallet.edgeWallet.currencyInfo.pluginId)
-      const currencyCode = wallet.currencyCode === info.fioChainCode ? info.chainCode : wallet.currencyCode
+      const pluginId = wallet.edgeWallet.currencyInfo.pluginId
+      const { tokenCode: currencyCode } = convertFIOToEdgeCodes(pluginId, wallet.chainCode, wallet.currencyCode)
 
       return (
         <View style={[styles.wallet, disabled ? styles.walletDisabled : null]}>
           <View style={styles.rowContainerTop}>
-            <View style={styles.containerLeft}>{wallet != null ? <CryptoIcon currencyCode={currencyCode} /> : <EdgeText>{noWalletSymbol}</EdgeText>}</View>
+            <View style={styles.containerLeft}>
+              {wallet != null ? <CryptoIcon pluginId={pluginId} currencyCode={currencyCode} /> : <EdgeText>{noWalletSymbol}</EdgeText>}
+            </View>
             <View style={styles.walletDetailsContainer}>
               <View style={styles.walletDetailsCol}>
                 <EdgeText style={styles.walletDetailsRowCurrency}>{currencyCode}</EdgeText>

--- a/src/modules/FioAddress/util.ts
+++ b/src/modules/FioAddress/util.ts
@@ -3,7 +3,7 @@ import { Disklet } from 'disklet'
 import { EdgeAccount, EdgeCurrencyConfig, EdgeCurrencyWallet, EdgeDenomination } from 'edge-core-js'
 import { sprintf } from 'sprintf-js'
 
-import { FIO_STR, getSpecialCurrencyInfo } from '../../constants/WalletAndCurrencyConstants'
+import { FIO_STR, getSpecialCurrencyInfo, SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import s from '../../locales/strings'
 import { CcWalletMap } from '../../reducers/FioReducer'
 import { BooleanMap, FioAddress, FioConnectionWalletItem, FioDomain, FioObtRecord, StringMap } from '../../types/types'
@@ -944,4 +944,18 @@ export const refreshFioNames = async (
   }
 
   return { fioAddresses, fioDomains, fioWalletsById }
+}
+
+export const convertFIOToEdgeCodes = (pluginId: string, fioChainCode: string, fioTokenCode: string) => {
+  const chainCode = fioChainCode === SPECIAL_CURRENCY_INFO[pluginId].fioChainCode ? SPECIAL_CURRENCY_INFO[pluginId].chainCode : fioChainCode
+  const tokenCode = fioTokenCode === fioChainCode ? chainCode : fioTokenCode
+
+  return { chainCode, tokenCode }
+}
+
+export const convertEdgeToFIOCodes = (pluginId: string, edgeChainCode: string, edgeTokenCode: string) => {
+  const fioChainCode = SPECIAL_CURRENCY_INFO[pluginId].fioChainCode ?? edgeChainCode
+  const fioTokenCode = edgeTokenCode === edgeChainCode ? fioChainCode : edgeTokenCode
+
+  return { fioChainCode, fioTokenCode }
 }


### PR DESCRIPTION
FIO uses BSC for Binance smart chain. Edge uses BNB so we need to convert back and forth to make them compatible.

This was technically started some time ago to make connected wallets work but these other features didn't really work and displayed data was messed up.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202301192532726