### PR TITLE
Fix broken 1st logout routing for accounts created from USPs 

### DIFF
--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -79,6 +79,7 @@ const sections: SectionData[] = [
 export const GettingStartedScene = (props: Props) => {
   const { navigation } = props
   const context = useSelector(state => state.core.context)
+  const isLoggedIn = useSelector(state => state.ui.settings.settingsLoaded ?? false)
   const localUsers = useWatch(context, 'localUsers')
   const hasLocalUsers = localUsers.length > 0
 
@@ -154,11 +155,14 @@ export const GettingStartedScene = (props: Props) => {
   }, [])
 
   // Redirect to login screen if device has memory of accounts
+  // HACK: It's unknown how the localUsers dependency makes the routing work
+  // properly, but use isLoggedIn explicitly to address the bug where this
+  // effect would cause an unwanted navigation while logged in.
   useEffect(() => {
-    if (hasLocalUsers) {
+    if (localUsers.length > 0 && !isLoggedIn) {
       navigation.navigate('login', {})
     }
-  }, [navigation, hasLocalUsers])
+  }, [isLoggedIn, localUsers, navigation])
 
   return (
     <SceneWrapper hasHeader={false}>


### PR DESCRIPTION
For some reason, the fix in #4358 was too broad and caused regressions in the logout behavior for accounts created from the USPs. This change resolves the regression while preserving the original fix.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205225723936372