### PR TITLE
Analytics: Add "isFirstOpen" Param 

### DIFF
--- a/src/actions/FirstOpenActions.tsx
+++ b/src/actions/FirstOpenActions.tsx
@@ -1,0 +1,25 @@
+import { makeReactNativeDisklet } from 'disklet'
+
+import { FIRST_OPEN } from '../constants/constantSettings'
+
+const firstOpenDisklet = makeReactNativeDisklet()
+
+let isFirstOpen: boolean | undefined
+
+/**
+ * Returns whether this session was the first time the user opened the app.
+ * Repeated calls will return the same result.
+ */
+export const getIsFirstOpen = async () => {
+  if (isFirstOpen != null) return isFirstOpen
+  else {
+    try {
+      await firstOpenDisklet.getText(FIRST_OPEN)
+      isFirstOpen = false
+    } catch (error: any) {
+      await firstOpenDisklet.setText(FIRST_OPEN, '')
+      isFirstOpen = true
+    }
+    return isFirstOpen
+  }
+}

--- a/src/constants/constantSettings.ts
+++ b/src/constants/constantSettings.ts
@@ -1,4 +1,5 @@
 export const AAVE_WELCOME = 'aaveWelcome.json'
+export const FIRST_OPEN = 'firstOpen.json'
 export const SCAM_WARNING = 'scamWarning.json'
 export const SETTINGS_PERMISSION_LIMITS = 'SETTINGS_PERMISSION_LIMIT'
 export const SETTINGS_PERMISSION_QUANTITY = 3

--- a/src/constants/constantSettings.ts
+++ b/src/constants/constantSettings.ts
@@ -1,7 +1,6 @@
+export const AAVE_WELCOME = 'aaveWelcome.json'
+export const SCAM_WARNING = 'scamWarning.json'
 export const SETTINGS_PERMISSION_LIMITS = 'SETTINGS_PERMISSION_LIMIT'
 export const SETTINGS_PERMISSION_QUANTITY = 3
-export const TUTORIAL = 'tutorial.json'
-export const SCAM_WARNING = 'scamWarning.json'
-export const AAVE_WELCOME = 'aaveWelcome.json'
-export const TOKEN_TERMS_AGREEMENT = 'ttAgreement.json'
 export const STICKY_CONFIG = 'remoteConfigSticky.json'
+export const TOKEN_TERMS_AGREEMENT = 'ttAgreement.json'

--- a/src/util/tracking.ts
+++ b/src/util/tracking.ts
@@ -2,6 +2,7 @@ import Bugsnag from '@bugsnag/react-native'
 import analytics from '@react-native-firebase/analytics'
 import { getUniqueId, getVersion } from 'react-native-device-info'
 
+import { getIsFirstOpen } from '../actions/FirstOpenActions'
 import { ENV } from '../env'
 import { getStickyConfig, StickyConfig } from '../stickyConfig'
 import { fetchReferral } from './network'
@@ -70,7 +71,6 @@ if (ENV.USE_FIREBASE) {
 /**
  * Track error to external reporting service (ie. Bugsnag)
  */
-
 export function trackError(
   error: unknown,
   tag?: string,
@@ -111,8 +111,10 @@ async function logToFirebase(name: TrackingEventName, values: TrackingValues) {
   // @ts-expect-error
   if (!global.firebase) return
 
+  // Persistent params:
+  const params: any = { edgeVersion: getVersion(), isFirstOpen: await getIsFirstOpen() }
+
   // Adjust params:
-  const params: any = { edgeVersion: getVersion() }
   if (accountDate != null) params.adate = accountDate
   if (currencyCode != null) params.currency = currencyCode
   if (dollarValue != null) {


### PR DESCRIPTION
Allow greater control over this tracking aspect compared to Firebase's/Google Analytics' built-in "first_open" param.

Currently limited to all events reported by the GUI, but would be nice to extend this to all events. See Asana task dependencies for this punted "nice-to-have"

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205244918309566