### PR TITLE
Downgrade fresco:animated-gif package

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -218,7 +218,7 @@ dependencies {
     // If your app supports Android versions before Ice Cream Sandwich (API level 14)
     implementation 'com.facebook.fresco:animated-base-support:1.3.0'
     // For animated GIF support
-    implementation 'com.facebook.fresco:animated-gif:2.6.0'
+    implementation 'com.facebook.fresco:animated-gif:2.5.0'
 }
 
 // Run this once to be able to run the application with BUCK


### PR DESCRIPTION
Following the issue tracked [here](https://github.com/facebook/react-native/issues/32884) leads us to resolving the Android image caching issue by downgrading a dependency.

### CHANGELOG

- Fixed: Bug in Android causing incorrect static images/icons to display in various places throughout the app

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204353886812628