### PR TITLE
Remove non-existing `navigation.popTo` method

### DIFF
--- a/src/__tests__/components/__snapshots__/MenuTab.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/MenuTab.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`MenuTab should render with loading props 1`] = `
       "navigate": [Function],
       "openDrawer": [Function],
       "pop": [Function],
-      "popTo": [Function],
       "popToTop": [Function],
       "push": [Function],
       "replace": [Function],

--- a/src/actions/CreateWalletActions.tsx
+++ b/src/actions/CreateWalletActions.tsx
@@ -182,7 +182,7 @@ export function createAccountTransaction(
               notes: sprintf(s.strings.create_wallet_account_metadata_notes, createdWalletCurrencyCode, createdWalletCurrencyCode, config.supportEmail)
             }
             paymentWallet.saveTxMetadata(edgeTransaction.txid, currencyCode, edgeMetadata).then(() => {
-              navigation.popTo('walletListScene')
+              navigation.navigate('walletListScene', {})
               setTimeout(() => {
                 Alert.alert(s.strings.create_wallet_account_payment_sent_title, s.strings.create_wallet_account_payment_sent_message)
               }, 750)

--- a/src/actions/CryptoExchangeActions.tsx
+++ b/src/actions/CryptoExchangeActions.tsx
@@ -70,7 +70,7 @@ export function getQuoteForTransaction(navigation: NavigationBase, info: SetNati
       })
       dispatch({ type: 'UPDATE_SWAP_QUOTE', data: swapInfo })
     } catch (error: any) {
-      navigation.popTo('exchangeScene')
+      navigation.navigate('exchangeScene', {})
       const insufficientFunds = asMaybeInsufficientFundsError(error)
       if (insufficientFunds != null && insufficientFunds.currencyCode != null && fromCurrencyCode !== insufficientFunds.currencyCode && fromWalletId != null) {
         const { currencyCode, networkFee = '' } = insufficientFunds
@@ -121,7 +121,7 @@ export function exchangeTimerExpired(navigation: NavigationBase, swapInfo: GuiSw
       })
       dispatch({ type: 'UPDATE_SWAP_QUOTE', data: swapInfo })
     } catch (error: any) {
-      navigation.popTo('exchangeScene')
+      navigation.navigate('exchangeScene', {})
       dispatch(processSwapQuoteError(error))
     }
   }

--- a/src/components/scenes/Loans/LoanCreateConfirmationScene.tsx
+++ b/src/components/scenes/Loans/LoanCreateConfirmationScene.tsx
@@ -167,16 +167,13 @@ export const LoanCreateConfirmationScene = (props: Props) => {
         await dispatch(saveLoanAccount(loanAccount))
         await dispatch(runLoanActionProgram(loanAccount, actionProgram, 'loan-create'))
 
-        // Route to LoanStatusScene only if Action Program contains multiple ops
+        navigation.popToTop()
+        navigation.navigate('loanDetails', { loanAccountId: loanAccount.id })
+
+        // Further route to LoanStatusScene only if Action Program contains multiple ops
         const seq = actionProgram.actionOp.type === 'seq' ? actionProgram.actionOp : null
         if (seq != null && seq.actions.length > 1) {
-          // HACK: Until Main.ui fully deprecates Actions usage, use this hack to handle back button routing.
-          navigation.popTo('loanCreate')
-          navigation.replace('loanDetails', { loanAccountId: loanAccount.id })
-
           navigation.navigate('loanStatus', { actionQueueId: actionProgram.programId, loanAccountId: loanAccount.id })
-        } else {
-          navigation.navigate('loanDetails', { loanAccountId: loanAccount.id })
         }
       } catch (e: any) {
         showError(e)

--- a/src/types/routerTypes.tsx
+++ b/src/types/routerTypes.tsx
@@ -365,7 +365,6 @@ export interface NavigationBase {
   // Returning:
   goBack: () => void
   pop: () => void
-  popTo: (sceneKey: string) => void
   popToTop: () => void
 
   // Drawer:
@@ -435,9 +434,6 @@ export function withNavigation<Props>(Component: React.ComponentType<Props>): Re
       },
       pop() {
         props.navigation.pop()
-      },
-      popTo(name) {
-        props.navigation.popTo(name)
       },
       popToTop() {
         props.navigation.popToTop()

--- a/src/util/fake/fakeNavigation.ts
+++ b/src/util/fake/fakeNavigation.ts
@@ -15,7 +15,6 @@ export const fakeNavigation: NavigationProp<any> = {
 
   goBack() {},
   pop() {},
-  popTo: () => {},
   popToTop() {},
 
   closeDrawer() {},


### PR DESCRIPTION
Somehow this slipped into the types, even though it doesn't actually exist.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203773088083078