### PR TITLE
Fix withdraw amount after closing loan with swap and repay

### DIFF
--- a/src/plugins/borrow-plugins/plugins/aave/BorrowEngineFactory.ts
+++ b/src/plugins/borrow-plugins/plugins/aave/BorrowEngineFactory.ts
@@ -262,6 +262,16 @@ export const makeBorrowEngineFactory = (blueprint: BorrowEngineBlueprint) => {
       async withdraw(request: WithdrawRequest): Promise<ApprovableAction> {
         const { tokenId, toWallet = wallet } = request
 
+        // Refresh collaterals. It's possible that this follows an op including
+        // a repay with collateral.
+        const reserveTokenBalances = await aaveNetwork.getReserveTokenBalances(walletAddress)
+        instance.collaterals = reserveTokenBalances.map(({ address, aBalance }) => {
+          return {
+            tokenId: addressToTokenId(address),
+            nativeAmount: aBalance.toString()
+          }
+        })
+
         const collateral = instance.collaterals.find(debt => debt.tokenId === tokenId)
         if (collateral == null) throw new Error(`No collateral to withdraw for ${tokenId}`)
 


### PR DESCRIPTION
Swap and repay (repay with collateral) affects collateral balance. When a max withdraw action is chained after a swap and repay, the collateral balance is stale, causing the action to fail due to over-withdrawal.

When evaluating a withdraw, refresh the borrow engine instance's collaterals prior to the rest of the withdraw evaluation.

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
