### PR TITLE
Use stake method params in FIO max stake

### DIFF
--- a/src/components/scenes/Fio/FioStakingChangeScene.tsx
+++ b/src/components/scenes/Fio/FioStakingChangeScene.tsx
@@ -88,7 +88,15 @@ export const FioStakingChangeSceneComponent = (props: Props) => {
         currencyWallet
           .getMaxSpendable({
             currencyCode,
-            spendTargets: [{ nativeAmount: '', otherParams: {}, publicAddress: '' }]
+            spendTargets: [{ publicAddress: '' }],
+            otherParams: {
+              action: {
+                name: 'stakeFioTokens',
+                params: {
+                  fioAddress: selectedFioAddress
+                }
+              }
+            }
           })
           .then(nativeAmount => {
             onAmountChanged(nativeAmount, add(convertNativeToDenomination(currencyDenomination.multiplier)(nativeAmount), '0'))


### PR DESCRIPTION
Using getMaxSpendable without the stake method name follows the transfer path which results in a higher fee and therefore lower staked amount.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204728849187738