### PR TITLE
Fix Liberland tx history scene display

### DIFF
--- a/src/components/themed/ExplorerCard.tsx
+++ b/src/components/themed/ExplorerCard.tsx
@@ -48,10 +48,12 @@ export const ExplorerCard = (props: Props) => {
   return (
     <View>
       <ButtonBox onPress={handlePress} paddingRem={1}>
-        <View style={styles.container}>
-          <CryptoIcon walletId={wallet.id} tokenId={tokenId} marginRem={[0.25, 0]} sizeRem={2.25} />
-          <EdgeText style={styles.explorerButtonText}>{lstrings.transaction_details_advance_details_show_explorer}</EdgeText>
-        </View>
+        {addressExplorer === '' ? null : (
+          <View style={styles.container}>
+            <CryptoIcon walletId={wallet.id} tokenId={tokenId} marginRem={[0.25, 0]} sizeRem={2.25} />
+            <EdgeText style={styles.explorerButtonText}>{lstrings.transaction_details_advance_details_show_explorer}</EdgeText>
+          </View>
+        )}
       </ButtonBox>
       <View style={styles.noTransactionContainer}>
         <EdgeText style={styles.noTransactionText}>{lstrings.transaction_list_no_tx_support_yet}</EdgeText>

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -670,6 +670,7 @@ export const SPECIAL_CURRENCY_INFO: {
       alertMessage: lstrings.request_dot_minimum_notification_alert_body
     },
     isCustomTokensSupported: true,
+    isTransactionListUnsupported: true,
     isImportKeySupported: true
   },
   liberlandtestnet: {
@@ -684,6 +685,7 @@ export const SPECIAL_CURRENCY_INFO: {
       alertMessage: lstrings.request_dot_minimum_notification_alert_body
     },
     isCustomTokensSupported: true,
+    isTransactionListUnsupported: true,
     isImportKeySupported: true
   },
   zcash: {


### PR DESCRIPTION
Disable tx history for Liberland plugins and hide the explorer button if there is no explorer available


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205380689310357