### PR TITLE
Fix the bottom gap on the transaction list scene

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -703,15 +703,6 @@ const EdgeAppStack = () => {
         }}
       />
       <Stack.Screen
-        name="transactionList"
-        component={TransactionList}
-        listeners={{
-          focus: () => {
-            requestPermission('contacts').catch(showError)
-          }
-        }}
-      />
-      <Stack.Screen
         name="transactionsExport"
         component={TransactionsExportScene}
         options={{

--- a/src/components/scenes/GuiPluginViewScene.tsx
+++ b/src/components/scenes/GuiPluginViewScene.tsx
@@ -190,7 +190,7 @@ export function GuiPluginViewScene(props: Props): JSX.Element {
       : 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1'
 
   return (
-    <SceneWrapper background="theme">
+    <SceneWrapper background="theme" hasTabs={route.name !== 'pluginView'}>
       <WebView
         allowFileAccess
         allowUniversalAccessFromFileURLs

--- a/src/components/scenes/TransactionListScene.tsx
+++ b/src/components/scenes/TransactionListScene.tsx
@@ -214,7 +214,7 @@ class TransactionListComponent extends React.PureComponent<Props, State> {
     const transactions = this.isUnsupported() || reset ? [] : searching ? filteredTransactions : this.props.transactions
     const checkFilteredTransactions = searching && filteredTransactions.length === 0
     return (
-      <SceneWrapper>
+      <SceneWrapper hasTabs>
         {SHOW_FLIP_INPUT_TESTER ? (
           <ExchangedFlipInputTester />
         ) : (


### PR DESCRIPTION
Also remove the second copy, so the scene only exists inside the tab navigator.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204340335884555
  - https://app.asana.com/0/0/1204343630586365