### PR TITLE
Remove NodeJS as tool dependency in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,5 @@
 pipeline {
   agent any
-  tools {
-    nodejs "stable"
-  }
   options {
     timestamps()
     skipDefaultCheckout true


### PR DESCRIPTION
We never use it but instead use the locally installed NVM version specified via the PATH variable.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
