### PR TITLE
Fix categories with no ':'

### DIFF
--- a/src/util/categories.ts
+++ b/src/util/categories.ts
@@ -13,6 +13,9 @@ export interface SplitCategory {
  * The subcategory can be localized and freely edited.
  */
 export function splitCategory(fullCategory: string = '', defaultCategory: Category = 'income'): SplitCategory {
+  if (fullCategory.length > 0 && !fullCategory.includes(':')) {
+    fullCategory += ':'
+  }
   for (const [category, test, n] of tests) {
     if (test.test(fullCategory)) {
       return {


### PR DESCRIPTION
Assume the entire category is a primary category and append a ':' to the end. If it doesn't match the GUI will default to income or expense accordingly

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204352698460546