### PR TITLE
Respect isAccountBalanceVisible state prop in RequestScene

### DIFF
--- a/src/__tests__/scenes/RequestScene.test.tsx
+++ b/src/__tests__/scenes/RequestScene.test.tsx
@@ -23,6 +23,8 @@ describe('Request', () => {
         theme={getTheme()}
         refreshAllFioAddresses={() => undefined}
         onSelectWallet={(walletId, currencyCode) => undefined}
+        toggleAccountBalanceVisibility={() => undefined}
+        showBalance
       />
     )
 
@@ -50,6 +52,8 @@ describe('Request', () => {
         theme={getTheme()}
         refreshAllFioAddresses={() => undefined}
         onSelectWallet={(walletId, currencyCode) => undefined}
+        toggleAccountBalanceVisibility={() => undefined}
+        showBalance
       />
     )
 

--- a/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
@@ -53,9 +53,13 @@ exports[`Request should render with loaded props 1`] = `
         }
       }
     >
-      <WithTheme(EdgeTextComponent)>
-        You have 0 undefined
-      </WithTheme(EdgeTextComponent)>
+      <TouchableOpacity
+        onPress={[Function]}
+      >
+        <WithTheme(EdgeTextComponent)>
+          You have 0 undefined
+        </WithTheme(EdgeTextComponent)>
+      </TouchableOpacity>
       <WithTheme(EdgeTextComponent)
         style={
           Object {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/90650827/230533181-2ca2a58a-928e-49e2-a354-6aae921804a2.png)

### CHANGELOG

- Hide balance in RequestScene consistently with the rest of the app

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204167844639231