### PR TITLE
Fix insufficient funds error when activating xrp tokens

### DIFF
--- a/src/actions/WalletActions.tsx
+++ b/src/actions/WalletActions.tsx
@@ -1,6 +1,5 @@
-import { div, log10, round } from 'biggystring'
+import { div, log10, lt, round } from 'biggystring'
 import { EdgeCurrencyWallet } from 'edge-core-js'
-import { lt } from 'lodash'
 import * as React from 'react'
 import { sprintf } from 'sprintf-js'
 


### PR DESCRIPTION
Use biggystring not lodash for `lt` comparison

### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203924335664727