### PR TITLE
Call withServices HOC only once by moving invocation to `LoginScene.tsx`

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -19,7 +19,6 @@ import { AppParamList } from '../types/routerTypes'
 import { logEvent } from '../util/tracking'
 import { ifLoggedIn } from './hoc/IfLoggedIn'
 import { useBackEvent } from './hoc/useBackEvent'
-import { withServices } from './hoc/withServices'
 import { BackButton } from './navigation/BackButton'
 import { CurrencySettingsTitle } from './navigation/CurrencySettingsTitle'
 import { EdgeLogoHeader } from './navigation/EdgeLogoHeader'
@@ -121,7 +120,7 @@ export const Main = () => {
           headerShown: false
         }}
       >
-        <Stack.Screen name="login" component={withServices(LoginScene)} />
+        <Stack.Screen name="login" component={LoginScene} />
         <Stack.Screen name="edgeApp" component={EdgeApp} />
       </Stack.Navigator>
     </NavigationContainer>

--- a/src/components/scenes/LoginScene.tsx
+++ b/src/components/scenes/LoginScene.tsx
@@ -20,6 +20,7 @@ import { Dispatch } from '../../types/reduxTypes'
 import { NavigationBase } from '../../types/routerTypes'
 import { GuiTouchIdInfo } from '../../types/types'
 import { pickRandom } from '../../util/utils'
+import { withServices } from '../hoc/withServices'
 import { showHelpModal } from '../modals/HelpModal'
 import { UpdateModal } from '../modals/UpdateModal'
 import { Airship, showError } from '../services/AirshipInstance'
@@ -212,7 +213,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   }
 }))
 
-export const LoginScene = (props: OwnProps) => {
+export const LoginScene = withServices((props: OwnProps) => {
   const { navigation } = props
   const dispatch = useDispatch()
   const account = useSelector(state => state.core.account)
@@ -248,4 +249,4 @@ export const LoginScene = (props: OwnProps) => {
   }
 
   return <LoginSceneComponent {...props} {...dispatchProps} {...stateProps} {...themeProps} />
-}
+})


### PR DESCRIPTION
It's a footgun to invoke an HOC within a component renders (Main)
because the HOC can (and usually does) return a new component function
on each invocation causing the render to always unmount the previous
component and mount the new component returned. This is a cause for
some really bad behavior.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
