### PR TITLE
Receive: Fix Balance Text Overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 - changed: Replace text 'plugins' with 'providers' in Buy/Sell
 - changed: Tweak the boot background color on Android.
 - changed: Include stake plugin display name in error message on transaction list scene
+- changed: Include stake plugin display name in error message on transaction
 - fixed: Error showing in some cases during auto logout
+  list scene
+- fixed: Possible balance text overflow in Receive scene
 - fixed: Incorrect wording when disabling a token
 - fixed: Min/max price label position on the Markets charts
 - fixed: Do not error when recording sends to FIO addresses.

--- a/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
@@ -55,6 +55,13 @@ exports[`Request should render with loaded props 1`] = `
     >
       <TouchableOpacity
         onPress={[Function]}
+        style={
+          {
+            "flex": 1,
+            "justifyContent": "center",
+            "marginRight": 6,
+          }
+        }
       >
         <WithTheme(EdgeTextComponent)>
           You have 0 undefined

--- a/src/components/scenes/RequestScene.tsx
+++ b/src/components/scenes/RequestScene.tsx
@@ -321,7 +321,7 @@ export class RequestSceneComponent extends React.Component<Props, State> {
             <EdgeText style={styles.exchangeRate}>{denomString}</EdgeText>
           </View>
           <View style={styles.balanceContainer}>
-            <TouchableOpacity onPress={this.toggleBalanceVisibility}>
+            <TouchableOpacity onPress={this.toggleBalanceVisibility} style={styles.balanceAmountContainer}>
               {this.props.showBalance ? <EdgeText>{displayBalanceString}</EdgeText> : <EdgeText>{lstrings.string_show_balance}</EdgeText>}
             </TouchableOpacity>
             <EdgeText style={styles.exchangeRate}>
@@ -501,6 +501,11 @@ const getStyles = cacheStyles((theme: Theme) => ({
     justifyContent: 'space-between',
     flexDirection: 'row',
     marginBottom: theme.rem(0.5)
+  },
+  balanceAmountContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    marginRight: theme.rem(0.25)
   },
   exchangeRate: {
     textAlign: 'right',


### PR DESCRIPTION
<img width="398" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/2290eabf-1919-4224-b49c-ec238a524489">

### CHANGELOG

- fixed: Possible balance text overflow in Receive scene

### Dependencies
<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205078841293962