### PR TITLE
Put an "X" back on the scan modal

### DIFF
--- a/src/components/modals/ScanModal.tsx
+++ b/src/components/modals/ScanModal.tsx
@@ -20,7 +20,7 @@ import { checkAndRequestPermission } from '../services/PermissionsManager'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage } from '../themed/ModalParts'
+import { ModalFooter, ModalMessage } from '../themed/ModalParts'
 import { SceneHeader } from '../themed/SceneHeader'
 
 interface Props {
@@ -207,6 +207,7 @@ export const ScanModal = (props: Props) => {
       maxWidth={windowWidth}
     >
       {renderModalContent()}
+      <ModalFooter onPress={handleClose} />
     </AirshipModal>
   )
 }


### PR DESCRIPTION
We accidentally deleted this in 1c8ea1f333119a8da4ba3366c11f047f8ce421e6

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205417996153449