### PR TITLE
Force 'skipChecks: true' for all wyre-sell ops

### DIFF
--- a/src/controllers/action-queue/runtime/evaluateAction.ts
+++ b/src/controllers/action-queue/runtime/evaluateAction.ts
@@ -157,13 +157,17 @@ export async function evaluateAction(context: ExecutionContext, program: ActionP
 
       const paymentAddress = await wyreClient.getCryptoPaymentAddress(wyreAccountId, walletId)
 
-      const makeExecutionOutput = async (dryrun: boolean, pendingTxMap: Readonly<PendingTxMap>): Promise<ExecutionOutput> => {
+      const makeExecutionOutput = async (_dryrun: boolean, pendingTxMap: Readonly<PendingTxMap>): Promise<ExecutionOutput> => {
         // Get any pending txs for this wallet
         const pendingTxs = pendingTxMap[walletId]
 
         const unsignedTx = await wallet.makeSpend({
           currencyCode,
-          skipChecks: dryrun,
+          // Always skip checks instead of inheriting from dryrun param because
+          // USDC balance isn't available when using this action op specifically
+          // in the case of being contained in a par, preceeded by a borrow, and
+          // with this par being the first op of the ActionProgram.
+          skipChecks: true,
           spendTargets: [
             {
               nativeAmount,


### PR DESCRIPTION
USDC balance isn't available when using the 'wyre-sell' action op specifically in the case of being contained in a par, preceeded by a borrow, and with this par being the first op of the ActionProgram.

### CHANGELOG

AAVE: Force 'skipChecks: true' for all wyre-sell ops

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203355923167213