### PR TITLE
Fix text input

### DIFF
--- a/src/__tests__/components/__snapshots__/OutlinedTextInput.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/OutlinedTextInput.test.tsx.snap
@@ -10,9 +10,10 @@ exports[`OutlinedTextInput should render with some props 1`] = `
     style={
       [
         {
+          "alignItems": "center",
           "backgroundColor": "rgba(255, 255, 255, 0)",
           "borderRadius": 11,
-          "justifyContent": "center",
+          "flexDirection": "row",
           "minHeight": 67,
           "paddingHorizontal": 22,
         },
@@ -252,61 +253,47 @@ exports[`OutlinedTextInput should render with some props 1`] = `
         }
       />
     </TouchableOpacity>
-    <View
+    <TextInput
+      accessibilityState={
+        {
+          "disabled": false,
+        }
+      }
+      accessible={true}
+      autoCapitalize="none"
+      autoCorrect={true}
+      autoFocus={true}
+      blurOnSubmit={true}
+      editable={true}
+      inputAccessoryViewID="string"
+      keyboardType="default"
+      maxLength={11}
+      multiline={true}
+      onBlur={[Function]}
+      onChangeText={[Function]}
+      onFocus={[Function]}
+      onSubmitEditing={[Function]}
+      returnKeyType="done"
+      secureTextEntry={false}
+      selectionColor="#E85466"
       style={
         [
           {
-            "flexDirection": "row",
-            "justifyContent": "flex-start",
+            "color": "#FFFFFF",
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "fontFamily": "Quicksand-Regular",
+            "padding": 0,
           },
           {
-            "paddingRight": 65,
+            "fontSize": 22,
           },
         ]
       }
