### PR TITLE
Remove unused showHeader prop

### DIFF
--- a/src/__tests__/scenes/__snapshots__/ChangePasswordScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/ChangePasswordScene.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`ChangePasswordComponent should render with loading props 1`] = `
       }
     }
     onComplete={[Function]}
-    showHeader={false}
   />
 </SceneWrapper>
 `;

--- a/src/__tests__/scenes/__snapshots__/ChangePinScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/ChangePinScene.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`ChangePinComponent should render with loading props 1`] = `
       }
     }
     onComplete={[Function]}
-    showHeader={false}
   />
 </SceneWrapper>
 `;

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -26,7 +26,7 @@ export class ChangePasswordComponent extends React.Component<Props> {
     }
     return (
       <SceneWrapper hasTabs={false} background="theme">
-        <ChangePasswordScreen account={account} context={context} onComplete={handleComplete} showHeader={false} />
+        <ChangePasswordScreen account={account} context={context} onComplete={handleComplete} />
       </SceneWrapper>
     )
   }

--- a/src/components/scenes/ChangePinScene.tsx
+++ b/src/components/scenes/ChangePinScene.tsx
@@ -25,7 +25,7 @@ export class ChangePinComponent extends React.Component<Props> {
     }
     return (
       <SceneWrapper hasTabs={false} background="theme">
-        <ChangePinScreen account={account} context={context} onComplete={handleComplete} showHeader={false} />
+        <ChangePinScreen account={account} context={context} onComplete={handleComplete} />
       </SceneWrapper>
     )
   }


### PR DESCRIPTION
The `showHeader` prop is unused in both these scenes and needs to be removed before merging [Recovery UI2](https://github.com/EdgeApp/edge-login-ui-rn/tree/itay/recovery-ui2), since that PR removes the last remaining [usage](https://github.com/EdgeApp/edge-login-ui-rn/blob/6131489867e3e57e868904bc2693118355876d1d/src/components/common/Header.tsx#L22-L26) of the old UI1 Header and deletes the component. 
 
### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)