### PR TITLE
Loosen up asPaymentProtoVerificationResponse cleaner

### DIFF
--- a/src/actions/PaymentProtoActions.tsx
+++ b/src/actions/PaymentProtoActions.tsx
@@ -341,8 +341,6 @@ const asPaymentProtoTransaction: Cleaner<PaymentProtoTransaction> = asObject({
 })
 
 const asPaymentProtoVerificationPayment: Cleaner<PaymentProtoVerificationPayment> = asObject({
-  currency: asString,
-  chain: asString,
   transactions: asArray(asPaymentProtoTransaction)
 })
 

--- a/src/types/PaymentProtoTypes.ts
+++ b/src/types/PaymentProtoTypes.ts
@@ -68,8 +68,6 @@ export interface PaymentProtoTransaction {
 }
 
 export interface PaymentProtoVerificationPayment {
-  currency: string
-  chain: string
   transactions: PaymentProtoTransaction[]
 }
 


### PR DESCRIPTION
These don't appear to be used anywhere (and aren't present in the tested response object) so they shouldn't be here.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203822895117909