### PR TITLE
Initial Maestro Q/A tests & common utility flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ buck-out/
 
 # CocoaPods
 /ios/Pods/
+
+# Maestro
+/maestro/env.js

--- a/maestro/02-launch-login/C310-launch-no-crash.yaml
+++ b/maestro/02-launch-login/C310-launch-no-crash.yaml
@@ -1,0 +1,10 @@
+# Priority: Critical
+# Test ID: C310
+# Title: Launch Edge without crashing
+# Expected Result:
+#   1. User is able to open Edge without crashing
+
+appId: co.edgesecure.app
+---
+- runFlow:
+    file: ../common/launch.yaml

--- a/maestro/02-launch-login/C311-relaunch-no-crash.yaml
+++ b/maestro/02-launch-login/C311-relaunch-no-crash.yaml
@@ -1,0 +1,15 @@
+# Priority: Critical
+# Test ID: C311
+# Title: Verify you're able to Re-Launch/Open App
+# Expected Result:
+#   1. Edge should not crash when relaunching the App
+
+appId: co.edgesecure.app
+---
+- runFlow:
+    file: ../common/launch.yaml
+
+- pressKey: home
+
+- runFlow:
+    file: ../common/launch.yaml

--- a/maestro/02-launch-login/entrypoint.yaml
+++ b/maestro/02-launch-login/entrypoint.yaml
@@ -1,0 +1,6 @@
+appId: co.edgesecure.app
+---
+- runFlow:
+    file: C310-launch-no-crash.yaml
+- runFlow:
+    file: C311-relaunch-no-crash.yaml

--- a/maestro/common/clear-app-data.yaml
+++ b/maestro/common/clear-app-data.yaml
@@ -1,0 +1,6 @@
+# Launches the app just to clear the data and closes it back.
+appId: co.edgesecure.app
+---
+- launchApp:
+    clearState: true
+- stopApp

--- a/maestro/common/close-modal-hack.yaml
+++ b/maestro/common/close-modal-hack.yaml
@@ -1,0 +1,7 @@
+# Hacky close modal utility flow
+# Replace with clicking on the "X" button when it's targetable.
+
+appId: co.edgesecure.app
+---
+- tapOn:
+    point: '0%,50%' # Left side + verticlaly middle edge of the screen

--- a/maestro/common/launch-cleared.yaml
+++ b/maestro/common/launch-cleared.yaml
@@ -1,0 +1,9 @@
+# Launches the app with a cleared cache, and waits for the Edge logo to appear.
+appId: co.edgesecure.app
+---
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible: 'Edge Logo'
+    timeout: 30000
+- assertNotVisible: 'Oops!'

--- a/maestro/common/launch.yaml
+++ b/maestro/common/launch.yaml
@@ -1,0 +1,8 @@
+# Launches the app and waits for the Edge logo to appear.
+appId: co.edgesecure.app
+---
+- launchApp
+- extendedWaitUntil:
+    visible: 'Edge Logo'
+    timeout: 30000
+- assertNotVisible: 'Oops!'

--- a/maestro/entrypoint.yaml
+++ b/maestro/entrypoint.yaml
@@ -1,0 +1,6 @@
+appId: co.edgesecure.app
+---
+- runFlow:
+    file: common/clear-app-data.yaml
+- runFlow:
+    file: 02-launch-login/entrypoint.yaml

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint": "eslint .",
     "localize": "node -r sucrase/register ./scripts/localizeLanguage.ts; git add ./src/locales/strings",
     "logging-server": "node -r sucrase/register scripts/loggingServer.ts",
+    "maestro": "(cd maestro && maestro test entrypoint.yaml)",
     "copy-checkpoints": "cp -r node_modules/edge-currency-accountbased/android/src/main/assets/saplingtree/mainnet ios/Pods/ZcashLightClientKit/Sources/ZcashLightClientKit/Resources/saplingtree-checkpoints && cp -r node_modules/edge-currency-accountbased/android/src/main/assets/piratesaplingtree/mainnet ios/Pods/PirateLightClientKit/Sources/PirateLightClientKit/Resources/piratesaplingtree-checkpoints",
     "precommit": "npm run localize && lint-staged && tsc && npm test",
     "prepare.ios": "(cd ios; pod repo update; pod install) && npm run copy-checkpoints",


### PR DESCRIPTION
The following Maestro Q/A automation tests are added:
| Name 	| Expected Result 	|
|---	|---	|
| C310-launch-no-crash.yaml 	| User is able to open Edge without crashing 	|
| C311-relaunch-no-crash.yaml 	| Edge should not crash when relaunching the App 	|
| ~C314-login-no-2fa.yaml~ 	| ~User is able to login with a valid Username and Password without 2FA or IP2FA blocked.~ 	|
| ~C431-create-account.yaml~ 	| ~Tapping "Create" takes user to new Wallet List Scene with: BTC, ETH, LTC, BCH, DASH.~ 	|
| ~C753-login-2fa.yaml~ 	| ~User is able to login with a valid Username + Password + Backup Code~ 	|

EDIT: The final three tests in the above table have been removed from this PR as they require refactoring due to UI changes. 

Additionally this PR sets up the:
- `./maestro` subfolder
- `./maestro/env.js` account credential store (added to `.gitignore`)
- primary `entrypoint.yaml` with subfolders used to group tests, each having their own `entrypoint.yaml` (currently only `./maestro/02-launch-login/`)

<video src="https://user-images.githubusercontent.com/4023066/223303035-05f0ecd9-14f6-4aa6-9cc0-07f719ec3c1f.mp4" width="500"></video>

### CHANGELOG

### Dependencies

### Requirements

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [x] Tested on large-screen device (tablet)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203878358693337