### PR TITLE
Remove payment protocol custom fee from spendInfo.otherParams

### DIFF
--- a/src/actions/BitPayActions.tsx
+++ b/src/actions/BitPayActions.tsx
@@ -178,14 +178,7 @@ export async function launchBitPay(
         publicAddress: output.address
       }
     }),
-    metadata,
-    otherParams: {
-      paymentProtocolInfo: {
-        merchant: {
-          requiredFeeRate
-        }
-      }
-    }
+    metadata
   }
   if (requiredFeeRate != null) {
     spendInfo.networkFeeOption = 'custom'


### PR DESCRIPTION
This would override any custom fee settings a user might want to set.

Handling of payment protocol and its custom fees by the plugin is a legacy feature that is now handled entirely in the GUI.

### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203587144810191