### PR TITLE
Add back navigation on transaction list if token becomes disabled

### DIFF
--- a/src/components/scenes/TransactionListScene.tsx
+++ b/src/components/scenes/TransactionListScene.tsx
@@ -6,6 +6,7 @@ import { RefreshControl, SectionList } from 'react-native'
 import { fetchMoreTransactions } from '../../actions/TransactionListActions'
 import { SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import { useHandler } from '../../hooks/useHandler'
+import { useWatch } from '../../hooks/useWatch'
 import { lstrings } from '../../locales/strings'
 import { getExchangeDenomination } from '../../selectors/DenominationSelectors'
 import { useDispatch, useSelector } from '../../types/reactRedux'
@@ -70,6 +71,7 @@ function TransactionListComponent(props: Props) {
     }
   }, [exchangeDenom, exchangeRate, spamFilterOn])
 
+  const enabledTokenIds = useWatch(wallet, 'enabledTokenIds')
   const tokenId = React.useMemo(() => getTokenId(account, pluginId, currencyCode), [account, currencyCode, pluginId])
 
   const { isTransactionListUnsupported = false } = SPECIAL_CURRENCY_INFO[pluginId] ?? {}
@@ -125,6 +127,13 @@ function TransactionListComponent(props: Props) {
       setReset(false)
     }
   }, [currencyCode, dispatch, reset, wallet])
+
+  // Navigate back if the token is disabled from Archive Wallet action
+  React.useEffect(() => {
+    if (tokenId != null && !enabledTokenIds.includes(tokenId)) {
+      navigation.goBack()
+    }
+  }, [enabledTokenIds, navigation, tokenId])
 
   // ---------------------------------------------------------------------------
   // Handlers

--- a/src/components/scenes/TransactionListScene.tsx
+++ b/src/components/scenes/TransactionListScene.tsx
@@ -60,14 +60,6 @@ function TransactionListComponent(props: Props) {
   const spamFilterOn = useSelector(state => state.ui.settings.spamFilterOn)
   const transactions = useSelector(state => state.ui.transactionList.transactions)
 
-  // Effects:
-  React.useEffect(() => {
-    dispatch(fetchMoreTransactions(wallet, currencyCode, reset))
-    if (reset) {
-      setReset(false)
-    }
-  }, [currencyCode, dispatch, reset, wallet])
-
   // ---------------------------------------------------------------------------
   // Derived values
   // ---------------------------------------------------------------------------
@@ -122,6 +114,17 @@ function TransactionListComponent(props: Props) {
     }
     return sections
   }, [filteredTransactions.length, finalTransactions, loading, searching])
+
+  // ---------------------------------------------------------------------------
+  // Side-Effects
+  // ---------------------------------------------------------------------------
+
+  React.useEffect(() => {
+    dispatch(fetchMoreTransactions(wallet, currencyCode, reset))
+    if (reset) {
+      setReset(false)
+    }
+  }, [currencyCode, dispatch, reset, wallet])
 
   // ---------------------------------------------------------------------------
   // Handlers


### PR DESCRIPTION
We should navigate back if the token is disabled from Archive Wallet action.

### CHANGELOG

- Fixed: Navigate back when disabling a token from the transaction list scene.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204356538335349