### PR TITLE
Don't fallback to empty object for otherParams when creating spend info

### DIFF
--- a/src/actions/SendConfirmationActions.tsx
+++ b/src/actions/SendConfirmationActions.tsx
@@ -572,7 +572,7 @@ const getSpendInfo = (state: RootState, newSpendInfo: GuiMakeSpendInfo = {}, sel
     spendTargets,
     networkFeeOption: newSpendInfo.networkFeeOption || getNetworkFeeOption(state),
     customNetworkFee: newSpendInfo.customNetworkFee ? { ...getCustomNetworkFee(state), ...newSpendInfo.customNetworkFee } : getCustomNetworkFee(state),
-    otherParams: newSpendInfo.otherParams || {}
+    otherParams: newSpendInfo.otherParams
   }
 }
 


### PR DESCRIPTION
`otherParams` is allowed to be null so we shouldn't set a fallback value as it can break consumers that are checking for null.