### PR TITLE
Reverse the default and patch values for FIRDebug

### DIFF
--- a/deployPatches/edge/develop/edgeXcscheme.patch
+++ b/deployPatches/edge/develop/edgeXcscheme.patch
@@ -6,13 +6,13 @@ index 029990137..9bee5519f 100644
        <CommandLineArguments>
           <CommandLineArgument
              argument = "-FIRDebugEnabled"
--            isEnabled = "YES">
-+            isEnabled = "NO">
+-            isEnabled = "NO">
++            isEnabled = "YES">
           </CommandLineArgument>
           <CommandLineArgument
              argument = "-FIRDebugDisabled"
--            isEnabled = "NO">
-+            isEnabled = "YES">
+-            isEnabled = "YES">
++            isEnabled = "NO">
           </CommandLineArgument>
        </CommandLineArguments>
     </LaunchAction>

--- a/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme
+++ b/ios/edge.xcodeproj/xcshareddata/xcschemes/edge.xcscheme
@@ -53,11 +53,11 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "-FIRDebugEnabled"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-FIRDebugDisabled"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>


### PR DESCRIPTION
Default iOS edge.xcscheme is now with FIRDebug disabled, while the patch for the develop build enables it.

### CHANGELOG

- fixed: iOS Firebase debug settings improperly set.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205227220396846