### PR TITLE
Fix the log upload regexp

### DIFF
--- a/src/components/modals/LogsModal.tsx
+++ b/src/components/modals/LogsModal.tsx
@@ -18,7 +18,7 @@ interface Props {
   logs: MultiLogOutput
 }
 
-const SENSITIVE_KEY_REGEX = /(allKeys|displayPrivateSeed|displayPublicSeed|otpKey|loginKey|recoveryKey|dataKey|syncKey)/g
+const SENSITIVE_KEY_REGEX = /"(?:allKeys|displayPrivateSeed|displayPublicSeed|otpKey|loginKey|recoveryKey|dataKey|syncKey)\\*"/
 
 export const LogsModal = (props: Props) => {
   const { bridge, logs } = props

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -410,7 +410,8 @@ const strings = {
   settings_modal_send_logs_success: 'Logs have been sent',
   settings_modal_send_logs_failure: 'Sending logs has failed',
   settings_modal_share_logs_failure: 'Sharing logs has failed',
-  settings_modal_send_unsafe: 'These logs appear to contain sensitive information, so it is not safe to send them to Edge servers.',
+  settings_modal_send_unsafe:
+    'These logs appear to contain sensitive information, such as private keys and addresses, that could result in the loss of funds. Therefore, it is not safe to send these logs to Edge servers.',
   settings_modal_send_logs_label: 'Type Notes Here',
   settings_options_title_cap: 'Options',
   settings_seconds: 'Second(s)',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -348,7 +348,7 @@
   "settings_modal_send_logs_success": "Logs have been sent",
   "settings_modal_send_logs_failure": "Sending logs has failed",
   "settings_modal_share_logs_failure": "Sharing logs has failed",
-  "settings_modal_send_unsafe": "These logs appear to contain sensitive information, so it is not safe to send them to Edge servers.",
+  "settings_modal_send_unsafe": "These logs appear to contain sensitive information, such as private keys and addresses, that could result in the loss of funds. Therefore, it is not safe to send these logs to Edge servers.",
   "settings_modal_send_logs_label": "Type Notes Here",
   "settings_options_title_cap": "Options",
   "settings_seconds": "Second(s)",


### PR DESCRIPTION
### CHANGELOG

- Only match sensitive words surrounded by quotes (and maybe slashes). So `"loginKey"` or `"loginKey\\\\"` would match, but not `loginKey`.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204108903827493