### PR TITLE
Fix a broken NaN check for fiat metadata

### DIFF
--- a/src/components/tiles/TransactionFiatTiles.tsx
+++ b/src/components/tiles/TransactionFiatTiles.tsx
@@ -84,7 +84,7 @@ export function TransactionFiatTiles(props: Props) {
         const amountFiat = parseFloat(inputText.replace(',', '.'))
 
         // Check for NaN, Infinity, and 0:
-        if (amountFiat === 0 || JSON.stringify(amountFiat) == null) return
+        if (amountFiat === 0 || JSON.stringify(amountFiat) === 'null') return
         await onMetadataEdit({ amountFiat })
       })
       .catch(showError)


### PR DESCRIPTION
### CHANGELOG

- fixed: Do not save NaN fiat amounts (such as by entering a blank string).

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204252182594185