### PR TITLE
Open links in a browser if account isn't logged in

### DIFF
--- a/src/components/modals/HelpModal.tsx
+++ b/src/components/modals/HelpModal.tsx
@@ -6,9 +6,12 @@ import { sprintf } from 'sprintf-js'
 
 import { Fontello } from '../../assets/vector'
 import { useHandler } from '../../hooks/useHandler'
+import { useWatch } from '../../hooks/useWatch'
 import { lstrings } from '../../locales/strings'
 import { config } from '../../theme/appConfig'
+import { useSelector } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
+import { openBrowserUri } from '../../util/WebUtils'
 import { Airship } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
@@ -31,12 +34,20 @@ interface Props {
 export const HelpModal = (props: Props) => {
   const { bridge, navigation } = props
   const theme = useTheme()
+  const account = useSelector(state => state.core.account)
+  const loggedIn = useWatch(account, 'loggedIn')
 
   const handleClose = useHandler(() => bridge.resolve())
 
   const handleSitePress = useHandler((title: string, uri: string) => {
-    navigation.navigate('webView', { title, uri })
-    Airship.clear()
+    if (loggedIn) {
+      navigation.navigate('webView', { title, uri })
+      Airship.clear()
+    } else {
+      // Just open in a browser since we don't all the features of a full
+      // logged-in scene:
+      openBrowserUri(uri)
+    }
   })
 
   React.useEffect(() => {


### PR DESCRIPTION
We still want to avoid modals on top of modals as in the old implementation, so opening a browser window is the next best thing.

We may want to consider opening a browser for this modal in all cases (logged in/out) since the pages are difficult to navigate without a browser back button.

### CHANGELOG

- fixed: Help modal links inoperable while logged out

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205332221444460