### PR TITLE
Add Optimism

### DIFF
--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { sprintf } from 'sprintf-js'
@@ -202,17 +202,21 @@ export function WalletListMenuModal(props: Props) {
         </View>
       )}
 
-      {options.map((option: Option) => (
-        <TouchableOpacity key={option.value} onPress={() => optionAction(option.value)} style={styles.row}>
-          <AntDesignIcon
-            // @ts-expect-error
-            name={icons[option.value] ?? 'arrowsalt'} // for split keys like splitBCH, splitETH, etc.
-            size={theme.rem(1)}
-            style={option.value === 'delete' ? [styles.optionIcon, styles.warningColor] : styles.optionIcon}
-          />
-          <Text style={option.value === 'delete' ? [styles.optionText, styles.warningColor] : styles.optionText}>{option.label}</Text>
-        </TouchableOpacity>
-      ))}
+      <View style={styles.scrollViewContainer}>
+        <ScrollView>
+          {options.map((option: Option) => (
+            <TouchableOpacity key={option.value} onPress={() => optionAction(option.value)} style={styles.row}>
+              <AntDesignIcon
+                // @ts-expect-error
+                name={icons[option.value] ?? 'arrowsalt'} // for split keys like splitBCH, splitETH, etc.
+                size={theme.rem(1)}
+                style={option.value === 'delete' ? [styles.optionIcon, styles.warningColor] : styles.optionIcon}
+              />
+              <Text style={option.value === 'delete' ? [styles.optionText, styles.warningColor] : styles.optionText}>{option.label}</Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+      </View>
       <ModalCloseArrow onPress={handleCancel} />
     </ThemedModal>
   )
@@ -232,6 +236,10 @@ const getStyles = cacheStyles((theme: Theme) => ({
     fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(1),
     margin: theme.rem(0.5)
+  },
+  scrollViewContainer: {
+    marginBottom: theme.rem(-0.75),
+    flexShrink: 1
   },
   warningColor: {
     color: theme.warningText

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
+import LinearGradient from 'react-native-linear-gradient'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { sprintf } from 'sprintf-js'
 
@@ -43,6 +44,9 @@ const icons = {
   resync: 'sync',
   viewXPub: 'eye'
 }
+
+const xButtonGradientStart = { x: 0, y: 0 }
+const xButtonGradientEnd = { x: 0, y: 0.75 }
 
 /**
  * Customizes which coins get which options on the wallet list scene.
@@ -190,6 +194,9 @@ export function WalletListMenuModal(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const xButtonTopColor = theme.modal + '00' // Add full transparency to the modal color
+  const xButtonBottomColor = theme.modal
+
   return (
     <ThemedModal bridge={bridge} onCancel={handleCancel}>
       {wallet != null && (
@@ -203,7 +210,7 @@ export function WalletListMenuModal(props: Props) {
       )}
 
       <View style={styles.scrollViewContainer}>
-        <ScrollView>
+        <ScrollView contentContainerStyle={styles.scrollViewPadding}>
           {options.map((option: Option) => (
             <TouchableOpacity key={option.value} onPress={() => optionAction(option.value)} style={styles.row}>
               <AntDesignIcon
@@ -217,7 +224,9 @@ export function WalletListMenuModal(props: Props) {
           ))}
         </ScrollView>
       </View>
-      <ModalCloseArrow onPress={handleCancel} />
+      <LinearGradient style={styles.modalCloseButton} colors={[xButtonTopColor, xButtonBottomColor]} start={xButtonGradientStart} end={xButtonGradientEnd}>
+        <ModalCloseArrow onPress={handleCancel} />
+      </LinearGradient>
     </ThemedModal>
   )
 }
@@ -237,9 +246,17 @@ const getStyles = cacheStyles((theme: Theme) => ({
     fontSize: theme.rem(1),
     margin: theme.rem(0.5)
   },
+  modalCloseButton: {
+    position: 'absolute',
+    width: '100%',
+    bottom: theme.rem(4),
+    height: theme.rem(3)
+  },
   scrollViewContainer: {
-    marginBottom: theme.rem(-0.75),
     flexShrink: 1
+  },
+  scrollViewPadding: {
+    paddingBottom: theme.rem(3)
   },
   warningColor: {
     color: theme.warningText

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -168,15 +168,6 @@ export function WalletListMenuModal(props: Props) {
 
     const result: Option[] = []
 
-    const splittable = await account.listSplittableWalletTypes(wallet.id)
-
-    const currencyInfos = getCurrencyInfos(account)
-    for (const splitWalletType of splittable) {
-      const info = currencyInfos.find(({ walletType }) => walletType === splitWalletType)
-      if (info == null || getSpecialCurrencyInfo(info.pluginId).isSplittingDisabled) continue
-      result.push({ label: sprintf(s.strings.string_split_wallet, info.displayName), value: `split${info.currencyCode}` })
-    }
-
     const { pluginId } = wallet.currencyInfo
     for (const option of WALLET_LIST_MENU) {
       const { pluginIds, label, value } = option
@@ -189,6 +180,16 @@ export function WalletListMenuModal(props: Props) {
       }
       result.push({ label, value })
     }
+
+    const splittable = await account.listSplittableWalletTypes(wallet.id)
+
+    const currencyInfos = getCurrencyInfos(account)
+    for (const splitWalletType of splittable) {
+      const info = currencyInfos.find(({ walletType }) => walletType === splitWalletType)
+      if (info == null || getSpecialCurrencyInfo(info.pluginId).isSplittingDisabled) continue
+      result.push({ label: sprintf(s.strings.string_split_wallet, info.displayName), value: `split${info.currencyCode}` })
+    }
+
     setOptions(result)
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -252,7 +252,6 @@ export const SPECIAL_CURRENCY_INFO: {
       privateKeyLabel: s.strings.create_wallet_import_input_key_or_seed_prompt,
       privateKeyInstructions: s.strings.create_wallet_import_input_key_or_seed_instructions
     },
-    isSplittingDisabled: true,
     isCustomTokensSupported: true
   },
   stellar: {
@@ -406,7 +405,6 @@ export const SPECIAL_CURRENCY_INFO: {
     initWalletName: s.strings.string_first_ethereum_classic_wallet_name,
     chainCode: 'ETC',
     dummyPublicAddress: '0x0d73358506663d484945ba85d0cd435ad610b0a0',
-    isSplittingDisabled: true,
     isImportKeySupported: {
       privateKeyLabel: s.strings.create_wallet_import_input_key_or_seed_prompt,
       privateKeyInstructions: s.strings.create_wallet_import_input_key_or_seed_instructions
@@ -487,8 +485,7 @@ export const SPECIAL_CURRENCY_INFO: {
       privateKeyLabel: s.strings.create_wallet_import_input_key_or_seed_prompt,
       privateKeyInstructions: s.strings.create_wallet_import_input_key_or_seed_instructions
     },
-    isCustomTokensSupported: true,
-    isSplittingDisabled: true
+    isCustomTokensSupported: true
   },
   fio: {
     initWalletName: s.strings.string_first_fio_wallet_name,

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -57,6 +57,7 @@ export const WALLET_TYPE_ORDER = [
   'wallet:zcash',
   'wallet:tron',
   'wallet:polkadot',
+  'wallet:optimism',
   'wallet:ethereumclassic',
   'wallet:binance',
   'wallet:solana',
@@ -422,6 +423,18 @@ export const SPECIAL_CURRENCY_INFO: {
     isCustomTokensSupported: true,
     isPaymentProtocolSupported: false,
     isTransactionListUnsupported: true
+  },
+  optimism: {
+    initWalletName: s.strings.string_first_optimism_wallet_name,
+    chainCode: 'OP',
+    dummyPublicAddress: '0x0d73358506663d484945ba85d0cd435ad610b0a0',
+    allowZeroTx: true,
+    isImportKeySupported: {
+      privateKeyLabel: s.strings.create_wallet_import_input_key_or_seed_prompt,
+      privateKeyInstructions: s.strings.create_wallet_import_input_key_or_seed_instructions
+    },
+    isCustomTokensSupported: true,
+    isPaymentProtocolSupported: false
   },
   tezos: {
     initWalletName: s.strings.string_first_tezos_wallet_name,

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -149,6 +149,11 @@ export const asEnvConfig = asObject({
       apiKey: asOptional(asString, '')
     }).withRest
   ),
+  OPTIMISM_INIT: asCorePluginInit(
+    asObject({
+      evmScanApiKey: asOptional(asArray(asString), [])
+    }).withRest
+  ),
   POLYGON_INIT: asCorePluginInit(
     asObject({
       evmScanApiKey: asOptional(asArray(asString), []),

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -506,6 +506,7 @@ const strings = {
   string_first_polkadot_wallet_name: 'My Polkadot',
   string_first_polygon_wallet_name: 'My Polygon',
   string_first_avalanche_wallet_name: 'My Avalanche',
+  string_first_optimism_wallet_name: 'My Optimism',
   my_crypto_wallet_name: 'My %s',
   string_help: 'Help',
   string_exit: 'Exit',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -444,6 +444,7 @@
   "string_first_polkadot_wallet_name": "My Polkadot",
   "string_first_polygon_wallet_name": "My Polygon",
   "string_first_avalanche_wallet_name": "My Avalanche",
+  "string_first_optimism_wallet_name": "My Optimism",
   "my_crypto_wallet_name": "My %s",
   "string_help": "Help",
   "string_exit": "Exit",

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -17,6 +17,7 @@ export const currencyPlugins: EdgeCorePluginsInit = {
   fantom: ENV.FANTOM_INIT,
   fio: ENV.FIO_INIT,
   kovan: ENV.KOVAN_INIT,
+  optimism: ENV.OPTIMISM_INIT,
   polygon: ENV.POLYGON_INIT,
   avalanche: true,
   ripple: true,

--- a/src/util/fake/fakeRootState.ts
+++ b/src/util/fake/fakeRootState.ts
@@ -1003,6 +1003,13 @@ export const fakeRootState = {
             multiplier: '1000000000000000000'
           }
         },
+        optimism: {
+          OP: {
+            name: 'ETH',
+            multiplier: '1000000000000000000',
+            symbol: 'Ξ'
+          }
+        },
         polygon: {
           MATIC: {
             name: 'MATIC',


### PR DESCRIPTION
I thought it was important to allow OP to be splittable since it shares the same currency code with Ethereum. Since the splittable wallet list causes the wallet options modal to extend beyond small screens I went ahead and made it scrollable and unlocked the other splittable wallet types.

### Dependencies

https://github.com/EdgeApp/edge-currency-accountbased/pull/511
https://github.com/EdgeApp/edge-exchange-plugins/pull/262

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203860831628486