### PR TITLE
Add UI to SendScene for self-transfers

### DIFF
--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -179,6 +179,7 @@ const strings = {
   scan_invalid_address_error_title: 'Invalid Address',
   scan_invalid_address_error_description: 'Not a valid public address',
   fragment_send_subtitle: 'Send',
+  fragment_send_myself: 'Myself',
   fragment_send_from_label: 'From',
   fragment_stake_label: 'Stake',
   fragment_transaction_exchange: 'Exchange',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -128,6 +128,7 @@
   "scan_invalid_address_error_title": "Invalid Address",
   "scan_invalid_address_error_description": "Not a valid public address",
   "fragment_send_subtitle": "Send",
+  "fragment_send_myself": "Myself",
   "fragment_send_from_label": "From",
   "fragment_stake_label": "Stake",
   "fragment_transaction_exchange": "Exchange",


### PR DESCRIPTION
### CHANGELOG

Added the option to send to self when the user has 2 or more wallets/tokens of the same type.

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

https://user-images.githubusercontent.com/4023066/215663708-b0082e4f-ad82-49ae-abdb-2cbd99130691.mp4



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203374649830361