### PR TITLE
Fix back button for guiPluginEnterAmount in the EdgeBuyTabScreen

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -785,7 +785,6 @@ const EdgeBuyTabScreen = () => {
         name="guiPluginEnterAmount"
         component={FiatPluginEnterAmountScene}
         options={{
-          headerLeft: () => <PluginBackButton />,
           headerRight: () => null
         }}
       />


### PR DESCRIPTION
### CHANGELOG

fix - Back button functionality in some Buy scenes

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204190490723666