### PR TITLE
Filter Uniswap based policies by pool address in addition to currency code

### DIFF
--- a/src/plugins/stake-plugins/uniswapV2/policyInfo/optimism.ts
+++ b/src/plugins/stake-plugins/uniswapV2/policyInfo/optimism.ts
@@ -100,6 +100,7 @@ function generateVelodromeV2StakePolicyInfo(poolContractKey: string): StakePolic
   const [keyType, poolType, tokenA, tokenB] = poolContractKey.split('_')
   if (keyType !== 'POOL') return null
   const isStablePool = poolType[0] === 's'
+  const lpTokenContract = eco.makeContract(poolContractKey)
 
   return {
     stakePolicyId: `optimism_velodrome_${poolType}_${tokenA}_${tokenB}`,
@@ -107,9 +108,10 @@ function generateVelodromeV2StakePolicyInfo(poolContractKey: string): StakePolic
     parentPluginId: 'optimism',
     parentCurrencyCode: 'ETH',
     isStablePool,
+    poolAddress: lpTokenContract.address,
     policy: makeVelodromeV2StakePolicy({
       isStablePool,
-      lpTokenContract: eco.makeContract(poolContractKey),
+      lpTokenContract,
       stakingContract: eco.makeContract(`GAUGE_${poolType}_${tokenA}_${tokenB}`),
       swapRouterContract: eco.makeContract(`ROUTER_VELODROME_V2`),
       tokenAContract: eco.makeContract(tokenA),

--- a/src/plugins/stake-plugins/uniswapV2/stakePolicy.ts
+++ b/src/plugins/stake-plugins/uniswapV2/stakePolicy.ts
@@ -9,6 +9,7 @@ export interface StakePolicyInfo {
   parentCurrencyCode: string
   policy: StakePluginPolicy
   isStablePool?: boolean
+  poolAddress?: string
   stakeAssets: AssetId[]
   rewardAssets: AssetId[]
 }


### PR DESCRIPTION
For ease of use for the user, we show pools that utilize WETH in both ETH and WETH wallets. They are counted as unique stake policies despite being the same exact pool underneath. The other staked assets in the pool (like OP in WETH/OP) is therefore counted twice when the wallet determines it's total staked balance. Also, the user was presented with two options, ETH/OP and WETH/OP when staking OP.

This commit removes duplicate pools if the `getPolicies` caller uses the currencyCode filter. It now has enough unique functionality to remove the need for the shared policy filter utility function.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205532912231602