### PR TITLE
Fix crash caused by missing navigation prop for MenuTab

### DIFF
--- a/src/components/Main.ui.tsx
+++ b/src/components/Main.ui.tsx
@@ -193,7 +193,7 @@ export class MainComponent extends React.Component<Props> {
       >
         {/* Wrapper Scene needed to fix a bug where the tabs would reload as a modal ontop of itself */}
         <Scene key="AllMyTabs" hideNavBar>
-          <Tabs key="edge" swipeEnabled={false} tabBarPosition="bottom" tabBarComponent={MenuTab}>
+          <Tabs key="edge" swipeEnabled={false} tabBarPosition="bottom" tabBarComponent={withNavigation(MenuTab)}>
             <Stack key="walletList">
               <Scene
                 key="walletListScene"


### PR DESCRIPTION
### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
