### PR TITLE
Fix asset logic on LoanCreateScene

### DIFF
--- a/src/hooks/useTokenDisplayData.ts
+++ b/src/hooks/useTokenDisplayData.ts
@@ -30,7 +30,7 @@ export const useTokenDisplayData = (props: { tokenId?: string; wallet: EdgeCurre
   // - 'Fiat' is the QUOTE, defined by the wallet's fiatCurrencyCode
   // - 'Yest' is an index for a historical price from 24 hours ago.
   const usdFiatPrice = useSelector(state => state.exchangeRates[`iso:USD_${isoFiatCurrencyCode}`])
-  const assetFiatPrice = useSelector(state => state.exchangeRates[`${currencyCode}_${isoFiatCurrencyCode}`])
+  const assetFiatPrice = useCurrencyFiatRate({ currencyCode, isoFiatCurrencyCode })
   const assetFiatYestPrice = useSelector(state => {
     // The extra _ at the end means there is yesterday's date string at the end of the key
     const pair = Object.keys(state.exchangeRates).find(pair => pair.includes(`${currencyCode}_iso:USD_`))
@@ -47,4 +47,11 @@ export const useTokenDisplayData = (props: { tokenId?: string; wallet: EdgeCurre
     usdToWalletFiatRate: !zeroString(usdFiatPrice) ? usdFiatPrice : '0',
     assetToYestFiatRate: !zeroString(assetFiatYestPrice) ? assetFiatYestPrice : '0'
   }
+}
+
+export const useCurrencyFiatRate = ({ currencyCode, isoFiatCurrencyCode }: { currencyCode?: string; isoFiatCurrencyCode?: string }): string => {
+  return useSelector(state => {
+    if (currencyCode == null || isoFiatCurrencyCode == null) return '0'
+    else return state.exchangeRates[`${currencyCode}_${isoFiatCurrencyCode}`]
+  })
 }


### PR DESCRIPTION
In the use case described by the bug report, the user does not have USDC enabled. After finalizing all input fields in the LoanCreateScene, useTokenDisplayData returns 0. This causes a divide by 0 crash.

Additionally, this part of the implementation was operating on the assumption that the borrowEngineWallet will always == collateral source wallet, which is no longer the case with the support of native BTC collateral.

Fix the asset logic around this area to resolve the two points mentioned.

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203313944862165