### PR TITLE
Provide a side-menu fallback component

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -117,7 +117,7 @@ import { WcDisconnectScene as WcDisconnectSceneComponent } from './scenes/WcDisc
 import { Airship } from './services/AirshipInstance'
 import { useTheme } from './services/ThemeContext'
 import { MenuTabs } from './themed/MenuTabs'
-import { SideMenu as SideMenuComponent } from './themed/SideMenu'
+import { SideMenu } from './themed/SideMenu'
 
 const ChangeMiningFeeScene = ifLoggedIn(ChangeMiningFeeSceneComponent)
 const ChangeMiningFeeScene2 = ifLoggedIn(ChangeMiningFeeScene2Component)
@@ -127,7 +127,6 @@ const ChangeRecoveryScene = ifLoggedIn(ChangeRecoverySceneComponent)
 const CoinRankingDetailsScene = ifLoggedIn(CoinRankingDetailsSceneComponent)
 const CoinRankingScene = ifLoggedIn(CoinRankingSceneComponent)
 const ConfirmScene = ifLoggedIn(ConfirmSceneComponent)
-const SideMenu = ifLoggedIn(SideMenuComponent)
 const CreateWalletAccountSelectScene = ifLoggedIn(CreateWalletAccountSelectSceneComponent)
 const CreateWalletAccountSetupScene = ifLoggedIn(CreateWalletAccountSetupSceneComponent)
 const CreateWalletCompletionScene = ifLoggedIn(CreateWalletCompletionSceneComponent)

--- a/src/components/themed/SideMenu.tsx
+++ b/src/components/themed/SideMenu.tsx
@@ -34,6 +34,7 @@ import { SceneWrapper } from '../common/SceneWrapper'
 import { CryptoIcon } from '../icons/CryptoIcon'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { ScanModal } from '../modals/ScanModal'
+import { LoadingScene } from '../scenes/LoadingScene'
 import { Airship, showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { FiatText } from '../text/FiatText'
@@ -44,7 +45,7 @@ import { ModalMessage, ModalTitle } from './ModalParts'
 const xButtonGradientStart = { x: 0, y: 0 }
 const xButtonGradientEnd = { x: 0, y: 0.75 }
 
-export function SideMenu(props: DrawerContentComponentProps) {
+export function SideMenuComponent(props: DrawerContentComponentProps) {
   // Fix this type assertion (seems like DrawerContentComponentProps works just fine as NavigationBase?)
   const navigation: NavigationBase = props.navigation as any
   const isDrawerOpen = useDrawerStatus() === 'open'
@@ -508,3 +509,14 @@ const getStyles = cacheStyles((theme: Theme) => ({
     zIndex: 1
   }
 }))
+
+export function SideMenu(props: DrawerContentComponentProps) {
+  const { navigation } = props
+
+  const { loggedIn } = useSelector(state => state.core.account)
+  React.useEffect(() => {
+    if (!loggedIn) navigation.navigate('login')
+  }, [loggedIn, navigation])
+
+  return loggedIn ? <SideMenuComponent {...props} /> : <LoadingScene />
+}


### PR DESCRIPTION
Edit: After talking to Jon, we have decided to make the scene automatically go back, instead of offering a button. It's one less thing to press.

~When React Native does a live-reload, sometimes the app gets stuck in a weird state. Providing a simple logout button makes development much easier, since it provides a way to get back to the login screen:~

![simulator_screenshot_26189CCE-D527-4685-BBCB-6D9C419CBD50](https://github.com/EdgeApp/edge-react-gui/assets/276214/0e2d1ea8-9a29-4bee-923d-e966b46f1bd7)

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

https://github.com/EdgeApp/edge-react-gui/pull/4269

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204845813405431
  - https://app.asana.com/0/0/1204827955021796