### PR TITLE
Fix broken `navigation.replace` poly-fill cleanup

### DIFF
--- a/src/types/routerTypes.tsx
+++ b/src/types/routerTypes.tsx
@@ -414,7 +414,7 @@ export function withNavigation<Props>(Component: React.ComponentType<Props>): Re
       },
       replace(name, params) {
         Flux.Actions.replace(name, { route: { name, params } })
-        // TODO: Replace FLux.Actions.replace with props.navigation.replace
+        // TODO: Replace Flux.Actions.replace with props.navigation.replace
         // which will require debugging why it doesn't work for certain scenes.
         // props.navigation.replace(name, { route: { name, params } })
       },

--- a/src/types/routerTypes.tsx
+++ b/src/types/routerTypes.tsx
@@ -413,7 +413,9 @@ export function withNavigation<Props>(Component: React.ComponentType<Props>): Re
         props.navigation.push(name, { route: { name, params } })
       },
       replace(name, params) {
-        Actions.replace(name, params)
+        Flux.Actions.replace(name, { route: { name, params } })
+        // TODO: Replace FLux.Actions.replace with props.navigation.replace
+        // which will require debugging why it doesn't work for certain scenes.
         // props.navigation.replace(name, { route: { name, params } })
       },
       setParams(params) {


### PR DESCRIPTION
### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
