### PR TITLE
Fix crash in markets view

### DIFF
--- a/src/components/data/row/CoinRankRow.tsx
+++ b/src/components/data/row/CoinRankRow.tsx
@@ -1,4 +1,4 @@
-import { lt, round } from 'biggystring'
+import { div, lt, round } from 'biggystring'
 import * as React from 'react'
 import { TouchableOpacity, View } from 'react-native'
 import FastImage from 'react-native-fast-image'
@@ -15,6 +15,7 @@ import { useSelector } from '../../../types/reactRedux'
 import { NavigationProp } from '../../../types/routerTypes'
 import { triggerHaptic } from '../../../util/haptic'
 import { debugLog, LOG_COINRANK } from '../../../util/logger'
+import { DECIMAL_PRECISION } from '../../../util/utils'
 import { Theme, useTheme } from '../../services/ThemeContext'
 import { EdgeText } from '../../themed/EdgeText'
 
@@ -130,7 +131,9 @@ const CoinRankRowComponent = (props: Props) => {
   // Calculate percent change string
   const percentChangeRaw = percentChange[percentChangeTimeFrame]
   numDecimals = getNumDecimals(percentChangeRaw, 2)
-  const percentChangeString = toPercentString(percentChangeRaw / 100, { noGrouping: true })
+
+  const decimalChangeRaw = div(String(percentChangeRaw), '100', DECIMAL_PRECISION)
+  const percentChangeString = toPercentString(decimalChangeRaw, { noGrouping: true })
   const negative = lt(percentChangeString, '0')
 
   // Calculate price string

--- a/src/locales/intl.ts
+++ b/src/locales/intl.ts
@@ -273,8 +273,10 @@ export const trimEnd = (val: string): string => {
 // and greater than -1.0
 export const toPercentString = (percentVal: string | number, options?: IntlNumberFormatOptionsType): string => {
   if (typeof percentVal === 'string') {
+    // Remove negative sign
+    const checkVal = percentVal.replace('-', '')
     // Check that this is a regular decimal (not hex) number
-    if (!/^\d*\.?\d+$/.test(percentVal)) {
+    if (!/^\d*\.?\d+$/.test(checkVal)) {
       return ''
     }
   }


### PR DESCRIPTION
Use biggystring div to prevent exponent notation which crashes toPercentString

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
