### PR TITLE
Set FlipInputModal2 to fullscreen for Android

### DIFF
--- a/src/components/modals/FlipInputModal2.tsx
+++ b/src/components/modals/FlipInputModal2.tsx
@@ -2,7 +2,7 @@ import { div, log10, toFixed } from 'biggystring'
 import { EdgeCurrencyWallet } from 'edge-core-js'
 import * as React from 'react'
 import { memo, useState } from 'react'
-import { Dimensions, TouchableWithoutFeedback, View } from 'react-native'
+import { Dimensions, Platform, TouchableWithoutFeedback, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome'
 import { sprintf } from 'sprintf-js'
@@ -240,7 +240,7 @@ const deviceHeight = Dimensions.get('window').height
 
 const getStyles = cacheStyles((theme: Theme) => ({
   hackContainer: {
-    flex: deviceHeight <= 580 ? 1 : 0
+    flex: deviceHeight <= 580 || Platform.OS === 'android' ? 1 : 0
   },
   flipInput: {
     justifyContent: 'flex-start'

--- a/src/components/themed/FlipInput2.tsx
+++ b/src/components/themed/FlipInput2.tsx
@@ -80,7 +80,6 @@ export const FlipInput2 = React.forwardRef<FlipInputRef, Props>((props: Props, r
       if (done === true) runOnJS(setPrimaryField)(otherField)
     }
 
-    console.log(`animating to ${otherField}`)
     animatedValue.value = withTiming(
       otherField,
       {
@@ -107,7 +106,7 @@ export const FlipInput2 = React.forwardRef<FlipInputRef, Props>((props: Props, r
 
   const bottomRow = useHandler((fieldNum: FieldNum) => {
     const primaryAmount = amounts[fieldNum]
-    const amountBlank = eq(primaryAmount, '0')
+    const amountBlank = eq(primaryAmount, '0') ? lstrings.string_amount : ''
     const currencyNameStyle = amountBlank ? styles.bottomCurrencyMuted : styles.bottomCurrency
     const currencyName = fieldInfos[fieldNum].currencyName
 
@@ -118,7 +117,10 @@ export const FlipInput2 = React.forwardRef<FlipInputRef, Props>((props: Props, r
             style={styles.bottomAmount}
             value={primaryAmount}
             maxDecimals={fieldInfos[fieldNum].maxEntryDecimals}
-            placeholder={amountBlank ? lstrings.string_amount : ''}
+            // HACK: For some reason there's no way to avoid the rightmost
+            // visual cutoff of the 'Amount' string in Android. Pad with an
+            // extra space.
+            placeholder={Platform.OS === 'android' ? amountBlank + ' ' : amountBlank}
             placeholderTextColor={theme.deactivatedText}
             onChangeText={onNumericInputChange}
             autoCorrect={false}
@@ -177,55 +179,60 @@ export const FlipInput2 = React.forwardRef<FlipInputRef, Props>((props: Props, r
   )
 })
 
-const getStyles = cacheStyles((theme: Theme) => ({
-  // Flip Input
-  flipInputContainer: {
-    flexDirection: 'row',
-    alignItems: 'center'
-  },
-  flipInput: {
-    flex: 1,
-    paddingRight: theme.rem(0.5)
-  },
-  flipInputFront: {
-    backfaceVisibility: 'hidden'
-  },
-  flipContainerBack: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0
-  },
-  flipIcon: {
-    marginRight: -theme.rem(0.125)
-  },
+const getStyles = cacheStyles((theme: Theme) => {
+  const isIos = Platform.OS === 'ios'
+  return {
+    // Flip Input
+    flipInputContainer: {
+      flexDirection: 'row',
+      alignItems: 'center'
+    },
+    flipInput: {
+      flex: 1,
+      paddingRight: theme.rem(0.5)
+    },
+    flipInputFront: {
+      backfaceVisibility: 'hidden'
+    },
+    flipContainerBack: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0
+    },
+    flipIcon: {
+      marginRight: -theme.rem(0.125)
+    },
 
-  // Top Amount
-  bottomContainer: {
-    flexDirection: 'row',
-    marginRight: theme.rem(1.5),
-    minHeight: theme.rem(2)
-  },
-  valueContainer: {
-    flexDirection: 'row',
-    marginRight: theme.rem(0.5),
-    marginLeft: Platform.OS === 'ios' ? 0 : -3,
-    marginTop: Platform.OS === 'ios' ? 0 : -theme.rem(0.75),
-    marginBottom: Platform.OS === 'ios' ? 0 : -theme.rem(1)
-  },
-  bottomAmount: {
-    paddingRight: Platform.OS === 'ios' ? 0 : theme.rem(0.25),
-    color: theme.primaryText,
-    includeFontPadding: false,
-    fontFamily: theme.fontFaceMedium,
-    fontSize: theme.rem(1.5)
-  },
-  bottomCurrency: {
-    paddingTop: Platform.OS === 'ios' ? theme.rem(0.125) : theme.rem(1)
-  },
-  bottomCurrencyMuted: {
-    paddingTop: Platform.OS === 'ios' ? theme.rem(0.125) : theme.rem(1),
-    color: theme.deactivatedText
+    // Top Amount
+    bottomContainer: {
+      flexDirection: 'row',
+      marginRight: theme.rem(1.5),
+      minHeight: theme.rem(2)
+    },
+    valueContainer: {
+      flexDirection: 'row',
+      marginRight: theme.rem(0.5),
+      marginLeft: isIos ? 0 : -6,
+      marginTop: isIos ? 0 : -theme.rem(0.75),
+      marginBottom: isIos ? 0 : -theme.rem(1)
+    },
+    bottomAmount: {
+      paddingRight: isIos ? 0 : theme.rem(0.25),
+      color: theme.primaryText,
+      includeFontPadding: false,
+      fontFamily: theme.fontFaceMedium,
+      fontSize: isIos ? theme.rem(1.5) : theme.rem(1.45)
+    },
+    bottomCurrency: {
+      paddingTop: isIos ? theme.rem(0.125) : theme.rem(1),
+      marginLeft: isIos ? 0 : -theme.rem(0.25)
+    },
+    bottomCurrencyMuted: {
+      paddingTop: isIos ? theme.rem(0.125) : theme.rem(1),
+      color: theme.deactivatedText,
+      marginLeft: isIos ? 0 : -theme.rem(0.25)
+    }
   }
-}))
+})


### PR DESCRIPTION
Force the FlipInput modal to be fullscreen for Android devices. Also fix the Android-specific visual cutoff of the right side of the 'Amount' placeholder text while there is no user input:

Old vs new:
<img width="193" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/832e1872-bd96-415a-9ea4-3ce6d3093345">
<img width="200" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/c4485f7c-5a07-4ae0-b710-80925117e656">

Comparison - iOS(top) Android(bottom):
<img width="430" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/6376b725-9823-4dfc-87bb-c8906622eab2">

### CHANGELOG

- fixed: Android FlipInputModal visual cutoffs

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205341170579571