### PR TITLE
Implement persistent floating card

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,5 +1,5 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
-import { createDrawerNavigator } from '@react-navigation/drawer'
+import { createDrawerNavigator, DrawerContentComponentProps, useDrawerStatus } from '@react-navigation/drawer'
 import { HeaderTitleProps } from '@react-navigation/elements'
 import { DefaultTheme, NavigationContainer } from '@react-navigation/native'
 import { createStackNavigator, StackNavigationOptions } from '@react-navigation/stack'
@@ -25,6 +25,7 @@ import { defaultAccount } from '../reducers/CoreReducer'
 import { useSelector } from '../types/reactRedux'
 import { AppParamList } from '../types/routerTypes'
 import { logEvent } from '../util/tracking'
+import { FloatingCard } from './cards/FloatingCard'
 import { ifLoggedIn } from './hoc/IfLoggedIn'
 import { useBackEvent } from './hoc/useBackEvent'
 import { BackButton } from './navigation/BackButton'
@@ -118,6 +119,13 @@ import { Airship } from './services/AirshipInstance'
 import { useTheme } from './services/ThemeContext'
 import { ControlPanel as ControlPanelComponent } from './themed/ControlPanel'
 import { MenuTabs } from './themed/MenuTabs'
+
+// This is necessary to lift the drawer state up to components outside of the
+// Drawer.Navigator. The hook useDrawerStatus() is accessible only from
+// components within the Drawer.Navigator component.
+interface LiftDrawerStateProps {
+  setIsDrawerOpen: (isOpen: boolean) => void
+}
 
 const ChangeMiningFeeScene = ifLoggedIn(ChangeMiningFeeSceneComponent)
 const ChangeMiningFeeScene2 = ifLoggedIn(ChangeMiningFeeScene2Component)
