### PR TITLE
William/fix fiat deep links

### DIFF
--- a/src/__tests__/DeepLink.test.ts
+++ b/src/__tests__/DeepLink.test.ts
@@ -184,66 +184,39 @@ describe('parseDeepLink', function () {
 
   describe('plugin', function () {
     makeLinkTests({
-      'edge://plugin/simplex/buy///rabbit/hole?param=alice': {
+      'edge://plugin/simplex/rabbit/hole?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
-        providerId: '',
-        direction: 'buy',
-        paymentType: '',
         path: '/rabbit/hole',
         query: { param: 'alice' }
       },
-      'edge://plugin/simplex/buy?param=alice': {
+      'edge://plugin/simplex/?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
-        providerId: '',
-        direction: 'buy',
-        paymentType: '',
-        path: '',
+        path: '/',
         query: { param: 'alice' }
       },
       'edge://plugin/simplex?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
-        providerId: '',
-        direction: 'buy',
-        paymentType: '',
         path: '',
         query: { param: 'alice' }
       },
       'edge://plugin/simplex': {
         type: 'plugin',
         pluginId: 'simplex',
-        providerId: '',
-        direction: 'buy',
-        paymentType: '',
         path: '',
         query: {}
       },
-      'https://deep.edge.app/plugin/simplex/buy///rabbit/hole?param=alice': {
+      'https://deep.edge.app/plugin/simplex/rabbit/hole?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
-        providerId: '',
-        direction: 'buy',
-        paymentType: '',
         path: '/rabbit/hole',
         query: { param: 'alice' }
       },
-      'edge-ret://plugins/simplex/buy///rabbit/hole?param=alice': {
+      'edge-ret://plugins/simplex/rabbit/hole?param=alice': {
         type: 'plugin',
         pluginId: 'simplex',
-        providerId: '',
-        direction: 'buy',
-        paymentType: '',
-        path: '/rabbit/hole',
-        query: { param: 'alice' }
-      },
-      'https://deep.edge.app/plugin/creditcard/buy/moonpay/applepay/rabbit/hole?param=alice': {
-        type: 'plugin',
-        pluginId: 'creditcard',
-        providerId: 'moonpay',
-        direction: 'buy',
-        paymentType: 'applepay',
         path: '/rabbit/hole',
         query: { param: 'alice' }
       }

--- a/src/__tests__/DeepLink.test.ts
+++ b/src/__tests__/DeepLink.test.ts
@@ -223,6 +223,18 @@ describe('parseDeepLink', function () {
     })
   })
 
+  describe('fiatPlugin', function () {
+    makeLinkTests({
+      'https://deep.edge.app/plugin/creditcard/buy/moonpay/applepay/rabbit/hole?param=alice': {
+        type: 'fiatPlugin',
+        pluginId: 'creditcard',
+        providerId: 'moonpay',
+        direction: 'buy',
+        paymentType: 'applepay'
+      }
+    })
+  })
+
   describe('promotion', function () {
     makeLinkTests({
       'edge://promotion/bob': {

--- a/src/actions/DeepLinkingActions.ts
+++ b/src/actions/DeepLinkingActions.ts
@@ -5,6 +5,7 @@ import { pickWallet } from '../components/modals/WalletListModal'
 import { showError, showToast } from '../components/services/AirshipInstance'
 import { guiPlugins } from '../constants/plugins/GuiPlugins'
 import { lstrings } from '../locales/strings'
+import { executePlugin } from '../plugins/gui/fiatPlugin'
 import { DeepLink } from '../types/DeepLinkTypes'
 import { Dispatch, RootState, ThunkAction } from '../types/reduxTypes'
 import { NavigationBase } from '../types/routerTypes'
@@ -77,14 +78,49 @@ export async function handleLink(navigation: NavigationBase, dispatch: Dispatch,
     case 'plugin': {
       const { pluginId, path, query } = link
       const plugin = guiPlugins[pluginId]
-      if (pluginId === 'custom' || plugin == null || plugin.pluginId == null) {
-        showError(new Error(`No plugin named ${pluginId} exists`))
+      if (plugin?.pluginId == null || plugin?.pluginId === 'custom') {
+        showError(`No plugin named "${pluginId}" exists`)
         return true
       }
+
+      // Check the disabled status:
+      if (state.ui.exchangeInfo.buy.disablePlugins[pluginId] === true || state.ui.exchangeInfo.sell.disablePlugins[pluginId] === true) {
+        showError(`Plugin "${pluginId}" is disabled`)
+        return true
+      }
+
       navigation.push('pluginView', {
         plugin,
         deepPath: path,
         deepQuery: query
+      })
+      return true
+    }
+
+    case 'fiatPlugin': {
+      const { direction = 'buy', paymentType, pluginId, providerId } = link
+      const plugin = guiPlugins[pluginId]
+      if (plugin?.nativePlugin == null) {
+        showError(new Error(`No fiat plugin named "${pluginId}" exists`))
+        return true
+      }
+
+      // Check the disabled status:
+      const disableProviders = state.ui.exchangeInfo[direction].disablePlugins[pluginId] ?? {}
+      if (disableProviders === true) {
+        showError(`Plugin "${pluginId}" is disabled`)
+        return true
+      }
+
+      await executePlugin({
+        account,
+        disablePlugins: disableProviders,
+        guiPlugin: plugin,
+        direction,
+        regionCode: { countryCode: state.ui.settings.countryCode },
+        paymentType,
+        providerId,
+        navigation
       })
       return true
     }

--- a/src/actions/DeepLinkingActions.ts
+++ b/src/actions/DeepLinkingActions.ts
@@ -5,7 +5,6 @@ import { pickWallet } from '../components/modals/WalletListModal'
 import { showError, showToast } from '../components/services/AirshipInstance'
 import { guiPlugins } from '../constants/plugins/GuiPlugins'
 import { lstrings } from '../locales/strings'
-import { asFiatPaymentType } from '../plugins/gui/fiatPluginTypes'
 import { DeepLink } from '../types/DeepLinkTypes'
 import { Dispatch, RootState, ThunkAction } from '../types/reduxTypes'
 import { NavigationBase } from '../types/routerTypes'
@@ -76,23 +75,17 @@ export async function handleLink(navigation: NavigationBase, dispatch: Dispatch,
       return false
 
     case 'plugin': {
-      const { direction, paymentType: pType, pluginId, providerId, path, query } = link
+      const { pluginId, path, query } = link
       const plugin = guiPlugins[pluginId]
       if (pluginId === 'custom' || plugin == null || plugin.pluginId == null) {
         showError(new Error(`No plugin named ${pluginId} exists`))
         return true
       }
-
-      const paymentType = pType === '' ? undefined : asFiatPaymentType(pType)
-
-      if (direction == null) return true
-      if (direction === 'buy') {
-        navigation.navigate('pluginListBuy', { direction: 'buy', pluginId, providerId, deepPath: path, deepQuery: query, paymentType })
-      } else if (direction === 'sell') {
-        navigation.navigate('pluginListSell', { direction: 'sell', pluginId, providerId, deepPath: path, deepQuery: query, paymentType })
-      } else {
-        throw new Error(`Invalid plugin direction ${direction}`)
-      }
+      navigation.push('pluginView', {
+        plugin,
+        deepPath: path,
+        deepQuery: query
+      })
       return true
     }
 

--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -236,10 +236,9 @@ class GuiPluginList extends React.PureComponent<Props, State> {
     const plugin = guiPlugins[pluginId]
 
     // Grab a custom URI if necessary:
-    let { deepPath } = listRow
+    let { deepPath = undefined } = listRow
     if (pluginId === 'custom') {
       const { developerUri } = this.state
-      // @ts-expect-error
       deepPath = await Airship.show<string | undefined>(bridge => (
         <TextInputModal
           autoCorrect={false}
@@ -264,18 +263,19 @@ class GuiPluginList extends React.PureComponent<Props, State> {
 
     const direction = this.getSceneDirection()
     if (plugin.nativePlugin != null) {
-      const filteredDisablePlugins: { [pluginId: string]: true } = {}
-      for (const [key, value] of Object.entries(disablePlugins[plugin.pluginId] ?? {})) {
-        if (value === true) filteredDisablePlugins[key] = true
-      }
+      const disableProviders = disablePlugins[pluginId]
+
+      // This should not happen, since we don't show disabled rows:
+      if (disableProviders === true) return
+
       await executePlugin({
-        disablePlugins: filteredDisablePlugins,
-        guiPlugin: plugin,
+        account,
         direction,
-        regionCode: { countryCode },
-        paymentType,
+        disablePlugins: disableProviders,
+        guiPlugin: plugin,
         navigation,
-        account
+        paymentType,
+        regionCode: { countryCode }
       })
     } else {
       // Launch!

--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -269,11 +269,6 @@ class GuiPluginList extends React.PureComponent<Props, State> {
     const { countryCode, disablePlugins, navigation, account } = this.props
     const plugin = guiPlugins[pluginId]
 
-    // Add countryCode
-    if (plugin.needsCountryCode) {
-      deepQuery.countryCode = countryCode
-    }
-
     // Grab a custom URI if necessary:
     if (pluginId === 'custom') {
       const { developerUri } = this.state

--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -9,7 +9,7 @@ import FastImage from 'react-native-fast-image'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { sprintf } from 'sprintf-js'
 
-import { NestedPluginMap } from '../../actions/ExchangeInfoActions'
+import { NestedDisableMap } from '../../actions/ExchangeInfoActions'
 import { updateOneSetting } from '../../actions/SettingsActions'
 import { FLAG_LOGO_URL } from '../../constants/CdnConstants'
 import { COUNTRY_CODES } from '../../constants/CountryConstants'
@@ -92,7 +92,7 @@ interface StateProps {
   coreDisklet: Disklet
   countryCode: string
   developerModeOn: boolean
-  disablePlugins: NestedPluginMap
+  disablePlugins: NestedDisableMap
 }
 
 interface DispatchProps {

--- a/src/components/scenes/GuiPluginViewScene.tsx
+++ b/src/components/scenes/GuiPluginViewScene.tsx
@@ -9,8 +9,10 @@ import { methodCleaners } from '../../controllers/edgeProvider/types/edgeProvide
 import { asRpcCall, rpcErrorCodes, RpcReturn } from '../../controllers/edgeProvider/types/jsonRpcCleaners'
 import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { useHandler } from '../../hooks/useHandler'
+import { GuiPlugin } from '../../types/GuiPluginTypes'
 import { useDispatch, useSelector } from '../../types/reactRedux'
 import { NavigationBase, RouteProp } from '../../types/routerTypes'
+import { UriQueryMap } from '../../types/WebTypes'
 import { getTokenId } from '../../util/CurrencyInfoHelpers'
 import { makePluginUri } from '../../util/GuiPluginTools'
 import { bestOfPlugins } from '../../util/ReferralHelpers'
@@ -18,6 +20,15 @@ import { SceneWrapper } from '../common/SceneWrapper'
 import { setPluginScene } from '../navigation/GuiPluginBackButton'
 import { showToast } from '../services/AirshipInstance'
 import { requestPermissionOnSettings } from '../services/PermissionsManager'
+
+export interface PluginViewParams {
+  // The GUI plugin we are showing the user:
+  plugin: GuiPlugin
+
+  // Set these to add stuff to the plugin URI:
+  deepPath?: string
+  deepQuery?: UriQueryMap
+}
 
 interface Props {
   navigation: NavigationBase
@@ -31,7 +42,15 @@ interface WebViewEvent {
 export function GuiPluginViewScene(props: Props): JSX.Element {
   const { route, navigation } = props
   const { deepPath, deepQuery, plugin } = route.params
-  const { displayName, mandatoryPermissions = false, originWhitelist = ['file://*', 'https://*', 'http://*', 'edge://*'], permissions = [], pluginId } = plugin
+
+  const {
+    displayName,
+    mandatoryPermissions = false,
+    needsCountryCode = false,
+    originWhitelist = ['file://*', 'https://*', 'http://*', 'edge://*'],
+    permissions = [],
+    pluginId
+  } = plugin
 
   // Redux stuff:
   const dispatch = useDispatch()
@@ -41,6 +60,7 @@ export function GuiPluginViewScene(props: Props): JSX.Element {
   const accountReferral = useSelector(state => state.account.accountReferral)
   const selectedWalletId = useSelector(state => state.ui.wallets.selectedWalletId)
   const selectedCurrencyCode = useSelector(state => state.ui.wallets.selectedCurrencyCode)
+  const countryCode = useSelector(state => state.ui.settings.countryCode)
 
   // Get the promo information:
   const { promoCode, promoMessage } = React.useMemo(() => {
@@ -107,7 +127,11 @@ export function GuiPluginViewScene(props: Props): JSX.Element {
       reloadWebView,
       selectedTokenId,
       selectedWallet,
-      deepLink: { deepPath, deepQuery, promoCode }
+      deepLink: {
+        deepPath,
+        deepQuery: needsCountryCode ? { ...deepQuery, countryCode } : deepQuery,
+        promoCode
+      }
     })
   })
 

--- a/src/plugins/gui/fiatPlugin.tsx
+++ b/src/plugins/gui/fiatPlugin.tsx
@@ -5,7 +5,7 @@ import { Platform } from 'react-native'
 import { CustomTabs } from 'react-native-custom-tabs'
 import SafariView from 'react-native-safari-view'
 
-import { DisablePluginMap } from '../../actions/ExchangeInfoActions'
+import { DisablePluginMap, NestedDisableMap } from '../../actions/ExchangeInfoActions'
 import { RadioListModal } from '../../components/modals/RadioListModal'
 import { WalletListModal, WalletListResult } from '../../components/modals/WalletListModal'
 import { Airship, showError, showToastSpinner } from '../../components/services/AirshipInstance'
@@ -23,9 +23,9 @@ import {
 import { createStore } from './pluginUtils'
 
 export const executePlugin = async (params: {
-  disablePlugins: DisablePluginMap
   account: EdgeAccount
   direction: 'buy' | 'sell'
+  disablePlugins: NestedDisableMap
   guiPlugin: GuiPlugin
   navigation: NavigationBase
   paymentType?: FiatPaymentType
@@ -86,7 +86,15 @@ export const executePlugin = async (params: {
     throw new Error('executePlugin: missing nativePlugin')
   }
 
-  const plugin = await guiPlugin.nativePlugin({ disablePlugins, showUi, account })
+  const filteredDisablePlugins: DisablePluginMap = {}
+  for (const key of Object.keys(disablePlugins)) {
+    if (disablePlugins[key] === true) filteredDisablePlugins[key] = true
+  }
+  const plugin = await guiPlugin.nativePlugin({
+    disablePlugins: filteredDisablePlugins,
+    showUi,
+    account
+  })
   if (plugin == null) {
     throw new Error(`pluginId ${pluginId} not found`)
   }

--- a/src/plugins/gui/fiatPlugin.tsx
+++ b/src/plugins/gui/fiatPlugin.tsx
@@ -10,7 +10,7 @@ import { RadioListModal } from '../../components/modals/RadioListModal'
 import { WalletListModal, WalletListResult } from '../../components/modals/WalletListModal'
 import { Airship, showError, showToastSpinner } from '../../components/services/AirshipInstance'
 import { GuiPlugin } from '../../types/GuiPluginTypes'
-import { NavigationProp } from '../../types/routerTypes'
+import { NavigationBase } from '../../types/routerTypes'
 import { logEvent } from '../../util/tracking'
 import {
   FiatPaymentType,
@@ -27,7 +27,7 @@ export const executePlugin = async (params: {
   account: EdgeAccount
   direction: 'buy' | 'sell'
   guiPlugin: GuiPlugin
-  navigation: NavigationProp<'pluginListBuy'> | NavigationProp<'pluginListSell'>
+  navigation: NavigationBase
   paymentType?: FiatPaymentType
   providerId?: string
   regionCode: FiatPluginRegionCode

--- a/src/plugins/gui/fiatPluginTypes.ts
+++ b/src/plugins/gui/fiatPluginTypes.ts
@@ -7,7 +7,6 @@ import { EnterAmountPoweredBy } from './scenes/EnterAmountScene'
 
 export const asFiatPaymentType = asValue('credit', 'applepay', 'googlepay', 'iach')
 export type FiatPaymentType = ReturnType<typeof asFiatPaymentType>
-export type FiatPaymentTypes = FiatPaymentType[]
 
 export interface FiatPluginGetMethodsResponse {
   setStatusText: (params: { statusText: string; options?: { textType?: 'warning' | 'error' } }) => void
@@ -72,7 +71,7 @@ export interface FiatPluginRegionCode {
 }
 export interface FiatPluginStartParams {
   isBuy: boolean
-  paymentTypes: FiatPaymentTypes
+  paymentTypes: FiatPaymentType[]
   regionCode: FiatPluginRegionCode
   providerId?: string
 }

--- a/src/plugins/gui/fiatPluginTypes.ts
+++ b/src/plugins/gui/fiatPluginTypes.ts
@@ -5,6 +5,9 @@ import { DisablePluginMap } from '../../actions/ExchangeInfoActions'
 import { EdgeTokenId } from '../../types/types'
 import { EnterAmountPoweredBy } from './scenes/EnterAmountScene'
 
+export const asFiatDirection = asValue('buy', 'sell')
+export type FiatDirection = ReturnType<typeof asFiatDirection>
+
 export const asFiatPaymentType = asValue('credit', 'applepay', 'googlepay', 'iach')
 export type FiatPaymentType = ReturnType<typeof asFiatPaymentType>
 

--- a/src/plugins/gui/fiatProviderTypes.ts
+++ b/src/plugins/gui/fiatProviderTypes.ts
@@ -1,7 +1,7 @@
 import { EdgeCurrencyWallet } from 'edge-core-js'
 
 import { EdgeTokenId } from '../../types/types'
-import { FiatPaymentTypes, FiatPluginRegionCode, FiatPluginUi } from './fiatPluginTypes'
+import { FiatPaymentType, FiatPluginRegionCode, FiatPluginUi } from './fiatPluginTypes'
 
 export interface FiatProviderApproveQuoteParams {
   showUi: FiatPluginUi
@@ -20,7 +20,7 @@ export interface FiatProviderQuote {
   readonly direction: 'buy' | 'sell'
   readonly expirationDate?: Date
   readonly regionCode: FiatPluginRegionCode
-  readonly paymentTypes: FiatPaymentTypes
+  readonly paymentTypes: FiatPaymentType[]
 
   approveQuote: (params: FiatProviderApproveQuoteParams) => Promise<void>
   closeQuote: () => Promise<void>
@@ -64,7 +64,7 @@ export interface FiatProviderGetQuoteParams {
   amountType: 'fiat' | 'crypto'
   direction: 'buy' | 'sell'
   regionCode: FiatPluginRegionCode
-  paymentTypes: FiatPaymentTypes
+  paymentTypes: FiatPaymentType[]
 }
 
 export interface FiatProviderStore {

--- a/src/types/DeepLinkTypes.ts
+++ b/src/types/DeepLinkTypes.ts
@@ -59,9 +59,6 @@ export interface PasswordRecoveryLink {
 export interface PluginLink {
   type: 'plugin'
   pluginId: string
-  direction: string
-  providerId: string
-  paymentType: string
   path: string
   query: { [key: string]: string | null }
 }

--- a/src/types/DeepLinkTypes.ts
+++ b/src/types/DeepLinkTypes.ts
@@ -34,6 +34,7 @@
  * protocols like `bitcoin:`, which we just pass through as "other".
  */
 import { PriceChangePayload } from '../controllers/action-queue/types/pushPayloadTypes'
+import { FiatDirection, FiatPaymentType } from '../plugins/gui/fiatPluginTypes'
 import { AppParamList } from './routerTypes'
 
 export interface AztecoLink {
@@ -61,6 +62,14 @@ export interface PluginLink {
   pluginId: string
   path: string
   query: { [key: string]: string | null }
+}
+
+export interface FiatPluginLink {
+  type: 'fiatPlugin'
+  pluginId: string
+  direction?: FiatDirection
+  providerId?: string
+  paymentType?: FiatPaymentType
 }
 
 export interface PromotionLink {
@@ -93,16 +102,17 @@ export interface DevLink {
 
 export type DeepLink =
   | AztecoLink
-  | PaymentProtoLink
+  | DevLink
   | EdgeLoginLink
+  | FiatPluginLink
   | PasswordRecoveryLink
+  | PaymentProtoLink
   | PluginLink
   | PriceChangePayload
   | PromotionLink
   | RequestAddressLink
-  | WalletConnectLink
   | SwapLink
-  | DevLink
+  | WalletConnectLink
   | {
       type: 'other'
       protocol: string // Without the ':'

--- a/src/types/routerTypes.tsx
+++ b/src/types/routerTypes.tsx
@@ -6,6 +6,7 @@ import { InitialRouteName } from 'edge-login-ui-rn'
 import { ConfirmSceneParams } from '../components/scenes/ConfirmScene'
 import { FioCreateHandleProps } from '../components/scenes/Fio/FioCreateHandleScene'
 import { PluginListProps } from '../components/scenes/GuiPluginListScene'
+import { PluginViewParams } from '../components/scenes/GuiPluginViewScene'
 import { LoanManageType } from '../components/scenes/Loans/LoanManageScene'
 import { MigrateWalletItem } from '../components/scenes/MigrateWalletSelectCryptoScene'
 import { SendScene2Params } from '../components/scenes/SendScene2'
@@ -16,7 +17,6 @@ import { BorrowEngine, BorrowPlugin } from '../plugins/borrow-plugins/types'
 import { FiatPluginEnterAmountResponse, FiatPluginGetMethodsResponse } from '../plugins/gui/fiatPluginTypes'
 import { ChangeQuoteRequest, StakePlugin, StakePolicy, StakePosition } from '../plugins/stake-plugins/types'
 import { CoinRankingData } from './coinrankTypes'
-import { GuiPlugin } from './GuiPluginTypes'
 import {
   CreateWalletType,
   EdgeTokenId,
@@ -30,20 +30,10 @@ import {
   TransactionListTx,
   WcConnectionInfo
 } from './types'
-import { UriQueryMap } from './WebTypes'
 
-interface PluginViewParams {
-  // The GUI plugin we are showing the user:
-  plugin: GuiPlugin
-
-  // Set these to add stuff to the plugin URI:
-  deepPath?: string
-  deepQuery?: UriQueryMap
-}
 /**
  * Defines the acceptable route parameters for each scene key.
  */
-
 interface RouteParamList {
   // Top-level router:
   login: {

--- a/src/types/routerTypes.tsx
+++ b/src/types/routerTypes.tsx
@@ -5,7 +5,6 @@ import { InitialRouteName } from 'edge-login-ui-rn'
 
 import { ConfirmSceneParams } from '../components/scenes/ConfirmScene'
 import { FioCreateHandleProps } from '../components/scenes/Fio/FioCreateHandleScene'
-import { PluginListProps } from '../components/scenes/GuiPluginListScene'
 import { PluginViewParams } from '../components/scenes/GuiPluginViewScene'
 import { LoanManageType } from '../components/scenes/Loans/LoanManageScene'
 import { MigrateWalletItem } from '../components/scenes/MigrateWalletSelectCryptoScene'
@@ -259,8 +258,8 @@ interface RouteParamList {
   }
   otpSetup: {}
   passwordRecovery: {}
-  pluginListBuy: PluginListProps
-  pluginListSell: PluginListProps
+  pluginListBuy: {}
+  pluginListSell: {}
   pluginViewBuy: PluginViewParams
   pluginViewSell: PluginViewParams
   pluginView: PluginViewParams

--- a/src/util/DeepLinkParser.ts
+++ b/src/util/DeepLinkParser.ts
@@ -99,10 +99,10 @@ function parseEdgeProtocol(url: URL<string>): DeepLink {
     }
 
     case 'plugin': {
-      const [pluginId, direction = 'buy', providerId = '', paymentType = '', ...deepPath] = pathParts
+      const [pluginId = '', ...deepPath] = pathParts
       const path = deepPath.length !== 0 ? '/' + deepPath.join('/') : ''
       const query = parseQuery(url.query)
-      return { type: 'plugin', direction, paymentType, pluginId, providerId, path, query }
+      return { type: 'plugin', pluginId, path, query }
     }
 
     case 'price-change': {

--- a/src/util/DeepLinkParser.ts
+++ b/src/util/DeepLinkParser.ts
@@ -1,6 +1,8 @@
 import URL from 'url-parse'
 
+import { guiPlugins } from '../constants/plugins/GuiPlugins'
 import { ENV } from '../env'
+import { asFiatDirection, asFiatPaymentType } from '../plugins/gui/fiatPluginTypes'
 import { DeepLink, PromotionLink } from '../types/DeepLinkTypes'
 import { parseQuery, stringifyQuery } from './WebUtils'
 
@@ -99,10 +101,28 @@ function parseEdgeProtocol(url: URL<string>): DeepLink {
     }
 
     case 'plugin': {
-      const [pluginId = '', ...deepPath] = pathParts
-      const path = deepPath.length !== 0 ? '/' + deepPath.join('/') : ''
-      const query = parseQuery(url.query)
-      return { type: 'plugin', pluginId, path, query }
+      const [pluginId, ...deepPath] = pathParts
+
+      // Is this a plugin we know about?
+      const plugin = guiPlugins[pluginId]
+      if (plugin?.nativePlugin == null) {
+        return {
+          type: 'plugin',
+          pluginId,
+          path: stringifyPath(deepPath),
+          query: parseQuery(url.query)
+        }
+      }
+
+      // New-style fiat plugins:
+      const [direction, providerId, paymentType] = deepPath
+      return {
+        type: 'fiatPlugin',
+        pluginId,
+        direction: asFiatDirection(direction),
+        providerId,
+        paymentType: asFiatPaymentType(paymentType)
+      }
     }
 
     case 'price-change': {
@@ -152,6 +172,10 @@ function parseEdgeProtocol(url: URL<string>): DeepLink {
   }
 
   throw new SyntaxError('Unknown deep link format')
+}
+
+function stringifyPath(path: string[]): string {
+  return path.length === 0 ? '' : '/' + path.join('/')
 }
 
 function parseDownloadLink(url: URL<string>): PromotionLink {

--- a/src/util/GuiPluginTools.ts
+++ b/src/util/GuiPluginTools.ts
@@ -1,4 +1,4 @@
-import { NestedPluginMap } from '../actions/ExchangeInfoActions'
+import { NestedDisableMap } from '../actions/ExchangeInfoActions'
 import { GuiPlugin, GuiPluginJson, GuiPluginRow } from '../types/GuiPluginTypes'
 import { UriQueryMap } from '../types/WebTypes'
 import { stringifyQuery } from './WebUtils'
@@ -7,7 +7,7 @@ import { stringifyQuery } from './WebUtils'
  * Helper function to turn a GuiPluginJson into a cooked list.
  * Call `asGuiPluginJson` to clean & validate the input file first.
  */
-export function filterGuiPluginJson(cleanJson: GuiPluginJson, platform: string, countryCode: string, disablePlugins: NestedPluginMap): GuiPluginRow[] {
+export function filterGuiPluginJson(cleanJson: GuiPluginJson, platform: string, countryCode: string, disablePlugins: NestedDisableMap): GuiPluginRow[] {
   // Filter and merge related rows:
   const mergedRows: { [id: string]: GuiPluginRow } = {}
   const sortIndexes: { [id: string]: number } = {}


### PR DESCRIPTION
### CHANGELOG

- fixed: Restore the original "edge://plugin/pluginId" deep link behavior for non-fiat plugins. For fiat plugins, parse the new "edge://plugin/pluginId/direction/provider/paymentType" format.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204331801949563