### PR TITLE
Add target-ability to 'Next' button in select crypto scene

### DIFF
--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -726,19 +726,19 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
         </RCTScrollView>
       </View>
       <View
-        pointerEvents="none"
         style={
           Object {
-            "opacity": 0,
+            "flex": 1,
+            "justifyContent": "flex-end",
+            "paddingBottom": 22,
           }
         }
       >
         <View
+          pointerEvents="none"
           style={
             Object {
-              "alignSelf": "center",
-              "bottom": 22,
-              "position": "absolute",
+              "opacity": 0,
             }
           }
         >

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -202,19 +202,20 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
 
   const renderCreateWalletRow: ListRenderItem<WalletCreateItem> = useHandler(item => {
     const { key, displayName, pluginId, tokenId } = item.item
-
+    const value = selectedItems[key]
     const accessibilityHint = sprintf(lstrings.create_wallet_hint, displayName)
+    const accessibilityState = { checked: value, selected: value }
     const toggle = (
       <Switch
+        accessibilityState={accessibilityState}
         accessibilityRole="switch"
-        accessibilityState={{ selected: selectedItems[key] }}
         accessibilityHint={accessibilityHint}
         ios_backgroundColor={theme.toggleButtonOff}
         trackColor={{
           false: theme.toggleButtonOff,
           true: theme.toggleButton
         }}
-        value={selectedItems[key]}
+        value={value}
         onValueChange={() => handleCreateWalletToggle(key)}
       />
     )
@@ -223,6 +224,7 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
       <CreateWalletSelectCryptoRow
         pluginId={pluginId}
         tokenId={tokenId}
+        key={displayName}
         walletName={displayName}
         onPress={() => handleCreateWalletToggle(key)}
         rightSide={toggle}
@@ -235,12 +237,10 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
   const renderNextButton = React.useMemo(
     () => (
       <Fade noFadeIn={defaultSelection.length > 0} visible={numSelected > 0} duration={300}>
-        <View style={styles.bottomButton}>
-          <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, -0.5]} onPress={handleNext} alignSelf="center" />
-        </View>
+        <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, -0.5]} onPress={handleNext} alignSelf="center" />
       </Fade>
     ),
-    [defaultSelection, handleNext, numSelected, styles.bottomButton]
+    [defaultSelection, handleNext, numSelected]
   )
 
   return (
@@ -273,7 +273,7 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
             keyExtractor={keyExtractor}
             renderItem={renderCreateWalletRow}
           />
-          {renderNextButton}
+          <View style={styles.bottomArea}>{renderNextButton}</View>
         </View>
       )}
     </SceneWrapper>
@@ -281,10 +281,10 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
-  bottomButton: {
-    alignSelf: 'center',
-    bottom: theme.rem(1),
-    position: 'absolute'
+  bottomArea: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    paddingBottom: theme.rem(1)
   },
   content: {
     flex: 1


### PR DESCRIPTION
### CHANGELOG

none

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

![image](https://github.com/EdgeApp/edge-react-gui/assets/4023066/6ef3e7b7-f6cd-4884-828c-a3dd67041c49)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204794247143971