### PR TITLE
Fix Banxa quoting

### DIFF
--- a/src/plugins/gui/providers/banxaProvider.ts
+++ b/src/plugins/gui/providers/banxaProvider.ts
@@ -218,7 +218,7 @@ export const banxaProvider: FiatProviderFactory = {
         return allowedCurrencyCodes
       },
       getQuote: async (params: FiatProviderGetQuoteParams): Promise<FiatProviderQuote> => {
-        const { regionCode, exchangeAmount, amountType, paymentTypes, fiatCurrencyCode, displayCurrencyCode, direction } = params
+        const { pluginId, regionCode, exchangeAmount, amountType, paymentTypes, fiatCurrencyCode, displayCurrencyCode, direction } = params
 
         if (direction !== 'buy') throw new Error('Only buy supported by Banxa')
 
@@ -227,7 +227,7 @@ export const banxaProvider: FiatProviderFactory = {
 
         let banxaCrypto
         try {
-          banxaCrypto = edgeToBanxaCrypto(providerId, displayCurrencyCode)
+          banxaCrypto = edgeToBanxaCrypto(pluginId, displayCurrencyCode)
         } catch (e: any) {
           throw new FiatProviderError({ errorType: 'assetUnsupported' })
         }


### PR DESCRIPTION
Broken in 0acc8c6: 'pluginId' was being passed to parse the asset, but it was using the pluginId (later clarified to providerId) of Banxa, instead of the pluginId of the asset requested from the quote.

### CHANGELOG

- fixed: Banxa failing to provide a credit quote

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204497037101681