@@ -222,6 +230,9 @@ const firstSceneScreenOptions: StackNavigationOptions = {
 
 export const Main = () => {
   const theme = useTheme()
+
+  const [isDrawerOpen, setIsDrawerOpen] = React.useState(false)
+
   // Match react navigation theme background with the patina theme
   const reactNavigationTheme = React.useMemo(() => {
     return {
@@ -239,21 +250,36 @@ export const Main = () => {
 
   return (
     <NavigationContainer theme={reactNavigationTheme}>
-      <Stack.Navigator
-        initialRouteName={ENV.USE_WELCOME_SCREENS ? 'gettingStarted' : 'login'}
-        screenOptions={{
-          headerShown: false
-        }}
-      >
-        <Stack.Screen name="edgeApp" component={EdgeApp} />
-        <Stack.Screen name="gettingStarted" component={GettingStartedScene} />
-        <Stack.Screen name="login" component={LoginScene} />
-      </Stack.Navigator>
+      <MainContent setIsDrawerOpen={setIsDrawerOpen} />
+      <FloatingCard title={lstrings.light_account_card_backup_title} message={lstrings.light_account_card_backup_message} visible={!isDrawerOpen} />
     </NavigationContainer>
   )
 }
 
-const EdgeApp = () => {
+const MainContent = ({ setIsDrawerOpen }: LiftDrawerStateProps) => {
+  return (
+    <Stack.Navigator
+      initialRouteName={ENV.USE_WELCOME_SCREENS ? 'gettingStarted' : 'login'}
+      screenOptions={{
+        headerShown: false
+      }}
+    >
+      <Stack.Screen name="edgeApp">{() => <EdgeApp setIsDrawerOpen={setIsDrawerOpen} />}</Stack.Screen>
+      <Stack.Screen name="gettingStarted" component={GettingStartedScene} />
+      <Stack.Screen name="login" component={LoginScene} />
+    </Stack.Navigator>
+  )
+}
+
+// Wrapper to pass the drawer status out of Drawer.Navigator
+const DrawerContent = (props: DrawerContentComponentProps & LiftDrawerStateProps) => {
+  const isDrawerOpen = useDrawerStatus() === 'open'
+  props.setIsDrawerOpen(isDrawerOpen)
+
+  return <ControlPanel {...props} />
+}
+
+const EdgeApp = ({ setIsDrawerOpen }: LiftDrawerStateProps) => {
   const backPressedOnce = React.useRef(false)
   const dispatch = useDispatch()
   const account = useSelector(state => state.core.account)
@@ -284,7 +310,7 @@ const EdgeApp = () => {
 
   return (
     <Drawer.Navigator
-      drawerContent={props => ControlPanel(props)}
+      drawerContent={props => <DrawerContent {...props} setIsDrawerOpen={setIsDrawerOpen} />}
       initialRouteName="edgeAppStack"
       screenOptions={{
         drawerPosition: 'right',

--- a/src/components/cards/FloatingCard.tsx
+++ b/src/components/cards/FloatingCard.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+import { View } from 'react-native'
+import FastImage from 'react-native-fast-image'
+
+import { useSelector } from '../../types/reactRedux'
+import { getLightAccountIconUri } from '../../util/CdnUris'
+import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
+import { EdgeText } from '../themed/EdgeText'
+import { Fade } from '../themed/Fade'
+
+interface Props {
+  title: string
+  message: string
+  visible?: boolean // Master toggle that trumps other visibility logic
+}
+
+const DUR_FADEIN = 250
+const DUR_FADEOUT = 100
+
+const FloatingCardComponent = (props: Props) => {
+  const { title, message, visible = false } = props
+  const theme = useTheme()
+  const styles = getStyles(theme)
+
+  const loginStatus = useSelector(state => state.ui.settings.loginStatus ?? false)
+  const activeUsername = useSelector(state => state.core.account.username)
+
+  const isCardShown = visible && loginStatus && activeUsername == null
+
+  return (
+    <Fade visible={isCardShown} duration={isCardShown ? DUR_FADEIN : DUR_FADEOUT}>
+      <View style={styles.cardContainer}>
+        <FastImage style={styles.icon} source={{ uri: getLightAccountIconUri(theme, 'icon-notif') }} />
+        <View>
+          <EdgeText style={styles.textTitle}>{title}</EdgeText>
+          <EdgeText style={styles.textMessage} numberOfLines={3}>
+            {message}
+          </EdgeText>
+        </View>
+      </View>
+    </Fade>
+  )
+}
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  cardContainer: {
+    position: 'absolute',
+    alignSelf: 'center',
+    bottom: theme.rem(6),
+    height: theme.rem(3.5),
+    backgroundColor: theme.modal,
+    borderRadius: theme.rem(0.5),
+    shadowOffset: { width: 0, height: theme.rem(0.125) },
+    shadowOpacity: 0.7,
+    shadowRadius: theme.rem(0.5),
+    elevation: 6,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginHorizontal: theme.rem(0.5),
+    padding: theme.rem(0.5)
+  },
+  icon: {
+    height: theme.rem(2.5),
+    width: theme.rem(2.5)
+  },
+  textTitle: {
+    color: theme.warningIcon,
+    marginLeft: theme.rem(0.5),
+    fontSize: theme.rem(0.75),
+    fontFamily: theme.fontFaceBold
+  },
+  textMessage: {
+    color: theme.warningIcon,
+    marginLeft: theme.rem(0.5),
+    fontSize: theme.rem(0.75)
+  }
+}))
+
+export const FloatingCard = React.memo(FloatingCardComponent)

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -1314,6 +1314,13 @@ const strings = {
 
   // #endregion GuiPlugins
 
+  // #region Light Account
+
+  light_account_card_backup_title: 'Back up your account',
+  light_account_card_backup_message: 'Without a backup, you risk losing your funds!',
+
+  // #endregion Light Account
+
   // Currency Labels
   currency_label_AFN: 'Afghani',
   currency_label_ALL: 'Lek',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -1143,6 +1143,8 @@
   "bank_transfer_reference": "Reference",
   "sepa_form_title": "Enter Bank Info",
   "sepa_transfer_prompt_s": "Your order %1$s has been submitted!\n\nPlease save the order details below for your records and instruct your bank to make the payment with the information in the Payment Details section.",
+  "light_account_card_backup_title": "Back up your account",
+  "light_account_card_backup_message": "Without a backup, you risk losing your funds!",
   "currency_label_AFN": "Afghani",
   "currency_label_ALL": "Lek",
   "currency_label_DZD": "Algerian Dinar",

--- a/src/util/CdnUris.ts
+++ b/src/util/CdnUris.ts
@@ -65,3 +65,10 @@ export function getCurrencyIconUris(pluginId: string, contractAddress: string = 
 export function getPartnerIconUri(partnerIconPath: string) {
   return `${EDGE_CONTENT_SERVER_URI}/${partnerIconPath}`
 }
+
+/**
+ * Light Account Icons
+ */
+export const getLightAccountIconUri = (theme: Theme, iconName: string) => {
+  return `${theme.iconServerBaseUri}/lightAccount/${iconName}.png`
+}


### PR DESCRIPTION
Persistent floating card, that shows app-wide while logged in with an empty username AND ControlPanel isn't open

![Simulator Screen Shot - iPhone 14 Pro - 2023-05-26 at 18 13 32](https://github.com/EdgeApp/edge-react-gui/assets/90650827/7d5835b5-68de-4cdf-b1e5-511dca76a3cc)

### CHANGELOG

Add persistent card notification for light accounts

### Dependencies

https://app.asana.com/0/1200382638405084/1204451072447705/f

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204680458642169