### PR TITLE
Update Info.plist NSLocation* property

### DIFF
--- a/ios/edge/Info.plist
+++ b/ios/edge/Info.plist
@@ -97,7 +97,7 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>This allows you to find nearby places where you can purchase bitcoin.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$(PRODUCT_NAME) uses photos to retrieve QR Code images.</string>


### PR DESCRIPTION
The old key has been deprecated for
`NSLocationAlwaysAndWhenInUseUsageDescription` for all iOS >11 versions. Because we don't support iOS 11, we no longer need the `NSLocationWhenInUseUsageDescription` key.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203519984726837