### PR TITLE
Re-enable DASH for Visa® Card Program

### DIFF
--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -472,7 +472,7 @@ export const SPECIAL_CURRENCY_INFO: {
     maxSpendTargets: UTXO_MAX_SPEND_TARGETS,
     initWalletName: lstrings.string_first_dash_wallet_name,
     chainCode: 'DASH',
-    displayIoniaRewards: false,
+    displayIoniaRewards: true,
     isImportKeySupported: true,
     isPrivateKeySweepable: true,
     isPaymentProtocolSupported: true

--- a/src/plugins/gui/RewardsCardPlugin.tsx
+++ b/src/plugins/gui/RewardsCardPlugin.tsx
@@ -31,11 +31,13 @@ export const makeRewardsCardPlugin: FiatPluginFactory = async params => {
   const { showUi, account, guiPlugin } = params
   const { pluginId } = guiPlugin
 
-  const SUPPORTED_ASSETS: EdgeTokenId[] = ['bitcoin', 'bitcoincash', 'dogecoin', 'litecoin'].map(pluginId => ({ pluginId }))
-
   const providers = await initializeProviders<IoniaMethods>(PROVIDER_FACTORIES, params)
   if (providers.length === 0) throw new Error('No enabled providers for RewardsCardPlugin')
   const provider = providers[0]
+
+  // Get supported crypto assets:
+  const supportedAssetMap = await provider.getSupportedAssets([])
+  const allowedAssets: EdgeTokenId[] = Object.keys(supportedAssetMap.crypto).map(pluginId => ({ pluginId }))
 
   //
   // Helpers:
@@ -244,7 +246,7 @@ export const makeRewardsCardPlugin: FiatPluginFactory = async params => {
   const showNewCardWalletListModal = async () => {
     const walletListResult: FiatPluginWalletPickerResult = await showUi.walletPicker({
       headerTitle: lstrings.rewards_card_select_wallet,
-      allowedAssets: SUPPORTED_ASSETS,
+      allowedAssets,
       showCreateWallet: false
     })
     showNewCardEnterAmount(walletListResult)


### PR DESCRIPTION
### CHANGELOG

- Changed: Re-enable DASH for Visa® Card Program

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204651918588690