### PR TITLE
Parse `deep.edge.app/recovery#token` URI's

### DIFF
--- a/src/__tests__/DeepLink.test.ts
+++ b/src/__tests__/DeepLink.test.ts
@@ -160,6 +160,14 @@ describe('parseDeepLink', function () {
       'https://recovery.edgesecure.co?token=1234567890a': {
         type: 'passwordRecovery',
         passwordRecoveryKey: '1234567890a'
+      },
+      'https://deep.edge.app/recovery#1234567890a': {
+        type: 'passwordRecovery',
+        passwordRecoveryKey: '1234567890a'
+      },
+      'edge://recovery#1234567890a': {
+        type: 'passwordRecovery',
+        passwordRecoveryKey: '1234567890a'
       }
     })
   })

--- a/src/util/DeepLinkParser.ts
+++ b/src/util/DeepLinkParser.ts
@@ -117,6 +117,14 @@ function parseEdgeProtocol(url: URL<string>): DeepLink {
     }
 
     case 'recovery': {
+      // The new & improved format stores the token as a fragment:
+      if (url.hash != null && url.hash !== '') {
+        return {
+          type: 'passwordRecovery',
+          passwordRecoveryKey: url.hash.replace(/^#/, '')
+        }
+      }
+      // The old format puts the token in the query:
       const { token } = parseQuery(url.query)
       if (token == null) throw new SyntaxError('No recovery token')
       return { type: 'passwordRecovery', passwordRecoveryKey: token }


### PR DESCRIPTION
### CHANGELOG

- added: Support `https://deep.edge.app/recovery#token` deep links.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203495863964074