### PR TITLE
Change the private key warning modal text to use a dynamic wallet name

### DIFF
--- a/src/actions/WalletListMenuActions.tsx
+++ b/src/actions/WalletListMenuActions.tsx
@@ -169,7 +169,7 @@ export function walletListMenuAction(
                 type="warning"
                 title={lstrings.string_warning}
                 marginRem={0.5}
-                message={lstrings.fragment_wallets_view_private_view_key_warning}
+                message={sprintf(lstrings.fragment_wallets_view_private_view_key_warning_s, getWalletName(wallet))}
                 numberOfLines={0}
               />
             )}

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -210,7 +210,7 @@ const strings = {
   fragment_wallets_copied_seed: 'Copied Seed',
   fragment_wallets_get_seed_wallet: 'Get Seed',
   fragment_wallets_view_private_view_key: 'Private View Key',
-  fragment_wallets_view_private_view_key_warning: `The private view key allows the receiver to see the balance in your Monero wallet. Do not share this key unless necessary, such as for tax purposes, accounting, or similar reasons.`,
+  fragment_wallets_view_private_view_key_warning_s: `The private view key allows the receiver to see the balance in your %1$s wallet. Do not share this key unless necessary, such as for tax purposes, accounting, or similar reasons.`,
   fragment_wallets_view_xpub: 'View XPub Address',
   fragment_wallets_pubkey_copied_title: 'XPub Address Copied',
   fragment_wallets_export_transactions: 'Export Transactions',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -158,7 +158,7 @@
   "fragment_wallets_copied_seed": "Copied Seed",
   "fragment_wallets_get_seed_wallet": "Get Seed",
   "fragment_wallets_view_private_view_key": "Private View Key",
-  "fragment_wallets_view_private_view_key_warning": "The private view key allows the receiver to see the balance in your Monero wallet. Do not share this key unless necessary, such as for tax purposes, accounting, or similar reasons.",
+  "fragment_wallets_view_private_view_key_warning_s": "The private view key allows the receiver to see the balance in your %1$s wallet. Do not share this key unless necessary, such as for tax purposes, accounting, or similar reasons.",
   "fragment_wallets_view_xpub": "View XPub Address",
   "fragment_wallets_pubkey_copied_title": "XPub Address Copied",
   "fragment_wallets_export_transactions": "Export Transactions",


### PR DESCRIPTION
<img width="400" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/7262c516-ce81-4444-b86c-1cb4e60b5e6f">

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205066911531007