### PR TITLE
AAVE: Explicit dashboard navigation on null LoanAccount

### DIFF
--- a/src/components/hoc/withLoanAccount.tsx
+++ b/src/components/hoc/withLoanAccount.tsx
@@ -2,10 +2,11 @@ import * as React from 'react'
 
 import { LoanAccount } from '../../controllers/loan-manager/types'
 import { useSelector } from '../../types/reactRedux'
+import { NavigationProp, ParamList } from '../../types/routerTypes'
 import { LoadingScene } from '../scenes/LoadingScene'
 
 interface NavigationProps {
-  navigation: { popToTop: () => void }
+  navigation: NavigationProp<keyof ParamList>
   route: { params: { loanAccountId: string } }
 }
 
@@ -25,11 +26,15 @@ export function withLoanAccount<Props extends { loanAccount: LoanAccount }>(
     const loanAccount = loanAccounts[route.params.loanAccountId]
 
     React.useEffect(() => {
-      if (loanAccount == null) navigation.popToTop()
+      if (loanAccount == null) navigation.navigate('loanDashboard', {})
     }, [navigation, loanAccount, loanAccounts])
 
-    if (loanAccount == null) return <LoadingScene />
-
-    return <Component {...(props as any)} loanAccount={loanAccount} />
+    if (loanAccount == null) {
+      // Prevent the wrapped scene from being called with a null LoanAccount.
+      // useEffect will instantly navigate back to the dashboard in this case.
+      return <LoadingScene />
+    } else {
+      return <Component {...(props as any)} loanAccount={loanAccount} />
+    }
   }
 }


### PR DESCRIPTION
navigation.popToTop() does not reliably navigate back to the dashboard scene in all scenarios.

In any case where the loan account is not available, always navigate to the dashboard scene.

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203444815739776