### PR TITLE
Fix PasswordReminderModal Button Overlap

### DIFF
--- a/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
@@ -37,16 +37,29 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
     secureTextEntry={true}
     value=""
   />
-  <MainButton
-    label="Check Password"
-    marginRem={0.5}
-    onPress={[Function]}
+  <View
+    style={
+      {
+        "margin": 11,
+      }
+    }
   />
-  <MainButton
-    label="I forgot, change password"
-    marginRem={0.5}
-    onPress={[Function]}
-    type="secondary"
+  <Memo
+    layout="column"
+    primary={
+      {
+        "disabled": true,
+        "label": "Check Password",
+        "onPress": [Function],
+      }
+    }
+    secondary={
+      {
+        "disabled": false,
+        "label": "I forgot, change password",
+        "onPress": [Function],
+      }
+    }
   />
   <ModalFooter
     onPress={[Function]}

--- a/src/components/buttons/ButtonsContainer.tsx
+++ b/src/components/buttons/ButtonsContainer.tsx
@@ -4,6 +4,8 @@ import { View } from 'react-native'
 import { styled } from '../hoc/styled'
 import { MainButton, MainButtonType } from '../themed/MainButton'
 
+const BUTTON_MARGINS = [0.5, 0]
+
 export interface ButtonInfo {
   label: string
   onPress: () => void | Promise<void>
@@ -24,7 +26,7 @@ export const ButtonsContainer = React.memo(({ primary, secondary, escape, layout
   const renderButton = (type: MainButtonType, buttonProps?: ButtonInfo) => {
     if (buttonProps == null) return null
     const { label, onPress, disabled } = buttonProps
-    return <MainButton label={label} onPress={onPress} type={type} marginRem={0.5} disabled={disabled} />
+    return <MainButton label={label} onPress={onPress} type={type} marginRem={BUTTON_MARGINS} disabled={disabled} />
   }
 
   return (
@@ -37,10 +39,11 @@ export const ButtonsContainer = React.memo(({ primary, secondary, escape, layout
 })
 
 const StyledButtonContainer = styled(View)<{ layout: 'row' | 'column' }>(props => {
+  const isRowLayout = props.layout === 'row'
   return {
-    flexDirection: props.layout === 'row' ? 'row-reverse' : 'column',
-    justifyContent: 'space-between',
-    padding: props.theme.rem(0.5),
-    paddingHorizontal: props.theme.rem(1)
+    flexDirection: isRowLayout ? 'row-reverse' : 'column',
+    justifyContent: 'space-evenly',
+    margin: props.theme.rem(0.5),
+    marginHorizontal: isRowLayout ? 0 : props.theme.rem(0.5)
   }
 })

--- a/src/components/modals/PasswordReminderModal.tsx
+++ b/src/components/modals/PasswordReminderModal.tsx
@@ -6,9 +6,9 @@ import { AirshipBridge } from 'react-native-airship'
 import { lstrings } from '../../locales/strings'
 import { connect } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
+import { ButtonsContainer } from '../buttons/ButtonsContainer'
 import { showError, showToast } from '../services/AirshipInstance'
 import { ThemeProps, withTheme } from '../services/ThemeContext'
-import { MainButton } from '../themed/MainButton'
 import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { OutlinedTextInput } from '../themed/OutlinedTextInput'
 import { ThemedModal } from '../themed/ThemedModal'
@@ -31,7 +31,7 @@ interface DispatchProps {
 interface State {
   errorMessage?: string
   password: string
-  spinning: boolean
+  checkingPassword: boolean
 }
 
 type Props = OwnProps & StateProps & DispatchProps & ThemeProps
@@ -39,49 +39,44 @@ type Props = OwnProps & StateProps & DispatchProps & ThemeProps
 export class PasswordReminderModalComponent extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { spinning: false, password: '' }
+    this.state = { checkingPassword: false, password: '' }
   }
 
   handleCancel = () => {
-    if (!this.state.spinning) {
+    if (!this.state.checkingPassword) {
       this.props.onPostpone()
       this.props.bridge.resolve()
     }
   }
 
   handleRequestChangePassword = () => {
-    if (!this.state.spinning) {
+    if (!this.state.checkingPassword) {
       this.props.bridge.resolve()
       this.props.onRequestChangePassword()
       setTimeout(() => this.props.navigation.navigate('changePassword', {}), 10)
     }
   }
 
-  handleSubmit = () => {
+  handleSubmit = async () => {
     const { bridge, account } = this.props
     const { password } = this.state
 
-    this.setState({ spinning: true })
-    account
-      .checkPassword(password)
-      .then(isValidPassword => {
-        if (isValidPassword) {
-          this.props.onSuccess()
-          this.setState({ spinning: false })
-          showToast(lstrings.password_reminder_great_job)
-          setTimeout(() => bridge.resolve(), 10)
-        } else {
-          this.setState({ errorMessage: lstrings.password_reminder_invalid, spinning: false })
-        }
-      })
-      .catch(err => showError(err))
+    const isValidPassword = await account.checkPassword(password).catch(err => showError(err))
+    if (isValidPassword) {
+      this.props.onSuccess()
+      this.setState({ checkingPassword: false })
+      showToast(lstrings.password_reminder_great_job)
+      setTimeout(() => bridge.resolve(), 10)
+    } else {
+      this.setState({ errorMessage: lstrings.password_reminder_invalid, checkingPassword: false })
+    }
   }
 
   handleChangeText = (password: string) => this.setState({ password })
 
   render() {
     const { bridge, theme } = this.props
-    const { errorMessage, password, spinning } = this.state
+    const { errorMessage, password, checkingPassword } = this.state
 
     return (
       <ThemedModal bridge={bridge} onCancel={this.handleCancel}>
@@ -98,16 +93,19 @@ export class PasswordReminderModalComponent extends React.PureComponent<Props, S
           onSubmitEditing={this.handleSubmit}
           value={password}
         />
+        {/* HACK: Extra padding to accommodate potential error message 
+            TODO: Roll this into the built-in OutlinedTextInput margins and 
+            update all callers */}
+        <View style={{ margin: theme.rem(0.5) }} />
         {
           // Hack around the Android keyboard glitch:
           Platform.OS === 'android' ? <View style={{ flex: 1 }} /> : null
         }
-        {spinning ? (
-          <MainButton marginRem={0.5} spinner />
-        ) : (
-          <MainButton label={lstrings.password_reminder_check_password} marginRem={0.5} onPress={this.handleSubmit} />
-        )}
-        <MainButton label={lstrings.password_reminder_forgot_password} marginRem={0.5} type="secondary" onPress={this.handleRequestChangePassword} />
+        <ButtonsContainer
+          primary={{ label: lstrings.password_reminder_check_password, onPress: this.handleSubmit, disabled: password.length === 0 }}
+          secondary={{ label: lstrings.password_reminder_forgot_password, onPress: this.handleRequestChangePassword, disabled: checkingPassword }}
+          layout="column"
+        />
         <ModalFooter onPress={this.handleCancel} />
       </ThemedModal>
     )


### PR DESCRIPTION
Punted task to modify OutlinedTextInput such that this bug can no longer happen: https://app.asana.com/0/0/1205078580542521/f

<img width="410" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/27bb444e-02f3-4e97-aa6c-c33c53cd0613">

### CHANGELOG

- fixed: Password Reminder button overlap with error text on wrong password

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205013500013787