### PR TITLE
Restrict token allowance

### DIFF
--- a/src/plugins/borrow-plugins/plugins/aave/AaveBorrowEngineFactory.ts
+++ b/src/plugins/borrow-plugins/plugins/aave/AaveBorrowEngineFactory.ts
@@ -105,16 +105,12 @@ export const makeAaveBorrowEngineFactory = (blueprint: BorrowEngineBlueprint) =>
         overrides = { ...overrides, gasPrice }
         console.warn(`getApproveAllowanceTx was called without a gasPrice overrides parameter. The caller should pass the gasPrice instead.`)
       }
-      const allowance = await tokenContract.allowance(ownerAddress, spenderAddress)
-      if (!allowance.sub(allowanceAmount).gte(0)) {
-        return asGracefulTxInfo(
-          await tokenContract.populateTransaction.approve(spenderAddress, ethers.constants.MaxUint256, {
-            gasLimit: '500000',
-            ...overrides
-          })
-        )
-      }
-      return null
+      return asGracefulTxInfo(
+        await tokenContract.populateTransaction.approve(spenderAddress, BigNumber.from(allowanceAmount), {
+          gasLimit: '500000',
+          ...overrides
+        })
+      )
     }
 
     //


### PR DESCRIPTION
Each AAVE smart contract interaction handled by Edge now overrides any existing (typically infinite) token allowances with only what is needed.

### CHANGELOG

AAVE: Restrict token allowances to only what is needed for each smart contract call.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
