### PR TITLE
Add "Private View Key" menu option for Monero wallets

### DIFF
--- a/src/actions/WalletListMenuActions.tsx
+++ b/src/actions/WalletListMenuActions.tsx
@@ -7,6 +7,7 @@ import { ButtonInfo, ButtonsModal } from '../components/modals/ButtonsModal'
 import { RawTextModal } from '../components/modals/RawTextModal'
 import { TextInputModal } from '../components/modals/TextInputModal'
 import { Airship, showError, showToast } from '../components/services/AirshipInstance'
+import { Alert } from '../components/themed/Alert'
 import { ModalMessage } from '../components/themed/ModalParts'
 import { deleteLoanAccount } from '../controllers/loan-manager/redux/actions'
 import { lstrings } from '../locales/strings'
@@ -139,7 +140,7 @@ export function walletListMenuAction(
         dispatch(showSplitWalletModal(walletId, option.replace('split', '')))
       }
     }
-
+    case 'viewPrivateViewKey':
     case 'viewXPub': {
       return (dispatch, getState) => {
         const state = getState()
@@ -157,14 +158,20 @@ export function walletListMenuAction(
         }
         const buttons = xpubExplorer != null ? { copy, link } : { copy }
 
+        const title = switchString === 'viewPrivateViewKey' ? lstrings.fragment_wallets_view_private_view_key : lstrings.fragment_wallets_view_xpub
+
         Airship.show<'copy' | 'link' | undefined>(bridge => (
-          <ButtonsModal
-            bridge={bridge}
-            buttons={buttons as { copy: ButtonInfo; link: ButtonInfo }}
-            closeArrow
-            message={displayPublicSeed ?? ''}
-            title={lstrings.fragment_wallets_view_xpub}
-          />
+          <ButtonsModal bridge={bridge} buttons={buttons as { copy: ButtonInfo; link: ButtonInfo }} closeArrow message={displayPublicSeed ?? ''} title={title}>
+            {switchString === 'viewXPub' ? null : (
+              <Alert
+                type="warning"
+                title={lstrings.string_warning}
+                marginRem={0.5}
+                message={lstrings.fragment_wallets_view_private_view_key_warning}
+                numberOfLines={0}
+              />
+            )}
+          </ButtonsModal>
         )).then(result => {
           switch (result) {
             case 'copy':

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -42,6 +42,7 @@ const icons = {
   manageTokens: 'plus',
   rename: 'edit',
   resync: 'sync',
+  viewPrivateViewKey: 'eye',
   viewXPub: 'eye'
 }
 
@@ -99,12 +100,16 @@ export const WALLET_LIST_MENU: Array<{
       'ufo',
       'vertcoin',
       'wax',
-      'monero',
       'piratechain',
       'zcash'
     ],
     label: lstrings.fragment_wallets_view_xpub,
     value: 'viewXPub'
+  },
+  {
+    pluginIds: ['monero', 'piratechain'],
+    label: lstrings.fragment_wallets_view_private_view_key,
+    value: 'viewPrivateViewKey'
   },
   {
     label: lstrings.string_get_raw_keys,

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -209,6 +209,8 @@ const strings = {
   fragment_wallets_copy_seed: 'Copy Seed',
   fragment_wallets_copied_seed: 'Copied Seed',
   fragment_wallets_get_seed_wallet: 'Get Seed',
+  fragment_wallets_view_private_view_key: 'Private View Key',
+  fragment_wallets_view_private_view_key_warning: `The private view key allows the receiver to see the balance in your Monero wallet. Do not share this key unless necessary, such as for tax purposes, accounting, or similar reasons.`,
   fragment_wallets_view_xpub: 'View XPub Address',
   fragment_wallets_pubkey_copied_title: 'XPub Address Copied',
   fragment_wallets_export_transactions: 'Export Transactions',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -157,6 +157,8 @@
   "fragment_wallets_copy_seed": "Copy Seed",
   "fragment_wallets_copied_seed": "Copied Seed",
   "fragment_wallets_get_seed_wallet": "Get Seed",
+  "fragment_wallets_view_private_view_key": "Private View Key",
+  "fragment_wallets_view_private_view_key_warning": "The private view key allows the receiver to see the balance in your Monero wallet. Do not share this key unless necessary, such as for tax purposes, accounting, or similar reasons.",
   "fragment_wallets_view_xpub": "View XPub Address",
   "fragment_wallets_pubkey_copied_title": "XPub Address Copied",
   "fragment_wallets_export_transactions": "Export Transactions",


### PR DESCRIPTION
### CHANGELOG

- Changed: Monero "Private View Key" wallet menu option replaces "View XPub Address" and includes disclaimer.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204176035281206