### PR TITLE
Use `walletId` over deprecated `wallet` on `EdgeTransaction`

### DIFF
--- a/src/__tests__/scenes/TransactionDetailsScene.test.tsx
+++ b/src/__tests__/scenes/TransactionDetailsScene.test.tsx
@@ -71,7 +71,7 @@ describe('TransactionDetailsScene', () => {
             name: 'transactionDetails',
             params: {
               edgeTransaction: {
-                walletId: '',
+                walletId: fakeCoreWallet.id,
                 txid: 'this is the txid',
                 currencyCode: 'BTC',
                 date: 1535752780.947, // 2018-08-31T21:59:40.947Z
@@ -80,7 +80,6 @@ describe('TransactionDetailsScene', () => {
                 ourReceiveAddresses: ['this is an address'],
                 signedTx: 'this is a signed tx',
                 otherParams: {},
-                wallet: fakeCoreWallet,
                 blockHeight: 0
               },
               walletId: fakeCoreWallet.id,
@@ -103,7 +102,7 @@ describe('TransactionDetailsScene', () => {
             name: 'transactionDetails',
             params: {
               edgeTransaction: {
-                walletId: '',
+                walletId: fakeCoreWallet.id,
                 txid: 'this is the txid',
                 currencyCode: 'BTC',
                 date: 1535752780.947, // 2018-08-31T21:59:40.947Z
@@ -112,7 +111,6 @@ describe('TransactionDetailsScene', () => {
                 ourReceiveAddresses: ['this is an address'],
                 signedTx: 'this is a signed tx',
                 otherParams: {},
-                wallet: fakeCoreWallet,
                 blockHeight: 0,
                 metadata: {
                   amountFiat: -6392.93

--- a/src/actions/SendConfirmationActions.tsx
+++ b/src/actions/SendConfirmationActions.tsx
@@ -320,7 +320,6 @@ export function signBroadcastAndSave(
       await wallet.saveTxMetadata(edgeSignedTransaction.txid, edgeSignedTransaction.currencyCode, edgeMetadata)
 
       edgeSignedTransaction.metadata = edgeMetadata
-      edgeSignedTransaction.wallet = wallet
 
       if (payeeFioAddress != null) {
         addToFioAddressCache(account, [payeeFioAddress])
@@ -351,7 +350,7 @@ export function signBroadcastAndSave(
           } else if ((guiMakeSpendInfo.publicAddress != null || publicAddress != null) && (!skipRecord || edgeSignedTransaction.currencyCode === FIO_STR)) {
             const payerPublicAddress = wallet.publicWalletInfo.keys.publicKey
             const amount = guiMakeSpendInfo.nativeAmount ?? '0'
-            const chainCode = edgeSignedTransaction.wallet.currencyInfo.currencyCode
+            const chainCode = wallet.currencyInfo.currencyCode
 
             try {
               recordSend(fioWallet, fioAddress, {

--- a/src/actions/TransactionListActions.ts
+++ b/src/actions/TransactionListActions.ts
@@ -155,7 +155,7 @@ export function newTransactionsRequest(walletId: string, edgeTransactions: EdgeT
       if (isReceivedTransaction(transaction)) {
         receivedTxs.push(transaction)
       }
-      if (transaction.currencyCode === selectedCurrencyCode && transaction.wallet && transaction.wallet.id === selectedWalletId) {
+      if (transaction.currencyCode === selectedCurrencyCode && transaction.walletId === selectedWalletId) {
         isTransactionForSelectedWallet = true
         // this next part may be unnecessary
         const indexOfNewTransaction = currentViewableTransactions.findIndex(tx => tx.txid === transaction.txid)
@@ -171,7 +171,7 @@ export function newTransactionsRequest(walletId: string, edgeTransactions: EdgeT
     if (isTransactionForSelectedWallet) dispatch(fetchTransactions(walletId, selectedCurrencyCode, options))
     if (receivedTxs.length) dispatch(checkFioObtData(walletId, receivedTxs))
     if (!isReceivedTransaction(edgeTransaction)) return
-    showTransactionDropdown(edgeTransaction, walletId)
+    showTransactionDropdown(edgeTransaction)
   }
 }
 

--- a/src/components/scenes/TransactionDetailsScene.tsx
+++ b/src/components/scenes/TransactionDetailsScene.tsx
@@ -172,9 +172,8 @@ class TransactionDetailsComponent extends React.Component<Props, State> {
   }
 
   openAccelerateModel = () => {
-    const { route } = this.props
+    const { route, wallet } = this.props
     const { edgeTransaction } = route.params
-    const { wallet } = edgeTransaction
 
     if (wallet) {
       Airship.show(bridge => <AccelerateTxModel bridge={bridge} edgeTransaction={edgeTransaction} wallet={wallet} />)


### PR DESCRIPTION
#### PR Dependencies

https://github.com/EdgeApp/edge-core-js/pull/484

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202793832335293