### PR TITLE
Drop the wallet menu as soon as possible

### DIFF
--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -16,6 +16,7 @@ import { NavigationProp } from '../../types/routerTypes'
 import { getCurrencyCode, getCurrencyInfos } from '../../util/CurrencyInfoHelpers'
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import { CryptoIcon } from '../icons/CryptoIcon'
+import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { ModalFooter, ModalTitle } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
@@ -135,11 +136,8 @@ export function WalletListMenuModal(props: Props) {
   const handleCancel = () => props.bridge.resolve()
 
   const optionAction = useHandler((option: WalletListMenuKey) => {
-    dispatch(walletListMenuAction(navigation, walletId, option, tokenId))
-      .then(() => bridge.resolve())
-      .catch((error: any) => {
-        bridge.reject(error)
-      })
+    bridge.resolve()
+    dispatch(walletListMenuAction(navigation, walletId, option, tokenId)).catch(error => showError(error))
   })
 
   useAsyncEffect(async () => {


### PR DESCRIPTION
We used to wait for the action to finish, but resyncing the wallet can take a while, leaving the menu visible. Instead, drop the modal immediately.

### CHANGELOG

none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205100282680505