### PR TITLE
Fix showError to submit Error object to Bugsnag

### DIFF
--- a/src/components/services/AirshipInstance.tsx
+++ b/src/components/services/AirshipInstance.tsx
@@ -19,12 +19,20 @@ export interface ShowErrorWarningOptions {
  */
 export function showError(error: unknown, options: ShowErrorWarningOptions = {}): void {
   const { trackError = true, tag } = options
-  const translatedError = tag ? `Tag: ${tag}. ` + translateError(error) : translateError(error)
+  const tagMessage = tag == null ? '' : `Tag: ${tag}. `
+  const translatedMessage = tagMessage + translateError(error)
   if (trackError) {
-    Bugsnag.notify(`showError: ${translatedError}`)
+    if (error instanceof Error) {
+      // Log error with stack trace and a translated message to Bugsnag:
+      error.message = translatedMessage
+      Bugsnag.notify(error)
+    } else {
+      // Any other types we just send the translated message to Bugsnag:
+      Bugsnag.notify(translatedMessage)
+    }
   }
   console.log(redText('Showing error drop-down alert: ' + makeErrorLog(error)))
-  Airship.show(bridge => <AlertDropdown bridge={bridge} message={translatedError} />).catch(err => console.error(err))
+  Airship.show(bridge => <AlertDropdown bridge={bridge} message={translatedMessage} />).catch(err => console.error(err))
 }
 
 /**

--- a/src/util/translateError.ts
+++ b/src/util/translateError.ts
@@ -25,7 +25,7 @@ export function makeErrorLog(error: unknown): string {
 }
 
 /**
- * Something got thrown, so turn that into a human-friendly string.
+ * Something got thrown, so turn that into a human-friendly message string.
  * @param {*} error Some value we got from `catch`
  * @returns A translated, human-friendly string (in many cases).
  */


### PR DESCRIPTION
Instead of sending the string to Bugsnag, we send the entire error
object so we retain the stack trace.

We will fallback to using `translateError` for unknown data types.

### CHANGELOG

- Fixed: Bugsnag error reporting for showError includes error stack trace

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204848238190311