### PR TITLE
Fix stuck showToastSpinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fixed: Min/max price label position on the Markets charts
 - fixed: Prevent setting invalid spending limits
 - fixed: Turning off 'Dark Mode' causes crash
+- fixed: Stuck showToastSpinner never going away
 - removed: 'Add/Edit Tokens" option for token rows
 
 ## 3.17.2 (2023-09-15)

--- a/src/components/services/AirshipInstance.tsx
+++ b/src/components/services/AirshipInstance.tsx
@@ -64,8 +64,8 @@ export function showToast(message: string, autoHideMs?: number): void {
 export async function showToastSpinner<T>(message: string, activity: Promise<T>): Promise<T> {
   Airship.show(bridge => {
     activity.then(
-      () => bridge.resolve(),
-      () => bridge.resolve()
+      () => setTimeout(() => bridge.resolve(), 0),
+      () => setTimeout(() => bridge.resolve(), 0)
     )
     return (
       <AirshipToast bridge={bridge} message={message} autoHideMs={0}>


### PR DESCRIPTION
Add setTimeout to ensure bridge.resolve is called in another 'tick'

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205551203742083