### PR TITLE
Fix treatment of EdgeTransaction confirmations

### DIFF
--- a/src/components/themed/TransactionRow.tsx
+++ b/src/components/themed/TransactionRow.tsx
@@ -80,9 +80,10 @@ const TransactionRowComponent = (props: Props) => {
       ? s.strings.fragment_wallet_unconfirmed
       : currentConfirmations === 'dropped'
       ? s.strings.fragment_transaction_list_tx_dropped
-      : currentConfirmations == null
-      ? s.strings.fragment_transaction_list_tx_synchronizing
-      : sprintf(s.strings.fragment_transaction_list_confirmation_progress, currentConfirmations, requiredConfirmations)
+      : typeof currentConfirmations === 'number'
+      ? sprintf(s.strings.fragment_transaction_list_confirmation_progress, currentConfirmations, requiredConfirmations)
+      : s.strings.fragment_transaction_list_tx_synchronizing
+
   const pendingStyle = currentConfirmations === 'confirmed' ? styles.completedTime : styles.partialTime
 
   // Transaction Category


### PR DESCRIPTION
If the confirmations is a number, then show the appropriate localized
string and interpolation function.
Otherwise, treat `'syncing'` and/or undefined using the synchronization
localized string.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203762594629679