### PR TITLE
Rename tracking event for usp swipe

### DIFF
--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -101,12 +101,13 @@ export const GettingStartedScene = (props: Props) => {
         swipeOffset.value = 0
       }, 500)
 
-      if (localUsersLength > 0) navigation.navigate('login', { loginUiInitialRoute: 'login-password' })
-      else {
-        logEvent('Signup_Account_Review_Done', {
-          variantId,
-          variantParams: { method: 'swipe' }
-        })
+      logEvent('Signup_Welcome', {
+        variantId,
+        variantParams: { doneMethod: 'swipe' }
+      })
+      if (localUsersLength > 0) {
+        navigation.navigate('login', { loginUiInitialRoute: 'login-password' })
+      } else {
         navigation.navigate('login', { loginUiInitialRoute: 'new-account' })
       }
     }
@@ -119,7 +120,7 @@ export const GettingStartedScene = (props: Props) => {
     navigation.navigate('login', { loginUiInitialRoute: 'login-password' })
   })
   const handlePressSignUp = useHandler(() => {
-    logEvent('Signup_Account_Review_Done', { variantId, variantParams: { method: 'click' } })
+    logEvent('Signup_Welcome', { variantId, variantParams: { doneMethod: 'click' } })
     navigation.navigate('login', { loginUiInitialRoute: 'new-account' })
   })
   const handlePressSkip = useHandler(() => {

--- a/src/util/tracking.ts
+++ b/src/util/tracking.ts
@@ -28,7 +28,7 @@ export type TrackingEventName =
   | 'Sell_Quote'
   | 'Sell_Quote_Change_Provider'
   | 'Sell_Quote_Next'
-  | 'Signup_Account_Review_Done'
+  | 'Signup_Welcome'
   | 'Signup_Wallets_Created_Failed'
   | 'Signup_Wallets_Created_Success'
   | 'Start_App'


### PR DESCRIPTION
The event `Signup_Account_Review_Done` was incorrectly named implying the end of the signup process, while in reality it happens at the very beginning of the signup flow (after USPs are viewed).


Rename to `Signup_Welcome`

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204664120652186
  - https://app.asana.com/0/0/1204697741640174