### PR TITLE
Disable the xanpool PayNow buy/sell plugins for Singapore

### DIFF
--- a/src/constants/plugins/buyPluginList.json
+++ b/src/constants/plugins/buyPluginList.json
@@ -512,7 +512,6 @@
     "title": "PayNow",
     "partnerIconPath": "xanpool-logo.png",
     "forCountries": [
-      "SG"
     ],
     "paymentTypeLogoKey": "paynow",
     "deepQuery": {

--- a/src/constants/plugins/sellPluginList.json
+++ b/src/constants/plugins/sellPluginList.json
@@ -507,7 +507,6 @@
     "title": "PayNow",
     "partnerIconPath": "xanpool-logo.png",
     "forCountries": [
-      "SG"
     ],
     "paymentTypeLogoKey": "paynow",
     "deepQuery": {


### PR DESCRIPTION
### CHANGELOG

- Disable buy/sell via XanPool PayNow for Singapore countries

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204035151622698