### PR TITLE
Update AAVE BTC->WBTC Swap Minimums to $30

### DIFF
--- a/src/components/scenes/Loans/LoanCreateScene.tsx
+++ b/src/components/scenes/Loans/LoanCreateScene.tsx
@@ -199,7 +199,7 @@ export const LoanCreateScene = (props: Props) => {
 
   const minSwapInputNativeAmount = useSelector(state =>
     isRequiresSwap && borrowPlugin.borrowInfo.currencyPluginId === 'polygon' && srcCurrencyCode != null && srcExchangeMultiplier != null
-      ? truncateDecimals(mul('110', convertCurrency(state, 'iso:USD', srcCurrencyCode, srcExchangeMultiplier)), 0)
+      ? truncateDecimals(mul('30', convertCurrency(state, 'iso:USD', srcCurrencyCode, srcExchangeMultiplier)), 0)
       : '0'
   )
 


### PR DESCRIPTION
### CHANGELOG

- changed: Update BTC->WBTC swap minimums from $110 to $30 for AAVE loans

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
