### PR TITLE
Allow fiat deep links to omit elements

### DIFF
--- a/src/actions/DeepLinkingActions.ts
+++ b/src/actions/DeepLinkingActions.ts
@@ -98,7 +98,7 @@ export async function handleLink(navigation: NavigationBase, dispatch: Dispatch,
     }
 
     case 'fiatPlugin': {
-      const { direction = 'buy', paymentType, pluginId, providerId } = link
+      const { direction = 'buy', paymentType = 'credit', pluginId, providerId } = link
       const plugin = guiPlugins[pluginId]
       if (plugin?.nativePlugin == null) {
         showError(new Error(`No fiat plugin named "${pluginId}" exists`))

--- a/src/plugins/gui/fiatPlugin.tsx
+++ b/src/plugins/gui/fiatPlugin.tsx
@@ -25,14 +25,14 @@ import { createStore } from './pluginUtils'
 export const executePlugin = async (params: {
   account: EdgeAccount
   direction: 'buy' | 'sell'
-  disablePlugins: NestedDisableMap
+  disablePlugins?: NestedDisableMap
   guiPlugin: GuiPlugin
   navigation: NavigationBase
   paymentType?: FiatPaymentType
   providerId?: string
   regionCode: FiatPluginRegionCode
 }): Promise<void> => {
-  const { disablePlugins, account, direction, guiPlugin, navigation, paymentType, providerId, regionCode } = params
+  const { disablePlugins = {}, account, direction, guiPlugin, navigation, paymentType, providerId, regionCode } = params
   const { pluginId } = guiPlugin
   const isBuy = direction === 'buy'
 

--- a/src/util/DeepLinkParser.ts
+++ b/src/util/DeepLinkParser.ts
@@ -1,3 +1,4 @@
+import { asOptional } from 'cleaners'
 import URL from 'url-parse'
 
 import { guiPlugins } from '../constants/plugins/GuiPlugins'
@@ -119,9 +120,9 @@ function parseEdgeProtocol(url: URL<string>): DeepLink {
       return {
         type: 'fiatPlugin',
         pluginId,
-        direction: asFiatDirection(direction),
+        direction: asOptional(asFiatDirection)(direction),
         providerId,
-        paymentType: asFiatPaymentType(paymentType)
+        paymentType: asOptional(asFiatPaymentType)(paymentType)
       }
     }
 


### PR DESCRIPTION
I have no idea if this is the right thing or not, but it does clear up the "unsupported asset" error.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204353815854945