### PR TITLE
Reorganize Modal UI Heirarchy

### DIFF
--- a/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
@@ -53,8 +53,5 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
       showSpinner={false}
     />
   </View>
-  <ModalFooter
-    onPress={[Function]}
-  />
 </ThemedModal>
 `;

--- a/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
@@ -75,8 +75,5 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
       type="secondary"
     />
   </View>
-  <ModalFooter
-    onPress={[Function]}
-  />
 </ThemedModal>
 `;

--- a/src/__tests__/modals/__snapshots__/AdvancedDetailsModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AdvancedDetailsModal.test.tsx.snap
@@ -365,67 +365,64 @@ exports[`AdvancedDetailsModal should render with loading props 1`] = `
         </View>
       </RCTScrollView>
     </View>
-    <View>
-      <View>
-        <View
-          accessibilityState={
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": -22,
+          "opacity": 1,
+          "padding": 22,
+        }
+      }
+    >
+      <Text
+        accessibilityHint="Close modal"
+        allowFontScaling={false}
+        style={
+          [
             {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
+              "color": "#00f1a2",
+              "fontSize": 28,
+            },
+            undefined,
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            {
-              "alignItems": "center",
-              "opacity": 1,
-              "padding": 22,
-            }
-          }
-        >
-          <Text
-            accessibilityHint="Close modal"
-            allowFontScaling={false}
-            style={
-              [
-                {
-                  "color": "#00f1a2",
-                  "fontSize": 28,
-                },
-                undefined,
-                {
-                  "fontFamily": "anticon",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-          >
-            
-          </Text>
-        </View>
-      </View>
+              "fontFamily": "anticon",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            {},
+          ]
+        }
+      >
+        
+      </Text>
     </View>
   </View>,
 ]

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -715,55 +715,33 @@ exports[`CategoryModal should render with a subcategory 1`] = `
       style={
         {
           "flex": 1,
-          "overflow": "hidden",
         }
       }
     >
