### PR TITLE
Fix use of "biometric" verbiage for Android devices

### DIFF
--- a/src/components/scenes/SettingsScene.tsx
+++ b/src/components/scenes/SettingsScene.tsx
@@ -104,18 +104,21 @@ export class SettingsSceneComponent extends React.Component<Props, State> {
   async loadBiometryType(): Promise<void> {
     if (!this.props.supportsTouchId) return
 
-    const biometryType = await getSupportedBiometryType()
-    if (Platform.OS !== 'ios') this.setState({ touchIdText: s.strings.settings_button_use_biometric })
-    switch (biometryType) {
-      case 'FaceID':
-        this.setState({ touchIdText: s.strings.settings_button_use_faceID })
-        break
-      case 'TouchID':
-        this.setState({ touchIdText: s.strings.settings_button_use_touchID })
-        break
+    if (Platform.OS === 'ios') {
+      const biometryType = await getSupportedBiometryType()
+      switch (biometryType) {
+        case 'FaceID':
+          this.setState({ touchIdText: s.strings.settings_button_use_faceID })
+          break
+        case 'TouchID':
+          this.setState({ touchIdText: s.strings.settings_button_use_touchID })
+          break
 
-      case false:
-        break
+        case false:
+          break
+      }
+    } else {
+      this.setState({ touchIdText: s.strings.settings_button_use_biometric })
     }
   }
 


### PR DESCRIPTION
### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
