### PR TITLE
Implement `wcRequestResponse` from the Ethereum plugin engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "detect-bundler": "^1.1.0",
     "disklet": "^0.5.2",
     "edge-core-js": "^0.19.48",
-    "edge-currency-accountbased": "^0.22.21",
+    "edge-currency-accountbased": "^0.23.0",
     "edge-currency-monero": "^0.5.5",
     "edge-currency-plugins": "^1.3.6",
     "edge-exchange-plugins": "^0.17.7",

--- a/src/components/navigation/FlashNotification.tsx
+++ b/src/components/navigation/FlashNotification.tsx
@@ -10,7 +10,7 @@ import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 interface Props {
   bridge: AirshipBridge<void>
   message: string
-  onPress: () => void
+  onPress?: () => void
 }
 
 export function FlashNotification(props: Props) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1712,10 +1712,9 @@
     randombytes "^2.1.0"
     text-encoding "0.7.0"
 
-"@fioprotocol/fiosdk@^1.5.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@fioprotocol/fiosdk/-/fiosdk-1.7.0.tgz#699c47a87e797eac8df3563ac99760ab69a3e827"
-  integrity sha512-9nHH2SL4FExwFVRssl8t9s3RPIMTEM/xcTWZapL95HTXTmBgzmAty4infatDdkXNfX3eROYHLGu2K8lQRkZQvQ==
+"@fioprotocol/fiosdk@git+https://github.com/peachbits/fiosdk_typescript.git#d04449fff9f9b8c1487359a5b6bf64b7b53d0b6b":
+  version "1.8.0"
+  resolved "git+https://github.com/peachbits/fiosdk_typescript.git#d04449fff9f9b8c1487359a5b6bf64b7b53d0b6b"
   dependencies:
     "@fioprotocol/fiojs" "1.0.1"
     "@types/text-encoding" "0.0.35"
@@ -7792,15 +7791,15 @@ edge-core-js@^0.19.37, edge-core-js@^0.19.48:
     yaob "^0.3.9"
     yavent "^0.1.3"
 
-edge-currency-accountbased@^0.22.21:
-  version "0.22.21"
-  resolved "https://registry.yarnpkg.com/edge-currency-accountbased/-/edge-currency-accountbased-0.22.21.tgz#b497247cc107da25ef60b8d860c7c56d027f5563"
-  integrity sha512-q3clIJRF6Zcyuh2kncyumnvULF1rsuXy1MrFY3YaCeLhjMtF9uOIGZh8mxWKW3EsG1NHWbp/8txObCN5JYX1Jg==
+edge-currency-accountbased@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/edge-currency-accountbased/-/edge-currency-accountbased-0.23.0.tgz#6df8b16b1b17167d49eb29968bb1793e63ff5ee2"
+  integrity sha512-s/Hhr+1uvDX+uyIcHPQ8CNjFzK3AUwLm4tSf4cv1dT5/vwdOcUHXp4A5zGNzjMmVs0xVLN4lT+6vkMJWsdhnoQ==
   dependencies:
     "@binance-chain/javascript-sdk" "^4.2.0"
     "@ethereumjs/common" "^2.4.0"
     "@ethereumjs/tx" "^3.3.0"
-    "@fioprotocol/fiosdk" "^1.5.0"
+    "@fioprotocol/fiosdk" "https://github.com/peachbits/fiosdk_typescript.git#d04449fff9f9b8c1487359a5b6bf64b7b53d0b6b"
     "@greymass/eosio" "^0.6.8"
     "@greymass/eosio-resources" "^0.7.0"
     "@hashgraph/sdk" "^1.1.9"
@@ -9014,9 +9013,9 @@ eyes@^0.1.8:
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
 
-"eztz.js@https://github.com/EdgeApp/eztz.git#edge-fixes":
+"eztz.js@git+https://github.com/EdgeApp/eztz.git#edge-fixes":
   version "0.0.1"
-  resolved "https://github.com/EdgeApp/eztz.git#eefa603586810c3d62f852e7f28cfe57c523b7db"
+  resolved "git+https://github.com/EdgeApp/eztz.git#eefa603586810c3d62f852e7f28cfe57c523b7db"
   dependencies:
     bignumber.js "^7.2.1"
     bip39 "^3.0.2"


### PR DESCRIPTION
### CHANGELOG

- changed: Implement Ethereum WalletConnect response handling in the GUI over the plugin using the updated WalletConnect API provided by the plugin.

### Dependencies

- https://github.com/EdgeApp/edge-currency-accountbased/pull/533

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204222679938644