### PR TITLE
Add a fake provider for testing

### DIFF
--- a/src/__tests__/components/BuyCrypto.test.tsx
+++ b/src/__tests__/components/BuyCrypto.test.tsx
@@ -1,22 +1,19 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import renderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { BuyCrypto } from '../../components/themed/BuyCrypto'
-import { rootReducer } from '../../reducers/RootReducer'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('BuyCrypto', () => {
-  const mockState: any = {
+  const mockState: FakeState = {
     ui: {
       settings: {
         defaultIsoFiat: 'iso:DOLLA'
       }
     }
   }
-  const store = createStore(rootReducer, mockState)
 
   it('should render with some props', () => {
     const fakeWallet: any = {
@@ -25,9 +22,9 @@ describe('BuyCrypto', () => {
     }
 
     const actual = renderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={mockState}>
         <BuyCrypto wallet={fakeWallet} tokenId={undefined} navigation={fakeNavigation} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(actual).toMatchSnapshot()

--- a/src/__tests__/components/CreateWalletSelectCryptoRow.test.tsx
+++ b/src/__tests__/components/CreateWalletSelectCryptoRow.test.tsx
@@ -1,15 +1,13 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
 import IonIcon from 'react-native-vector-icons/Ionicons'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { CreateWalletSelectCryptoRow } from '../../components/themed/CreateWalletSelectCryptoRow'
-import { rootReducer } from '../../reducers/RootReducer'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('WalletListRow', () => {
-  const mockState: any = {
+  const mockState: FakeState = {
     core: {
       account: {
         currencyConfig: {
@@ -23,7 +21,6 @@ describe('WalletListRow', () => {
       }
     }
   }
-  const store = createStore(rootReducer, mockState)
 
   it('should render with loading props', () => {
     const pluginId = 'bitcoin'
@@ -32,9 +29,9 @@ describe('WalletListRow', () => {
     const rightSide = <IonIcon size={26} color="#66EDA8" name="chevron-forward-outline" />
 
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={mockState}>
         <CreateWalletSelectCryptoRow pluginId={pluginId} walletName={walletName} onPress={onPress} rightSide={rightSide} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/components/CurrencyIcon.test.tsx
+++ b/src/__tests__/components/CurrencyIcon.test.tsx
@@ -1,32 +1,28 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { CryptoIcon } from '../../components/icons/CryptoIcon'
-import { rootReducer } from '../../reducers/RootReducer'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('CryptoIcon', () => {
-  const mockState: any = {
+  const mockState: FakeState = {
     core: {
       account: {
         currencyWallets: {
           '332s0ds39f': {
-            pluginId: 'bitcoin',
             watch: () => {}
           }
         }
       }
     }
   }
-  const store = createStore(rootReducer, mockState)
 
   it('should render with loading props', () => {
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={mockState}>
         <CryptoIcon pluginId="bitcoin" tokenId="bitcoin" walletId="332s0ds39f" marginRem={1} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/components/MenuTabs.test.tsx
+++ b/src/__tests__/components/MenuTabs.test.tsx
@@ -1,23 +1,23 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { createRenderer } from 'react-test-renderer/shallow'
+import TestRenderer from 'react-test-renderer'
 
 import { MenuTabs } from '../../components/themed/MenuTabs'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
+import { FakeProviders } from '../../util/fake/FakeProviders'
 
 describe('MenuTabs', () => {
   it('should render with loading props', () => {
-    const renderer = createRenderer()
-
-    const actual = renderer.render(
-      <MenuTabs
-        // @ts-expect-error
-        navigation={fakeNavigation}
-        // @ts-expect-error
-        state={{ index: 0, routes: [] }}
-      />
+    const renderer = TestRenderer.create(
+      <FakeProviders>
+        <MenuTabs
+          // @ts-expect-error
+          navigation={fakeNavigation}
+          // @ts-expect-error
+          state={{ index: 0, routes: [] }}
+        />
+      </FakeProviders>
     )
-
-    expect(actual).toMatchSnapshot()
+    expect(renderer.toJSON()).toMatchSnapshot()
   })
 })

--- a/src/__tests__/components/MenuTabs.test.tsx
+++ b/src/__tests__/components/MenuTabs.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from '@jest/globals'
-import { BottomTabBarProps } from '@react-navigation/bottom-tabs'
 import * as React from 'react'
 import { createRenderer } from 'react-test-renderer/shallow'
 
@@ -10,9 +9,14 @@ describe('MenuTabs', () => {
   it('should render with loading props', () => {
     const renderer = createRenderer()
 
-    const props: BottomTabBarProps = { navigation: fakeNavigation, state: { index: 0, routes: [] } } as any
-
-    const actual = renderer.render(<MenuTabs {...props} />)
+    const actual = renderer.render(
+      <MenuTabs
+        // @ts-expect-error
+        navigation={fakeNavigation}
+        // @ts-expect-error
+        state={{ index: 0, routes: [] }}
+      />
+    )
 
     expect(actual).toMatchSnapshot()
   })

--- a/src/__tests__/components/PromoCard.test.tsx
+++ b/src/__tests__/components/PromoCard.test.tsx
@@ -1,13 +1,11 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import renderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { PromoCard } from '../../components/cards/PromoCard'
-import { rootReducer } from '../../reducers/RootReducer'
 import { MessageTweak } from '../../types/TweakTypes'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('PromoCard', () => {
   const fakeMessage: MessageTweak = {
@@ -16,27 +14,26 @@ describe('PromoCard', () => {
     durationDays: 1
   }
 
-  const mockState: any = {
+  const mockState: FakeState = {
     account: {
       accountReferral: {
         installerId: 'string',
         currencyCodes: ['BTC'],
         promotions: [],
         ignoreAccountSwap: true,
-        hiddenAccountMessages: ['messageId']
+        hiddenAccountMessages: { messageId: true }
       },
       referralCache: {
         accountMessages: [fakeMessage]
       }
     }
   }
-  const store = createStore(rootReducer, mockState)
 
   it('should render', () => {
     const actual = renderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={mockState}>
         <PromoCard navigation={fakeNavigation} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(actual).toMatchSnapshot()

--- a/src/__tests__/components/TransactionListRow.test.tsx
+++ b/src/__tests__/components/TransactionListRow.test.tsx
@@ -1,12 +1,10 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { TransactionListRow } from '../../components/themed/TransactionListRow'
-import { rootReducer } from '../../reducers/RootReducer'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('TransactionListRow', () => {
   it('should render with loading props', () => {
@@ -30,22 +28,21 @@ describe('TransactionListRow', () => {
       fiatCurrencyCode: 'iso:USD'
     }
 
-    const mockStore: any = {
+    const mockStore: FakeState = {
       core: {
         account: {
           currencyConfig: {
             bitcoin: {
-              allTokens: [],
+              allTokens: {},
               currencyInfo
             }
           }
         }
       }
     }
-    const store = createStore(rootReducer, mockStore)
 
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={mockStore}>
         <TransactionListRow
           navigation={fakeNavigation}
           wallet={fakeWallet}
@@ -65,7 +62,7 @@ describe('TransactionListRow', () => {
             ourReceiveAddresses: []
           }}
         />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/components/TransactionListTop.test.tsx
+++ b/src/__tests__/components/TransactionListTop.test.tsx
@@ -1,14 +1,11 @@
 import { describe, expect, it } from '@jest/globals'
 import { EdgeCurrencyInfo } from 'edge-core-js'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { applyMiddleware, createStore } from 'redux'
-import thunk from 'redux-thunk'
 
 import { TransactionListTop } from '../../components/themed/TransactionListTop'
-import { rootReducer } from '../../reducers/RootReducer'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('TransactionListTop', () => {
   const currencyInfo: EdgeCurrencyInfo = {
@@ -51,7 +48,7 @@ describe('TransactionListTop', () => {
     watch() {}
   }
 
-  const fakeState: any = {
+  const fakeState: FakeState = {
     core: {
       account: {
         currencyWallets: { '123': fakeWallet },
@@ -60,11 +57,9 @@ describe('TransactionListTop', () => {
     }
   }
 
-  const store = createStore(rootReducer, fakeState, applyMiddleware(thunk))
-
   it('should render', () => {
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={fakeState}>
         <TransactionListTop
           currencyCode="BTC"
           isEmpty={false}
@@ -74,7 +69,7 @@ describe('TransactionListTop', () => {
           onChangeSortingState={() => undefined}
           onSearchTransaction={() => undefined}
         />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/components/WalletListFooter.test.tsx
+++ b/src/__tests__/components/WalletListFooter.test.tsx
@@ -1,21 +1,17 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { WalletListFooter } from '../../components/themed/WalletListFooter'
-import { rootReducer } from '../../reducers/RootReducer'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
+import { FakeProviders } from '../../util/fake/FakeProviders'
 
 describe('WalletListFooter', () => {
   it('should render with loading props', () => {
-    const store = createStore(rootReducer)
-
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders>
         <WalletListFooter navigation={fakeNavigation} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/components/__snapshots__/MenuTabs.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/MenuTabs.test.tsx.snap
@@ -2,28 +2,56 @@
 
 exports[`MenuTabs should render with loading props 1`] = `
 <View>
-  <DividerLine
+  <BVLinearGradient
     colors={
       Array [
-        "#121d25",
-        "#121d25",
+        4279377189,
+        4279377189,
+      ]
+    }
+    endPoint={
+      Object {
+        "x": 1,
+        "y": 0.5,
+      }
+    }
+    locations={null}
+    startPoint={
+      Object {
+        "x": 0,
+        "y": 0.5,
+      }
+    }
+    style={
+      Array [
+        Object {
+          "alignSelf": "stretch",
+          "height": 1,
+        },
+        Object {
+          "marginBottom": 0,
+          "marginLeft": 0,
+          "marginRight": -22,
+          "marginTop": 0,
+        },
       ]
     }
   />
-  <LinearGradient
+  <BVLinearGradient
     colors={
       Array [
-        "#121d25",
-        "#121d25",
+        4279377189,
+        4279377189,
       ]
     }
-    end={
+    endPoint={
       Object {
         "x": 1,
         "y": 1,
       }
     }
-    start={
+    locations={null}
+    startPoint={
       Object {
         "x": 0,
         "y": 0,

--- a/src/__tests__/modals/AdvancedDetailsModal.test.tsx
+++ b/src/__tests__/modals/AdvancedDetailsModal.test.tsx
@@ -1,19 +1,15 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { AdvancedDetailsModal } from '../../components/modals/AdvancedDetailsModal'
-import { rootReducer } from '../../reducers/RootReducer'
 import { fakeAirshipBridge } from '../../util/fake/fakeAirshipBridge'
+import { FakeProviders } from '../../util/fake/FakeProviders'
 
 describe('AdvancedDetailsModal', () => {
-  const store = createStore(rootReducer)
-
   it('should render with loading props', () => {
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders>
         <AdvancedDetailsModal
           bridge={fakeAirshipBridge}
           transaction={{
@@ -29,7 +25,7 @@ describe('AdvancedDetailsModal', () => {
             txid: ''
           }}
         />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/modals/CategoryModal.test.tsx
+++ b/src/__tests__/modals/CategoryModal.test.tsx
@@ -1,16 +1,14 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { CategoryModal } from '../../components/modals/CategoryModal'
-import { rootReducer } from '../../reducers/RootReducer'
 import { defaultCategories } from '../../util/categories'
 import { fakeAirshipBridge } from '../../util/fake/fakeAirshipBridge'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('CategoryModal', () => {
-  const fakeState: any = {
+  const fakeState: FakeState = {
     ui: {
       scenes: {
         transactionDetails: {
@@ -19,13 +17,12 @@ describe('CategoryModal', () => {
       }
     }
   }
-  const store = createStore(rootReducer, fakeState)
 
   it('should render with an empty subcategory', () => {
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={fakeState}>
         <CategoryModal bridge={fakeAirshipBridge} initialCategory="Exchange:" />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()
@@ -33,9 +30,9 @@ describe('CategoryModal', () => {
 
   it('should render with a subcategory', () => {
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={fakeState}>
         <CategoryModal bridge={fakeAirshipBridge} initialCategory="Income:Paycheck" />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/modals/WalletListModal.test.tsx
+++ b/src/__tests__/modals/WalletListModal.test.tsx
@@ -1,23 +1,19 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { upgradeCurrencyCodes, WalletListModal } from '../../components/modals/WalletListModal'
-import { rootReducer } from '../../reducers/RootReducer'
 import { EdgeTokenId } from '../../types/types'
 import { fakeAirshipBridge } from '../../util/fake/fakeAirshipBridge'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
+import { FakeProviders } from '../../util/fake/FakeProviders'
 
 describe('WalletListModal', () => {
   it('should render with loading props', () => {
-    const store = createStore(rootReducer)
-
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders>
         <WalletListModal bridge={fakeAirshipBridge} navigation={fakeNavigation} headerTitle="Wallet List" />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/scenes/CreateWalletImportScene.test.tsx
+++ b/src/__tests__/scenes/CreateWalletImportScene.test.tsx
@@ -1,14 +1,12 @@
 import { describe, expect, it, jest } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { CreateWalletImportScene } from '../../components/scenes/CreateWalletImportScene'
-import { rootReducer } from '../../reducers/RootReducer'
 import { RouteProp } from '../../types/routerTypes'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
 import { fakeNonce } from '../../util/fake/fakeNonce'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 jest.mock('react-native-keyboard-aware-scroll-view', () => {
   const KeyboardAwareScrollView = (blob: { children: React.ReactNode }) => blob.children
@@ -20,7 +18,7 @@ jest.mock('../../assets/images/import-key-icon.svg', () => 'ImportKeySvg')
 
 describe('CreateWalletImportScene', () => {
   const nonce = fakeNonce(0)
-  const mockState: any = {
+  const mockState: FakeState = {
     core: {
       account: {
         currencyConfig: {
@@ -31,7 +29,6 @@ describe('CreateWalletImportScene', () => {
       }
     }
   }
-  const store = createStore(rootReducer, mockState)
 
   it('should render with loading props', () => {
     const navigation = fakeNavigation
@@ -54,9 +51,9 @@ describe('CreateWalletImportScene', () => {
     }
 
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={mockState}>
         <CreateWalletImportScene navigation={navigation} route={route} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/scenes/CreateWalletSelectCryptoScene.test.tsx
+++ b/src/__tests__/scenes/CreateWalletSelectCryptoScene.test.tsx
@@ -1,18 +1,16 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { CreateWalletSelectCryptoScene } from '../../components/scenes/CreateWalletSelectCryptoScene'
-import { rootReducer } from '../../reducers/RootReducer'
 import { RouteProp } from '../../types/routerTypes'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
 import { fakeNonce } from '../../util/fake/fakeNonce'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('CreateWalletSelectCrypto', () => {
   const nonce = fakeNonce(0)
-  const mockState: any = {
+  const mockState: FakeState = {
     core: {
       account: {
         currencyConfig: {
@@ -62,7 +60,6 @@ describe('CreateWalletSelectCrypto', () => {
       }
     }
   }
-  const store = createStore(rootReducer, mockState)
 
   it('should render with loading props', () => {
     const navigation = fakeNavigation
@@ -73,9 +70,9 @@ describe('CreateWalletSelectCrypto', () => {
     }
 
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={mockState}>
         <CreateWalletSelectCryptoScene navigation={navigation} route={route} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/scenes/CreateWalletSelectFiatScene.test.tsx
+++ b/src/__tests__/scenes/CreateWalletSelectFiatScene.test.tsx
@@ -1,18 +1,16 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { CreateWalletSelectFiatScene } from '../../components/scenes/CreateWalletSelectFiatScene'
-import { rootReducer } from '../../reducers/RootReducer'
 import { RouteProp } from '../../types/routerTypes'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
 import { fakeNonce } from '../../util/fake/fakeNonce'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('CreateWalletSelectFiatComponent', () => {
   const nonce = fakeNonce(0)
-  const mockState: any = {
+  const mockState: FakeState = {
     ui: {
       settings: {
         defaultIsoFiat: 'USD'
@@ -48,7 +46,6 @@ describe('CreateWalletSelectFiatComponent', () => {
       }
     }
   }
-  const store = createStore(rootReducer, mockState)
 
   it('should render with loading props', () => {
     const navigation = fakeNavigation
@@ -77,9 +74,9 @@ describe('CreateWalletSelectFiatComponent', () => {
       }
     }
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={mockState}>
         <CreateWalletSelectFiatScene navigation={navigation} route={route} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/scenes/CurrencyNotificationScene.test.tsx
+++ b/src/__tests__/scenes/CurrencyNotificationScene.test.tsx
@@ -1,16 +1,14 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { CurrencyNotificationScene } from '../../components/scenes/CurrencyNotificationScene'
-import { rootReducer } from '../../reducers/RootReducer'
 import { fakeNonce } from '../../util/fake/fakeNonce'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('CurrencyNotificationComponent', () => {
   const nonce = fakeNonce(0)
-  const mockStore: any = {
+  const mockStore: FakeState = {
     notificationSettings: {
       plugins: {
         bitcoin: {
@@ -23,11 +21,9 @@ describe('CurrencyNotificationComponent', () => {
     }
   }
 
-  const store = createStore(rootReducer, mockStore)
-
   it('should render with loading props', () => {
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={mockStore}>
         <CurrencyNotificationScene
           route={{
             key: `currencyNotificationSettings-${nonce()}`,
@@ -63,7 +59,7 @@ describe('CurrencyNotificationComponent', () => {
             }
           }}
         />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/scenes/CurrencySettings.ui.test.tsx
+++ b/src/__tests__/scenes/CurrencySettings.ui.test.tsx
@@ -1,12 +1,10 @@
 import { describe, expect, it } from '@jest/globals'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { CurrencySettingsScene } from '../../components/scenes/CurrencySettingsScene'
-import { rootReducer } from '../../reducers/RootReducer'
 import { fakeNonce } from '../../util/fake/fakeNonce'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 describe('CurrencySettings', () => {
   const nonce = fakeNonce(0)
@@ -21,17 +19,19 @@ describe('CurrencySettings', () => {
       ],
       pluginId: 'bitcoin-gold'
     }
-    const account: any = {
-      currencyConfig: {
-        'bitcoin-gold': { currencyInfo }
+
+    const state: FakeState = {
+      core: {
+        account: {
+          currencyConfig: {
+            'bitcoin-gold': { currencyInfo }
+          }
+        }
       }
     }
 
-    const state: any = { core: { account } }
-    const store = createStore(rootReducer, state)
-
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={state}>
         <CurrencySettingsScene
           route={{
             key: `currencySettings-${nonce()}`,
@@ -39,7 +39,7 @@ describe('CurrencySettings', () => {
             params: { currencyInfo }
           }}
         />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/scenes/EdgeLoginScene.test.tsx
+++ b/src/__tests__/scenes/EdgeLoginScene.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals'
 import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
 import { Provider } from 'react-redux'
-import { createRenderer } from 'react-test-renderer/shallow'
+import TestRenderer from 'react-test-renderer'
 import { createStore } from 'redux'
 
 import { EdgeLoginScene } from '../../components/scenes/EdgeLoginScene'
@@ -17,7 +17,6 @@ let account: EdgeAccount | undefined
 describe('EdgeLoginScene', () => {
   const nonce = fakeNonce(0)
   it('should render with loading props', () => {
-    const renderer = createRenderer()
     const route: RouteProp<'edgeLogin'> = {
       key: `edgeLogin-${nonce()}`,
       name: 'edgeLogin',
@@ -30,12 +29,12 @@ describe('EdgeLoginScene', () => {
       account
     }
     const store = createStore(rootReducer, rootState)
-    const actual = renderer.render(
+    const renderer = TestRenderer.create(
       <Provider store={store}>
         <EdgeLoginScene route={route} navigation={fakeNavigation} />
       </Provider>
     )
 
-    expect(actual).toMatchSnapshot()
+    expect(renderer.toJSON()).toMatchSnapshot()
   })
 })

--- a/src/__tests__/scenes/EdgeLoginScene.test.tsx
+++ b/src/__tests__/scenes/EdgeLoginScene.test.tsx
@@ -1,15 +1,13 @@
 import { describe, expect, it } from '@jest/globals'
 import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { EdgeLoginScene } from '../../components/scenes/EdgeLoginScene'
-import { rootReducer } from '../../reducers/RootReducer'
 import { RouteProp } from '../../types/routerTypes'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
 import { fakeNonce } from '../../util/fake/fakeNonce'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 import { fakeRootState } from '../../util/fake/fakeRootState'
 
 let account: EdgeAccount | undefined
@@ -24,15 +22,12 @@ describe('EdgeLoginScene', () => {
         lobbyId: 'AmNsSBDVeF2837'
       }
     }
-    const rootState: any = fakeRootState
-    rootState.core = {
-      account
-    }
-    const store = createStore(rootReducer, rootState)
+    const rootState: FakeState = { ...fakeRootState, core: { account } }
+
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <EdgeLoginScene route={route} navigation={fakeNavigation} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/scenes/SendScene2.ui.test.tsx
+++ b/src/__tests__/scenes/SendScene2.ui.test.tsx
@@ -2,12 +2,9 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals'
 import { asDate, asMap, asObject, asOptional, asString, asUnknown } from 'cleaners'
 import { addEdgeCorePlugins, EdgeAccount, EdgeContext, EdgeCurrencyWallet, lockEdgeCorePlugins, makeFakeEdgeWorld } from 'edge-core-js'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { createStore } from 'redux'
 
 import { SendScene2 } from '../../components/scenes/SendScene2'
-import { rootReducer } from '../../reducers/RootReducer'
 import { RouteProp } from '../../types/routerTypes'
 import { avaxCurrencyInfo } from '../../util/fake/fakeAvaxInfo'
 import { btcCurrencyInfo } from '../../util/fake/fakeBtcInfo'
@@ -15,6 +12,7 @@ import { makeFakePlugin } from '../../util/fake/fakeCurrencyPlugin'
 import { ethCurrencyInfo } from '../../util/fake/fakeEthInfo'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
 import { fakeNonce } from '../../util/fake/fakeNonce'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 import { fakeRootState } from '../../util/fake/fakeRootState'
 import fakeUser from '../../util/fake/fakeUserDump.json'
 
@@ -86,7 +84,7 @@ describe('SendScene2', () => {
   it('Render SendScene', () => {
     if (btcWallet == null) return
 
-    const rootState: any = fakeRootState
+    const rootState: FakeState = { ...fakeRootState, core: { account } }
     const navigation = fakeNavigation
     const route: RouteProp<'send2'> = {
       key: `send2-${nonce()}`,
@@ -97,15 +95,10 @@ describe('SendScene2', () => {
       }
     }
 
-    rootState.core = {
-      account
-    }
-    const store = createStore(rootReducer, rootState)
-
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()
@@ -113,7 +106,7 @@ describe('SendScene2', () => {
   it('1 spendTarget', () => {
     if (btcWallet == null) return
 
-    const rootState: any = fakeRootState
+    const rootState: FakeState = { ...fakeRootState, core: { account } }
     const navigation = fakeNavigation
     const route: RouteProp<'send2'> = {
       key: `send2-${nonce()}`,
@@ -127,15 +120,10 @@ describe('SendScene2', () => {
       }
     }
 
-    rootState.core = {
-      account
-    }
-    const store = createStore(rootReducer, rootState)
-
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()
@@ -143,7 +131,7 @@ describe('SendScene2', () => {
   it('1 spendTarget with info tiles', () => {
     if (btcWallet == null) return
 
-    const rootState: any = fakeRootState
+    const rootState: FakeState = { ...fakeRootState, core: { account } }
     const navigation = fakeNavigation
     const route: RouteProp<'send2'> = {
       key: `send2-${nonce()}`,
@@ -161,15 +149,10 @@ describe('SendScene2', () => {
       }
     }
 
-    rootState.core = {
-      account
-    }
-    const store = createStore(rootReducer, rootState)
-
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()
@@ -177,7 +160,7 @@ describe('SendScene2', () => {
   it('2 spendTargets', () => {
     if (btcWallet == null) return
 
-    const rootState: any = fakeRootState
+    const rootState: FakeState = { ...fakeRootState, core: { account } }
     const navigation = fakeNavigation
     const route: RouteProp<'send2'> = {
       key: `send2-${nonce()}`,
@@ -194,15 +177,10 @@ describe('SendScene2', () => {
       }
     }
 
-    rootState.core = {
-      account
-    }
-    const store = createStore(rootReducer, rootState)
-
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()
@@ -211,7 +189,7 @@ describe('SendScene2', () => {
   it('2 spendTargets hide tiles', () => {
     if (btcWallet == null) return
 
-    const rootState: any = fakeRootState
+    const rootState: FakeState = { ...fakeRootState, core: { account } }
     const navigation = fakeNavigation
     const route: RouteProp<'send2'> = {
       key: `send2-${nonce()}`,
@@ -229,16 +207,11 @@ describe('SendScene2', () => {
       }
     }
 
-    rootState.core = {
-      account
-    }
-    const store = createStore(rootReducer, rootState)
-
     // Hide Address
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
     expect(renderer.toJSON()).toMatchSnapshot()
 
@@ -246,9 +219,9 @@ describe('SendScene2', () => {
     // @ts-expect-error
     route.params.hiddenTilesMap = { amount: true }
     const renderer2 = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
     expect(renderer2.toJSON()).toMatchSnapshot()
 
@@ -256,9 +229,9 @@ describe('SendScene2', () => {
     // @ts-expect-error
     route.params.hiddenTilesMap = { amount: true, address: true }
     const renderer3 = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
     expect(renderer3.toJSON()).toMatchSnapshot()
   })
@@ -266,7 +239,7 @@ describe('SendScene2', () => {
   it('2 spendTargets lock tiles', () => {
     if (btcWallet == null) return
 
-    const rootState: any = fakeRootState
+    const rootState: FakeState = { ...fakeRootState, core: { account } }
     const navigation = fakeNavigation
     const route: RouteProp<'send2'> = {
       key: `send2-${nonce()}`,
@@ -284,16 +257,11 @@ describe('SendScene2', () => {
       }
     }
 
-    rootState.core = {
-      account
-    }
-    const store = createStore(rootReducer, rootState)
-
     // Lock Address
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
     expect(renderer.toJSON()).toMatchSnapshot()
 
@@ -301,9 +269,9 @@ describe('SendScene2', () => {
     // @ts-expect-error
     route.params.lockTilesMap = { amount: true }
     const renderer2 = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
     expect(renderer2.toJSON()).toMatchSnapshot()
 
@@ -311,9 +279,9 @@ describe('SendScene2', () => {
     // @ts-expect-error
     route.params.lockTilesMap = { amount: true, address: true }
     const renderer3 = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={rootState}>
         <SendScene2 route={route} navigation={navigation} />
-      </Provider>
+      </FakeProviders>
     )
     expect(renderer3.toJSON()).toMatchSnapshot()
   })

--- a/src/__tests__/scenes/SettingsScene.test.tsx
+++ b/src/__tests__/scenes/SettingsScene.test.tsx
@@ -6,6 +6,7 @@ import TestRenderer from 'react-test-renderer'
 import { SettingsSceneComponent } from '../../components/scenes/SettingsScene'
 import { config } from '../../theme/appConfig'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
+import { FakeProviders } from '../../util/fake/FakeProviders'
 
 const typeHack: any = {
   currencyConfig: {},
@@ -19,33 +20,35 @@ const context: EdgeContext = typeHack
 describe('MyComponent', () => {
   it('should render UnLocked SettingsOverview', () => {
     const renderer = TestRenderer.create(
-      <SettingsSceneComponent
-        theme={config.darkTheme}
-        navigation={fakeNavigation}
-        // StateProps:
-        account={account}
-        context={context}
-        autoLogoutTimeInSeconds={600}
-        defaultFiat="iso:USD"
-        developerModeOn
-        spamFilterOn
-        isLocked={false}
-        pinLoginEnabled
-        supportsTouchId={false}
-        touchIdEnabled
-        // DispatchProps:
-        dispatchUpdateEnableTouchIdEnable={async () => undefined}
-        handleClearLogs={() => undefined}
-        handleSendLogs={() => undefined}
-        lockSettings={() => undefined}
-        onTogglePinLoginEnabled={async () => undefined}
-        setAutoLogoutTimeInSeconds={() => undefined}
-        showRestoreWalletsModal={() => undefined}
-        showUnlockSettingsModal={() => undefined}
-        toggleDeveloperMode={() => undefined}
-        toggleSpamFilter={() => undefined}
-        logoutRequest={async () => undefined}
-      />
+      <FakeProviders>
+        <SettingsSceneComponent
+          theme={config.darkTheme}
+          navigation={fakeNavigation}
+          // StateProps:
+          account={account}
+          context={context}
+          autoLogoutTimeInSeconds={600}
+          defaultFiat="iso:USD"
+          developerModeOn
+          spamFilterOn
+          isLocked={false}
+          pinLoginEnabled
+          supportsTouchId={false}
+          touchIdEnabled
+          // DispatchProps:
+          dispatchUpdateEnableTouchIdEnable={async () => undefined}
+          handleClearLogs={() => undefined}
+          handleSendLogs={() => undefined}
+          lockSettings={() => undefined}
+          onTogglePinLoginEnabled={async () => undefined}
+          setAutoLogoutTimeInSeconds={() => undefined}
+          showRestoreWalletsModal={() => undefined}
+          showUnlockSettingsModal={() => undefined}
+          toggleDeveloperMode={() => undefined}
+          toggleSpamFilter={() => undefined}
+          logoutRequest={async () => undefined}
+        />
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()
@@ -53,33 +56,35 @@ describe('MyComponent', () => {
 
   it('should render Locked SettingsOverview', () => {
     const renderer = TestRenderer.create(
-      <SettingsSceneComponent
-        theme={config.darkTheme}
-        navigation={fakeNavigation}
-        // StateProps:
-        account={account}
-        context={context}
-        autoLogoutTimeInSeconds={600}
-        defaultFiat="iso:USD"
-        developerModeOn
-        spamFilterOn
-        isLocked
-        pinLoginEnabled
-        supportsTouchId={false}
-        touchIdEnabled
-        // DispatchProps:
-        dispatchUpdateEnableTouchIdEnable={async () => undefined}
-        lockSettings={() => undefined}
-        handleClearLogs={() => undefined}
-        handleSendLogs={() => undefined}
-        onTogglePinLoginEnabled={async () => undefined}
-        setAutoLogoutTimeInSeconds={() => undefined}
-        showRestoreWalletsModal={() => undefined}
-        showUnlockSettingsModal={() => undefined}
-        toggleDeveloperMode={() => undefined}
-        toggleSpamFilter={() => undefined}
-        logoutRequest={async () => undefined}
-      />
+      <FakeProviders>
+        <SettingsSceneComponent
+          theme={config.darkTheme}
+          navigation={fakeNavigation}
+          // StateProps:
+          account={account}
+          context={context}
+          autoLogoutTimeInSeconds={600}
+          defaultFiat="iso:USD"
+          developerModeOn
+          spamFilterOn
+          isLocked
+          pinLoginEnabled
+          supportsTouchId={false}
+          touchIdEnabled
+          // DispatchProps:
+          dispatchUpdateEnableTouchIdEnable={async () => undefined}
+          lockSettings={() => undefined}
+          handleClearLogs={() => undefined}
+          handleSendLogs={() => undefined}
+          onTogglePinLoginEnabled={async () => undefined}
+          setAutoLogoutTimeInSeconds={() => undefined}
+          showRestoreWalletsModal={() => undefined}
+          showUnlockSettingsModal={() => undefined}
+          toggleDeveloperMode={() => undefined}
+          toggleSpamFilter={() => undefined}
+          logoutRequest={async () => undefined}
+        />
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/scenes/TransactionDetailsScene.test.tsx
+++ b/src/__tests__/scenes/TransactionDetailsScene.test.tsx
@@ -1,15 +1,12 @@
 import { describe, expect, it } from '@jest/globals'
 import { EdgeCurrencyInfo } from 'edge-core-js'
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
-import { applyMiddleware, createStore } from 'redux'
-import thunk from 'redux-thunk'
 
 import { TransactionDetailsScene } from '../../components/scenes/TransactionDetailsScene'
-import { rootReducer } from '../../reducers/RootReducer'
 import { fakeNavigation } from '../../util/fake/fakeNavigation'
 import { fakeNonce } from '../../util/fake/fakeNonce'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
 
 const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'bitcoin',
@@ -53,7 +50,7 @@ const fakeCoreWallet: any = {
 
 describe('TransactionDetailsScene', () => {
   const nonce = fakeNonce(0)
-  const fakeState: any = {
+  const fakeState: FakeState = {
     core: {
       account: {
         currencyWallets: { '123': fakeCoreWallet },
@@ -62,11 +59,9 @@ describe('TransactionDetailsScene', () => {
     }
   }
 
-  const store = createStore(rootReducer, fakeState, applyMiddleware(thunk))
-
   it('should render', () => {
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={fakeState}>
         <TransactionDetailsScene
           navigation={fakeNavigation}
           route={{
@@ -90,7 +85,7 @@ describe('TransactionDetailsScene', () => {
             }
           }}
         />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()
@@ -98,7 +93,7 @@ describe('TransactionDetailsScene', () => {
 
   it('should render with negative nativeAmount and fiatAmount', () => {
     const renderer = TestRenderer.create(
-      <Provider store={store}>
+      <FakeProviders initialState={fakeState}>
         <TransactionDetailsScene
           navigation={fakeNavigation}
           route={{
@@ -125,7 +120,7 @@ describe('TransactionDetailsScene', () => {
             }
           }}
         />
-      </Provider>
+      </FakeProviders>
     )
 
     expect(renderer.toJSON()).toMatchSnapshot()

--- a/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
@@ -1,66 +1,432 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EdgeLoginScene should render with loading props 1`] = `
-<Context.Provider
-  value={
+<BVLinearGradient
+  colors={
+    Array [
+      4278585612,
+      4279971643,
+    ]
+  }
+  endPoint={
     Object {
-      "store": Object {
-        "@@observable": [Function],
-        "dispatch": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      },
-      "subscription": Subscription {
-        "handleChangeWrapper": [Function],
-        "listeners": Object {
-          "notify": [Function],
-        },
-        "onStateChange": [Function],
-        "parentSub": undefined,
-        "store": Object {
-          "@@observable": [Function],
-          "dispatch": [Function],
-          "getState": [Function],
-          "replaceReducer": [Function],
-          "subscribe": [Function],
-        },
-        "unsubscribe": null,
-      },
+      "x": 1,
+      "y": 0,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "bottom": 0,
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
     }
   }
 >
-  <EdgeLoginScene
-    navigation={
-      Object {
-        "addListener": [Function],
-        "canGoBack": [Function],
-        "dispatch": [Function],
-        "getId": [Function],
-        "getParent": [Function],
-        "getState": [Function],
-        "goBack": [Function],
-        "isFocused": [Function],
-        "navigate": [Function],
-        "pop": [Function],
-        "popToTop": [Function],
-        "push": [Function],
-        "removeListener": [Function],
-        "replace": [Function],
-        "reset": [Function],
-        "setOptions": [Function],
-        "setParams": [Function],
-      }
-    }
-    route={
-      Object {
-        "key": "edgeLogin-1",
-        "name": "edgeLogin",
-        "params": Object {
-          "lobbyId": "AmNsSBDVeF2837",
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "stretch",
+          "flexDirection": "column",
+          "justifyContent": "flex-start",
+          "position": "absolute",
         },
-      }
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "padding": 0,
+          "right": 0,
+          "top": 64,
+        },
+      ]
     }
-  />
-</Context.Provider>
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "opacity": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <ActivityIndicator
+            color="#00f1a2"
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+    <View
+      pointerEvents="none"
+      style={
+        Object {
+          "opacity": 0,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignSelf": "stretch",
+              "borderColor": "#F1AA19",
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "margin": 22,
+            },
+            Object {
+              "marginBottom": 22,
+              "marginLeft": 22,
+              "marginRight": 22,
+              "marginTop": 22,
+            },
+            Object {
+              "paddingBottom": 22,
+              "paddingLeft": 22,
+              "paddingRight": 22,
+              "paddingTop": 22,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "#F1AA19",
+                  "fontSize": 18,
+                },
+                Object {
+                  "marginRight": 11,
+                },
+                Object {
+                  "fontFamily": "Ionicons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            adjustsFontSizeToFit={true}
+            minimumFontScale={0.65}
+            numberOfLines={1}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "Quicksand-Regular",
+                  "fontSize": 22,
+                  "includeFontPadding": false,
+                },
+                Object {
+                  "color": "#F1AA19",
+                  "fontFamily": "Quicksand-Bold",
+                  "fontSize": 17,
+                  "marginLeft": 6,
+                },
+                null,
+              ]
+            }
+          >
+            Warning
+          </Text>
+        </View>
+        <Text
+          adjustsFontSizeToFit={true}
+          minimumFontScale={0.65}
+          numberOfLines={0}
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontFamily": "Quicksand-Regular",
+                "fontSize": 22,
+                "includeFontPadding": false,
+              },
+              Object {
+                "color": "#F1AA19",
+                "fontFamily": "Quicksand-Regular",
+                "fontSize": 17,
+                "marginTop": 22,
+              },
+              null,
+            ]
+          }
+        >
+          This application would like to create or access its wallet in your Edge account.
+
+ It will not have access to any other wallets.
+        </Text>
+      </View>
+    </View>
+    <View
+      pointerEvents="none"
+      style={
+        Object {
+          "opacity": 0,
+        }
+      }
+    >
+      <View
+        accessibilityState={
+          Object {
+            "disabled": false,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "elevation": 2,
+            "opacity": 1,
+            "shadowColor": "#FFFFFF",
+            "shadowOffset": Object {
+              "height": 0,
+              "width": 0,
+            },
+            "shadowOpacity": 0.25,
+            "shadowRadius": 8,
+          }
+        }
+      >
+        <BVLinearGradient
+          colors={
+            Array [
+              4278754931,
+              4278251938,
+            ]
+          }
+          endPoint={
+            Object {
+              "x": 1,
+              "y": 0,
+            }
+          }
+          locations={null}
+          startPoint={
+            Object {
+              "x": 0,
+              "y": 0,
+            }
+          }
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(255, 255, 255, 0)",
+                "borderRadius": 6,
+                "borderWidth": 0,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "minHeight": 67,
+                "minWidth": 202,
+              },
+              Object {
+                "alignSelf": "auto",
+                "marginBottom": 22,
+                "marginLeft": 22,
+                "marginRight": 22,
+                "marginTop": 22,
+                "opacity": 1,
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+              },
+              Object {
+                "borderRadius": 6,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+              },
+            ]
+          }
+        >
+          <Text
+            adjustsFontSizeToFit={true}
+            minimumFontScale={0.75}
+            numberOfLines={1}
+            style={
+              Object {
+                "color": "#1b2f3b",
+                "fontFamily": "Quicksand-Medium",
+                "fontSize": 22,
+                "marginHorizontal": 0,
+                "paddingBottom": 11,
+                "paddingLeft": 17,
+                "paddingRight": 17,
+                "paddingTop": 11,
+                "textShadowColor": "#000000",
+                "textShadowOffset": Object {
+                  "height": 0,
+                  "width": 0,
+                },
+                "textShadowRadius": 0,
+              }
+            }
+          >
+            Accept
+          </Text>
+        </BVLinearGradient>
+      </View>
+    </View>
+    <View
+      accessibilityState={
+        Object {
+          "disabled": false,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "elevation": 0,
+          "opacity": 1,
+          "shadowColor": "#000000",
+          "shadowOffset": Object {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        }
+      }
+    >
+      <BVLinearGradient
+        colors={
+          Array [
+            16777215,
+            16777215,
+          ]
+        }
+        endPoint={
+          Object {
+            "x": 1,
+            "y": 1,
+          }
+        }
+        locations={null}
+        startPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "borderColor": "rgba(255, 255, 255, 0)",
+              "borderRadius": 6,
+              "borderWidth": 0,
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "minHeight": 67,
+              "minWidth": 202,
+            },
+            Object {
+              "alignSelf": "auto",
+              "marginBottom": 22,
+              "marginLeft": 22,
+              "marginRight": 22,
+              "marginTop": 0,
+              "opacity": 1,
+              "paddingBottom": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 0,
+            },
+            Object {
+              "borderRadius": 6,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+            },
+          ]
+        }
+      >
+        <Text
+          adjustsFontSizeToFit={true}
+          minimumFontScale={0.75}
+          numberOfLines={1}
+          style={
+            Object {
+              "color": "#00f1a2",
+              "fontFamily": "Quicksand-Regular",
+              "fontSize": 22,
+              "marginHorizontal": 0,
+              "paddingBottom": 11,
+              "paddingLeft": 17,
+              "paddingRight": 17,
+              "paddingTop": 11,
+            }
+          }
+        >
+          Cancel
+        </Text>
+      </BVLinearGradient>
+    </View>
+  </View>
+</BVLinearGradient>
 `;

--- a/src/util/fake/FakeProviders.tsx
+++ b/src/util/fake/FakeProviders.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { applyMiddleware, createStore } from 'redux'
+import thunk from 'redux-thunk'
+
+import { rootReducer, RootState } from '../../reducers/RootReducer'
+
+type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>
+    }
+  : T
+
+export type FakeState = DeepPartial<RootState>
+
+interface Props {
+  children: React.ReactNode
+  initialState?: FakeState
+}
+
+export function FakeProviders(props: Props) {
+  const { children, initialState = {} } = props
+
+  const store = React.useMemo(() => createStore(rootReducer, initialState as any, applyMiddleware(thunk)), [initialState])
+  return <Provider store={store}>{children}</Provider>
+}

--- a/src/util/fake/fakeRootState.ts
+++ b/src/util/fake/fakeRootState.ts
@@ -1,4 +1,6 @@
-export const fakeRootState = {
+import { FakeState } from './FakeProviders'
+
+export const fakeRootState: FakeState = {
   contacts: [
     {
       jobTitle: '',


### PR DESCRIPTION
This PR only edits unit tests, not run-time code.

It creates a new `FakeProvider` component that is responsible for providing a Redux store to test components. It takes an optional initial state prop, which lets us get some type-safety on these fake initial states.

In the future, this component will also provide a place to mount other context providers, such as `SafeAreaProvider`.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204095781890178