### PR TITLE
Make scamWarning explicitly shown for Payment Protocol deep-linking

### DIFF
--- a/src/actions/DeepLinkingActions.ts
+++ b/src/actions/DeepLinkingActions.ts
@@ -175,7 +175,7 @@ export async function handleLink(navigation: NavigationBase, dispatch: Dispatch,
 
     case 'paymentProto': {
       if (!allWalletsLoaded) return false
-      launchPaymentProto(navigation, account, link.uri, {}).catch(showError)
+      launchPaymentProto(navigation, account, link.uri, { hideScamWarning: false }).catch(showError)
       return true
     }
 

--- a/src/actions/ScamWarningActions.tsx
+++ b/src/actions/ScamWarningActions.tsx
@@ -15,7 +15,7 @@ export const triggerScamWarningModal = async (disklet: Disklet) => {
   try {
     await disklet.getText(SCAM_WARNING)
   } catch (error: any) {
-    Airship.show<boolean>(bridge => {
+    await Airship.show<boolean>(bridge => {
       const warningMessage = `\u2022 ${lstrings.warning_scam_message_financial_advice}\n\n\u2022 ${lstrings.warning_scam_message_irreversibility}\n\n\u2022 ${lstrings.warning_scam_message_unknown_recipients}`
 
       return (
@@ -23,10 +23,9 @@ export const triggerScamWarningModal = async (disklet: Disklet) => {
           <ModalMessage isWarning>{warningMessage}</ModalMessage>
         </ConfirmContinueModal>
       )
-    }).then(async () => {
-      await disklet.setText(SCAM_WARNING, '')
-
-      isWarningChecked = true
     })
+    await disklet.setText(SCAM_WARNING, '')
+
+    isWarningChecked = true
   }
 }

--- a/src/actions/ScanActions.tsx
+++ b/src/actions/ScanActions.tsx
@@ -221,7 +221,7 @@ export function handleWalletUris(
       // React navigation doesn't like passing non-serializable objects as params. Convert date to string first
       // https://github.com/react-navigation/react-navigation/issues/7925
       const isoExpireDate = parsedUri?.expireDate?.toISOString()
-      navigation.push('send2', { walletId: wallet.id, minNativeAmount, spendInfo, isoExpireDate })
+      navigation.push('send2', { walletId: wallet.id, minNativeAmount, spendInfo, isoExpireDate, hiddenFeaturesMap: { scamWarning: false } })
     } catch (error: any) {
       // INVALID URI
       await Airship.show<'ok' | undefined>(bridge => (

--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -181,7 +181,7 @@ const SendComponent = (props: Props) => {
   spendInfo.currencyCode = currencyCode
 
   if (initialMount.current) {
-    if (hiddenFeaturesMap.scamWarning !== true) {
+    if (hiddenFeaturesMap.scamWarning === false) {
       triggerScamWarningModal(account.disklet)
     }
     initialMount.current = false

--- a/src/components/themed/TransactionListTop.tsx
+++ b/src/components/themed/TransactionListTop.tsx
@@ -302,7 +302,7 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
 
     triggerHaptic('impactLight')
     const { wallet, tokenId } = this.props
-    navigation.push('send2', { walletId: wallet.id, tokenId })
+    navigation.push('send2', { walletId: wallet.id, tokenId, hiddenFeaturesMap: { scamWarning: false } })
   }
 
   handleSearchDone = () => {

--- a/src/components/themed/WalletListSwipeableCurrencyRow.tsx
+++ b/src/components/themed/WalletListSwipeableCurrencyRow.tsx
@@ -76,7 +76,10 @@ function WalletListSwipeableCurrencyRowComponent(props: Props) {
         navigation.navigate('send2', {
           walletId: wallet.id,
           tokenId,
-          openCamera: true
+          openCamera: true,
+          hiddenFeaturesMap: {
+            scamWarning: false
+          }
         })
       }
     })


### PR DESCRIPTION
### CHANGELOG

- Fixed: Bug with scam warning modal shown in unwanted instances; only show once for first manual navigation to send scene.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204622252075405