### PR TITLE
GettingStartedScene style adjustments

### DIFF
--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -33,6 +33,7 @@ import { SceneWrapper } from '../common/SceneWrapper'
 import { styled } from '../hoc/styled'
 import { SwipeOffsetDetector } from '../interactions/SwipeOffsetDetector'
 import { Space } from '../layout/Space'
+import { useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
 
@@ -355,30 +356,37 @@ const PageIndicator = styled(Animated.View)<{ swipeOffset: SharedValue<number>; 
 // Sections
 //
 
-const SectionCoverAnimated = styled(Animated.View)<{ swipeOffset: SharedValue<number> }>(props => [
-  {
-    alignItems: 'stretch',
-    backgroundColor: '#0F1D26',
-    paddingVertical: props.theme.rem(1)
-  },
-  useAnimatedStyle(() => {
-    const backgroundColor = interpolateColor(props.swipeOffset.value, [0, 1], [`${props.theme.modal}00`, `${props.theme.modal}ff`])
-    const flex = interpolate(props.swipeOffset.value, [0, 1], [0.5, 1.5], Extrapolation.CLAMP)
-    return {
-      backgroundColor,
-      flex
-    }
-  })
-])
+const SectionCoverAnimated = styled(Animated.View)<{ swipeOffset: SharedValue<number> }>(props => {
+  const theme = useTheme()
+  const themeRem = theme.rem(1)
+  return [
+    {
+      alignItems: 'stretch',
+      justifyContent: 'space-between',
+      backgroundColor: '#0F1D26',
+      paddingVertical: props.theme.rem(1)
+    },
+    useAnimatedStyle(() => {
+      const backgroundColor = interpolateColor(props.swipeOffset.value, [0, 1], [`${props.theme.modal}00`, `${props.theme.modal}ff`])
+      const paddingVertical = interpolate(props.swipeOffset.value, [0, 1], [0, themeRem], Extrapolation.CLAMP)
+      const flexGrow = interpolate(props.swipeOffset.value, [0, 1], [0, 1.2], Extrapolation.CLAMP)
+      return {
+        backgroundColor,
+        paddingVertical,
+        flexGrow
+      }
+    })
+  ]
+})
 
 const Sections = styled(Animated.View)<{ swipeOffset: SharedValue<number> }>(props => [
   {
     paddingBottom: props.theme.rem(1)
   },
   useAnimatedStyle(() => {
-    const flex = interpolate(props.swipeOffset.value, [0, 1], [0.00000001, 1.5])
+    const flexGrow = interpolate(props.swipeOffset.value, [0, 1], [0, 1.5])
     return {
-      flex
+      flexGrow
     }
   })
 ])

--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -173,7 +173,9 @@ export const GettingStartedScene = (props: Props) => {
           <HeroContainer>
             <WelcomeHero swipeOffset={swipeOffset}>
               <Image source={edgeLogoIcon} />
-              <WelcomeHeroTitle>{parseMarkedText(lstrings.getting_started_welcome_title)}</WelcomeHeroTitle>
+              <WelcomeHeroTitle numberOfLines={2} adjustsFontSizeToFit minimumFontScale={0.5}>
+                {parseMarkedText(lstrings.getting_started_welcome_title)}
+              </WelcomeHeroTitle>
               <WelcomeHeroMessage>{lstrings.getting_started_welcome_message}</WelcomeHeroMessage>
               <WelcomeHeroPrompt>{lstrings.getting_started_welcome_prompt}</WelcomeHeroPrompt>
             </WelcomeHero>
@@ -265,6 +267,7 @@ const WelcomeHeroTitle = styled(Text)(props => ({
   fontFamily: props.theme.fontFaceDefault,
   fontSize: props.theme.rem(2.25),
   includeFontPadding: false,
+  lineHeight: props.theme.rem(2.8),
   paddingVertical: props.theme.rem(1),
   textAlign: 'center'
 }))

--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -14,7 +14,7 @@ import Animated, {
   useSharedValue,
   withTiming
 } from 'react-native-reanimated'
-import { useSafeAreaFrame } from 'react-native-safe-area-context'
+import { useSafeAreaFrame, useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import edgeLogoIcon from '../../assets/images/edgeLogo/Edge_logo_Icon_L.png'
 import slide1HeroImage from '../../assets/images/gettingStarted/slide1HeroImage.png'
@@ -359,12 +359,16 @@ const PageIndicator = styled(Animated.View)<{ swipeOffset: SharedValue<number>; 
 const SectionCoverAnimated = styled(Animated.View)<{ swipeOffset: SharedValue<number> }>(props => {
   const theme = useTheme()
   const themeRem = theme.rem(1)
+  const insets = useSafeAreaInsets()
+
   return [
     {
       alignItems: 'stretch',
       justifyContent: 'space-between',
       backgroundColor: '#0F1D26',
-      paddingVertical: props.theme.rem(1)
+      paddingVertical: props.theme.rem(1),
+      paddingBottom: insets.bottom,
+      marginBottom: -insets.bottom
     },
     useAnimatedStyle(() => {
       const backgroundColor = interpolateColor(props.swipeOffset.value, [0, 1], [`${props.theme.modal}00`, `${props.theme.modal}ff`])


### PR DESCRIPTION
### CHANGELOG

- Fixed: Remove bottom gap on iOS devices on GettingStartedScene (USP)
- Fixed: Fix GettingStartedScene (USP) spacing for smaller display devices (e.g. iPod Touch)

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204392823967163

# iPod Touch

![Simulator Screen Shot - iPod touch (7th generation) - 2023-06-07 at 15 06 28](https://github.com/EdgeApp/edge-react-gui/assets/517469/dfa9780e-b0c2-47b5-83c5-ba7669dafbcc)
![Simulator Screen Shot - iPod touch (7th generation) - 2023-06-07 at 15 06 30](https://github.com/EdgeApp/edge-react-gui/assets/517469/0e3ca2f0-9c2b-441c-938a-ca9e6a9c643b)


# iPhone 14 Pro

![Simulator Screen Shot - iPhone 14 Pro - 2023-06-07 at 15 06 38](https://github.com/EdgeApp/edge-react-gui/assets/517469/75a91c64-f229-4b6c-9b3d-3a7cfd107cc1)
![Simulator Screen Shot - iPhone 14 Pro - 2023-06-07 at 15 06 40](https://github.com/EdgeApp/edge-react-gui/assets/517469/11750d22-a4ae-4100-a0ff-8fc3e5555fb7)

# iPad Mini

![Simulator Screen Shot - iPad mini (6th generation) - 2023-06-07 at 15 06 50](https://github.com/EdgeApp/edge-react-gui/assets/517469/65d90ea6-055b-4104-937c-bb2f9ac14aa6)
![Simulator Screen Shot - iPad mini (6th generation) - 2023-06-07 at 15 06 53](https://github.com/EdgeApp/edge-react-gui/assets/517469/358a7b26-2726-46e5-84b1-9cb1b305cb47)
![Simulator Screen Shot - iPad mini (6th generation) - 2023-06-07 at 15 07 06](https://github.com/EdgeApp/edge-react-gui/assets/517469/ecc128a3-39e9-48b8-80ab-a37992b67c68)
![Simulator Screen Shot - iPad mini (6th generation) - 2023-06-07 at 15 07 08](https://github.com/EdgeApp/edge-react-gui/assets/517469/a8f5b571-9f6a-426d-b577-1055650d317f)