### PR TITLE
Support plugin provider in deep links

### DIFF
--- a/src/__tests__/DeepLink.test.ts
+++ b/src/__tests__/DeepLink.test.ts
@@ -184,39 +184,66 @@ describe('parseDeepLink', function () {
 
   describe('plugin', function () {
     makeLinkTests({
-      'edge://plugin/simplex/rabbit/hole?param=alice': {
+      'edge://plugin/simplex/buy///rabbit/hole?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
+        providerId: '',
+        direction: 'buy',
+        paymentType: '',
         path: '/rabbit/hole',
         query: { param: 'alice' }
       },
-      'edge://plugin/simplex/?param=alice': {
+      'edge://plugin/simplex/buy?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
-        path: '/',
+        providerId: '',
+        direction: 'buy',
+        paymentType: '',
+        path: '',
         query: { param: 'alice' }
       },
       'edge://plugin/simplex?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
+        providerId: '',
+        direction: 'buy',
+        paymentType: '',
         path: '',
         query: { param: 'alice' }
       },
       'edge://plugin/simplex': {
         type: 'plugin',
         pluginId: 'simplex',
+        providerId: '',
+        direction: 'buy',
+        paymentType: '',
         path: '',
         query: {}
       },
-      'https://deep.edge.app/plugin/simplex/rabbit/hole?param=alice': {
+      'https://deep.edge.app/plugin/simplex/buy///rabbit/hole?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
+        providerId: '',
+        direction: 'buy',
+        paymentType: '',
         path: '/rabbit/hole',
         query: { param: 'alice' }
       },
-      'edge-ret://plugins/simplex/rabbit/hole?param=alice': {
+      'edge-ret://plugins/simplex/buy///rabbit/hole?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
+        providerId: '',
+        direction: 'buy',
+        paymentType: '',
+        path: '/rabbit/hole',
+        query: { param: 'alice' }
+      },
+      'https://deep.edge.app/plugin/creditcard/buy/moonpay/applepay/rabbit/hole?param=alice': {
+        type: 'plugin',
+        pluginId: 'creditcard',
+        providerId: 'moonpay',
+        direction: 'buy',
+        paymentType: 'applepay',
         path: '/rabbit/hole',
         query: { param: 'alice' }
       }

--- a/src/actions/DeepLinkingActions.ts
+++ b/src/actions/DeepLinkingActions.ts
@@ -5,6 +5,7 @@ import { pickWallet } from '../components/modals/WalletListModal'
 import { showError, showToast } from '../components/services/AirshipInstance'
 import { guiPlugins } from '../constants/plugins/GuiPlugins'
 import s from '../locales/strings'
+import { asFiatPaymentType } from '../plugins/gui/fiatPluginTypes'
 import { DeepLink } from '../types/DeepLinkTypes'
 import { Dispatch, RootState, ThunkAction } from '../types/reduxTypes'
 import { NavigationBase } from '../types/routerTypes'
@@ -75,17 +76,23 @@ export async function handleLink(navigation: NavigationBase, dispatch: Dispatch,
       return false
 
     case 'plugin': {
-      const { pluginId, path, query } = link
+      const { direction, paymentType: pType, pluginId, providerId, path, query } = link
       const plugin = guiPlugins[pluginId]
       if (pluginId === 'custom' || plugin == null || plugin.pluginId == null) {
         showError(new Error(`No plugin named ${pluginId} exists`))
         return true
       }
-      navigation.push('pluginView', {
-        plugin,
-        deepPath: path,
-        deepQuery: query
-      })
+
+      const paymentType = pType === '' ? undefined : asFiatPaymentType(pType)
+
+      if (direction == null) return true
+      if (direction === 'buy') {
+        navigation.navigate('pluginListBuy', { direction: 'buy', pluginId, providerId, deepPath: path, deepQuery: query, paymentType })
+      } else if (direction === 'sell') {
+        navigation.navigate('pluginListSell', { direction: 'sell', pluginId, providerId, deepPath: path, deepQuery: query, paymentType })
+      } else {
+        throw new Error(`Invalid plugin direction ${direction}`)
+      }
       return true
     }
 

--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -17,12 +17,14 @@ import { customPluginRow, guiPlugins } from '../../constants/plugins/GuiPlugins'
 import s from '../../locales/strings'
 import { getSyncedSettings, setSyncedSettings } from '../../modules/Core/Account/settings'
 import { checkWyreHasLinkedBank, executePlugin } from '../../plugins/gui/fiatPlugin'
+import { FiatPaymentType } from '../../plugins/gui/fiatPluginTypes'
 import { config } from '../../theme/appConfig'
 import { asBuySellPlugins, asGuiPluginJson, BuySellPlugins, GuiPluginRow } from '../../types/GuiPluginTypes'
 import { connect } from '../../types/reactRedux'
 import { AccountReferral } from '../../types/ReferralTypes'
 import { NavigationProp, RouteProp } from '../../types/routerTypes'
 import { PluginTweak } from '../../types/TweakTypes'
+import { UriQueryMap } from '../../types/WebTypes'
 import { getPartnerIconUri } from '../../util/CdnUris'
 import { filterGuiPluginJson } from '../../util/GuiPluginTools'
 import { fetchInfo } from '../../util/network'
@@ -63,6 +65,17 @@ const paymentTypeLogosById = {
 const pluginPartnerLogos = {
   moonpay: 'guiPluginLogoMoonpay',
   bitaccess: 'guiPluginLogoBitaccess'
+}
+
+export interface PluginListProps {
+  direction: 'buy' | 'sell'
+  pluginId?: string
+  providerId?: string
+  paymentType?: FiatPaymentType
+  deepPath?: string
+  deepQuery?: {
+    [key: string]: string | null
+  }
 }
 
 interface OwnProps {
@@ -127,6 +140,11 @@ class GuiPluginList extends React.PureComponent<Props, State> {
         }
       })
       .catch((e: any) => console.error(e.message))
+    if (this.props.route.params.pluginId != null) {
+      const { deepPath, deepQuery = {}, paymentType, pluginId, providerId } = this.props.route.params
+      // The scene was deeplinked into. Route directly to plugin
+      this.openPlugin({ deepPath, deepQuery, paymentType, pluginId, providerId })
+    }
   }
 
   componentWillUnmount() {
@@ -230,9 +248,25 @@ class GuiPluginList extends React.PureComponent<Props, State> {
   /**
    * Launch the provided plugin, including pre-flight checks.
    */
-  async openPlugin(listRow: GuiPluginRow) {
+  async openPluginRow(listRow: GuiPluginRow) {
+    const { pluginId, paymentType, deepPath, deepQuery } = listRow
+    this.openPlugin({ pluginId, paymentType, deepPath, deepQuery })
+  }
+
+  async openPlugin({
+    pluginId,
+    paymentType,
+    providerId,
+    deepPath,
+    deepQuery = {}
+  }: {
+    pluginId: string
+    paymentType?: FiatPaymentType
+    providerId?: string
+    deepPath?: string
+    deepQuery: UriQueryMap
+  }) {
     const { countryCode, disablePlugins, navigation, account } = this.props
-    const { pluginId, paymentType, deepQuery = {} } = listRow
     const plugin = guiPlugins[pluginId]
 
     // Add countryCode
@@ -241,10 +275,8 @@ class GuiPluginList extends React.PureComponent<Props, State> {
     }
 
     // Grab a custom URI if necessary:
-    let { deepPath } = listRow
     if (pluginId === 'custom') {
       const { developerUri } = this.state
-      // @ts-expect-error
       deepPath = await Airship.show<string | undefined>(bridge => (
         <TextInputModal
           autoCorrect={false}
@@ -279,6 +311,7 @@ class GuiPluginList extends React.PureComponent<Props, State> {
         direction,
         regionCode: { countryCode },
         paymentType,
+        providerId,
         navigation,
         account
       })

--- a/src/plugins/gui/creditCardPlugin.ts
+++ b/src/plugins/gui/creditCardPlugin.ts
@@ -68,7 +68,7 @@ export const creditCardPlugin: FiatPluginFactory = async (params: FiatPluginFact
   const fiatPlugin: FiatPlugin = {
     pluginId,
     startPlugin: async (params: FiatPluginStartParams) => {
-      const { isBuy, regionCode, paymentTypes } = params
+      const { isBuy, regionCode, paymentTypes, providerId } = params
       const ps = fuzzyTimeout(assetPromises, 5000).catch(e => [])
       const assetArray = await showUi.showToastSpinner(s.strings.fiat_plugin_fetching_assets, ps)
 
@@ -166,7 +166,7 @@ export const creditCardPlugin: FiatPluginFactory = async (params: FiatPluginFact
             }
           }
 
-          const quotePromises = providers.map(async p => p.getQuote(quoteParams))
+          const quotePromises = providers.filter(p => (providerId == null ? true : providerId === p.pluginId)).map(async p => p.getQuote(quoteParams))
           let errors: unknown[] = []
           const quotes = await fuzzyTimeout(quotePromises, 5000).catch(e => {
             errors = e

--- a/src/plugins/gui/fiatPlugin.tsx
+++ b/src/plugins/gui/fiatPlugin.tsx
@@ -29,9 +29,10 @@ export const executePlugin = async (params: {
   guiPlugin: GuiPlugin
   navigation: NavigationProp<'pluginListBuy'> | NavigationProp<'pluginListSell'>
   paymentType?: FiatPaymentType
+  providerId?: string
   regionCode: FiatPluginRegionCode
 }): Promise<void> => {
-  const { disablePlugins, account, direction, guiPlugin, navigation, paymentType, regionCode } = params
+  const { disablePlugins, account, direction, guiPlugin, navigation, paymentType, providerId, regionCode } = params
   const { pluginId } = guiPlugin
   const isBuy = direction === 'buy'
 
@@ -94,7 +95,8 @@ export const executePlugin = async (params: {
   const startPluginParams = {
     isBuy,
     regionCode,
-    paymentTypes
+    paymentTypes,
+    providerId
   }
   plugin.startPlugin(startPluginParams)
 }

--- a/src/plugins/gui/fiatPluginTypes.ts
+++ b/src/plugins/gui/fiatPluginTypes.ts
@@ -74,6 +74,7 @@ export interface FiatPluginStartParams {
   isBuy: boolean
   paymentTypes: FiatPaymentTypes
   regionCode: FiatPluginRegionCode
+  providerId?: string
 }
 export interface FiatPlugin {
   pluginId: string

--- a/src/types/DeepLinkTypes.ts
+++ b/src/types/DeepLinkTypes.ts
@@ -59,6 +59,9 @@ export interface PasswordRecoveryLink {
 export interface PluginLink {
   type: 'plugin'
   pluginId: string
+  direction: string
+  providerId: string
+  paymentType: string
   path: string
   query: { [key: string]: string | null }
 }

--- a/src/types/routerTypes.tsx
+++ b/src/types/routerTypes.tsx
@@ -3,6 +3,7 @@ import { ParamListBase, StackActionHelpers } from '@react-navigation/native'
 import { EdgeCurrencyInfo, EdgeCurrencyWallet, EdgeSpendInfo, EdgeTransaction, JsonObject, OtpError } from 'edge-core-js'
 
 import { ConfirmSceneParams } from '../components/scenes/ConfirmScene'
+import { PluginListProps } from '../components/scenes/GuiPluginListScene'
 import { LoanManageType } from '../components/scenes/Loans/LoanManageScene'
 import { MigrateWalletItem } from '../components/scenes/MigrateWalletSelectCryptoScene'
 import { SendScene2Params } from '../components/scenes/SendScene2'
@@ -266,8 +267,8 @@ interface RouteParamList {
   }
   otpSetup: {}
   passwordRecovery: {}
-  pluginListBuy: {}
-  pluginListSell: {}
+  pluginListBuy: PluginListProps
+  pluginListSell: PluginListProps
   pluginViewBuy: PluginViewParams
   pluginViewSell: PluginViewParams
   pluginView: PluginViewParams

--- a/src/util/DeepLinkParser.ts
+++ b/src/util/DeepLinkParser.ts
@@ -99,10 +99,10 @@ function parseEdgeProtocol(url: URL<string>): DeepLink {
     }
 
     case 'plugin': {
-      const [pluginId = '', ...deepPath] = pathParts
+      const [pluginId, direction = 'buy', providerId = '', paymentType = '', ...deepPath] = pathParts
       const path = deepPath.length !== 0 ? '/' + deepPath.join('/') : ''
       const query = parseQuery(url.query)
-      return { type: 'plugin', pluginId, path, query }
+      return { type: 'plugin', direction, paymentType, pluginId, providerId, path, query }
     }
 
     case 'price-change': {


### PR DESCRIPTION
- Extend plugin URI format to require in path:
  - direction
  - providerId
  - paymentType
- Drill down providerId into Fiat Plugins
- Make fiat plugin filter providers if providerId exists

## New valid URLs for plugin deep links

/plugin/[pluginId]/[direction]/[providerId]/[paymentType]

direction = "buy" or "sell"

if pluginId is the last in path, direction is assumed "buy" and this link would deep link into old HTML webview plugins (not native FiatPlugins which providers). Note, path must not have a trailing '/' after pluginId

deepPath is everything after the [paymentType]

ie.

```
edge://plugin/ionia
edge://plugin/creditcard/buy/moonpay/credit
https://deep.edge.app/plugin/creditcard/buy/moonpay/credit
https://deep.edge.app/plugin/creditcard/buy/moonpay/iach
https://deep.edge.app/plugin/creditcard/buy/simplex/credit
https://deep.edge.app/plugin/creditcard/buy/simplex/applepay
https://deep.edge.app/plugin/creditcard/buy/banxa/credit
https://deep.edge.app/plugin/bitsofgold/buy///order/buy?order_id=null&page=0
```

### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203603633249944