### PR TITLE
Fix multiple wallet picker popups on deeplink payments

### DIFF
--- a/src/actions/DeepLinkingActions.ts
+++ b/src/actions/DeepLinkingActions.ts
@@ -22,6 +22,7 @@ import { doRequestAddress, handleWalletUris } from './ScanActions'
 export function launchDeepLink(navigation: NavigationBase, link: DeepLink): ThunkAction<Promise<void>> {
   return async (dispatch, getState) => {
     const state = getState()
+    dispatch({ type: 'DEEP_LINK_HANDLED' })
 
     const handled = await handleLink(navigation, dispatch, state, link)
     // If we couldn't handle the link, save it for later:
@@ -41,11 +42,12 @@ export function retryPendingDeepLink(navigation: NavigationBase): ThunkAction<Pr
     const state = getState()
     const { pendingDeepLink } = state
     if (pendingDeepLink == null) return
+    dispatch({ type: 'DEEP_LINK_HANDLED' })
 
     const handled = await handleLink(navigation, dispatch, state, pendingDeepLink)
     // If we handled the link, clear it:
-    if (handled) {
-      dispatch({ type: 'DEEP_LINK_HANDLED' })
+    if (!handled) {
+      dispatch({ type: 'DEEP_LINK_RECEIVED', data: pendingDeepLink })
     }
   }
 }


### PR DESCRIPTION
Mark deep link as HANDLED in redux before calling handleLink.

handleLink may take time to handle the link as it may need the user to choose a wallet or send a transaction before the link is "handled". This prevents repeated calls into handleLink while the first call is being handled.

### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203822895117897