### PR TITLE
Fixed missing `delay` dependency in `useFadeAnimation`

### DIFF
--- a/src/hooks/animations/useFadeAnimation.ts
+++ b/src/hooks/animations/useFadeAnimation.ts
@@ -18,7 +18,7 @@ export const useFadeAnimation = (visible: boolean, options: { noFadeIn?: boolean
     }
 
     opacity.value = withDelay(delay, withTiming(visible ? 1 : 0, { duration }))
-  }, [duration, opacity, visible])
+  }, [duration, opacity, visible, delay])
 
   return style
 }


### PR DESCRIPTION
I introduced a bug with [PR for UI2 login approval](https://github.com/EdgeApp/edge-react-gui/pull/3467/files#diff-7a3691109c1561a76149d6d534378553eeda20972de91d9d0d9271cf82be3111L21) that omitted adding the `delay` prop to `useEffect`'s `DependencyList` argument in `useFadeAnimation.js`.

This PR corrects that bug. 

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
