### PR TITLE
Fix RewardCardWelcomeScene minimum font scaling

### DIFF
--- a/src/plugins/gui/scenes/RewardsCardWelcomeScene.tsx
+++ b/src/plugins/gui/scenes/RewardsCardWelcomeScene.tsx
@@ -28,7 +28,7 @@ export const RewardsCardWelcomeScene = (props: Props) => {
         <WelcomeContainer>
           <IllustrationImage source={visaCardSayAnythingIllustration} />
           <VisaBrandImage source={visaBrandImage} />
-          <WelcomeInto adjustsFontSizeToFit numberOfLines={4}>
+          <WelcomeInto adjustsFontSizeToFit minimumFontScale={0.75} numberOfLines={4}>
             {lstrings.rewards_card_welcome_intro}
           </WelcomeInto>
         </WelcomeContainer>


### PR DESCRIPTION
### CHANGELOG

- Fixed: Bug with minimum font scaling on Visa Card Program welcome scene

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
