### PR TITLE
Speed up the useWatch hook

### DIFF
--- a/src/hooks/useWatch.ts
+++ b/src/hooks/useWatch.ts
@@ -9,12 +9,13 @@ export function useWatch<
   },
   Name extends keyof T
 >(object: T, name: Name): T[Name] {
-  const [out, setOut] = React.useState<any>(object[name])
+  // We need to re-render the component when the value changes.
+  // Since [] !== [], we can use an empty array to force an update:
+  const [, rerender] = React.useState([])
 
   React.useEffect(() => {
-    setOut(object[name])
-    return object.watch(name, setOut)
+    return object.watch(name, () => rerender([]))
   }, [object, name])
 
-  return out
+  return object[name]
 }


### PR DESCRIPTION
When changing the watched object (such as switching wallets), there is a one-tick delay before the hook's return value updates. We need to remove this delay to fix some bugs.

### CHANGELOG

- fixed: Do not accidentally back out of the transaction list scene when selecting a token wallet from the drop-down.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204827955021786
  - https://app.asana.com/0/0/1204845530898852