### PR TITLE
Parallelize all EVM transaction for close loan

### DIFF
--- a/src/util/ActionProgramUtils.ts
+++ b/src/util/ActionProgramUtils.ts
@@ -241,10 +241,7 @@ export const makeAaveCloseAction = async ({
   const { currencyWallet: wallet } = borrowEngine
   const { fiatCurrencyCode: isoFiatCurrencyCode } = wallet
 
-  const seqAction: SeqActionOp = {
-    type: 'seq',
-    actions: []
-  }
+  const evmActions: ActionOp[] = []
 
   // Only accept this request if the user has only singular debt/collateral assets
   const collaterals = borrowEngine.collaterals.filter(collateral => !zeroString(collateral.nativeAmount))
@@ -361,7 +358,7 @@ export const makeAaveCloseAction = async ({
 
       // Repay with balance actions
       if (!zeroString(repayWithBalanceNativeAmount))
-        seqAction.actions.push({
+        evmActions.push({
           type: 'loan-repay',
           nativeAmount: repayWithBalanceNativeAmount,
           borrowPluginId,
@@ -371,7 +368,7 @@ export const makeAaveCloseAction = async ({
 
       // Repay with collateral actions
       if (!zeroString(repayWithCollateralNativeAmount))
-        seqAction.actions.push({
+        evmActions.push({
           type: 'loan-repay',
           nativeAmount: repayWithCollateralNativeAmount,
           borrowPluginId,
@@ -382,7 +379,7 @@ export const makeAaveCloseAction = async ({
     }
 
     // Withdraw action
-    seqAction.actions.push({
+    evmActions.push({
       type: 'loan-withdraw',
       borrowPluginId,
       nativeAmount: MAX_AMOUNT.toString(),
@@ -391,5 +388,15 @@ export const makeAaveCloseAction = async ({
     })
   }
 
-  return seqAction.actions.length > 0 ? seqAction : null
+  return evmActions.length > 0
+    ? {
+        type: 'seq',
+        actions: [
+          {
+            type: 'par',
+            actions: evmActions
+          }
+        ]
+      }
+    : null
 }


### PR DESCRIPTION
This fixes issue that dry-running the `LoanWithdrawActionOp` does not invoke the `approve()` method for the `ApprovableAction` from the `BorrowEngine` API and therefore does not mutate the `BorrowEngine.collaterals` array.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203486127856838