-      <RCTScrollView
-        applyWindowCorrection={[Function]}
-        canChangeSize={true}
-        contentContainerStyle={
+      <View
+        style={
           {
-            "backgroundColor": undefined,
-            "minHeight": 1,
-            "minWidth": 1,
-            "paddingLeft": 0,
-            "paddingRight": 0,
+            "flex": 1,
+            "overflow": "hidden",
           }
         }
-        contentHeight={0}
-        contentWidth={0}
-        data={
-          [
+      >
+        <RCTScrollView
+          applyWindowCorrection={[Function]}
+          canChangeSize={true}
+          contentContainerStyle={
             {
-              "display": "Income: Paycheck",
-              "new": true,
-              "raw": "Income:Paycheck",
-              "selected": true,
-            },
-            {
-              "display": "Exchange: Paycheck",
-              "new": true,
-              "raw": "Exchange:Paycheck",
-              "selected": false,
-            },
-            {
-              "display": "Expense: Paycheck",
-              "new": true,
-              "raw": "Expense:Paycheck",
-              "selected": false,
-            },
-            {
-              "display": "Transfer: Paycheck",
-              "new": true,
-              "raw": "Transfer:Paycheck",
-              "selected": false,
-            },
-          ]
-        }
-        dataProvider={
-          DataProvider {
-            "_data": [
+              "backgroundColor": undefined,
+              "minHeight": 1,
+              "minWidth": 1,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+            }
+          }
+          contentHeight={0}
+          contentWidth={0}
+          data={
+            [
               {
                 "display": "Income: Paycheck",
                 "new": true,
@@ -788,58 +766,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 "raw": "Transfer:Paycheck",
                 "selected": false,
               },
-            ],
-            "_firstIndexToProcess": 0,
-            "_hasStableIds": true,
-            "_requiresDataChangeHandling": false,
-            "_size": 4,
-            "getStableId": [Function],
-            "rowHasChanged": [Function],
+            ]
           }
-        }
-        disableRecycling={false}
-        estimatedItemSize={67}
-        extendedState={{}}
-        externalScrollView={[Function]}
-        finalRenderAheadOffset={250}
-        forceNonDeterministicRendering={true}
-        horizontal={false}
-        initialOffset={0}
-        initialRenderIndex={0}
-        isHorizontal={false}
-        keyExtractor={[Function]}
-        keyboardShouldPersistTaps="handled"
-        layoutProvider={
-          GridLayoutProviderWithProps {
-            "_acceptableRelayoutDelta": 1,
-            "_getHeightOrWidth": [Function],
-            "_getLayoutTypeForIndex": [Function],
-            "_getSpan": [Function],
-            "_hasExpired": false,
-            "_maxSpan": 1,
-            "_setLayoutForType": [Function],
-            "_tempDim": {
-              "height": 0,
-              "width": 0,
-            },
-            "averageWindow": AverageWindow {
-              "currentAverage": 67,
-              "currentCount": 1,
-              "inputValues": [
-                67,
-              ],
-              "nextIndex": 1,
-            },
-            "defaultEstimatedItemSize": 100,
-            "layoutObject": {
-              "size": undefined,
-              "span": undefined,
-            },
-            "props": {
-              "contentContainerStyle": {
-                "paddingBottom": 56,
-              },
-              "data": [
+          dataProvider={
+            DataProvider {
+              "_data": [
                 {
                   "display": "Income: Paycheck",
                   "new": true,
@@ -865,110 +796,179 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                   "selected": false,
                 },
               ],
-              "estimatedItemSize": 67,
-              "keyExtractor": [Function],
-              "keyboardShouldPersistTaps": "handled",
-              "numColumns": 1,
-              "renderItem": [Function],
-            },
-            "renderWindowInsets": {
-              "height": 0,
-              "width": 0,
-            },
-            "shouldRefreshWithAnchoring": true,
-          }
-        }
-        maxRenderAhead={750}
-        numColumns={1}
-        onEndReached={[Function]}
-        onEndReachedThreshold={0}
-        onEndReachedThresholdRelative={0}
-        onItemLayout={[Function]}
-        onLayout={[Function]}
-        onScroll={[Function]}
-        onScrollBeginDrag={[Function]}
-        onSizeChanged={[Function]}
-        onVisibleIndicesChanged={[Function]}
-        removeClippedSubviews={false}
-        renderAheadOffset={0}
-        renderAheadStep={250}
-        renderContentContainer={[Function]}
-        renderItem={[Function]}
-        renderItemContainer={[Function]}
-        rowRenderer={[Function]}
-        scrollEventThrottle={16}
-        scrollThrottle={16}
-        scrollViewProps={
-          {
-            "contentContainerStyle": {
-              "backgroundColor": undefined,
-              "minHeight": 1,
-              "minWidth": 1,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-            },
-            "onLayout": [Function],
-            "onScrollBeginDrag": [Function],
-            "refreshControl": undefined,
-            "style": {
-              "minHeight": 1,
-              "minWidth": 1,
-            },
-          }
-        }
-        style={
-          {
-            "minHeight": 1,
-            "minWidth": 1,
-          }
-        }
-        suppressBoundedSizeException={true}
-        windowCorrectionConfig={
-          {
-            "applyToInitialOffset": true,
-            "applyToItemScroll": true,
-            "value": {
-              "endCorrection": 0,
-              "startCorrection": 0,
-              "windowShift": -0,
-            },
-          }
-        }
-      >
-        <View>
-          <View
-            style={
-              {
-                "flexDirection": "column",
-              }
+              "_firstIndexToProcess": 0,
+              "_hasStableIds": true,
+              "_requiresDataChangeHandling": false,
+              "_size": 4,
+              "getStableId": [Function],
+              "rowHasChanged": [Function],
             }
-          >
-            <AutoLayoutView
-              enableInstrumentation={false}
-              horizontal={false}
-              onBlankAreaEvent={[Function]}
-              onLayout={[Function]}
-              renderAheadOffset={0}
-              scrollOffset={0}
+          }
+          disableRecycling={false}
+          estimatedItemSize={67}
+          extendedState={{}}
+          externalScrollView={[Function]}
+          finalRenderAheadOffset={250}
+          forceNonDeterministicRendering={true}
+          horizontal={false}
+          initialOffset={0}
+          initialRenderIndex={0}
+          isHorizontal={false}
+          keyExtractor={[Function]}
+          keyboardShouldPersistTaps="handled"
+          layoutProvider={
+            GridLayoutProviderWithProps {
+              "_acceptableRelayoutDelta": 1,
+              "_getHeightOrWidth": [Function],
+              "_getLayoutTypeForIndex": [Function],
+              "_getSpan": [Function],
+              "_hasExpired": false,
+              "_maxSpan": 1,
+              "_setLayoutForType": [Function],
+              "_tempDim": {
+                "height": 0,
+                "width": 0,
+              },
+              "averageWindow": AverageWindow {
+                "currentAverage": 67,
+                "currentCount": 1,
+                "inputValues": [
+                  67,
+                ],
+                "nextIndex": 1,
+              },
+              "defaultEstimatedItemSize": 100,
+              "layoutObject": {
+                "size": undefined,
+                "span": undefined,
+              },
+              "props": {
+                "contentContainerStyle": {
+                  "paddingBottom": 67,
+                },
+                "data": [
+                  {
+                    "display": "Income: Paycheck",
+                    "new": true,
+                    "raw": "Income:Paycheck",
+                    "selected": true,
+                  },
+                  {
+                    "display": "Exchange: Paycheck",
+                    "new": true,
+                    "raw": "Exchange:Paycheck",
+                    "selected": false,
+                  },
+                  {
+                    "display": "Expense: Paycheck",
+                    "new": true,
+                    "raw": "Expense:Paycheck",
+                    "selected": false,
+                  },
+                  {
+                    "display": "Transfer: Paycheck",
+                    "new": true,
+                    "raw": "Transfer:Paycheck",
+                    "selected": false,
+                  },
+                ],
+                "estimatedItemSize": 67,
+                "keyExtractor": [Function],
+                "keyboardShouldPersistTaps": "handled",
+                "numColumns": 1,
+                "renderItem": [Function],
+              },
+              "renderWindowInsets": {
+                "height": 0,
+                "width": 0,
+              },
+              "shouldRefreshWithAnchoring": true,
+            }
+          }
+          maxRenderAhead={750}
+          numColumns={1}
+          onEndReached={[Function]}
+          onEndReachedThreshold={0}
+          onEndReachedThresholdRelative={0}
+          onItemLayout={[Function]}
+          onLayout={[Function]}
+          onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onSizeChanged={[Function]}
+          onVisibleIndicesChanged={[Function]}
+          removeClippedSubviews={false}
+          renderAheadOffset={0}
+          renderAheadStep={250}
+          renderContentContainer={[Function]}
+          renderItem={[Function]}
+          renderItemContainer={[Function]}
+          rowRenderer={[Function]}
+          scrollEventThrottle={16}
+          scrollThrottle={16}
+          scrollViewProps={
+            {
+              "contentContainerStyle": {
+                "backgroundColor": undefined,
+                "minHeight": 1,
+                "minWidth": 1,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+              },
+              "onLayout": [Function],
+              "onScrollBeginDrag": [Function],
+              "refreshControl": undefined,
+              "style": {
+                "minHeight": 1,
+                "minWidth": 1,
+              },
+            }
+          }
+          style={
+            {
+              "minHeight": 1,
+              "minWidth": 1,
+            }
+          }
+          suppressBoundedSizeException={true}
+          windowCorrectionConfig={
+            {
+              "applyToInitialOffset": true,
+              "applyToItemScroll": true,
+              "value": {
+                "endCorrection": 0,
+                "startCorrection": 0,
+                "windowShift": -0,
+              },
+            }
+          }
+        >
+          <View>
+            <View
               style={
                 {
-                  "height": 0,
-                  "width": 0,
+                  "flexDirection": "column",
                 }
               }
-              windowSize={0}
-            />
+            >
+              <AutoLayoutView
+                enableInstrumentation={false}
+                horizontal={false}
+                onBlankAreaEvent={[Function]}
+                onLayout={[Function]}
+                renderAheadOffset={0}
+                scrollOffset={0}
+                style={
+                  {
+                    "height": 0,
+                    "width": 0,
+                  }
+                }
+                windowSize={0}
+              />
+            </View>
           </View>
-        </View>
-      </RCTScrollView>
-    </View>
-    <View
-      style={
-        {
-          "marginBottom": -22,
-        }
-      }
-    >
+        </RCTScrollView>
+      </View>
       <View
         style={
           {
@@ -980,104 +980,105 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           }
         }
       >
-        <View
-          accessibilityState={
+        <BVLinearGradient
+          colors={
+            [
+              1187109,
+              856825125,
+              3205635365,
+              4279377189,
+            ]
+          }
+          endPoint={
             {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
+              "x": 0,
+              "y": 1,
             }
           }
-          accessibilityValue={
+          locations={
+            [
+              0,
+              0.2,
+              0.75,
+              1,
+            ]
+          }
+          pointerEvents="none"
+          startPoint={
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
+              "x": 0,
+              "y": 0,
             }
           }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             {
-              "alignItems": "center",
-              "opacity": 1,
-              "padding": 22,
+              "bottom": 0,
+              "height": 67,
+              "position": "absolute",
+              "width": "100%",
             }
           }
-        >
-          <Text
-            accessibilityHint="Close modal"
-            allowFontScaling={false}
-            style={
-              [
-                {
-                  "color": "#00f1a2",
-                  "fontSize": 28,
-                },
-                undefined,
-                {
-                  "fontFamily": "anticon",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-          >
-            
-          </Text>
-        </View>
+        />
       </View>
-      <BVLinearGradient
-        colors={
-          [
-            1187109,
-            856825125,
-            3205635365,
-            4279377189,
-          ]
+    </View>
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
         }
-        endPoint={
-          {
-            "x": 0,
-            "y": 1,
-          }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
         }
-        locations={
-          [
-            0,
-            0.2,
-            0.75,
-            1,
-          ]
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": -22,
+          "opacity": 1,
+          "padding": 22,
         }
-        pointerEvents="none"
-        startPoint={
-          {
-            "x": 0,
-            "y": 0,
-          }
-        }
+      }
+    >
+      <Text
+        accessibilityHint="Close modal"
+        allowFontScaling={false}
         style={
-          {
-            "bottom": 0,
-            "height": 67,
-            "position": "absolute",
-            "width": "100%",
-          }
+          [
+            {
+              "color": "#00f1a2",
+              "fontSize": 28,
+            },
+            undefined,
+            {
+              "fontFamily": "anticon",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            {},
+          ]
         }
-      />
+      >
+        
+      </Text>
     </View>
   </View>,
 ]
@@ -1735,55 +1736,33 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
       style={
         {
           "flex": 1,
-          "overflow": "hidden",
         }
       }
     >
-      <RCTScrollView
-        applyWindowCorrection={[Function]}
-        canChangeSize={true}
-        contentContainerStyle={
+      <View
+        style={
           {
-            "backgroundColor": undefined,
-            "minHeight": 1,
-            "minWidth": 1,
-            "paddingLeft": 0,
-            "paddingRight": 0,
+            "flex": 1,
+            "overflow": "hidden",
           }
         }
-        contentHeight={0}
-        contentWidth={0}
-        data={
-          [
+      >
+        <RCTScrollView
+          applyWindowCorrection={[Function]}
+          canChangeSize={true}
+          contentContainerStyle={
             {
-              "display": "Exchange: Buy Bitcoin",
-              "new": false,
-              "raw": "Exchange:Buy Bitcoin",
-              "selected": true,
-            },
-            {
-              "display": "Exchange: Sell Bitcoin",
-              "new": false,
-              "raw": "Exchange:Sell Bitcoin",
-              "selected": true,
-            },
-            {
-              "display": "Expense: Air Travel",
-              "new": false,
-              "raw": "Expense:Air Travel",
-              "selected": false,
-            },
-            {
-              "display": "Expense: Alcohol & Bars",
-              "new": false,
-              "raw": "Expense:Alcohol & Bars",
-              "selected": false,
-            },
-          ]
-        }
-        dataProvider={
-          DataProvider {
-            "_data": [
+              "backgroundColor": undefined,
+              "minHeight": 1,
+              "minWidth": 1,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+            }
+          }
+          contentHeight={0}
+          contentWidth={0}
+          data={
+            [
               {
                 "display": "Exchange: Buy Bitcoin",
                 "new": false,
@@ -1808,58 +1787,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                 "raw": "Expense:Alcohol & Bars",
                 "selected": false,
               },
-            ],
-            "_firstIndexToProcess": 0,
-            "_hasStableIds": true,
-            "_requiresDataChangeHandling": false,
-            "_size": 4,
-            "getStableId": [Function],
-            "rowHasChanged": [Function],
+            ]
           }
-        }
-        disableRecycling={false}
-        estimatedItemSize={67}
-        extendedState={{}}
-        externalScrollView={[Function]}
-        finalRenderAheadOffset={250}
-        forceNonDeterministicRendering={true}
-        horizontal={false}
-        initialOffset={0}
-        initialRenderIndex={0}
-        isHorizontal={false}
-        keyExtractor={[Function]}
-        keyboardShouldPersistTaps="handled"
-        layoutProvider={
-          GridLayoutProviderWithProps {
-            "_acceptableRelayoutDelta": 1,
-            "_getHeightOrWidth": [Function],
-            "_getLayoutTypeForIndex": [Function],
-            "_getSpan": [Function],
-            "_hasExpired": false,
-            "_maxSpan": 1,
-            "_setLayoutForType": [Function],
-            "_tempDim": {
-              "height": 0,
-              "width": 0,
-            },
-            "averageWindow": AverageWindow {
-              "currentAverage": 67,
-              "currentCount": 1,
-              "inputValues": [
-                67,
-              ],
-              "nextIndex": 1,
-            },
-            "defaultEstimatedItemSize": 100,
-            "layoutObject": {
-              "size": undefined,
-              "span": undefined,
-            },
-            "props": {
-              "contentContainerStyle": {
-                "paddingBottom": 56,
-              },
-              "data": [
+          dataProvider={
+            DataProvider {
+              "_data": [
                 {
                   "display": "Exchange: Buy Bitcoin",
                   "new": false,
@@ -1885,110 +1817,179 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                   "selected": false,
                 },
               ],
-              "estimatedItemSize": 67,
-              "keyExtractor": [Function],
-              "keyboardShouldPersistTaps": "handled",
-              "numColumns": 1,
-              "renderItem": [Function],
-            },
-            "renderWindowInsets": {
-              "height": 0,
-              "width": 0,
-            },
-            "shouldRefreshWithAnchoring": true,
-          }
-        }
-        maxRenderAhead={750}
-        numColumns={1}
-        onEndReached={[Function]}
-        onEndReachedThreshold={0}
-        onEndReachedThresholdRelative={0}
-        onItemLayout={[Function]}
-        onLayout={[Function]}
-        onScroll={[Function]}
-        onScrollBeginDrag={[Function]}
-        onSizeChanged={[Function]}
-        onVisibleIndicesChanged={[Function]}
-        removeClippedSubviews={false}
-        renderAheadOffset={0}
-        renderAheadStep={250}
-        renderContentContainer={[Function]}
-        renderItem={[Function]}
-        renderItemContainer={[Function]}
-        rowRenderer={[Function]}
-        scrollEventThrottle={16}
-        scrollThrottle={16}
-        scrollViewProps={
-          {
-            "contentContainerStyle": {
-              "backgroundColor": undefined,
-              "minHeight": 1,
-              "minWidth": 1,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-            },
-            "onLayout": [Function],
-            "onScrollBeginDrag": [Function],
-            "refreshControl": undefined,
-            "style": {
-              "minHeight": 1,
-              "minWidth": 1,
-            },
-          }
-        }
-        style={
-          {
-            "minHeight": 1,
-            "minWidth": 1,
-          }
-        }
-        suppressBoundedSizeException={true}
-        windowCorrectionConfig={
-          {
-            "applyToInitialOffset": true,
-            "applyToItemScroll": true,
-            "value": {
-              "endCorrection": 0,
-              "startCorrection": 0,
-              "windowShift": -0,
-            },
-          }
-        }
-      >
-        <View>
-          <View
-            style={
-              {
-                "flexDirection": "column",
-              }
+              "_firstIndexToProcess": 0,
+              "_hasStableIds": true,
+              "_requiresDataChangeHandling": false,
+              "_size": 4,
+              "getStableId": [Function],
+              "rowHasChanged": [Function],
             }
-          >
-            <AutoLayoutView
-              enableInstrumentation={false}
-              horizontal={false}
-              onBlankAreaEvent={[Function]}
-              onLayout={[Function]}
-              renderAheadOffset={0}
-              scrollOffset={0}
+          }
+          disableRecycling={false}
+          estimatedItemSize={67}
+          extendedState={{}}
+          externalScrollView={[Function]}
+          finalRenderAheadOffset={250}
+          forceNonDeterministicRendering={true}
+          horizontal={false}
+          initialOffset={0}
+          initialRenderIndex={0}
+          isHorizontal={false}
+          keyExtractor={[Function]}
+          keyboardShouldPersistTaps="handled"
+          layoutProvider={
+            GridLayoutProviderWithProps {
+              "_acceptableRelayoutDelta": 1,
+              "_getHeightOrWidth": [Function],
+              "_getLayoutTypeForIndex": [Function],
+              "_getSpan": [Function],
+              "_hasExpired": false,
+              "_maxSpan": 1,
+              "_setLayoutForType": [Function],
+              "_tempDim": {
+                "height": 0,
+                "width": 0,
+              },
+              "averageWindow": AverageWindow {
+                "currentAverage": 67,
+                "currentCount": 1,
+                "inputValues": [
+                  67,
+                ],
+                "nextIndex": 1,
+              },
+              "defaultEstimatedItemSize": 100,
+              "layoutObject": {
+                "size": undefined,
+                "span": undefined,
+              },
+              "props": {
+                "contentContainerStyle": {
+                  "paddingBottom": 67,
+                },
+                "data": [
+                  {
+                    "display": "Exchange: Buy Bitcoin",
+                    "new": false,
+                    "raw": "Exchange:Buy Bitcoin",
+                    "selected": true,
+                  },
+                  {
+                    "display": "Exchange: Sell Bitcoin",
+                    "new": false,
+                    "raw": "Exchange:Sell Bitcoin",
+                    "selected": true,
+                  },
+                  {
+                    "display": "Expense: Air Travel",
+                    "new": false,
+                    "raw": "Expense:Air Travel",
+                    "selected": false,
+                  },
+                  {
+                    "display": "Expense: Alcohol & Bars",
+                    "new": false,
+                    "raw": "Expense:Alcohol & Bars",
+                    "selected": false,
+                  },
+                ],
+                "estimatedItemSize": 67,
+                "keyExtractor": [Function],
+                "keyboardShouldPersistTaps": "handled",
+                "numColumns": 1,
+                "renderItem": [Function],
+              },
+              "renderWindowInsets": {
+                "height": 0,
+                "width": 0,
+              },
+              "shouldRefreshWithAnchoring": true,
+            }
+          }
+          maxRenderAhead={750}
+          numColumns={1}
+          onEndReached={[Function]}
+          onEndReachedThreshold={0}
+          onEndReachedThresholdRelative={0}
+          onItemLayout={[Function]}
+          onLayout={[Function]}
+          onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onSizeChanged={[Function]}
+          onVisibleIndicesChanged={[Function]}
+          removeClippedSubviews={false}
+          renderAheadOffset={0}
+          renderAheadStep={250}
+          renderContentContainer={[Function]}
+          renderItem={[Function]}
+          renderItemContainer={[Function]}
+          rowRenderer={[Function]}
+          scrollEventThrottle={16}
+          scrollThrottle={16}
+          scrollViewProps={
+            {
+              "contentContainerStyle": {
+                "backgroundColor": undefined,
+                "minHeight": 1,
+                "minWidth": 1,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+              },
+              "onLayout": [Function],
+              "onScrollBeginDrag": [Function],
+              "refreshControl": undefined,
+              "style": {
+                "minHeight": 1,
+                "minWidth": 1,
+              },
+            }
+          }
+          style={
+            {
+              "minHeight": 1,
+              "minWidth": 1,
+            }
+          }
+          suppressBoundedSizeException={true}
+          windowCorrectionConfig={
+            {
+              "applyToInitialOffset": true,
+              "applyToItemScroll": true,
+              "value": {
+                "endCorrection": 0,
+                "startCorrection": 0,
+                "windowShift": -0,
+              },
+            }
+          }
+        >
+          <View>
+            <View
               style={
                 {
-                  "height": 0,
-                  "width": 0,
+                  "flexDirection": "column",
                 }
               }
-              windowSize={0}
-            />
+            >
+              <AutoLayoutView
+                enableInstrumentation={false}
+                horizontal={false}
+                onBlankAreaEvent={[Function]}
+                onLayout={[Function]}
+                renderAheadOffset={0}
+                scrollOffset={0}
+                style={
+                  {
+                    "height": 0,
+                    "width": 0,
+                  }
+                }
+                windowSize={0}
+              />
+            </View>
           </View>
-        </View>
-      </RCTScrollView>
-    </View>
-    <View
-      style={
-        {
-          "marginBottom": -22,
-        }
-      }
-    >
+        </RCTScrollView>
+      </View>
       <View
         style={
           {
@@ -2000,104 +2001,105 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           }
         }
       >
-        <View
-          accessibilityState={
+        <BVLinearGradient
+          colors={
+            [
+              1187109,
+              856825125,
+              3205635365,
+              4279377189,
+            ]
+          }
+          endPoint={
             {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
+              "x": 0,
+              "y": 1,
             }
           }
-          accessibilityValue={
+          locations={
+            [
+              0,
+              0.2,
+              0.75,
+              1,
+            ]
+          }
+          pointerEvents="none"
+          startPoint={
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
+              "x": 0,
+              "y": 0,
             }
           }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             {
-              "alignItems": "center",
-              "opacity": 1,
-              "padding": 22,
+              "bottom": 0,
+              "height": 67,
+              "position": "absolute",
+              "width": "100%",
             }
           }
-        >
-          <Text
-            accessibilityHint="Close modal"
-            allowFontScaling={false}
-            style={
-              [
-                {
-                  "color": "#00f1a2",
-                  "fontSize": 28,
-                },
-                undefined,
-                {
-                  "fontFamily": "anticon",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-          >
-            
-          </Text>
-        </View>
+        />
       </View>
-      <BVLinearGradient
-        colors={
-          [
-            1187109,
-            856825125,
-            3205635365,
-            4279377189,
-          ]
+    </View>
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
         }
-        endPoint={
-          {
-            "x": 0,
-            "y": 1,
-          }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
         }
-        locations={
-          [
-            0,
-            0.2,
-            0.75,
-            1,
-          ]
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": -22,
+          "opacity": 1,
+          "padding": 22,
         }
-        pointerEvents="none"
-        startPoint={
-          {
-            "x": 0,
-            "y": 0,
-          }
-        }
+      }
+    >
+      <Text
+        accessibilityHint="Close modal"
+        allowFontScaling={false}
         style={
-          {
-            "bottom": 0,
-            "height": 67,
-            "position": "absolute",
-            "width": "100%",
-          }
+          [
+            {
+              "color": "#00f1a2",
+              "fontSize": 28,
+            },
+            undefined,
+            {
+              "fontFamily": "anticon",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            {},
+          ]
         }
-      />
+      >
+        
+      </Text>
     </View>
   </View>,
 ]

--- a/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
@@ -1136,67 +1136,64 @@ exports[`HelpModal should render with loading props 1`] = `
         Build 2019010101
       </Text>
     </View>
-    <View>
-      <View>
-        <View
-          accessibilityState={
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": -22,
+          "opacity": 1,
+          "padding": 22,
+        }
+      }
+    >
+      <Text
+        accessibilityHint="Close modal"
+        allowFontScaling={false}
+        style={
+          [
             {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
+              "color": "#00f1a2",
+              "fontSize": 28,
+            },
+            undefined,
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            {
-              "alignItems": "center",
-              "opacity": 1,
-              "padding": 22,
-            }
-          }
-        >
-          <Text
-            accessibilityHint="Close modal"
-            allowFontScaling={false}
-            style={
-              [
-                {
-                  "color": "#00f1a2",
-                  "fontSize": 28,
-                },
-                undefined,
-                {
-                  "fontFamily": "anticon",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-          >
-            
-          </Text>
-        </View>
-      </View>
+              "fontFamily": "anticon",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            {},
+          ]
+        }
+      >
+        
+      </Text>
     </View>
   </View>,
 ]

--- a/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
@@ -62,8 +62,5 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
       }
     }
   />
-  <ModalFooter
-    onPress={[Function]}
-  />
 </ThemedModal>
 `;

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -494,7 +494,7 @@ exports[`WalletListModal should render with loading props 1`] = `
               },
               "props": {
                 "contentContainerStyle": {
-                  "paddingBottom": 56,
+                  "paddingBottom": 67,
                 },
                 "data": [],
                 "estimatedItemSize": 96,
@@ -617,7 +617,7 @@ exports[`WalletListModal should render with loading props 1`] = `
               <View
                 style={
                   {
-                    "paddingBottom": 56,
+                    "paddingBottom": 67,
                     "paddingRight": 0,
                   }
                 }
@@ -626,14 +626,6 @@ exports[`WalletListModal should render with loading props 1`] = `
           </View>
         </RCTScrollView>
       </View>
-    </View>
-    <View
-      style={
-        {
-          "marginBottom": -22,
-        }
-      }
-    >
       <View
         style={
           {
@@ -645,104 +637,105 @@ exports[`WalletListModal should render with loading props 1`] = `
           }
         }
       >
-        <View
-          accessibilityState={
+        <BVLinearGradient
+          colors={
+            [
+              1187109,
+              856825125,
+              3205635365,
+              4279377189,
+            ]
+          }
+          endPoint={
             {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
+              "x": 0,
+              "y": 1,
             }
           }
-          accessibilityValue={
+          locations={
+            [
+              0,
+              0.2,
+              0.75,
+              1,
+            ]
+          }
+          pointerEvents="none"
+          startPoint={
             {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
+              "x": 0,
+              "y": 0,
             }
           }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             {
-              "alignItems": "center",
-              "opacity": 1,
-              "padding": 22,
+              "bottom": 0,
+              "height": 67,
+              "position": "absolute",
+              "width": "100%",
             }
           }
-        >
-          <Text
-            accessibilityHint="Close modal"
-            allowFontScaling={false}
-            style={
-              [
-                {
-                  "color": "#00f1a2",
-                  "fontSize": 28,
-                },
-                undefined,
-                {
-                  "fontFamily": "anticon",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-          >
-            
-          </Text>
-        </View>
+        />
       </View>
-      <BVLinearGradient
-        colors={
-          [
-            1187109,
-            856825125,
-            3205635365,
-            4279377189,
-          ]
+    </View>
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
         }
-        endPoint={
-          {
-            "x": 0,
-            "y": 1,
-          }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
         }
-        locations={
-          [
-            0,
-            0.2,
-            0.75,
-            1,
-          ]
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": -22,
+          "opacity": 1,
+          "padding": 22,
         }
-        pointerEvents="none"
-        startPoint={
-          {
-            "x": 0,
-            "y": 0,
-          }
-        }
+      }
+    >
+      <Text
+        accessibilityHint="Close modal"
+        allowFontScaling={false}
         style={
-          {
-            "bottom": 0,
-            "height": 67,
-            "position": "absolute",
-            "width": "100%",
-          }
+          [
+            {
+              "color": "#00f1a2",
+              "fontSize": 28,
+            },
+            undefined,
+            {
+              "fontFamily": "anticon",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            {},
+          ]
         }
-      />
+      >
+        
+      </Text>
     </View>
   </View>,
 ]

--- a/src/components/modals/AccelerateTxModal.tsx
+++ b/src/components/modals/AccelerateTxModal.tsx
@@ -9,7 +9,7 @@ import { connect } from '../../types/reactRedux'
 import { GuiExchangeRates } from '../../types/types'
 import { convertTransactionFeeToDisplayFee } from '../../util/utils'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
-import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { Slider } from '../themed/Slider'
 import { ThemedModal } from '../themed/ThemedModal'
 import { Tile } from '../tiles/Tile'
@@ -130,7 +130,6 @@ export class AccelerateTxModalComponent extends PureComponent<Props, State> {
             disabledText={lstrings.transaction_details_accelerate_transaction_slider_disabled}
           />
         </View>
-        <ModalFooter onPress={this.handleCancel} />
       </ThemedModal>
     )
   }

--- a/src/components/modals/AddressModal.tsx
+++ b/src/components/modals/AddressModal.tsx
@@ -19,7 +19,7 @@ import { FormattedText as Text } from '../legacy/FormattedText/FormattedText.ui'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalTitle } from '../themed/ModalParts'
+import { ModalTitle } from '../themed/ModalParts'
 import { OutlinedTextInput } from '../themed/OutlinedTextInput'
 import { ThemedModal } from '../themed/ThemedModal'
 
@@ -350,7 +350,6 @@ export class AddressModalComponent extends React.Component<Props, State> {
           )}
           <MainButton label={lstrings.submit} marginRem={[0, 4]} type="secondary" onPress={this.handleSubmit} />
         </View>
-        <ModalFooter onPress={this.handleClose} />
       </ThemedModal>
     )
   }

--- a/src/components/modals/AdvancedDetailsModal.tsx
+++ b/src/components/modals/AdvancedDetailsModal.tsx
@@ -7,7 +7,6 @@ import { lstrings } from '../../locales/strings'
 import { openBrowserUri } from '../../util/WebUtils'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
-import { ModalFooter } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
 import { Tile } from '../tiles/Tile'
 
@@ -115,7 +114,6 @@ export class AdvancedDetailsModalComponent extends PureComponent<Props> {
             {deviceDescription != null && <Tile type="static" title={lstrings.transaction_details_advance_details_device} body={deviceDescription} />}
           </ScrollView>
         </View>
-        <ModalFooter onPress={this.handleCancel} />
       </ThemedModal>
     )
   }

--- a/src/components/modals/ButtonsModal.tsx
+++ b/src/components/modals/ButtonsModal.tsx
@@ -5,7 +5,7 @@ import { AirshipBridge } from 'react-native-airship'
 import { showError } from '../services/AirshipInstance'
 import { useTheme } from '../services/ThemeContext'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
 
 export interface ButtonInfo {
@@ -62,7 +62,7 @@ export function ButtonsModal<Buttons extends { [key: string]: ButtonInfo }>(prop
   }
 
   return (
-    <ThemedModal warning={warning} bridge={bridge} paddingRem={1} onCancel={handleCancel}>
+    <ThemedModal closeButton={closeArrow} warning={warning} bridge={bridge} paddingRem={1} onCancel={handleCancel}>
       <View style={containerStyle}>
         <View style={textStyle}>
           {title != null ? <ModalTitle>{title}</ModalTitle> : null}
@@ -95,7 +95,6 @@ export function ButtonsModal<Buttons extends { [key: string]: ButtonInfo }>(prop
 
           return <MainButton key={key} label={label} marginRem={0.5} type={type} onPress={handlePress} />
         })}
-        {closeArrow ? <ModalFooter onPress={handleCancel} /> : null}
       </View>
     </ThemedModal>
   )

--- a/src/components/modals/CategoryModal.tsx
+++ b/src/components/modals/CategoryModal.tsx
@@ -14,7 +14,7 @@ import { MinimalButton } from '../buttons/MinimalButton'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { DividerLine } from '../themed/DividerLine'
 import { EdgeText } from '../themed/EdgeText'
-import { ModalFooter, ModalTitle } from '../themed/ModalParts'
+import { ModalFooter, ModalFooterFade, ModalTitle } from '../themed/ModalParts'
 import { OutlinedTextInput } from '../themed/OutlinedTextInput'
 import { ThemedModal } from '../themed/ThemedModal'
 
@@ -142,15 +142,17 @@ export function CategoryModal(props: Props) {
         onSubmitEditing={handleSubmit}
         value={subcategory}
       />
-      <FlashList
-        contentContainerStyle={styles.scrollPadding}
-        data={sortedCategories}
-        estimatedItemSize={theme.rem(3)}
-        keyboardShouldPersistTaps="handled"
-        keyExtractor={keyExtractor}
-        renderItem={renderRow}
-      />
-      <ModalFooter onPress={handleCancel} fadeOut />
+      <View style={styles.categoryListContainer}>
+        <FlashList
+          contentContainerStyle={styles.scrollPadding}
+          data={sortedCategories}
+          estimatedItemSize={theme.rem(3)}
+          keyboardShouldPersistTaps="handled"
+          keyExtractor={keyExtractor}
+          renderItem={renderRow}
+        />
+        <ModalFooterFade />
+      </View>
     </ThemedModal>
   )
 }
@@ -165,6 +167,9 @@ const getStyle = cacheStyles((theme: Theme) => ({
     justifyContent: 'space-between',
     marginHorizontal: theme.rem(1),
     marginBottom: theme.rem(1)
+  },
+  categoryListContainer: {
+    flex: 1
   },
   rowContainer: {
     flex: 1,

--- a/src/components/modals/ConfirmContinueModal.tsx
+++ b/src/components/modals/ConfirmContinueModal.tsx
@@ -9,7 +9,7 @@ import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { Fade } from '../themed/Fade'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
 
 interface Props {
@@ -48,7 +48,7 @@ export function ConfirmContinueModal(props: Props) {
   }
 
   return (
-    <ThemedModal bridge={bridge} warning={warning} onCancel={handleClose}>
+    <ThemedModal bridge={bridge} closeButton={isSkippable} warning={warning} onCancel={handleClose}>
       {title != null && (
         <View style={styles.headerContainer}>
           <Ionicons name="warning" size={theme.rem(1.75)} color={theme.warningIcon} />
@@ -71,7 +71,6 @@ export function ConfirmContinueModal(props: Props) {
           <MainButton alignSelf="center" label={lstrings.confirm_finish} marginRem={0.5} type="secondary" onPress={handleAgreed} />
         </Fade>
       </ScrollView>
-      {isSkippable && <ModalFooter onPress={handleClose} />}
     </ThemedModal>
   )
 }

--- a/src/components/modals/FioExpiredModal.tsx
+++ b/src/components/modals/FioExpiredModal.tsx
@@ -3,7 +3,7 @@ import { AirshipBridge } from 'react-native-airship'
 
 import { lstrings } from '../../locales/strings'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
 
 export function FioExpiredModal(props: { bridge: AirshipBridge<boolean>; fioName: string }) {
@@ -16,7 +16,6 @@ export function FioExpiredModal(props: { bridge: AirshipBridge<boolean>; fioName
       <ModalMessage>{lstrings.fio_domain_details_expired_soon}</ModalMessage>
       <ModalMessage>{fioName}</ModalMessage>
       <MainButton alignSelf="center" label={lstrings.title_fio_renew} marginRem={[1, 0.5, 0.5]} type="secondary" onPress={() => bridge.resolve(true)} />
-      <ModalFooter onPress={() => bridge.resolve(false)} />
     </ThemedModal>
   )
 }

--- a/src/components/modals/HelpModal.tsx
+++ b/src/components/modals/HelpModal.tsx
@@ -15,7 +15,7 @@ import { openBrowserUri } from '../../util/WebUtils'
 import { Airship } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
-import { ModalFooter, ModalTitle } from '../themed/ModalParts'
+import { ModalTitle } from '../themed/ModalParts'
 import { SelectableRow } from '../themed/SelectableRow'
 import { ThemedModal } from '../themed/ThemedModal'
 
@@ -127,8 +127,6 @@ export const HelpModal = (props: Props) => {
         <EdgeText style={styles.version}>{versionText}</EdgeText>
         <EdgeText style={styles.version}>{buildText}</EdgeText>
       </View>
-
-      <ModalFooter onPress={handleClose} />
     </ThemedModal>
   )
 }

--- a/src/components/modals/ListModal.tsx
+++ b/src/components/modals/ListModal.tsx
@@ -72,7 +72,7 @@ export function ListModal<T>({
   }, [theme])
 
   return (
-    <ThemedModal bridge={bridge} onCancel={handleCancel}>
+    <ThemedModal bridge={bridge} closeButton={closeArrow} onCancel={handleCancel}>
       {title == null ? null : <ModalTitle>{title}</ModalTitle>}
       {message == null ? null : <ModalMessage>{message}</ModalMessage>}
       {textInput == null ? null : (
@@ -102,7 +102,6 @@ export function ListModal<T>({
         onScroll={() => Keyboard.dismiss()}
         onViewableItemsChanged={onViewableItemsChanged}
       />
-      {!closeArrow ? null : <ModalFooter onPress={handleCancel} fadeOut />}
     </ThemedModal>
   )
 }

--- a/src/components/modals/LogsModal.tsx
+++ b/src/components/modals/LogsModal.tsx
@@ -9,7 +9,7 @@ import { lstrings } from '../../locales/strings'
 import { WarningCard } from '../cards/WarningCard'
 import { showToast } from '../services/AirshipInstance'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage, ModalScrollArea, ModalTitle } from '../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { OutlinedTextInput } from '../themed/OutlinedTextInput'
 import { ThemedModal } from '../themed/ThemedModal'
 interface Props {
@@ -71,26 +71,24 @@ export const LogsModal = (props: Props) => {
   }
 
   return (
-    <ThemedModal bridge={bridge} onCancel={handleCancel}>
-      <ModalScrollArea onCancel={handleCancel}>
-        <ModalTitle>{lstrings.settings_button_export_logs}</ModalTitle>
-        {!isDangerous ? null : <WarningCard key="warning" title={lstrings.string_warning} footer={lstrings.settings_modal_send_unsafe} marginRem={0.5} />}
-        {isDangerous ? null : <ModalMessage>{lstrings.settings_modal_export_logs_message}</ModalMessage>}
-        <OutlinedTextInput
-          autoCorrect
-          autoFocus={false}
-          label={lstrings.settings_modal_send_logs_label}
-          marginRem={1}
-          maxLength={1000}
-          onChangeText={setUserMessage}
-          returnKeyType="done"
-          value={userMessage}
-        />
-        {isDangerous ? null : (
-          <MainButton label={lstrings.settings_button_send_logs} marginRem={0.5} type="primary" onPress={handleSend} disabled={isDangerous} />
-        )}
-        <MainButton label={lstrings.settings_button_export_logs} marginRem={0.5} type="secondary" onPress={handleShare} />
-      </ModalScrollArea>
+    <ThemedModal bridge={bridge} onCancel={handleCancel} scroll>
+      <ModalTitle>{lstrings.settings_button_export_logs}</ModalTitle>
+      {!isDangerous ? null : <WarningCard key="warning" title={lstrings.string_warning} footer={lstrings.settings_modal_send_unsafe} marginRem={0.5} />}
+      {isDangerous ? null : <ModalMessage>{lstrings.settings_modal_export_logs_message}</ModalMessage>}
+      <OutlinedTextInput
+        autoCorrect
+        autoFocus={false}
+        label={lstrings.settings_modal_send_logs_label}
+        marginRem={1}
+        maxLength={1000}
+        onChangeText={setUserMessage}
+        returnKeyType="done"
+        value={userMessage}
+      />
+      {isDangerous ? null : (
+        <MainButton label={lstrings.settings_button_send_logs} marginRem={0.5} type="primary" onPress={handleSend} disabled={isDangerous} />
+      )}
+      <MainButton label={lstrings.settings_button_export_logs} marginRem={0.5} type="secondary" onPress={handleShare} />
     </ThemedModal>
   )
 }

--- a/src/components/modals/PasswordReminderModal.tsx
+++ b/src/components/modals/PasswordReminderModal.tsx
@@ -9,7 +9,7 @@ import { NavigationBase } from '../../types/routerTypes'
 import { ButtonsContainer } from '../buttons/ButtonsContainer'
 import { showError, showToast } from '../services/AirshipInstance'
 import { ThemeProps, withTheme } from '../services/ThemeContext'
-import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { OutlinedTextInput } from '../themed/OutlinedTextInput'
 import { ThemedModal } from '../themed/ThemedModal'
 
@@ -107,7 +107,6 @@ export class PasswordReminderModalComponent extends React.PureComponent<Props, S
           secondary={{ label: lstrings.password_reminder_forgot_password, onPress: this.handleRequestChangePassword, disabled: checkingPassword }}
           layout="column"
         />
-        <ModalFooter onPress={this.handleCancel} />
       </ThemedModal>
     )
   }

--- a/src/components/modals/PermissionsSettingModal.tsx
+++ b/src/components/modals/PermissionsSettingModal.tsx
@@ -10,7 +10,7 @@ import { Permission, permissionNames } from '../../reducers/PermissionsReducer'
 import { showError } from '../services/AirshipInstance'
 import { checkIfDenied } from '../services/PermissionsManager'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalMessage } from '../themed/ModalParts'
+import { ModalMessage } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
 
 export function PermissionsSettingModal(props: {
@@ -44,7 +44,6 @@ export function PermissionsSettingModal(props: {
     <ThemedModal bridge={bridge} paddingRem={1} onCancel={handleClose}>
       <ModalMessage>{message}</ModalMessage>
       <MainButton label={lstrings.string_ok_cap} marginRem={0.5} type="primary" onPress={handlePress} />
-      <ModalFooter onPress={handleClose} />
     </ThemedModal>
   )
 }

--- a/src/components/modals/RawTextModal.tsx
+++ b/src/components/modals/RawTextModal.tsx
@@ -6,7 +6,7 @@ import { AirshipBridge } from 'react-native-airship'
 import { lstrings } from '../../locales/strings'
 import { showToast } from '../services/AirshipInstance'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
 
 interface Props {
@@ -35,7 +35,6 @@ export function RawTextModal(props: Props) {
       {disableCopy ? null : (
         <MainButton alignSelf="center" label={lstrings.fragment_request_copy_title} marginRem={0.5} onPress={handleCopy} type="secondary" />
       )}
-      <ModalFooter onPress={handleCancel} />
     </ThemedModal>
   )
 }

--- a/src/components/modals/ScanModal.tsx
+++ b/src/components/modals/ScanModal.tsx
@@ -20,7 +20,7 @@ import { checkAndRequestPermission } from '../services/PermissionsManager'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalMessage } from '../themed/ModalParts'
+import { ModalMessage } from '../themed/ModalParts'
 import { SceneHeader } from '../themed/SceneHeader'
 
 interface Props {
@@ -207,7 +207,6 @@ export const ScanModal = (props: Props) => {
       maxWidth={windowWidth}
     >
       {renderModalContent()}
-      <ModalFooter onPress={handleClose} />
     </AirshipModal>
   )
 }

--- a/src/components/modals/TextInputModal.tsx
+++ b/src/components/modals/TextInputModal.tsx
@@ -6,7 +6,7 @@ import { lstrings } from '../../locales/strings'
 import { showError } from '../services/AirshipInstance'
 import { Alert } from '../themed/Alert'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { OutlinedTextInput } from '../themed/OutlinedTextInput'
 import { ThemedModal } from '../themed/ThemedModal'
 
@@ -122,7 +122,6 @@ export function TextInputModal(props: Props) {
       ) : (
         <MainButton alignSelf="center" label={submitLabel} marginRem={0.5} onPress={handleSubmit} type="secondary" />
       )}
-      <ModalFooter onPress={() => bridge.resolve(undefined)} />
     </ThemedModal>
   )
 }

--- a/src/components/modals/UpdateModal.tsx
+++ b/src/components/modals/UpdateModal.tsx
@@ -8,7 +8,7 @@ import { lstrings } from '../../locales/strings'
 import { config } from '../../theme/appConfig'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
 
 interface Props {
@@ -31,7 +31,7 @@ export function UpdateModal(props: Props) {
   const message = sprintf(lstrings.update_fresh_new_version, config.appName)
 
   return (
-    <ThemedModal bridge={bridge} onCancel={() => bridge.resolve()}>
+    <ThemedModal bridge={bridge} onCancel={handleClose}>
       <View style={styles.titleContainer}>
         <Image style={styles.titleImage} resizeMode="contain" source={theme.primaryLogo} />
         <ModalTitle>{lstrings.update_header}</ModalTitle>
@@ -39,7 +39,6 @@ export function UpdateModal(props: Props) {
       <ModalMessage>{message}</ModalMessage>
       <MainButton label={lstrings.update_now} marginRem={0.5} type="primary" onPress={handleUpdate} />
       <MainButton label={lstrings.update_later} marginRem={0.5} type="secondary" onPress={onSkip} />
-      <ModalFooter onPress={handleClose} />
     </ThemedModal>
   )
 }

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { ScrollView, Text, TouchableOpacity, View } from 'react-native'
+import { Text, TouchableOpacity, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
-import LinearGradient from 'react-native-linear-gradient'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { sprintf } from 'sprintf-js'
 
@@ -18,7 +17,7 @@ import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import { CryptoIcon } from '../icons/CryptoIcon'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
-import { ModalFooter, ModalTitle } from '../themed/ModalParts'
+import { ModalScrollArea, ModalTitle } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
 
 interface Option {
@@ -47,9 +46,6 @@ const icons = {
   viewPrivateViewKey: 'eye',
   viewXPub: 'eye'
 }
-
-const xButtonGradientStart = { x: 0, y: 0 }
-const xButtonGradientEnd = { x: 0, y: 0.75 }
 
 /**
  * Customizes which coins get which options on the wallet list scene.
@@ -204,9 +200,6 @@ export function WalletListMenuModal(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const xButtonTopColor = theme.modal + '00' // Add full transparency to the modal color
-  const xButtonBottomColor = theme.modal
-
   return (
     <ThemedModal bridge={bridge} onCancel={handleCancel}>
       {wallet != null && (
@@ -220,7 +213,7 @@ export function WalletListMenuModal(props: Props) {
       )}
 
       <View style={styles.scrollViewContainer}>
-        <ScrollView contentContainerStyle={styles.scrollViewPadding}>
+        <ModalScrollArea>
           {options.map((option: Option) => (
             <TouchableOpacity key={option.value} onPress={() => optionAction(option.value)} style={styles.row}>
               <AntDesignIcon
@@ -232,11 +225,8 @@ export function WalletListMenuModal(props: Props) {
               <Text style={option.value === 'delete' ? [styles.optionText, styles.warningColor] : styles.optionText}>{option.label}</Text>
             </TouchableOpacity>
           ))}
-        </ScrollView>
+        </ModalScrollArea>
       </View>
-      <LinearGradient style={styles.modalCloseButton} colors={[xButtonTopColor, xButtonBottomColor]} start={xButtonGradientStart} end={xButtonGradientEnd}>
-        <ModalFooter onPress={handleCancel} />
-      </LinearGradient>
     </ThemedModal>
   )
 }

--- a/src/components/modals/WalletListModal.tsx
+++ b/src/components/modals/WalletListModal.tsx
@@ -21,7 +21,7 @@ import { Airship, showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalTitle } from '../themed/ModalParts'
+import { ModalFooterFade, ModalTitle } from '../themed/ModalParts'
 import { OutlinedTextInput } from '../themed/OutlinedTextInput'
 import { ThemedModal } from '../themed/ThemedModal'
 import { WalletList } from '../themed/WalletList'
@@ -239,8 +239,8 @@ export function WalletListModal(props: Props) {
           onPress={handleWalletListPress}
           navigation={navigation}
         />
+        <ModalFooterFade />
       </View>
-      <ModalFooter onPress={handleCancel} fadeOut />
     </ThemedModal>
   )
 }

--- a/src/components/modals/WcSmartContractModal.tsx
+++ b/src/components/modals/WcSmartContractModal.tsx
@@ -19,7 +19,7 @@ import { Airship, showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { Alert } from '../themed/Alert'
 import { EdgeText } from '../themed/EdgeText'
-import { ModalFooter, ModalTitle } from '../themed/ModalParts'
+import { ModalFooter, ModalFooterFade, ModalTitle } from '../themed/ModalParts'
 import { SafeSlider } from '../themed/SafeSlider'
 import { ThemedModal } from '../themed/ThemedModal'
 import { CryptoFiatAmountTile } from '../tiles/CryptoFiatAmountTile'
@@ -146,7 +146,7 @@ export const WcSmartContractModal = (props: Props) => {
         <Image style={styles.logo} source={WalletConnectLogo} />
         <ModalTitle>{lstrings.wc_smartcontract_title}</ModalTitle>
       </View>
-      <ScrollView>
+      <ScrollView contentContainerStyle={styles.scrollPadding}>
         {renderWarning()}
         {zeroString(nativeAmount) ? null : (
           <CryptoFiatAmountTile
@@ -171,7 +171,7 @@ export const WcSmartContractModal = (props: Props) => {
         )}
         {slider}
       </ScrollView>
-      <ModalFooter onPress={handleClose} />
+      <ModalFooterFade />
     </ThemedModal>
   )
 }
@@ -187,6 +187,9 @@ const getStyles = cacheStyles((theme: Theme) => ({
     width: theme.rem(2),
     resizeMode: 'contain',
     padding: theme.rem(0.5)
+  },
+  scrollPadding: {
+    paddingBottom: theme.rem(ModalFooter.bottomRem)
   },
   slider: {
     paddingVertical: theme.rem(1)

--- a/src/components/modals/WebViewModal.tsx
+++ b/src/components/modals/WebViewModal.tsx
@@ -3,7 +3,7 @@ import { AirshipBridge } from 'react-native-airship'
 import { WebView } from 'react-native-webview'
 
 import { Airship } from '../services/AirshipInstance'
-import { ModalFooter, ModalTitle } from '../themed/ModalParts'
+import { ModalTitle } from '../themed/ModalParts'
 import { ThemedModal } from '../themed/ThemedModal'
 
 export async function showWebViewModal(title: string, uri: string): Promise<void> {
@@ -30,8 +30,6 @@ export const WebViewModal = (props: Props) => {
         {title}
       </ModalTitle>
       <WebView ref={webviewRef} source={{ uri }} />
-
-      <ModalFooter onPress={handleClose} />
     </ThemedModal>
   )
 }

--- a/src/components/scenes/Fio/FioStakingChangeScene.tsx
+++ b/src/components/scenes/Fio/FioStakingChangeScene.tsx
@@ -23,7 +23,7 @@ import { FlipInputModal, FlipInputModalResult } from '../../modals/FlipInputModa
 import { Airship, showToast } from '../../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../../services/ThemeContext'
 import { EdgeText } from '../../themed/EdgeText'
-import { ModalFooter, ModalMessage, ModalTitle } from '../../themed/ModalParts'
+import { ModalMessage, ModalTitle } from '../../themed/ModalParts'
 import { SceneHeader } from '../../themed/SceneHeader'
 import { Slider } from '../../themed/Slider'
 import { ThemedModal } from '../../themed/ThemedModal'
@@ -176,7 +176,6 @@ export const FioStakingChangeScene = withWallet((props: Props) => {
           </ModalTitle>
           <ModalMessage>{lstrings.staking_change_unlock_explainer1}</ModalMessage>
           <ModalMessage>{lstrings.staking_change_unlock_explainer2}</ModalMessage>
-          <ModalFooter onPress={bridge.resolve} />
         </ThemedModal>
       )
     })

--- a/src/components/themed/ThemedModal.tsx
+++ b/src/components/themed/ThemedModal.tsx
@@ -11,9 +11,6 @@ interface Props<T> {
   children?: React.ReactNode
   onCancel: () => void
 
-  // Use this to create space at the top for an icon circle:
-  iconRem?: number
-
   // Control over the content area:
   flexDirection?: ViewStyle['flexDirection']
   justifyContent?: ViewStyle['justifyContent']
@@ -27,11 +24,9 @@ interface Props<T> {
  * The Airship modal, but connected to our theming system.
  */
 export function ThemedModal<T>(props: Props<T>) {
-  const { bridge, children, flexDirection, iconRem = 0, justifyContent, warning = false, onCancel } = props
+  const { bridge, children, flexDirection, justifyContent, warning = false, onCancel } = props
   const paddingRem = fixSides(props.paddingRem, 1)
   const theme = useTheme()
-
-  paddingRem[0] += iconRem / 2
 
   // TODO: The warning styles are incorrectly hard-coded:
   const borderColor = warning ? theme.warningText : theme.modalBorderColor
@@ -46,7 +41,6 @@ export function ThemedModal<T>(props: Props<T>) {
       borderWidth={borderWidth}
       flexDirection={flexDirection}
       justifyContent={justifyContent}
-      margin={[theme.rem(iconRem / 2), 0, 0]}
       onCancel={onCancel}
       padding={paddingRem.map(theme.rem)}
       underlay={<BlurView blurType={theme.isDark ? 'light' : 'dark'} style={StyleSheet.absoluteFill} />}

--- a/src/components/themed/ThemedModal.tsx
+++ b/src/components/themed/ThemedModal.tsx
@@ -5,6 +5,7 @@ import { BlurView } from 'rn-id-blurview'
 
 import { fixSides } from '../../util/sides'
 import { useTheme } from '../services/ThemeContext'
+import { ModalFooter, ModalScrollArea } from './ModalParts'
 
 interface Props<T> {
   bridge: AirshipBridge<T>
@@ -12,9 +13,13 @@ interface Props<T> {
   onCancel: () => void
 
   // Control over the content area:
+  closeButton?: boolean
   flexDirection?: ViewStyle['flexDirection']
   justifyContent?: ViewStyle['justifyContent']
   paddingRem?: number[] | number
+
+  // Scroll area with a fade
+  scroll?: boolean
 
   // Gives the box a border:
   warning?: boolean
@@ -24,7 +29,7 @@ interface Props<T> {
  * The Airship modal, but connected to our theming system.
  */
 export function ThemedModal<T>(props: Props<T>) {
-  const { bridge, children, flexDirection, justifyContent, warning = false, onCancel } = props
+  const { bridge, closeButton = true, children, flexDirection, justifyContent, warning = false, scroll = false, onCancel } = props
   const paddingRem = fixSides(props.paddingRem, 1)
   const theme = useTheme()
 
@@ -45,7 +50,10 @@ export function ThemedModal<T>(props: Props<T>) {
       padding={paddingRem.map(theme.rem)}
       underlay={<BlurView blurType={theme.isDark ? 'light' : 'dark'} style={StyleSheet.absoluteFill} />}
     >
-      {children}
+      <>
+        {scroll ? <ModalScrollArea>{children}</ModalScrollArea> : children}
+        {closeButton ? <ModalFooter onPress={onCancel} /> : null}
+      </>
     </AirshipModal>
   )
 }

--- a/src/modules/FioAddress/components/DomainListModal.tsx
+++ b/src/modules/FioAddress/components/DomainListModal.tsx
@@ -7,7 +7,7 @@ import { Fontello } from '../../../assets/vector'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../../../components/services/ThemeContext'
 import { ClickableText } from '../../../components/themed/ClickableText'
 import { EdgeText } from '../../../components/themed/EdgeText'
-import { ModalFooter, ModalTitle } from '../../../components/themed/ModalParts'
+import { ModalFooter, ModalFooterFade, ModalTitle } from '../../../components/themed/ModalParts'
 import { OutlinedTextInput } from '../../../components/themed/OutlinedTextInput'
 import { ThemedModal } from '../../../components/themed/ThemedModal'
 import { FIO_ADDRESS_DELIMITER, FIO_DOMAIN_DEFAULT } from '../../../constants/WalletAndCurrencyConstants'
@@ -150,6 +150,8 @@ class DomainListModalComponent extends React.Component<Props, State> {
     const { bridge, theme } = this.props
     const { input } = this.state
     const items = this.getItems()
+    const styles = getStyles(theme)
+
     return (
       <ThemedModal bridge={bridge} onCancel={() => bridge.resolve(undefined)} paddingRem={[1, 0]}>
         <ModalTitle center paddingRem={[0, 3, 1]}>
@@ -174,8 +176,9 @@ class DomainListModalComponent extends React.Component<Props, State> {
           keyboardShouldPersistTaps="handled"
           keyExtractor={this.keyExtractor}
           renderItem={this.renderItem}
+          contentContainerStyle={styles.scrollPadding}
         />
-        <ModalFooter onPress={() => bridge.resolve(undefined)} />
+        <ModalFooterFade />
       </ThemedModal>
     )
   }
@@ -211,6 +214,9 @@ const getStyles = cacheStyles((theme: Theme) => ({
   },
   domainRegisterIcon: {
     marginTop: theme.rem(0.25)
+  },
+  scrollPadding: {
+    paddingBottom: theme.rem(ModalFooter.bottomRem)
   }
 }))
 


### PR DESCRIPTION
1. A bottom fade only applies to scrollable areas. It doesn't make sense to be attached to the ModalFooter (close button).
2. The ModalFooter should be attached to all ThemedModals unless otherwise specified. There's no reason for the modal callers to manage it.

Restructure so that the bottom fade is attached to ModalScrollArea, the footer is attached to ThemedModal by default, and adjust stylings to make sense with this new organization. 

Examples of styling adjustments made:

The close button correctly is tappable for the entire horizontal space per correct UX conventions, but the close button's tappable area is completely overlapping the button in the modal contents, making it prone to error:
<img width="1223" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/9961786e-2d80-4522-a0d3-2288e7bafb08">

The gradient has also been moved up so it's more apparent. Again note the removal of the overlap between the close button and other tappable areas on the modal:
<img width="1223" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/55c4a4e3-c18f-4486-a484-e90f35e2b54a">

### CHANGELOG

- changed: Modal UI adjustments

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204800075529342