### PR TITLE
Added `android:dev` and `android:dev:test-release` commands.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   ],
   "scripts": {
     "android:clean": "cd android && ./gradlew clean && rm -rf build && cd ../",
+    "android:dev": "react-native run-android --active-arch-only --variant=debug",
+    "android:dev:test-release": "react-native run-android --active-arch-only --variant=release",
     "android:logcat": "adb logcat *:S ReactNative:V ReactNativeJS:V",
     "android:release-clean-install": "npm run android:clean && npm run android:release && adb install -r android/app/build/outputs/apk/release/app-release.apk",
     "android:release-install": "npm run android:release && adb install -r android/app/build/outputs/apk/release/app-release.apk",


### PR DESCRIPTION
Add `--active-arch-only` flag for faster local builds based on react-native v0.71 docs:

>  This should reduce your native build time by a [~75% factor.](https://reactnative.dev/docs/0.71/build-speed#build-only-one-abi-during-development-android-only)

- `android:dev` adds `--active-arch-only`.
- `android:dev:test-release` additionally includes the `--variant=release` flag allows for [local release builds](https://reactnative.dev/docs/0.67/signed-apk-android#testing-the-release-build-of-your-app).
### CHANGELOG

none

### Dependencies

none

### Requirements
 
none

- [ ] Tested on iOS device
- [x] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204680683447164