### PR TITLE
Remove Header Buttons for New Account Wallet Creation

### DIFF
--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -385,7 +385,6 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
           onChangeText={[Function]}
           onFocus={[Function]}
           onSubmitEditing={[Function]}
-          returnKeyType="next"
           secureTextEntry={false}
           selectionColor="#FFFFFF"
           style={

--- a/src/actions/LoginActions.tsx
+++ b/src/actions/LoginActions.tsx
@@ -99,7 +99,7 @@ export function initializeAccount(navigation: NavigationBase, account: EdgeAccou
       navigation.navigate('edgeApp', {
         screen: 'edgeAppStack',
         params: {
-          screen: 'createWalletSelectCrypto',
+          screen: 'createWalletSelectCryptoNewAccount',
           params: { newAccountFlow, defaultSelection }
         }
       })

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -394,6 +394,15 @@ const EdgeAppStack = () => {
         }}
       />
       <Stack.Screen name="createWalletSelectCrypto" component={CreateWalletSelectCryptoScene} />
+      <Stack.Screen
+        name="createWalletSelectCryptoNewAccount"
+        component={CreateWalletSelectCryptoScene}
+        options={{
+          headerRight: () => null,
+          headerTitle: () => <EdgeLogoHeader />,
+          headerLeft: () => null
+        }}
+      />
       <Stack.Screen name="createWalletSelectFiat" component={CreateWalletSelectFiatScene} />
       <Stack.Screen
         name="currencyNotificationSettings"

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -1,6 +1,6 @@
 import { FlashList, ListRenderItem } from '@shopify/flash-list'
 import * as React from 'react'
-import { Switch, View } from 'react-native'
+import { Keyboard, Switch, View } from 'react-native'
 import { sprintf } from 'sprintf-js'
 
 import { enableTokensAcrossWallets, MainWalletCreateItem, PLACEHOLDER_WALLET_ID, splitCreateWalletItems } from '../../actions/CreateWalletActions'
@@ -198,7 +198,7 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
   })
 
   const handleSubmitEditing = useHandler(() => {
-    handleNextPress().catch(err => showError(err))
+    Keyboard.dismiss()
   })
 
   const renderCreateWalletRow: ListRenderItem<WalletCreateItem> = useHandler(item => {
@@ -255,7 +255,6 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
             onChangeText={setSearchTerm}
             value={searchTerm}
             label={lstrings.wallet_list_wallet_search}
-            returnKeyType="next"
             marginRem={[0.5, 1]}
             searchIcon
             clearIcon

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -24,11 +24,11 @@ import { filterWalletCreateItemListBySearchText, getCreateWalletList, WalletCrea
 import { WalletListCurrencyRow } from '../themed/WalletListCurrencyRow'
 
 export interface CreateWalletSelectCryptoParams {
-  newAccountFlow?: (navigation: NavigationProp<'createWalletSelectCrypto'>, items: WalletCreateItem[]) => Promise<void>
+  newAccountFlow?: (navigation: NavigationProp<'createWalletSelectCrypto' | 'createWalletSelectCryptoNewAccount'>, items: WalletCreateItem[]) => Promise<void>
   defaultSelection?: EdgeTokenId[]
 }
 
-interface Props extends EdgeSceneProps<'createWalletSelectCrypto'> {}
+interface Props extends EdgeSceneProps<'createWalletSelectCrypto' | 'createWalletSelectCryptoNewAccount'> {}
 
 const CreateWalletSelectCryptoComponent = (props: Props) => {
   const { navigation, route } = props

--- a/src/types/routerTypes.tsx
+++ b/src/types/routerTypes.tsx
@@ -95,6 +95,7 @@ export interface RouteParamList {
   createWalletImport: CreateWalletImportParams
   createWalletImportOptions: CreateWalletImportOptionsParams
   createWalletSelectCrypto: CreateWalletSelectCryptoParams
+  createWalletSelectCryptoNewAccount: CreateWalletSelectCryptoParams
   createWalletSelectFiat: CreateWalletSelectFiatParams
   currencyNotificationSettings: {
     currencyInfo: EdgeCurrencyInfo


### PR DESCRIPTION
Split the scene into newAccountFlow/non-newAccountFlow usage to allow independent configuration of header button visibility in Main.tsx

### CHANGELOG

- removed: Header buttons for new accounts' initial wallet creation

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205214041882472