### PR TITLE
Fix payment protocol payments from segwit wallets

### DIFF
--- a/src/actions/BitPayActions.tsx
+++ b/src/actions/BitPayActions.tsx
@@ -164,9 +164,10 @@ export async function launchBitPay(
 
   // Make the spend to generate the tx hexes
   let requiredFeeRate = invoiceInstruction.requiredFeeRate
-  // This is in addition to the 1.5x multiplier in edge-currency-bitcoin. It's an additional buffer
-  // because the protocol doesn't discount segwit transactions and we want to make sure the transaction succeeds.
-  if (typeof requiredFeeRate === 'number') requiredFeeRate *= 1.2
+  // This is an additional buffer because the protocol doesn't discount segwit
+  // transactions and we want to make sure the transaction succeeds.
+  const { pluginId } = selectedWallet.currencyInfo
+  if (typeof requiredFeeRate === 'number' && SPECIAL_CURRENCY_INFO[pluginId].hasSegwit) requiredFeeRate *= 1.8
   const spendInfo: EdgeSpendInfo = {
     currencyCode: selectedCurrencyCode,
     // Reverse the outputs since Anypay puts the merchant amount first. Making it last will have

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -125,6 +125,7 @@ interface SpecialCurrencyInfo {
   // Flags that could move to EdgeCurrencyInfo:
   fioChainCode?: string
   allowZeroTx?: boolean
+  hasSegwit?: boolean
   isAccountActivationRequired?: boolean
   isCustomTokensSupported?: boolean
   isUriEncodedStructure?: boolean
@@ -165,6 +166,7 @@ export const SPECIAL_CURRENCY_INFO: {
 } = {
   bitcoin: {
     maxSpendTargets: UTXO_MAX_SPEND_TARGETS,
+    hasSegwit: true,
     initWalletName: s.strings.string_first_bitcoin_wallet_name,
     chainCode: 'BTC',
     displayBuyCrypto: true,
@@ -178,6 +180,7 @@ export const SPECIAL_CURRENCY_INFO: {
     isBitPayProtocolSupported: true
   },
   bitcointestnet: {
+    hasSegwit: true,
     maxSpendTargets: UTXO_MAX_SPEND_TARGETS,
     initWalletName: s.strings.string_first_bitcoin_testnet_wallet_name,
     chainCode: 'TESTBTC',
@@ -227,6 +230,7 @@ export const SPECIAL_CURRENCY_INFO: {
     isBitPayProtocolSupported: true
   },
   litecoin: {
+    hasSegwit: true,
     maxSpendTargets: UTXO_MAX_SPEND_TARGETS,
     initWalletName: s.strings.string_first_litecoin_wallet_name,
     chainCode: 'LTC',


### PR DESCRIPTION
At least with Bitpay, payment protocol requests desire a sat/byte fee that doesn't include the segwit discount. Ensure that we scale by 1.8x in the client-side code since no longer use the plugin side payment protocol scaling.

### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203593993627360