### PR TITLE
Implement user-paused wallets

### DIFF
--- a/src/__tests__/reducers/__snapshots__/RootReducer.test.ts.snap
+++ b/src/__tests__/reducers/__snapshots__/RootReducer.test.ts.snap
@@ -232,6 +232,7 @@ exports[`initialState 1`] = `
           "isEnabled": false,
         },
       },
+      "userPausedWallets": [],
       "walletsSort": "manual",
     },
     "subcategories": [],

--- a/src/actions/SettingsActions.tsx
+++ b/src/actions/SettingsActions.tsx
@@ -261,6 +261,26 @@ export function showRestoreWalletsModal(navigation: NavigationBase): ThunkAction
   }
 }
 
+export const toggleUserPausedWallet =
+  (account: EdgeAccount, walletId: string): ThunkAction<Promise<void>> =>
+  async (dispatch, getState) => {
+    const settings = await readSyncedSettings(account)
+    const { userPausedWallets } = settings
+
+    const isPaused = userPausedWallets.includes(walletId)
+    const newPausedWallets = isPaused ? [...userPausedWallets.filter(id => id !== walletId)] : [...userPausedWallets, walletId]
+
+    await dispatch({
+      type: 'UI/SETTINGS/SET_USER_PAUSED_WALLETS',
+      data: { userPausedWallets: newPausedWallets }
+    })
+
+    return await writeSyncedSettings(account, {
+      ...settings,
+      userPausedWallets: [...newPausedWallets]
+    })
+  }
+
 export const asPasswordReminderLevels = asObject({
   '20': asMaybe(asBoolean, false),
   '200': asMaybe(asBoolean, false),
@@ -303,7 +323,8 @@ export const asSyncedAccountSettings = asObject({
   passwordRecoveryRemindersShown: asMaybe(asPasswordReminderLevels, () => asPasswordReminderLevels({})),
   walletsSort: asMaybe(asSortOption, 'manual'),
   denominationSettings: asMaybe<DenominationSettings>(asDenominationSettings, () => ({})),
-  securityCheckedWallets: asMaybe<SecurityCheckedWallets>(asSecurityCheckedWallets, () => ({}))
+  securityCheckedWallets: asMaybe<SecurityCheckedWallets>(asSecurityCheckedWallets, () => ({})),
+  userPausedWallets: asMaybe(asArray(asString), () => [])
 })
 
 export type SyncedAccountSettings = ReturnType<typeof asSyncedAccountSettings>

--- a/src/actions/WalletActions.tsx
+++ b/src/actions/WalletActions.tsx
@@ -33,7 +33,6 @@ const activateWalletName: MapObject<{ name: string; notes: string }> = {
     notes: lstrings.activate_wallet_token_transaction_notes_xrp
   }
 }
-
 const ACTIVATION_TOAST_AUTO_HIDE_MS = 5000
 
 export function selectWalletToken({ navigation, walletId, tokenId, alwaysActivate }: SelectWalletTokenParams): ThunkAction<Promise<boolean>> {

--- a/src/actions/WalletListMenuActions.tsx
+++ b/src/actions/WalletListMenuActions.tsx
@@ -19,6 +19,7 @@ import { logActivity } from '../util/logger'
 import { validatePassword } from './AccountActions'
 import { showDeleteWalletModal } from './DeleteWalletModalActions'
 import { showResyncWalletModal } from './ResyncWalletModalActions'
+import { toggleUserPausedWallet } from './SettingsActions'
 import { showSplitWalletModal } from './SplitWalletModalActions'
 
 export type WalletListMenuKey =
@@ -31,6 +32,7 @@ export type WalletListMenuKey =
   | 'viewXPub'
   | 'getRawKeys'
   | 'rawDelete'
+  | 'togglePause'
   | string // for split keys like splitbitcoincash, splitethereum, etc.
 
 export function walletListMenuAction(
@@ -291,6 +293,14 @@ export function walletListMenuAction(
             }}
           />
         ))
+      }
+    }
+
+    case 'togglePause': {
+      return async (dispatch, getState) => {
+        const state = getState()
+        const { account } = state.core
+        await dispatch(toggleUserPausedWallet(account, walletId))
       }
     }
 

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -36,13 +36,14 @@ interface Props {
 
 const icons = {
   delete: 'warning',
-  rawDelete: 'warning',
   exportWalletTransactions: 'export',
   getRawKeys: 'lock',
   getSeed: 'key',
   manageTokens: 'plus',
+  rawDelete: 'warning',
   rename: 'edit',
   resync: 'sync',
+  togglePause: 'pause',
   viewPrivateViewKey: 'eye',
   viewXPub: 'eye'
 }
@@ -124,6 +125,8 @@ export function WalletListMenuModal(props: Props) {
 
   const dispatch = useDispatch()
   const account = useSelector(state => state.core.account)
+  const pausedWallets = useSelector(state => state.ui.settings.userPausedWallets)
+
   const wallet = useWatch(account, 'currencyWallets')[walletId]
 
   const theme = useTheme()
@@ -166,6 +169,11 @@ export function WalletListMenuModal(props: Props) {
     const result: Option[] = []
 
     const { pluginId } = wallet.currencyInfo
+    result.push({
+      label: pausedWallets.includes(walletId) ? lstrings.fragment_wallets_unpause_wallet : lstrings.fragment_wallets_pause_wallet,
+      value: 'togglePause'
+    })
+
     for (const option of WALLET_LIST_MENU) {
       const { pluginIds, label, value } = option
 

--- a/src/components/services/WalletLifecycle.ts
+++ b/src/components/services/WalletLifecycle.ts
@@ -10,6 +10,7 @@ interface StateProps {
   account: EdgeAccount
   context: EdgeContext
   sortedWalletList: WalletListItem[]
+  userPausedWallets: string[]
 }
 type Props = StateProps
 
@@ -57,7 +58,7 @@ export class WalletLifecycleComponent extends React.Component<Props> {
    * Figures out what has changed and adapts.
    */
   handleChange = () => {
-    const { account, context, sortedWalletList } = this.props
+    const { account, context, sortedWalletList, userPausedWallets } = this.props
 
     // Check for login / logout:
     if (account !== this.edgeAccount || context !== this.edgeContext) {
@@ -79,8 +80,7 @@ export class WalletLifecycleComponent extends React.Component<Props> {
     // Grab the mutable core state:
     const { paused } = context
     const { currencyWallets } = account
-
-    // If we have become paused, shut down all wallets:
+    // If we have become paused (app into background), shut down all wallets:
     if (paused && !this.paused) {
       this.cancelBoot()
       Promise.all(Object.keys(currencyWallets).map(async walletId => await currencyWallets[walletId].changePaused(true))).catch(showError)
@@ -109,10 +109,12 @@ export class WalletLifecycleComponent extends React.Component<Props> {
       if (this.booting.length >= BOOT_LIMIT) break
       const { token, tokenId, wallet, walletId } = walletItem
 
-      // Ignore missing wallets, token rows, started wallets, and already-booting wallets:
+      // Ignore missing wallets, token rows, started wallets, already-booting
+      // wallets, and user-paused wallets:
       if (token != null || tokenId != null || wallet == null) continue
       if (!wallet.paused) continue
       if (this.booting.find(boot => boot.walletId === walletId) != null) continue
+      if (userPausedWallets.includes(walletId)) continue
 
       this.booting.push(bootWallet(wallet, this.handleChange))
     }
@@ -189,7 +191,8 @@ export const WalletLifecycle = connect<StateProps, {}, {}>(
   state => ({
     account: state.core.account,
     context: state.core.context,
-    sortedWalletList: state.sortedWalletList
+    sortedWalletList: state.sortedWalletList,
+    userPausedWallets: state.ui.settings.userPausedWallets
   }),
   dispatch => ({})
 )(WalletLifecycleComponent)

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -220,6 +220,8 @@ const strings = {
   fragment_wallets_copy_seed: 'Copy Seed',
   fragment_wallets_copied_seed: 'Copied Seed',
   fragment_wallets_get_seed_wallet: 'Get Seed',
+  fragment_wallets_pause_wallet: 'Pause Wallet',
+  fragment_wallets_unpause_wallet: 'Unpause Wallet',
   fragment_wallets_view_private_view_key: 'Private View Key',
   fragment_wallets_view_private_view_key_warning_s: `The private view key allows the receiver to see the balance in your %1$s wallet. Do not share this key unless necessary, such as for tax purposes, accounting, or similar reasons.`,
   fragment_wallets_view_xpub: 'View XPub Address',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -164,6 +164,8 @@
   "fragment_wallets_copy_seed": "Copy Seed",
   "fragment_wallets_copied_seed": "Copied Seed",
   "fragment_wallets_get_seed_wallet": "Get Seed",
+  "fragment_wallets_pause_wallet": "Pause Wallet",
+  "fragment_wallets_unpause_wallet": "Unpause Wallet",
   "fragment_wallets_view_private_view_key": "Private View Key",
   "fragment_wallets_view_private_view_key_warning_s": "The private view key allows the receiver to see the balance in your %1$s wallet. Do not share this key unless necessary, such as for tax purposes, accounting, or similar reasons.",
   "fragment_wallets_view_xpub": "View XPub Address",

--- a/src/reducers/scenes/SettingsReducer.ts
+++ b/src/reducers/scenes/SettingsReducer.ts
@@ -70,6 +70,7 @@ export const settingsLegacy = (state: SettingsState = initialState, action: Acti
         isAccountBalanceVisible,
         mostRecentWallets,
         passwordRecoveryRemindersShown,
+        userPausedWallets,
         pinLoginEnabled,
         preferredSwapPluginId,
         preferredSwapPluginType,
@@ -92,6 +93,7 @@ export const settingsLegacy = (state: SettingsState = initialState, action: Acti
         isTouchSupported: touchIdInfo ? touchIdInfo.isTouchSupported : false,
         mostRecentWallets,
         passwordRecoveryRemindersShown,
+        userPausedWallets,
         pinLoginEnabled,
         preferredSwapPluginId: preferredSwapPluginId === '' ? undefined : preferredSwapPluginId,
         preferredSwapPluginType,
@@ -200,6 +202,13 @@ export const settingsLegacy = (state: SettingsState = initialState, action: Acti
       return {
         ...state,
         isAccountBalanceVisible: action.data.isAccountBalanceVisible
+      }
+    }
+
+    case 'UI/SETTINGS/SET_USER_PAUSED_WALLETS': {
+      return {
+        ...state,
+        userPausedWallets: action.data.userPausedWallets
       }
     }
 

--- a/src/types/reduxActions.ts
+++ b/src/types/reduxActions.ts
@@ -128,6 +128,7 @@ export type Action =
   | { type: 'UI/SETTINGS/SET_PREFERRED_SWAP_PLUGIN_TYPE'; data: EdgeSwapPluginType | undefined }
   | { type: 'UI/SETTINGS/SET_SECURITY_CHECKED_WALLETS'; data: SecurityCheckedWallets }
   | { type: 'UI/SETTINGS/SET_SETTINGS_LOCK'; data: boolean }
+  | { type: 'UI/SETTINGS/SET_USER_PAUSED_WALLETS'; data: { userPausedWallets: string[] } }
   | { type: 'UI/SETTINGS/SET_WALLETS_SORT'; data: { walletsSort: SortOption } }
   | { type: 'UI/SETTINGS/TOGGLE_PIN_LOGIN_ENABLED'; data: { pinLoginEnabled: boolean } }
   | { type: 'UI/SETTINGS/UPDATE_SETTINGS'; data: { settings: SettingsState } }


### PR DESCRIPTION
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/9e1e5f33-10b9-4c03-b9c7-465eb487adfd)

### CHANGELOG

- added: Wallet menu option to 'pause' wallet, preventing boot

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205412692015465
  - https://app.asana.com/0/0/1205321359129572