### PR TITLE
Downgrade OS support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 27 // Edge modified from 21
+        minSdkVersion = 24 // Edge modified from 21, rnzcash needs 27
         compileSdkVersion = 33
         targetSdkVersion = 33
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,7 +4,7 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 # Edge addition to disable advertising ID collection:
 $RNFirebaseAnalyticsWithoutAdIdSupport = true
 
-platform :ios, '13.0'
+platform :ios, '12.4' # Was min_ios_version_supported, rnzchash needs 13.0
 prepare_react_native_project!
 
 # If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is set.


### PR DESCRIPTION
### CHANGELOG

- changed: Restore support for Android 7 and iOS v12.4.

### Dependencies

With this change, we can run the app again on these OS's. However, we are now getting a crash on iOS 12.4. Removing RNZcash fixes the crash, so now we need to debug RNZcash and implement a fix over there.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205551001606090