### PR TITLE
Use test servers for maestro

### DIFF
--- a/src/components/services/EdgeCoreManager.tsx
+++ b/src/components/services/EdgeCoreManager.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 import { Alert } from 'react-native'
 import RNBootSplash from 'react-native-bootsplash'
 import { getBrand, getDeviceId } from 'react-native-device-info'
+import { isMaestro } from 'react-native-is-maestro'
 
 import { ENV } from '../../env'
 import { useAsyncEffect } from '../../hooks/useAsyncEffect'
@@ -17,6 +18,10 @@ import { fakeUser } from '../../util/fake-user'
 import { LoadingScene } from '../scenes/LoadingScene'
 import { showError } from './AirshipInstance'
 import { Providers } from './Providers'
+
+const LOGIN_TEST_SERVER = 'https://login-tester.edge.app/api'
+const INFO_TEST_SERVER = 'https://info-tester.edge.app'
+const SYNC_TEST_SERVER = 'https://sync-tester-us1.edge.app'
 
 interface Props {}
 
@@ -110,6 +115,18 @@ export function EdgeCoreManager(props: Props) {
     ENV.DEBUG_ACCOUNTBASED ? accountbasedDebugUri : accountbasedUri,
     ENV.DEBUG_PLUGINS ? 'http://localhost:8101/plugin-bundle.js' : 'edge-core/plugin-bundle.js'
   ]
+
+  let infoServer: string | undefined
+  let loginServer: string | undefined
+  let syncServer: string | undefined
+
+  if ((ENV.ENABLE_TEST_SERVERS == null && isMaestro()) || ENV.ENABLE_TEST_SERVERS === true) {
+    console.log('Using test servers')
+    infoServer = INFO_TEST_SERVER
+    loginServer = LOGIN_TEST_SERVER
+    syncServer = SYNC_TEST_SERVER
+  }
+
   return (
     <>
       {ENV.USE_FAKE_CORE ? (
@@ -132,6 +149,9 @@ export function EdgeCoreManager(props: Props) {
           pluginUris={pluginUris}
           onLoad={handleContext}
           onError={handleError}
+          authServer={loginServer}
+          infoServer={infoServer}
+          syncServer={syncServer}
         />
       )}
       {context == null ? <LoadingScene /> : <Providers key={`redux${counter.current}`} context={context} />}

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -209,6 +209,7 @@ export const asEnvConfig = asObject({
   DEBUG_ACCOUNTBASED: asOptional(asBoolean, false),
   DEBUG_VERBOSE_ERRORS: asOptional(asBoolean, false),
   DEBUG_THEME: asOptional(asBoolean, false),
+  ENABLE_TEST_SERVERS: asOptional(asBoolean),
   ENABLE_REDUX_PERF_LOGGING: asOptional(asBoolean, false),
   LOG_SERVER: asNullable(
     asObject({


### PR DESCRIPTION
### CHANGELOG

added: Maestro testing ability to use custom testing login/sync/info servers

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205265280373599