### PR TITLE
Disable Slider for Sending Zero Amounts

### DIFF
--- a/src/components/scenes/SendScene.tsx
+++ b/src/components/scenes/SendScene.tsx
@@ -18,7 +18,7 @@ import { triggerScamWarningModal } from '../../actions/ScamWarningActions'
 import { checkAndShowGetCryptoModal } from '../../actions/ScanActions'
 import { FioSenderInfo, sendConfirmationUpdateTx, signBroadcastAndSave } from '../../actions/SendConfirmationActions'
 import { selectWalletToken } from '../../actions/WalletActions'
-import { FIO_STR, getSpecialCurrencyInfo } from '../../constants/WalletAndCurrencyConstants'
+import { FIO_STR, getSpecialCurrencyInfo, SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import { lstrings } from '../../locales/strings'
 import { getDisplayDenominationFromState, getExchangeDenominationFromState } from '../../selectors/DenominationSelectors'
 import { config } from '../../theme/appConfig'
@@ -28,7 +28,7 @@ import { GuiExchangeRates, GuiMakeSpendInfo } from '../../types/types'
 import { getTokenId } from '../../util/CurrencyInfoHelpers'
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import { checkRecordSendFee, FIO_NO_BUNDLED_ERR_CODE } from '../../util/FioAddressUtils'
-import { convertTransactionFeeToDisplayFee } from '../../util/utils'
+import { convertTransactionFeeToDisplayFee, zeroString } from '../../util/utils'
 import { getMemoError, getMemoLabel, getMemoTitle } from '../../util/validateMemos'
 import { WarningCard } from '../cards/WarningCard'
 import { SceneWrapper } from '../common/SceneWrapper'
@@ -725,23 +725,26 @@ const getStyles = cacheStyles((theme: Theme) => ({
 export const SendScene = connect<StateProps, DispatchProps, OwnProps>(
   state => {
     const { nativeAmount, transaction, transactionMetadata, error, guiMakeSpendInfo, isSendUsingFioAddress } = state.ui.sendConfirmation
+    const currencyWallets = state.core.account.currencyWallets
+    const defaultSelectedWalletId = state.ui.wallets.selectedWalletId
 
     return {
       account: state.core.account,
       authRequired: state.ui.sendConfirmation.authRequired,
-      defaultSelectedWalletId: state.ui.wallets.selectedWalletId,
+      defaultSelectedWalletId,
       defaultSelectedWalletCurrencyCode: state.ui.wallets.selectedCurrencyCode,
       error,
       exchangeRates: state.exchangeRates,
       nativeAmount,
       pin: state.ui.sendConfirmation.pin,
-      sliderDisabled: !transaction,
+      sliderDisabled:
+        !transaction || (zeroString(nativeAmount) && !SPECIAL_CURRENCY_INFO[currencyWallets[defaultSelectedWalletId].currencyInfo.pluginId].allowZeroTx),
       transaction,
       transactionMetadata,
       isSendUsingFioAddress,
       guiMakeSpendInfo,
       maxSpendSet: state.ui.sendConfirmation.maxSpendSet,
-      currencyWallets: state.core.account.currencyWallets
+      currencyWallets
     }
   },
   dispatch => ({

--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -17,7 +17,7 @@ import { sprintf } from 'sprintf-js'
 import { triggerScamWarningModal } from '../../actions/ScamWarningActions'
 import { checkAndShowGetCryptoModal } from '../../actions/ScanActions'
 import { playSendSound } from '../../actions/SoundActions'
-import { FIO_STR, getSpecialCurrencyInfo } from '../../constants/WalletAndCurrencyConstants'
+import { FIO_STR, getSpecialCurrencyInfo, SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { useDisplayDenom } from '../../hooks/useDisplayDenom'
 import { useExchangeDenom } from '../../hooks/useExchangeDenom'
@@ -35,7 +35,7 @@ import { getCurrencyCode } from '../../util/CurrencyInfoHelpers'
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import { addToFioAddressCache, checkRecordSendFee, FIO_NO_BUNDLED_ERR_CODE, recordSend } from '../../util/FioAddressUtils'
 import { logActivity } from '../../util/logger'
-import { convertTransactionFeeToDisplayFee, DECIMAL_PRECISION } from '../../util/utils'
+import { convertTransactionFeeToDisplayFee, DECIMAL_PRECISION, zeroString } from '../../util/utils'
 import { getMemoError, getMemoLabel, getMemoTitle } from '../../util/validateMemos'
 import { WarningCard } from '../cards/WarningCard'
 import { NotificationSceneWrapper } from '../common/SceneWrapper'
@@ -962,7 +962,12 @@ const SendComponent = (props: Props) => {
   let disableSlider = false
   let disabledText: string | undefined
 
-  if (edgeTransaction == null || processingAmountChanged || error != null) {
+  if (
+    edgeTransaction == null ||
+    processingAmountChanged ||
+    error != null ||
+    (zeroString(spendInfo.spendTargets[0].nativeAmount) && !SPECIAL_CURRENCY_INFO[pluginId].allowZeroTx)
+  ) {
     disableSlider = true
   } else if (pinSpendingLimitsEnabled && spendingLimitExceeded && (pinValue?.length ?? 0) < PIN_MAX_LENGTH) {
     disableSlider = true

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -585,6 +585,7 @@ export const SPECIAL_CURRENCY_INFO: {
     initWalletName: lstrings.string_first_fantom_wallet_name,
     chainCode: 'FTM',
     dummyPublicAddress: '0x0d73358506663d484945ba85d0cd435ad610b0a0',
+    allowZeroTx: true,
     isImportKeySupported: true,
     isStakingSupported: true,
     isCustomTokensSupported: true


### PR DESCRIPTION
### CHANGELOG

- changed: Disable slider while attempting to send zero amounts if unsupported for the asset

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205210905206152