### PR TITLE
AAVE: Fix partial repay with collateral transaction failure

### DIFF
--- a/src/plugins/borrow-plugins/plugins/aave/AaveBorrowEngineFactory.ts
+++ b/src/plugins/borrow-plugins/plugins/aave/AaveBorrowEngineFactory.ts
@@ -1,4 +1,4 @@
-import { add, div, gt, lt, min, mul } from 'biggystring'
+import { add, div, gt, gte, lt, min, mul } from 'biggystring'
 import { asMaybe, Cleaner } from 'cleaners'
 import { EdgeCurrencyWallet, EdgeToken } from 'edge-core-js'
 import { BigNumber, BigNumberish, ethers, Overrides } from 'ethers'
@@ -438,7 +438,7 @@ export const makeAaveBorrowEngineFactory = (blueprint: BorrowEngineBlueprint) =>
               priceWithSlippage,
               priceRoute.destAmount,
               2, // 1 = stable, 2 = variable
-              164, // buyAllBalanceOffset 164 = Augustus V5 buy. Function call to handle the slight interest accrued after the tx is broadcasted
+              gte(request.nativeAmount, debt.nativeAmount) ? 164 : 0, // buyAllBalanceOffset 164 = Augustus V5 buy. Function call to handle the slight interest accrued after the tx is broadcasted when closing the full principal
               ethers.utils.defaultAbiCoder.encode(['bytes', 'address'], [swapTxParams.data, swapTxParams.to]),
               {
                 amount: '0',


### PR DESCRIPTION
'buyAllBalance' prop of the eth tx only needs the '164' Augustus function when repaying the full principal.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203683948680923