### PR TITLE
Fix OutlinedTextInput suffix style for Android

### DIFF
--- a/src/components/themed/OutlinedTextInput.tsx
+++ b/src/components/themed/OutlinedTextInput.tsx
@@ -285,6 +285,7 @@ export const OutlinedTextInput = React.forwardRef<OutlinedTextInputRef, Outlined
   // @ts-expect-error
   const numpad = props.keyboardType === 'decimal-pad' || props.keyboardType === 'decimal'
   const textStyle = numpad ? styles.numberInput : styles.textInput
+  const suffixStyle = React.useMemo(() => [styles.suffixText, Platform.OS === 'android' ? styles.suffixTextAndroidAdjust : null], [styles])
 
   return (
     <TouchableWithoutFeedback onPress={() => focus()}>
@@ -365,7 +366,7 @@ export const OutlinedTextInput = React.forwardRef<OutlinedTextInputRef, Outlined
                 maxLength={maxLength}
               />
             )}
-            <EdgeText style={styles.suffixText}>{suffix}</EdgeText>
+            <EdgeText style={suffixStyle}>{suffix}</EdgeText>
           </View>
         ) : (
           // TODO: Remove this duplication
@@ -479,6 +480,9 @@ const getStyles = cacheStyles((theme: Theme) => {
     },
     suffixText: {
       color: theme.secondaryText
+    },
+    suffixTextAndroidAdjust: {
+      marginTop: 3.5
     },
     textInput: {
       alignSelf: 'stretch',


### PR DESCRIPTION
Test text to demonstrate alignment fix correctness on android:

![image](https://user-images.githubusercontent.com/90650827/236963759-96ba4112-784a-4afc-85d1-b9ae92dcc679.png)

### CHANGELOG

- fixed: Android text input domain misalignment when creating a FIO handle

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204554700015542