### PR TITLE
Enable keysOnlyMode for BSV

### DIFF
--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -219,6 +219,7 @@ export const SPECIAL_CURRENCY_INFO: {
     maxSpendTargets: UTXO_MAX_SPEND_TARGETS,
     initWalletName: lstrings.string_first_bitcoin_sv_wallet_name,
     chainCode: 'BSV',
+    keysOnlyMode: true,
     isImportKeySupported: true,
     isPrivateKeySweepable: true,
     isPaymentProtocolSupported: true


### PR DESCRIPTION
### CHANGELOG

- changed: Deprecated BSV to keys-only mode.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205330404045845