### PR TITLE
Fix Savers to only use a wallet's `publicAddress` not `segwitAddress`

### DIFF
--- a/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.ts
+++ b/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.ts
@@ -802,8 +802,8 @@ const updateInboundAddresses = async (opts: EdgeGuiPluginOptions): Promise<void>
 }
 
 const getPrimaryAddress = async (wallet: EdgeCurrencyWallet, currencyCode: string): Promise<{ primaryAddress: string; addressBalance: string }> => {
-  const { publicAddress, nativeBalance, segwitAddress, segwitNativeBalance } = await wallet.getReceiveAddress({ forceIndex: 0, currencyCode })
-  const primaryAddress = segwitAddress ?? publicAddress
+  const { publicAddress, nativeBalance } = await wallet.getReceiveAddress({ forceIndex: 0, currencyCode })
+  const primaryAddress = publicAddress
   let addressBalance = '0'
 
   if (wallet.displayPublicSeed?.toLowerCase() === primaryAddress.toLowerCase()) {
@@ -811,7 +811,7 @@ const getPrimaryAddress = async (wallet: EdgeCurrencyWallet, currencyCode: strin
     // the wallet balance
     addressBalance = await wallet.balances[currencyCode]
   } else {
-    addressBalance = segwitAddress != null ? segwitNativeBalance ?? '0' : nativeBalance ?? '0'
+    addressBalance = nativeBalance ?? '0'
   }
 
   return { primaryAddress, addressBalance }


### PR DESCRIPTION
This prevents previous deposits from not showing

### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203661324582192