-    >
-      <TextInput
-        accessibilityState={
-          {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        autoCapitalize="none"
-        autoCorrect={true}
-        autoFocus={true}
-        blurOnSubmit={true}
-        editable={true}
-        inputAccessoryViewID="string"
-        keyboardType="default"
-        maxLength={11}
-        multiline={true}
-        onBlur={[Function]}
-        onChangeText={[Function]}
-        onFocus={[Function]}
-        onSubmitEditing={[Function]}
-        returnKeyType="done"
-        secureTextEntry={false}
-        selectionColor="#E85466"
-        style={
-          [
-            {
-              "alignSelf": "stretch",
-              "color": "#FFFFFF",
-              "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "padding": 0,
-            },
-            {
-              "flexGrow": 1,
-            },
-          ]
-        }
-        testID="string.textInput"
-        textAlignVertical="top"
-        value="string"
-      />
-    </View>
+      testID="string.textInput"
+      textAlignVertical="top"
+      value="string"
+    />
   </View>
 </TouchableWithoutFeedback>
 `;

--- a/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
@@ -50,9 +50,10 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           style={
             [
               {
+                "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
                 "borderRadius": 11,
-                "justifyContent": "center",
+                "flexDirection": "row",
                 "minHeight": 67,
                 "paddingHorizontal": 22,
               },
@@ -275,54 +276,40 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           >
             
           </Text>
-          <View
+          <TextInput
+            accessibilityState={
+              {
+                "disabled": false,
+              }
+            }
+            accessible={true}
+            autoFocus={false}
+            editable={true}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            returnKeyType="search"
+            secureTextEntry={false}
+            selectionColor="#FFFFFF"
             style={
               [
                 {
-                  "flexDirection": "row",
-                  "justifyContent": "flex-start",
+                  "color": "#FFFFFF",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontFamily": "Quicksand-Regular",
+                  "padding": 0,
                 },
                 {
-                  "paddingRight": 65,
+                  "fontSize": 22,
                 },
               ]
             }
-          >
-            <TextInput
-              accessibilityState={
-                {
-                  "disabled": false,
-                }
-              }
-              accessible={true}
-              autoFocus={false}
-              editable={true}
-              multiline={false}
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
-              returnKeyType="search"
-              secureTextEntry={false}
-              selectionColor="#FFFFFF"
-              style={
-                [
-                  {
-                    "alignSelf": "stretch",
-                    "color": "#FFFFFF",
-                    "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "padding": 0,
-                  },
-                  {
-                    "flexGrow": 0,
-                  },
-                ]
-              }
-              testID="undefined.textInput"
-              textAlignVertical="top"
-              value=""
-            />
-          </View>
+            testID="undefined.textInput"
+            textAlignVertical="top"
+            value=""
+          />
         </View>
       </View>
     </View>
@@ -1155,9 +1142,10 @@ exports[`TransactionListTop should render 1`] = `
           style={
             [
               {
+                "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
                 "borderRadius": 11,
-                "justifyContent": "center",
+                "flexDirection": "row",
                 "minHeight": 67,
                 "paddingHorizontal": 22,
               },
@@ -1380,54 +1368,40 @@ exports[`TransactionListTop should render 1`] = `
           >
             
           </Text>
-          <View
+          <TextInput
+            accessibilityState={
+              {
+                "disabled": false,
+              }
+            }
+            accessible={true}
+            autoFocus={false}
+            editable={true}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            returnKeyType="search"
+            secureTextEntry={false}
+            selectionColor="#FFFFFF"
             style={
               [
                 {
-                  "flexDirection": "row",
-                  "justifyContent": "flex-start",
+                  "color": "#FFFFFF",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontFamily": "Quicksand-Regular",
+                  "padding": 0,
                 },
                 {
-                  "paddingRight": 65,
+                  "fontSize": 22,
                 },
               ]
             }
-          >
-            <TextInput
-              accessibilityState={
-                {
-                  "disabled": false,
-                }
-              }
-              accessible={true}
-              autoFocus={false}
-              editable={true}
-              multiline={false}
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
-              returnKeyType="search"
-              secureTextEntry={false}
-              selectionColor="#FFFFFF"
-              style={
-                [
-                  {
-                    "alignSelf": "stretch",
-                    "color": "#FFFFFF",
-                    "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "padding": 0,
-                  },
-                  {
-                    "flexGrow": 0,
-                  },
-                ]
-              }
-              testID="undefined.textInput"
-              textAlignVertical="top"
-              value=""
-            />
-          </View>
+            testID="undefined.textInput"
+            textAlignVertical="top"
+            value=""
+          />
         </View>
       </View>
     </View>

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -401,9 +401,10 @@ exports[`CategoryModal should render with a subcategory 1`] = `
       style={
         [
           {
+            "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderRadius": 11,
-            "justifyContent": "center",
+            "flexDirection": "row",
             "minHeight": 67,
             "paddingHorizontal": 22,
           },
@@ -662,56 +663,42 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           
         </Text>
       </View>
-      <View
+      <TextInput
+        accessibilityState={
+          {
+            "disabled": false,
+          }
+        }
+        accessible={true}
+        autoCapitalize="none"
+        autoFocus={true}
+        editable={true}
+        multiline={false}
+        onBlur={[Function]}
+        onChangeText={[Function]}
+        onFocus={[Function]}
+        onSubmitEditing={[Function]}
+        returnKeyType="done"
+        secureTextEntry={false}
+        selectionColor="#FFFFFF"
         style={
           [
             {
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "color": "#FFFFFF",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "fontFamily": "Quicksand-Regular",
+              "padding": 0,
             },
             {
-              "paddingRight": 65,
+              "fontSize": 22,
             },
           ]
         }
-      >
-        <TextInput
-          accessibilityState={
-            {
-              "disabled": false,
-            }
-          }
-          accessible={true}
-          autoCapitalize="none"
-          autoFocus={true}
-          editable={true}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          returnKeyType="done"
-          secureTextEntry={false}
-          selectionColor="#FFFFFF"
-          style={
-            [
-              {
-                "alignSelf": "stretch",
-                "color": "#FFFFFF",
-                "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
-                "padding": 0,
-              },
-              {
-                "flexGrow": 0,
-              },
-            ]
-          }
-          testID="undefined.textInput"
-          textAlignVertical="top"
-          value="Paycheck"
-        />
-      </View>
+        testID="undefined.textInput"
+        textAlignVertical="top"
+        value="Paycheck"
+      />
     </View>
     <View
       style={
@@ -1486,9 +1473,10 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
       style={
         [
           {
+            "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderRadius": 11,
-            "justifyContent": "center",
+            "flexDirection": "row",
             "minHeight": 67,
             "paddingHorizontal": 22,
           },
@@ -1684,56 +1672,42 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
         }
         testID="undefined.charLimit"
       />
-      <View
+      <TextInput
+        accessibilityState={
+          {
+            "disabled": false,
+          }
+        }
+        accessible={true}
+        autoCapitalize="none"
+        autoFocus={true}
+        editable={true}
+        multiline={false}
+        onBlur={[Function]}
+        onChangeText={[Function]}
+        onFocus={[Function]}
+        onSubmitEditing={[Function]}
+        returnKeyType="done"
+        secureTextEntry={false}
+        selectionColor="#FFFFFF"
         style={
           [
             {
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "color": "#FFFFFF",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "fontFamily": "Quicksand-Regular",
+              "padding": 0,
             },
             {
-              "paddingRight": 65,
+              "fontSize": 22,
             },
           ]
         }
-      >
-        <TextInput
-          accessibilityState={
-            {
-              "disabled": false,
-            }
-          }
-          accessible={true}
-          autoCapitalize="none"
-          autoFocus={true}
-          editable={true}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          returnKeyType="done"
-          secureTextEntry={false}
-          selectionColor="#FFFFFF"
-          style={
-            [
-              {
-                "alignSelf": "stretch",
-                "color": "#FFFFFF",
-                "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
-                "padding": 0,
-              },
-              {
-                "flexGrow": 0,
-              },
-            ]
-          }
-          testID="undefined.textInput"
-          textAlignVertical="top"
-          value=""
-        />
-      </View>
+        testID="undefined.textInput"
+        textAlignVertical="top"
+        value=""
+      />
     </View>
     <View
       style={

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -141,9 +141,10 @@ exports[`WalletListModal should render with loading props 1`] = `
       style={
         [
           {
+            "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderRadius": 11,
-            "justifyContent": "center",
+            "flexDirection": "row",
             "minHeight": 67,
             "paddingHorizontal": 22,
           },
@@ -366,54 +367,40 @@ exports[`WalletListModal should render with loading props 1`] = `
       >
         
       </Text>
-      <View
+      <TextInput
+        accessibilityState={
+          {
+            "disabled": false,
+          }
+        }
+        accessible={true}
+        autoFocus={false}
+        editable={true}
+        multiline={false}
+        onBlur={[Function]}
+        onChangeText={[Function]}
+        onFocus={[Function]}
+        returnKeyType="search"
+        secureTextEntry={false}
+        selectionColor="#FFFFFF"
         style={
           [
             {
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "color": "#FFFFFF",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "fontFamily": "Quicksand-Regular",
+              "padding": 0,
             },
             {
-              "paddingRight": 65,
+              "fontSize": 22,
             },
           ]
         }
-      >
-        <TextInput
-          accessibilityState={
-            {
-              "disabled": false,
-            }
-          }
-          accessible={true}
-          autoFocus={false}
-          editable={true}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          returnKeyType="search"
-          secureTextEntry={false}
-          selectionColor="#FFFFFF"
-          style={
-            [
-              {
-                "alignSelf": "stretch",
-                "color": "#FFFFFF",
-                "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
-                "padding": 0,
-              },
-              {
-                "flexGrow": 0,
-              },
-            ]
-          }
-          testID="undefined.textInput"
-          textAlignVertical="top"
-          value=""
-        />
-      </View>
+        testID="undefined.textInput"
+        textAlignVertical="top"
+        value=""
+      />
     </View>
     <View
       style={

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -163,9 +163,10 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
       style={
         [
           {
+            "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderRadius": 11,
-            "justifyContent": "center",
+            "flexDirection": "row",
             "minHeight": 67,
             "paddingHorizontal": 22,
           },
@@ -361,57 +362,43 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
         }
         testID="undefined.charLimit"
       />
-      <View
+      <TextInput
+        accessibilityState={
+          {
+            "disabled": false,
+          }
+        }
+        accessible={true}
+        autoCapitalize="none"
+        autoCorrect={false}
+        autoFocus={true}
+        editable={true}
+        multiline={false}
+        onBlur={[Function]}
+        onChangeText={[Function]}
+        onFocus={[Function]}
+        onSubmitEditing={[Function]}
+        returnKeyType="next"
+        secureTextEntry={false}
+        selectionColor="#FFFFFF"
         style={
           [
             {
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "color": "#FFFFFF",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "fontFamily": "Quicksand-Regular",
+              "padding": 0,
             },
             {
-              "paddingRight": 65,
+              "fontSize": 22,
             },
           ]
         }
-      >
-        <TextInput
-          accessibilityState={
-            {
-              "disabled": false,
-            }
-          }
-          accessible={true}
-          autoCapitalize="none"
-          autoCorrect={false}
-          autoFocus={true}
-          editable={true}
-          multiline={false}
-          onBlur={[Function]}
-          onChangeText={[Function]}
-          onFocus={[Function]}
-          onSubmitEditing={[Function]}
-          returnKeyType="next"
-          secureTextEntry={false}
-          selectionColor="#FFFFFF"
-          style={
-            [
-              {
-                "alignSelf": "stretch",
-                "color": "#FFFFFF",
-                "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
-                "padding": 0,
-              },
-              {
-                "flexGrow": 0,
-              },
-            ]
-          }
-          testID="undefined.textInput"
-          textAlignVertical="top"
-          value=""
-        />
-      </View>
+        testID="undefined.textInput"
+        textAlignVertical="top"
+        value=""
+      />
     </View>
     <View
       accessibilityState={

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -132,9 +132,10 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
         style={
           [
             {
+              "alignItems": "center",
               "backgroundColor": "rgba(255, 255, 255, 0)",
               "borderRadius": 11,
-              "justifyContent": "center",
+              "flexDirection": "row",
               "minHeight": 67,
               "paddingHorizontal": 22,
             },
@@ -357,57 +358,43 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
         >
           
         </Text>
-        <View
+        <TextInput
+          accessibilityState={
+            {
+              "disabled": false,
+            }
+          }
+          accessible={true}
+          autoCapitalize="words"
+          autoCorrect={false}
+          autoFocus={false}
+          editable={true}
+          multiline={false}
+          onBlur={[Function]}
+          onChangeText={[Function]}
+          onFocus={[Function]}
+          onSubmitEditing={[Function]}
+          returnKeyType="next"
+          secureTextEntry={false}
+          selectionColor="#FFFFFF"
           style={
             [
               {
-                "flexDirection": "row",
-                "justifyContent": "flex-start",
+                "color": "#FFFFFF",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "fontFamily": "Quicksand-Regular",
+                "padding": 0,
               },
               {
-                "paddingRight": 65,
+                "fontSize": 22,
               },
             ]
           }
-        >
-          <TextInput
-            accessibilityState={
-              {
-                "disabled": false,
-              }
-            }
-            accessible={true}
-            autoCapitalize="words"
-            autoCorrect={false}
-            autoFocus={false}
-            editable={true}
-            multiline={false}
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            onSubmitEditing={[Function]}
-            returnKeyType="next"
-            secureTextEntry={false}
-            selectionColor="#FFFFFF"
-            style={
-              [
-                {
-                  "alignSelf": "stretch",
-                  "color": "#FFFFFF",
-                  "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "padding": 0,
-                },
-                {
-                  "flexGrow": 0,
-                },
-              ]
-            }
-            testID="undefined.textInput"
-            textAlignVertical="top"
-            value=""
-          />
-        </View>
+          testID="undefined.textInput"
+          textAlignVertical="top"
+          value=""
+        />
       </View>
       <View
         style={

--- a/src/components/themed/OutlinedTextInput.tsx
+++ b/src/components/themed/OutlinedTextInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ActivityIndicator, Platform, TextInput, TextStyle, TouchableOpacity, TouchableWithoutFeedback, View, ViewStyle } from 'react-native'
+import { ActivityIndicator, LayoutChangeEvent, Platform, TextInput, TextStyle, TouchableOpacity, TouchableWithoutFeedback, View, ViewStyle } from 'react-native'
 import Animated, { interpolateColor, useAnimatedStyle, useSharedValue, withDelay, withTiming } from 'react-native-reanimated'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import IonIcon from 'react-native-vector-icons/Ionicons'
@@ -140,13 +140,11 @@ export const OutlinedTextInput = React.forwardRef<OutlinedTextInputRef, Outlined
 
   // Captures the width of the placeholder label:
   const [labelWidth, setLabelWidth] = React.useState(0)
-  // @ts-expect-error
-  const handleLabelLayout = event => setLabelWidth(event.nativeEvent.layout.width)
+  const handleLabelLayout = (event: LayoutChangeEvent) => setLabelWidth(event.nativeEvent.layout.width)
 
   // Captures the width of the counter label:
   const [counterWidth, setCounterWidth] = React.useState(0)
-  // @ts-expect-error
-  const handleCounterLayout = event => setCounterWidth(event.nativeEvent.layout.width)
+  const handleCounterLayout = (event: LayoutChangeEvent) => setCounterWidth(event.nativeEvent.layout.width)
 
   // Animates between 0 and 1 based our disabled state:
   const disabledAnimation = useSharedValue(0)
@@ -327,8 +325,7 @@ export const OutlinedTextInput = React.forwardRef<OutlinedTextInputRef, Outlined
   // Character limit
   const charLimitLabel = maxLength === undefined ? '' : `${maxLength - value.length}`
 
-  // @ts-expect-error
-  const numpad = props.keyboardType === 'decimal-pad' || props.keyboardType === 'decimal'
+  const numpad = props.keyboardType === 'decimal-pad'
   const textStyle = numpad ? styles.numberInput : styles.textInput
   const suffixStyle = React.useMemo(() => [styles.suffixText, Platform.OS === 'android' ? styles.suffixAndroidAdjust : null], [styles])
 


### PR DESCRIPTION
The "suffix" feature on the FIO registration scene works by making the text input tiny. As the user enters text, the input gets wider, and the suffix moves to the right.

This means that the text input itself is tiny to start, so there is no tappable area for a user to long-press on. This is unacceptable, so the FIO effect needs to go. We can still keep the suffix, just not attached to the text:

![simulator_screenshot_39BC1F00-A76E-41DC-96DC-595DFDE78E0B](https://github.com/EdgeApp/edge-react-gui/assets/276214/d17f40d0-04d2-4a9d-9f1c-93371259a992)

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205064445212746