### PR TITLE
Eliminate the legacy appcompat library

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -219,6 +219,14 @@ dependencies {
     implementation 'com.facebook.fresco:animated-base-support:1.3.0'
     // For animated GIF support
     implementation 'com.facebook.fresco:animated-gif:2.5.0'
+
+    // This is the latest appcompat that is compatible with RN 0.67.
+    // Anything newer will cause runtime crashes:
+    implementation ("androidx.appcompat:appcompat:1.3.1") {
+        version {
+            strictly '1.3.1'
+        }
+    }
 }
 
 // Run this once to be able to run the application with BUCK

--- a/patches/edge-login-ui-rn+2.2.0.patch
+++ b/patches/edge-login-ui-rn+2.2.0.patch
@@ -1,0 +1,31 @@
+diff --git a/node_modules/edge-login-ui-rn/android/build.gradle b/node_modules/edge-login-ui-rn/android/build.gradle
+index 2319567..ef69da0 100644
+--- a/node_modules/edge-login-ui-rn/android/build.gradle
++++ b/node_modules/edge-login-ui-rn/android/build.gradle
+@@ -55,6 +55,6 @@ dependencies {
+     implementation 'com.squareup.whorlwind:whorlwind:2.0.0'
+     implementation 'io.reactivex.rxjava2:rxjava:2.1.14'
+     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
+-    implementation 'com.android.support:appcompat-v7:${safeExtGet("supportLibVersion", "27.0.1"}'
++    implementation 'androidx.appcompat:appcompat:1.4.1'
+     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
+ }
+diff --git a/node_modules/edge-login-ui-rn/android/src/main/java/co/airbitz/AbcCoreJsUi/AbcCoreJsUiModule.java b/node_modules/edge-login-ui-rn/android/src/main/java/co/airbitz/AbcCoreJsUi/AbcCoreJsUiModule.java
+index d34140e..9d63523 100644
+--- a/node_modules/edge-login-ui-rn/android/src/main/java/co/airbitz/AbcCoreJsUi/AbcCoreJsUiModule.java
++++ b/node_modules/edge-login-ui-rn/android/src/main/java/co/airbitz/AbcCoreJsUi/AbcCoreJsUiModule.java
+@@ -7,10 +7,10 @@ import android.content.pm.PackageManager;
+ import android.hardware.fingerprint.FingerprintManager;
+ import android.os.Build;
+ import android.os.Handler;
+-import android.support.annotation.NonNull;
+-import android.support.v4.app.ActivityCompat;
+-import android.support.v4.content.ContextCompat;
+-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
++import androidx.annotation.NonNull;
++import androidx.core.app.ActivityCompat;
++import androidx.core.content.ContextCompat;
++import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
+ import android.util.Log;
+ import android.view.View;
+ import android.widget.ImageView;

--- a/patches/react-native-piratechain+0.3.2.patch
+++ b/patches/react-native-piratechain+0.3.2.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/react-native-piratechain/android/build.gradle b/node_modules/react-native-piratechain/android/build.gradle
+index 5ea6c9e..f158ae3 100644
+--- a/node_modules/react-native-piratechain/android/build.gradle
++++ b/node_modules/react-native-piratechain/android/build.gradle
+@@ -81,9 +81,5 @@ dependencies {
+     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
+     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9"
+
+-    implementation ("androidx.appcompat:appcompat:1.3.1") {
+-        version {
+-            strictly '1.3.1'
+-        }
+-    }
++    implementation "androidx.appcompat:appcompat:1.3.1"
+ }

--- a/patches/react-native-smart-splash-screen+2.3.5.patch
+++ b/patches/react-native-smart-splash-screen+2.3.5.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-smart-splash-screen/android/build.gradle b/node_modules/react-native-smart-splash-screen/android/build.gradle
-index dfbd150..6980b86 100644
+index dfbd150..16b8fdb 100644
 --- a/node_modules/react-native-smart-splash-screen/android/build.gradle
 +++ b/node_modules/react-native-smart-splash-screen/android/build.gradle
 @@ -1,12 +1,16 @@
@@ -23,14 +23,29 @@ index dfbd150..6980b86 100644
          versionCode 1
          versionName "1.0"
      }
-@@ -20,6 +24,6 @@ android {
+@@ -19,7 +23,6 @@ android {
+ }
  
  dependencies {
-     compile fileTree(include: ['*.jar'], dir: 'libs')
+-    compile fileTree(include: ['*.jar'], dir: 'libs')
 -    compile 'com.android.support:appcompat-v7:23.4.0'
-+    compile 'com.android.support:appcompat-v7:${safeExtGet("supportLibVersion", "23.4.0")}'
-     compile 'com.facebook.react:react-native:+'
+-    compile 'com.facebook.react:react-native:+'
++    implementation 'com.facebook.react:react-native:+'
++    implementation "androidx.appcompat:appcompat:1.4.1"
  }
+diff --git a/node_modules/react-native-smart-splash-screen/android/src/main/java/com/reactnativecomponent/splashscreen/RCTSplashScreenModule.java b/node_modules/react-native-smart-splash-screen/android/src/main/java/com/reactnativecomponent/splashscreen/RCTSplashScreenModule.java
+index 9679439..34b577a 100644
+--- a/node_modules/react-native-smart-splash-screen/android/src/main/java/com/reactnativecomponent/splashscreen/RCTSplashScreenModule.java
++++ b/node_modules/react-native-smart-splash-screen/android/src/main/java/com/reactnativecomponent/splashscreen/RCTSplashScreenModule.java
+@@ -1,7 +1,7 @@
+ package com.reactnativecomponent.splashscreen;
+ 
+ import android.os.Handler;
+-import android.support.annotation.Nullable;
++import androidx.annotation.Nullable;
+ 
+ import com.facebook.react.bridge.ReactApplicationContext;
+ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 diff --git a/node_modules/react-native-smart-splash-screen/ios/RCTSplashScreen/RCTSplashScreen/RCTSplashScreen.m b/node_modules/react-native-smart-splash-screen/ios/RCTSplashScreen/RCTSplashScreen/RCTSplashScreen.m
 index 278fefd..8868489 100644
 --- a/node_modules/react-native-smart-splash-screen/ios/RCTSplashScreen/RCTSplashScreen/RCTSplashScreen.m

--- a/patches/react-native-zcash+0.3.2.patch
+++ b/patches/react-native-zcash+0.3.2.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/react-native-zcash/android/build.gradle b/node_modules/react-native-zcash/android/build.gradle
+index 32c6b6b..a77225c 100644
+--- a/node_modules/react-native-zcash/android/build.gradle
++++ b/node_modules/react-native-zcash/android/build.gradle
+@@ -81,9 +81,5 @@ dependencies {
+     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
+     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9"
+
+-    implementation ("androidx.appcompat:appcompat:1.3.1") {
+-        version {
+-            strictly '1.3.1'
+-        }
+-    }
++    implementation "androidx.appcompat:appcompat:1.3.1"
+ }


### PR DESCRIPTION
Google moved this library from the "android.support" namespace to the "androidx" namespace a few years ago. Not everybody has upgraded, so fix the stragglers.

This PR uses patch-package to solve the appcompat problem once and for all. Once this is merged, we can updot / upgrade react-native-zcash, react-native-piratechain, and edge-login-ui-rn at our leisure, since they will work together correctly. If we don't merge this first, Android builds will be broken in various exciting ways if we updot any of those 3 libraries.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204867804743082