### PR TITLE
No Segwit DGB/LTC in GUI

### DIFF
--- a/src/util/CurrencyInfoHelpers.ts
+++ b/src/util/CurrencyInfoHelpers.ts
@@ -61,22 +61,22 @@ export function getCreateWalletTypes(account: EdgeAccount, filterActivation: boo
 
   const out: CreateWalletType[] = []
   for (const currencyInfo of infos) {
-    const { currencyCode, pluginId } = currencyInfo
+    const { currencyCode, displayName, pluginId, walletType } = currencyInfo
     // Prevent plugins that are "watch only" from being allowed to create new wallets
     if (keysOnlyModePlugins.includes(pluginId)) continue
     // Prevent currencies that needs activation from being created from a modal
     if (filterActivation && activationRequiredCurrencyCodes.includes(currencyCode.toUpperCase())) continue
     // FIO disable changes
-    if (pluginId === 'bitcoin') {
+    if (['bitcoin', 'litecoin', 'digibyte'].includes(pluginId)) {
       out.push({
-        currencyName: 'Bitcoin (Segwit)',
-        walletType: 'wallet:bitcoin-bip49',
+        currencyName: `${displayName} (Segwit)`,
+        walletType: `${walletType}-bip49`,
         pluginId,
         currencyCode
       })
       out.push({
-        currencyName: 'Bitcoin (no Segwit)',
-        walletType: 'wallet:bitcoin-bip44',
+        currencyName: `${displayName} (no Segwit)`,
+        walletType: `${walletType}-bip44`,
         pluginId,
         currencyCode
       })


### PR DESCRIPTION
### CHANGELOG

- Added: Non-segwit wallet options for Litecoin and Digibyte to support Jaxx wallet imports

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203651461107953