### PR TITLE
Hard code fiat currency code to USD for rewards card plugin

### DIFF
--- a/src/plugins/gui/RewardsCardPlugin.tsx
+++ b/src/plugins/gui/RewardsCardPlugin.tsx
@@ -18,6 +18,8 @@ import { initializeProviders } from './util/initializeProviders'
 
 const SUPPORT_URL = 'https://edge.app/visa-card-how-to'
 
+const HARD_CODED_FIAT_CURRENCY_CODE = 'iso:USD'
+
 export interface RewardsCardItem {
   id: number
   creationDate: Date
@@ -133,7 +135,7 @@ export const makeRewardsCardPlugin: FiatPluginFactory = async params => {
 
     let providerQuote: FiatProviderQuote | undefined
     let counter = 0
-    const fiatCurrencyCode = wallet.fiatCurrencyCode
+    const fiatCurrencyCode = HARD_CODED_FIAT_CURRENCY_CODE // wallet.fiatCurrencyCode
     const displayFiatCurrencyCode = fiatCurrencyCode.replace('iso:', '')
     showUi.enterAmount({
       headerTitle: lstrings.rewards_card_add_new_input_amount_title,


### PR DESCRIPTION
### CHANGELOG

- Fixed: Hard coded USD fiat currency for enter amount for Visa® Card Program.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204779772531292