### PR TITLE
Jon/aave/loan-details-ltv-color

### DIFF
--- a/src/components/cards/LoanDetailsSummaryCard.tsx
+++ b/src/components/cards/LoanDetailsSummaryCard.tsx
@@ -5,6 +5,7 @@ import s from '../../locales/strings'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { Thermostat } from '../themed/Thermostat'
+import { getLtvColorValue } from '../tiles/LtvRatioTile'
 import { Card } from './Card'
 
 interface SummaryDetail {
@@ -52,7 +53,7 @@ export const LoanDetailsSummaryCard = (props: Props) => {
         {ltv != null ? (
           <View style={styles.ltvContainer}>
             <EdgeText style={styles.detailLabel}>{s.strings.loan_loan_to_value_ratio}</EdgeText>
-            <Thermostat ratio={ltv} />
+            <Thermostat ratio={ltv} textColor={getLtvColorValue(ltv.toString(), theme)} />
           </View>
         ) : null}
       </View>

--- a/src/components/themed/Thermostat.tsx
+++ b/src/components/themed/Thermostat.tsx
@@ -7,13 +7,15 @@ import { EdgeText } from './EdgeText'
 
 interface Props {
   ratio: number
+  textColor: string
 }
 
-export const Thermostat = ({ ratio }: Props) => {
+export const Thermostat = ({ ratio, textColor }: Props) => {
   const theme = useTheme()
   const styles = getStyles(theme)
   const percent = Math.max(0, Math.min(1, ratio)) * 100
   const percentText = `${percent.toFixed(0)}%`
+
   return (
     <View style={styles.container}>
       <View style={styles.barContainer}>
@@ -28,7 +30,7 @@ export const Thermostat = ({ ratio }: Props) => {
           <Rect x={`${percent}%`} y="0" width="3" height="12" fill="white" rx="1" ry="1" />
         </Svg>
       </View>
-      <EdgeText style={styles.percentText}>{percentText}</EdgeText>
+      <EdgeText style={{ ...styles.percentText, color: textColor }}>{percentText}</EdgeText>
     </View>
   )
 }

--- a/src/components/tiles/LtvRatioTile.tsx
+++ b/src/components/tiles/LtvRatioTile.tsx
@@ -65,6 +65,6 @@ export const LtvRatioTile = (props: {
   )
 }
 
-const getLtvColorValue = (ltvValue: string, theme: Theme): string => {
-  return gt(ltvValue, '0.7') ? theme.dangerText : gt(ltvValue, '0.6') ? theme.warningText : theme.primaryText
+export const getLtvColorValue = (ltvValue: string, theme: Theme): string => {
+  return gt(ltvValue, '0.7') ? theme.dangerText : gt(ltvValue, '0.6') ? theme.warningText : theme.positiveText
 }


### PR DESCRIPTION
1. Change default/safe LTV color from white to green
2. Add LTV color to the LoanDetailsSummaryCard

![Simulator Screen Shot - iPhone 8 Plus - 2022-11-07 at 16 48 44](https://user-images.githubusercontent.com/90650827/200446902-5025523d-0382-49d6-80f9-853cb870b83f.png)

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202949679769451