### PR TITLE
Add `NSLocationWhenInUseUsageDescription` back to Info.plist

### DIFF
--- a/ios/edge/Info.plist
+++ b/ios/edge/Info.plist
@@ -97,6 +97,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This allows you to find nearby places where you can purchase bitcoin.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>This allows you to find nearby places where you can purchase bitcoin.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
This property is still required for iOS +11. This was confused with the deprecated `NSLocationAlwaysUsageDescription` property.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
