### PR TITLE
Force enable WBTC+USDC tokens on LoanCreateScene

### DIFF
--- a/src/components/scenes/Loans/LoanCreateScene.tsx
+++ b/src/components/scenes/Loans/LoanCreateScene.tsx
@@ -28,6 +28,7 @@ import { NavigationProp, RouteProp } from '../../../types/routerTypes'
 import { getWalletPickerExcludeWalletIds } from '../../../util/borrowUtils'
 import { getBorrowPluginIconUri } from '../../../util/CdnUris'
 import { getTokenId, guessFromCurrencyCode } from '../../../util/CurrencyInfoHelpers'
+import { enableToken } from '../../../util/CurrencyWalletHelpers'
 import { DECIMAL_PRECISION, truncateDecimals, zeroString } from '../../../util/utils'
 import { Card } from '../../cards/Card'
 import { FiatAmountInputCard } from '../../cards/FiatAmountInputCard'
@@ -63,6 +64,12 @@ export const LoanCreateScene = (props: Props) => {
   const existingProgramId = useRunningActionQueueId('loan-create', borrowEngineWallet.id)
   const existingLoanAccount = useSelector(state => state.loanManager.loanAccounts[borrowEngineWallet.id])
   if (existingProgramId != null) navigation.navigate('loanStatus', { actionQueueId: existingProgramId, loanAccountId: existingLoanAccount.id })
+
+  // Force enable tokens required for loan
+  useAsyncEffect(async () => {
+    await enableToken('WBTC', borrowEngineWallet)
+    await enableToken('USDC', borrowEngineWallet)
+  }, [])
 
   // #endregion Initialization
 


### PR DESCRIPTION
Tokens used for AAVE are not guaranteed to be enabled during the Create workflow - for example if the user selects BTC->bank. 
Tokens were being enabled upon ActionProgram creation after transitioning to LoanCreateConfirmationScene. 
However, the scene already needs the tokens to be enabled prior to entering the scene to properly calculate the nativeAmount passed to it.

Force enable the tokens prior to entering the LoanCreateConfirmationScene.

#### PR Dependencies

<!-- List any PRs on which this PR depends or leave as --> none

#### PR Requirements

If you have made **any** visual changes to the GUI. Make sure you have:
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203476237006127