### PR TITLE
Add a catch when saving FIO metadata

### DIFF
--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -796,7 +796,7 @@ const SendComponent = (props: Props) => {
 
       for (const target of spendInfo.spendTargets) {
         // Write FIO OBT per spendTarget
-        await recordFioObtData(target, currencyCode, broadcastedTx.txid)
+        await recordFioObtData(target, currencyCode, broadcastedTx.txid).catch(error => showError(error))
       }
 
       playSendSound().catch(error => console.log(error)) // Fail quietly


### PR DESCRIPTION
I ran out of time to fix this properly. We'll make a task for 3.18 to fix this for real, but at least the UX is improved.

### CHANGELOG

- changed: When sending to a FIO address, and something goes wrong on the FIO chain, don't show the send itself as having failed.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205280031506078