### PR TITLE
Sam/better space component

### DIFF
--- a/src/components/layout/Space.tsx
+++ b/src/components/layout/Space.tsx
@@ -9,6 +9,10 @@ interface OwnProps {
 }
 type Props = OwnProps & SpaceProps
 
+/**
+ * Numbers are rem units, and boolean means to fill up assigned space; this
+ * allows for centering and alignment (see useSpaceStyle hook for details).
+ */
 export const Space = React.memo((props: Props) => {
   const { children, style } = props
   const spaceStyle = useSpaceStyle(props)

--- a/src/components/modals/LoanWelcomeModal.tsx
+++ b/src/components/modals/LoanWelcomeModal.tsx
@@ -23,7 +23,7 @@ export const LoanWelcomeModal = (props: { bridge: AirshipBridge<'ok' | undefined
 
   return (
     <ButtonsModal bridge={bridge} buttons={{ ok: { label: s.strings.legacy_address_modal_continue } }}>
-      <Space around>
+      <Space around={1}>
         <FastImage style={styles.icon} source={{ uri: iconUri }} />
         <EdgeText numberOfLines={20}>{sprintf(s.strings.loan_welcome_6s, config.appName, s.strings.loan_aave_fragment, 'BTC', 'USDC', '10', '120')}</EdgeText>
       </Space>

--- a/src/components/scenes/Loans/LoanCloseScene.tsx
+++ b/src/components/scenes/Loans/LoanCloseScene.tsx
@@ -170,7 +170,7 @@ export const LoanCloseSceneComponent = (props: Props) => {
           />
         )}
 
-        <Space top bottom={2}>
+        <Space top={1} bottom={2}>
           <SafeSlider onSlidingComplete={handleSliderComplete} disabled={isActionProgramLoading} disabledText={s.strings.send_confirmation_slide_to_confirm} />
         </Space>
       </KeyboardAwareScrollView>

--- a/src/components/scenes/Loans/LoanCreateScene.tsx
+++ b/src/components/scenes/Loans/LoanCreateScene.tsx
@@ -359,7 +359,7 @@ export const LoanCreateScene = (props: Props) => {
           {isLoading ? (
             <ActivityIndicator color={theme.textLink} style={styles.cardContainer} />
           ) : (
-            <Space isItemCenter isGroupCenter>
+            <Space around>
               <AprCard apr={apr} />
             </Space>
           )}

--- a/src/components/scenes/Loans/LoanCreateScene.tsx
+++ b/src/components/scenes/Loans/LoanCreateScene.tsx
@@ -400,7 +400,7 @@ export const LoanCreateScene = (props: Props) => {
           {renderWarning()}
 
           {destWallet == null ? null : (
-            <Space around>
+            <Space around={1}>
               <MainButton
                 label={s.strings.string_next_capitalized}
                 disabled={isInsufficientCollateral || !isUserInputComplete}

--- a/src/components/scenes/Loans/LoanDashboardScene.tsx
+++ b/src/components/scenes/Loans/LoanDashboardScene.tsx
@@ -164,7 +164,7 @@ export const LoanDashboardScene = (props: Props) => {
           </Card>
         ) : null}
         {isLoansLoading ? (
-          <Space around>
+          <Space around={1}>
             <FillLoader />
           </Space>
         ) : (
@@ -202,17 +202,17 @@ export const LoanDashboardScene = (props: Props) => {
       {Object.keys(loanAccountsMap).length === 0 ? (
         <>
           {isLoansLoading ? (
-            <Space isFill isGroupCenter isItemCenter horizontal bottom={2.5}>
+            <Space isFill isGroupCenter isItemCenter horizontal={1} bottom={2.5}>
               <EdgeText style={styles.emptyText}>{s.strings.loan_loading_loans}</EdgeText>
             </Space>
           ) : (
             <>
-              <Space isFill isGroupCenter isItemCenter horizontal top>
+              <Space isFill isGroupCenter isItemCenter horizontal={1} top={1}>
                 <EdgeText style={styles.emptyText} numberOfLines={4}>
                   {s.strings.loan_no_active_loans}
                 </EdgeText>
               </Space>
-              <Space bottom>{renderFooter()}</Space>
+              <Space bottom={1}>{renderFooter()}</Space>
             </>
           )}
         </>

--- a/src/components/scenes/Loans/LoanDashboardScene.tsx
+++ b/src/components/scenes/Loans/LoanDashboardScene.tsx
@@ -202,17 +202,19 @@ export const LoanDashboardScene = (props: Props) => {
       {Object.keys(loanAccountsMap).length === 0 ? (
         <>
           {isLoansLoading ? (
-            <Space isFill isGroupCenter isItemCenter horizontal={1} bottom={2.5}>
+            <Space expand around horizontal={1} bottom={2.5}>
               <EdgeText style={styles.emptyText}>{s.strings.loan_loading_loans}</EdgeText>
             </Space>
           ) : (
             <>
-              <Space isFill isGroupCenter isItemCenter horizontal={1} top={1}>
+              <Space expand around horizontal={1} top={1}>
                 <EdgeText style={styles.emptyText} numberOfLines={4}>
                   {s.strings.loan_no_active_loans}
                 </EdgeText>
               </Space>
-              <Space bottom={1}>{renderFooter()}</Space>
+              <Space around bottom={1}>
+                {renderFooter()}
+              </Space>
             </>
           )}
         </>

--- a/src/components/scenes/Loans/LoanDetailsScene.tsx
+++ b/src/components/scenes/Loans/LoanDetailsScene.tsx
@@ -110,7 +110,7 @@ export const LoanDetailsSceneComponent = (props: Props) => {
       return (
         <TouchableOpacity onPress={() => handleProgramStatusCardPress(runningProgramEdge)}>
           <Card marginRem={[0, 0, 1]}>
-            <Space isSideways>
+            <Space sideways>
               <ActivityIndicator color={theme.iconTappable} style={styles.activityIndicator} />
               <EdgeText style={styles.programStatusText} numberOfLines={2}>
                 {runningProgramMessage}

--- a/src/components/scenes/Loans/LoanDetailsScene.tsx
+++ b/src/components/scenes/Loans/LoanDetailsScene.tsx
@@ -184,7 +184,7 @@ export const LoanDetailsSceneComponent = (props: Props) => {
           const { title, iconName, handlePress, isDisabled } = actionCardConfigData
           return (
             <TappableCard marginRem={[0, 0, 1, 0]} onPress={handlePress} disabled={isDisabled} key={iconName}>
-              <Space right>
+              <Space right={1}>
                 <Fontello name={iconName} size={theme.rem(2)} color={isDisabled ? theme.deactivatedText : theme.iconTappable} />
               </Space>
               <EdgeText style={isDisabled ? styles.actionLabelDisabled : styles.actionLabel}>{title}</EdgeText>
@@ -221,7 +221,7 @@ export const LoanDetailsSceneComponent = (props: Props) => {
         }
       />
       <KeyboardAwareScrollView extraScrollHeight={theme.rem(2.75)} enableOnAndroid>
-        <Space around>
+        <Space around={1}>
           {renderProgramStatusCard()}
           <LoanDetailsSummaryCard
             currencyIcon={<FiatIcon fiatCurrencyCode={fiatCurrencyCode} />}
@@ -231,8 +231,8 @@ export const LoanDetailsSceneComponent = (props: Props) => {
             ltv={loanToValue}
           />
         </Space>
-        <Space horizontal>
-          <Space bottom>
+        <Space horizontal={1}>
+          <Space bottom={1}>
             <SectionHeading>{s.strings.loan_loan_breakdown_title}</SectionHeading>
           </Space>
           {debts.map(debt => {
@@ -242,8 +242,8 @@ export const LoanDetailsSceneComponent = (props: Props) => {
             const aprText = sprintf(s.strings.loan_apr_s, toPercentString(debt.apr))
             return (
               <Card key={debt.tokenId} marginRem={[0, 0, 1]}>
-                <Space isSideways>
-                  <Space right>
+                <Space sideways>
+                  <Space right={1}>
                     <CryptoIcon currencyCode={currencyCode} hideSecondary />
                   </Space>
                   <Space>
@@ -259,8 +259,8 @@ export const LoanDetailsSceneComponent = (props: Props) => {
         </Space>
 
         {/* Tappable Action Cards */}
-        <Space horizontal>
-          <Space bottom>
+        <Space horizontal={1}>
+          <Space bottom={1}>
             <SectionHeading>{s.strings.loan_actions_title}</SectionHeading>
             {isActionProgramRunning ? (
               <Alert type="warning" title={s.strings.warning_please_wait_title} message={s.strings.loan_action_program_running} marginRem={[0.5, 0, 0, 0]} />

--- a/src/components/scenes/Loans/LoanManageScene.tsx
+++ b/src/components/scenes/Loans/LoanManageScene.tsx
@@ -414,7 +414,7 @@ export const LoanManageSceneComponent = (props: Props) => {
         </TouchableOpacity>
       }
     >
-      <Space vertical around={0.5}>
+      <Space vertical={1} around={0.5}>
         <FiatAmountInputCard
           wallet={borrowEngineWallet}
           iconUri={iconUri}
@@ -432,7 +432,7 @@ export const LoanManageSceneComponent = (props: Props) => {
           </Peek>
         </Space>
       </Space>
-      <Space vertical around={0.25}>
+      <Space vertical={1} around={0.25}>
         <TotalDebtCollateralTile
           title={isActionSideDebts ? s.strings.loan_current_principal : s.strings.loan_current_collateral}
           wallet={borrowEngineWallet}

--- a/src/hooks/useSpaceStyle.ts
+++ b/src/hooks/useSpaceStyle.ts
@@ -4,15 +4,15 @@ import { useTheme } from '../components/services/ThemeContext'
 
 export interface SpaceProps {
   // Compond space adjectives:
-  around?: boolean | number
-  horizontal?: boolean | number
-  vertical?: boolean | number
+  around?: number
+  horizontal?: number
+  vertical?: number
   isFill?: boolean
   // Unit space adjectives:
-  top?: boolean | number
-  right?: boolean | number
-  bottom?: boolean | number
-  left?: boolean | number
+  top?: number
+  right?: number
+  bottom?: number
+  left?: number
   // Direction:
   isSideways?: boolean
   // Alignment:

--- a/src/hooks/useSpaceStyle.ts
+++ b/src/hooks/useSpaceStyle.ts
@@ -3,51 +3,91 @@ import { ViewStyle } from 'react-native'
 import { useTheme } from '../components/services/ThemeContext'
 
 export interface SpaceProps {
-  // Compond space adjectives:
-  around?: number
-  horizontal?: number
-  vertical?: number
-  isFill?: boolean
-  // Unit space adjectives:
-  top?: number
-  right?: number
-  bottom?: number
-  left?: number
-  // Direction:
-  isSideways?: boolean
-  // Alignment:
-  isGroupStart?: boolean
-  isGroupCenter?: boolean
-  isGroupEnd?: boolean
-  isItemStart?: boolean
-  isItemCenter?: boolean
-  isItemEnd?: boolean
+  /**
+   * Space props a simple way to give a component space on the sides around
+   * the component. You can provide a number to give a specific rem unit of space
+   * or a boolean to give the maximum amount of space available relative to its
+   * parent component.
+   *
+   * `top`, `left`, `bottom`, and `right` props are specific sides of the
+   * component for which you can assign space. Additionally, `horizontal`,
+   * `vertical`, and `around` are a combination of two or more sides. Examples:
+   *
+   * ```tsx
+   * top={1} // 1rem above the component
+   * around={2} // 1rem around all sides
+   * horizontal={0.5} // 0.5rem on the left and right sides
+   * ```
+   *
+   * Because boolean means to "fill up with maximum space", this allows space
+   * props to be used to center and align a component trivially. Examples:
+   *
+   * ```tsx
+   * around={true} // Center vertically and horizontally
+   * vertical={true} // Center vertically
+   * left={true} // Align to the _right_ (because max space is on the left)
+   * ```
+   */
+  // Specific:
+  top?: boolean | number
+  right?: boolean | number
+  bottom?: boolean | number
+  left?: boolean | number
+  // Compound:
+  around?: boolean | number
+  horizontal?: boolean | number
+  vertical?: boolean | number
+
+  /*
+   * The `expand` space prop tells a component to expand its size within its
+   * parent component. This is sometimes useful when you want to use the space
+   * props to align the component.
+   */
+  expand?: boolean
+
+  /*
+   * The `sideways` prop is an additional, non-space props useful managing the
+   * stacking direction of child components. By default, child components stack
+   * vertically (column-based), from top to bottom. If `sideways={true}`, then
+   * child components stack horizontally (row-based).
+   * The `sideways` prop does not affect the space properties in anyway (i.e.
+   * vertical is always vertical regardless of the value set for the `sideways`
+   *  prop).
+   */
+  sideways?: boolean
 }
 
 export const useSpaceStyle = (props: SpaceProps): ViewStyle => {
   const theme = useTheme()
-  const { around, horizontal, vertical } = props
+  const { around, horizontal, vertical, top, bottom, left, right, expand: fill = false, sideways = false } = props
 
-  const flex = props.isFill ? 1 : undefined
+  const topFill = boolify(around, vertical, top)
+  const bottomFill = boolify(around, vertical, bottom)
+  const leftFill = boolify(around, horizontal, left)
+  const rightFill = boolify(around, horizontal, right)
 
-  const top = numberify(around ?? vertical ?? props.top ?? 0)
-  const bottom = numberify(around ?? vertical ?? props.bottom ?? 0)
-  const left = numberify(around ?? horizontal ?? props.left ?? 0)
-  const right = numberify(around ?? horizontal ?? props.right ?? 0)
+  const topUnits = numberify(around, vertical, top)
+  const bottomUnits = numberify(around, vertical, bottom)
+  const leftUnits = numberify(around, horizontal, left)
+  const rightUnits = numberify(around, horizontal, right)
 
-  const marginTop = theme.rem(typeof top === 'number' ? top : top ? 1 : 0)
-  const marginBottom = theme.rem(typeof bottom === 'number' ? bottom : bottom ? 1 : 0)
-  const marginLeft = theme.rem(typeof left === 'number' ? left : left ? 1 : 0)
-  const marginRight = theme.rem(typeof right === 'number' ? right : right ? 1 : 0)
+  // Margins:
+  const marginTop = theme.rem(topUnits)
+  const marginBottom = theme.rem(bottomUnits)
+  const marginLeft = theme.rem(leftUnits)
+  const marginRight = theme.rem(rightUnits)
 
   // Direction:
-  const { isSideways: sideways = false } = props
   const flexDirection = sideways ? 'row' : 'column'
 
   // Alignment:
-  const { isItemStart = false, isItemCenter = false, isItemEnd = false, isGroupStart = false, isGroupCenter = false, isGroupEnd = false } = props
-  const alignItems = isItemStart ? 'flex-start' : isItemCenter ? 'center' : isItemEnd ? 'flex-end' : undefined
-  const justifyContent = isGroupStart ? 'flex-start' : isGroupCenter ? 'center' : isGroupEnd ? 'flex-end' : undefined
+  const horizontalAlignment = leftFill && rightFill ? 'center' : rightFill ? 'flex-start' : leftFill ? 'flex-end' : undefined
+  const verticalAlignment = topFill && bottomFill ? 'center' : bottomFill ? 'flex-start' : topFill ? 'flex-end' : undefined
+  const alignItems = sideways ? verticalAlignment : horizontalAlignment
+  const justifyContent = sideways ? horizontalAlignment : verticalAlignment
+
+  // Flex:
+  const flex = fill ? 1 : undefined
 
   return {
     marginTop,
@@ -61,4 +101,16 @@ export const useSpaceStyle = (props: SpaceProps): ViewStyle => {
   }
 }
 
-const numberify = (thing: boolean | number): number => (typeof thing === 'number' ? thing : thing ? 1 : 0)
+const numberify = (...things: Array<boolean | number | undefined>): number => {
+  for (const thing of things) {
+    if (typeof thing === 'number') {
+      return thing
+    }
+  }
+  return 0
+}
+const boolify = (...things: Array<boolean | number | undefined>): boolean => {
+  return things.some(thing => {
+    return typeof thing === 'boolean' && thing
+  })
+}


### PR DESCRIPTION
# Motivation

Simplify the useSpaceStyles hook and therefore the Space component by removing any props that require the user to take a moment to mentally work out the appropriate meaning behind "group" or "item" concepts as well. This has been the issue with most CSS-APIs which require you to familiarize yourself with concepts such as "align" vs "justify". Added to this complexity is the factor of a main axis which can change with `flex-direction`. The goal for Space is to be a very simple abstraction from this API complexity where you only want to manage the space around your child components. This has been the original design of Space, and only when the ask for alignment properties become a concern, did the component veer from it's original design.

# Solution

In the spirit of the original design of the Space component, the API has been reduced to the set of props that are require no additional effort for the user to grok. These props are specific sides of the component–left, right, top, bottom–or a compound of these sides for convenience–around (all sides), vertical (top and bottom), and horizontal (left and right). 

Each of these props can be given number which will be the count of rems units with which to fill the side(s). When given a boolean, the side is filled with as much space as there is available. This allows for alignment: `left={true}` aligns to the right, `right={true}` aligns to the left. This mental modal requires the user simply to think in terms of filling space, rather than alignment.

Combinations of props can allow the user to achieve pretty much any alignment of the element without losing the ability to both align and add space units. For example, if a user were to add `around={true} horizontal={1} vertical={2}` then the component will center itself and have 1 rem units of margin on the left and right, and 2 rem units on the top and bottom.

The component's other remaining properties, fill and isSideways, have been simplified to expand and sideways booleans. 

The `fill` prop has been renamed to expand because it should not be confused with filling of space anywhere, but rather the expansion of space which the Space component occupies.

The `isSideways` prop has been renamed to a simple flag prop `sideways` which re-orients the flow of child elements **only**. It's important to note, that sideways does not impact the other space properties and therefore does not require the user to re-orient the alignment styling

Historical Reference: https://github.com/EdgeApp/edge-react-gui/pull/3677#discussion_r979122914

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203169649641990