### PR TITLE
Fix future unstake estimate

### DIFF
--- a/src/components/scenes/Staking/StakeModifyScene.tsx
+++ b/src/components/scenes/Staking/StakeModifyScene.tsx
@@ -158,12 +158,19 @@ export const StakeModifyScene = (props: Props) => {
 
   // @ts-expect-error
   const handleSlideComplete = reset => {
+    const message = {
+      stake: s.strings.stake_change_stake_success,
+      unstake: s.strings.stake_change_unstake_success,
+      claim: s.strings.stake_change_claim_success,
+      unstakeExact: ''
+    }
+
     if (changeQuote != null) {
       setSliderLocked(true)
       changeQuote
         .approve()
         .then(success => {
-          Airship.show(bridge => <FlashNotification bridge={bridge} message={s.strings[`stake_change_${modification}_success`]} onPress={() => {}} />)
+          Airship.show(bridge => <FlashNotification bridge={bridge} message={message[modification]} onPress={() => {}} />)
           navigation.pop()
         })
         .catch(err => {
@@ -438,7 +445,8 @@ export const StakeModifyScene = (props: Props) => {
     () => ({
       stake: getPolicyTitleName(stakePolicy),
       claim: s.strings.stake_claim_rewards,
-      unstake: s.strings.stake_unstake_claim
+      unstake: s.strings.stake_unstake_claim,
+      unstakeExact: '' // Only for internal use
     }),
     [stakePolicy]
   )

--- a/src/plugins/stake-plugins/types.ts
+++ b/src/plugins/stake-plugins/types.ts
@@ -77,7 +77,7 @@ export interface StakePolicy {
 // Change Quote
 // -----------------------------------------------------------------------------
 export interface ChangeQuoteRequest {
-  action: 'stake' | 'unstake' | 'claim'
+  action: 'stake' | 'unstake' | 'claim' | 'unstakeExact'
   stakePolicyId: string
   currencyCode: string
   nativeAmount: string


### PR DESCRIPTION
Force use of the exact unstake amount when simulating an unstake. The 'unstake' directive also includes the earned amount of the sample Saver which will cause much more slippage.

### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203655596713996