### PR TITLE
Add better error message when stake pools are full

### DIFF
--- a/src/components/scenes/Staking/StakeModifyScene.tsx
+++ b/src/components/scenes/Staking/StakeModifyScene.tsx
@@ -7,7 +7,7 @@ import { sprintf } from 'sprintf-js'
 
 import s from '../../../locales/strings'
 import { Slider } from '../../../modules/UI/components/Slider/Slider'
-import { ChangeQuote, ChangeQuoteRequest, QuoteAllocation, StakeBelowLimitError } from '../../../plugins/stake-plugins/types'
+import { ChangeQuote, ChangeQuoteRequest, QuoteAllocation, StakeBelowLimitError, StakePoolFullError } from '../../../plugins/stake-plugins/types'
 import { getDenominationFromCurrencyInfo, getDisplayDenomination } from '../../../selectors/DenominationSelectors'
 import { useSelector } from '../../../types/reactRedux'
 import { NavigationProp, RouteProp } from '../../../types/routerTypes'
@@ -117,6 +117,10 @@ const StakeModifySceneComponent = (props: Props) => {
             } else {
               setErrorMessage(errMessage)
             }
+          } else if (err instanceof StakePoolFullError) {
+            const { currencyCode } = err
+            const errMessage = sprintf(s.strings.state_error_pool_full_s, currencyCode)
+            setErrorMessage(errMessage)
           } else {
             setErrorMessage(err.message)
           }

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -1180,6 +1180,7 @@ const strings = {
   stake_error_insufficient_s: 'Insufficient %s',
   stake_error_stake_below_minimum: 'Stake amount below minimum',
   stake_error_unstake_below_minimum: 'Unstake amount below minimum',
+  state_error_pool_full_s: 'The %1$s asset pool is currency full. Please try again later.',
   stake_estimated_staking_fee: 'Estimated Staking Fee',
   stake_estimated_unstaking_fee: 'Estimated Unstaking Fee',
   stake_staking_fee_message: 'The specified Staking Fee will be deducted from the amount deposited reducing the amount staked.',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -1030,6 +1030,7 @@
   "stake_error_insufficient_s": "Insufficient %s",
   "stake_error_stake_below_minimum": "Stake amount below minimum",
   "stake_error_unstake_below_minimum": "Unstake amount below minimum",
+  "state_error_pool_full_s": "The %1$s asset pool is currency full. Please try again later.",
   "stake_estimated_staking_fee": "Estimated Staking Fee",
   "stake_estimated_unstaking_fee": "Estimated Unstaking Fee",
   "stake_staking_fee_message": "The specified Staking Fee will be deducted from the amount deposited reducing the amount staked.",

--- a/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.ts
+++ b/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.ts
@@ -12,6 +12,7 @@ import {
   StakeBelowLimitError,
   StakePlugin,
   StakePolicy,
+  StakePoolFullError,
   StakePosition,
   StakePositionRequest,
   StakeProviderInfo
@@ -378,6 +379,9 @@ const stakeRequest = async (opts: EdgeGuiPluginOptions, request: ChangeQuoteRequ
     const { error } = quoteDeposit
     if (error.includes('not enough fee')) {
       throw new StakeBelowLimitError(request, currencyCode)
+    }
+    if (error.includes('synth supply over target')) {
+      throw new StakePoolFullError(request, currencyCode)
     }
     throw new Error(error)
   }

--- a/src/plugins/stake-plugins/types.ts
+++ b/src/plugins/stake-plugins/types.ts
@@ -27,6 +27,23 @@ export class StakeBelowLimitError extends Error {
   }
 }
 
+/**
+ * Trying to stake or unstake an amount that is too low.
+ * @param nativeMin the minimum supported amount, in the currency specified
+ */
+export class StakePoolFullError extends Error {
+  name: string
+  request: ChangeQuoteRequest
+  currencyCode: string
+
+  constructor(request: ChangeQuoteRequest, currencyCode: string) {
+    super('Staking Pool Full')
+    this.currencyCode = currencyCode
+    this.name = 'StakePoolFullError'
+    this.request = request
+  }
+}
+
 export interface AssetId {
   pluginId: string
   currencyCode: string


### PR DESCRIPTION
<img width="491" alt="Screen Shot 2023-02-14 at 23 04 22" src="https://user-images.githubusercontent.com/6079354/218956807-897b3c09-eb14-446e-abad-bf5a88c92a28.png">

### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203568650150747