### PR TITLE
Fix the loan manager to work around suck wallets

### DIFF
--- a/src/controllers/loan-manager/redux/actions.ts
+++ b/src/controllers/loan-manager/redux/actions.ts
@@ -166,7 +166,7 @@ export function resyncLoanAccounts(account: EdgeAccount): ThunkAction<Promise<vo
     const typeHack: any = Object.values(borrowPluginMap)
     const borrowPlugins: BorrowPlugin[] = typeHack
 
-    const walletIds = Object.keys(account.currencyWallets)
+    const walletIds = account.activeWalletIds
 
     dispatch({
       type: 'LOAN_MANAGER/SET_SYNC_RATIO',


### PR DESCRIPTION
### CHANGELOG

- fixed: Allow the loan dashboard scene to appear correctly, even if the account has stuck-spinning wallets.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204200309083389