### PR TITLE
Correctly track changes to the account status

### DIFF
--- a/src/components/scenes/LoginScene.tsx
+++ b/src/components/scenes/LoginScene.tsx
@@ -13,6 +13,7 @@ import { cacheStyles, Theme, useTheme } from '../../components/services/ThemeCon
 import { ENV } from '../../env'
 import { useAsyncValue } from '../../hooks/useAsyncValue'
 import { useHandler } from '../../hooks/useHandler'
+import { useWatch } from '../../hooks/useWatch'
 import { lstrings } from '../../locales/strings'
 import { config } from '../../theme/appConfig'
 import { useDispatch, useSelector } from '../../types/reactRedux'
@@ -52,6 +53,7 @@ export function LoginSceneComponent(props: Props) {
   const disklet = useSelector(state => state.core.disklet)
   const pendingDeepLink = useSelector(state => state.pendingDeepLink)
   const nextUsername = useSelector(state => state.nextUsername ?? undefined)
+  const loggedIn = useWatch(account, 'loggedIn')
 
   const [counter, setCounter] = React.useState<number>(0)
   const [notificationPermissionsInfo, setNotificationPermissionsInfo] = React.useState<NotificationPermissionsInfo | undefined>()
@@ -176,7 +178,7 @@ export function LoginSceneComponent(props: Props) {
     dispatch(showSendLogsModal()).catch(err => showError(err))
   })
 
-  return account.loggedIn ? (
+  return loggedIn ? (
     <LoadingScene />
   ) : (
     <View style={styles.container} testID="edge: login-scene">


### PR DESCRIPTION
We weren't re-rendering correctly when the account logged in, so our previous login-scene state got left behind.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205003154684908