### PR TITLE
Fix deposit/send footer modal for native currencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - changed: Tweak the boot background color on Android.
 - changed: Include stake plugin display name in error message on transaction list scene
 - changed: Include stake plugin display name in error message on transaction
+- fixed: Deposit/Send footer buttons for native currencies
 - fixed: Error showing in some cases during auto logout
   list scene
 - fixed: Possible balance text overflow in Receive scene

--- a/src/components/modals/TransferModal.tsx
+++ b/src/components/modals/TransferModal.tsx
@@ -53,18 +53,19 @@ export const TransferModal = ({ account, bridge, depositOrSend, navigation }: Pr
     const { walletId, tokenId } = await Airship.show<WalletListResult>(bridge => (
       <WalletListModal bridge={bridge} headerTitle={lstrings.select_wallet_to_send_from} navigation={navigation} />
     ))
-    if (walletId != null && tokenId != null) {
+    if (walletId != null) {
       navigation.push('send2', { walletId, tokenId, hiddenFeaturesMap: { scamWarning: false } })
     }
     Airship.clear()
   })
+
   const handleReceive = useHandler(async () => {
     Airship.clear()
     const { walletId, tokenId } = await Airship.show<WalletListResult>(bridge => (
       <WalletListModal bridge={bridge} headerTitle={lstrings.select_receive_asset} navigation={navigation} showCreateWallet />
     ))
 
-    if (walletId != null && tokenId != null) {
+    if (walletId != null) {
       await dispatch(selectWalletToken({ navigation, walletId, tokenId }))
       navigation.navigate('request', {})
     }


### PR DESCRIPTION
Previously was only allowing tokens to work

### CHANGELOG

- fixed: Deposit/Send footer buttons for native currencies

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205587559823777