### PR TITLE
Disable Firebase Debug for iOS develop production builds

### DIFF
--- a/deployPatches/edge/develop/edgeXcscheme.patch
+++ b/deployPatches/edge/develop/edgeXcscheme.patch
@@ -1,0 +1,18 @@
+diff --git a/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme b/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme
+index 029990137..9bee5519f 100644
+--- a/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme
++++ b/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme
+@@ -53,11 +53,11 @@
+       <CommandLineArguments>
+          <CommandLineArgument
+             argument = "-FIRDebugEnabled"
+-            isEnabled = "YES">
++            isEnabled = "NO">
+          </CommandLineArgument>
+          <CommandLineArgument
+             argument = "-FIRDebugDisabled"
+-            isEnabled = "NO">
++            isEnabled = "YES">
+          </CommandLineArgument>
+       </CommandLineArguments>
+    </LaunchAction>

--- a/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme
+++ b/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme
@@ -55,6 +55,10 @@
             argument = "-FIRDebugEnabled"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FIRDebugDisabled"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
Disable Firebase debug flag for iOS production builds

### CHANGELOG

- changed: Disable Firebase debug flag for iOS production builds

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203804137771411