### PR TITLE
Remove problematic isDone logic from WalletSyncCircle

### DIFF
--- a/src/__tests__/components/__snapshots__/CurrencyIcon.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/CurrencyIcon.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`CryptoIcon should render with loading props 1`] = `
       <RNSVGCircle
         cx={22.5}
         cy={22.5}
+        opacity={0}
         propList={
           Array [
             "strokeWidth",

--- a/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
@@ -405,6 +405,7 @@ Array [
                     <RNSVGCircle
                       cx={17}
                       cy={17}
+                      opacity={0}
                       propList={
                         Array [
                           "strokeWidth",


### PR DESCRIPTION
This logic appears only to be present for two reasons:

1. To prevent the the sync circle from showing briefly while fading out
on a wallet with a fully synced state.
2. To hard-reset (without timing) the syncRatio when re-syncing.

In order to replace this extra state in order to simplify and fix
inconsistency issues:

1. Instead, we default to 0 opacity for the circle and immediately
invoke the `syncRatio` handler in the subscriber useEffect.
2. We derive the done state using `syncRatio.value` for the logic where
its needed.

### CHANGELOG

- Fixed: WalletSyncCircle inconsistency issues with wallets that are stuck syncing.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204316259619599