### PR TITLE
Show toast on pause/unpause wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added: Experiment config support between gui and login-ui
 - added: Experiment config for "Create Account" and "Login" button labels
+- added: Toast message when pausing or unpausing wallets
 - changed: Always show gas warning when enabling tokens
 - changed: Dynamically determine supported Thorchain Savers assets
 - changed: Replace text 'plugins' with 'providers' in Buy/Sell

--- a/src/actions/SettingsActions.tsx
+++ b/src/actions/SettingsActions.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { ButtonsModal } from '../components/modals/ButtonsModal'
 import { asSortOption, SortOption } from '../components/modals/WalletListSortModal'
-import { Airship, showError } from '../components/services/AirshipInstance'
+import { Airship, showError, showToast } from '../components/services/AirshipInstance'
 import { lstrings } from '../locales/strings'
 import { convertCurrency } from '../selectors/WalletSelectors'
 import { ThunkAction } from '../types/reduxTypes'
@@ -269,6 +269,8 @@ export const toggleUserPausedWallet =
 
     const isPaused = userPausedWallets.includes(walletId)
     const newPausedWallets = isPaused ? [...userPausedWallets.filter(id => id !== walletId)] : [...userPausedWallets, walletId]
+
+    showToast(isPaused ? lstrings.unpause_wallet_toast : lstrings.pause_wallet_toast)
 
     await dispatch({
       type: 'UI/SETTINGS/SET_USER_PAUSED_WALLETS',

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -1313,6 +1313,8 @@ const strings = {
   select_src_wallet: 'Select Source Wallet',
   deposit_to_bank: 'Deposit to Bank',
   your_wallets: 'Your Wallets',
+  pause_wallet_toast: 'This wallet will no longer synchronize with the blockchain and will not detect new transactions or balance changes',
+  unpause_wallet_toast: 'This wallet will now synchronize with the blockchain and detect new transactions and balance changes.',
 
   // #region CoinRanking
 
@@ -1384,6 +1386,7 @@ const strings = {
   // #endregion Light Account
 
   // #region Transfer Modal
+
   transfer_from_bank_title: 'From Bank/Cash',
   transfer_from_wallet_title: 'From Another Wallet/Exchange',
   transfer_to_bank_title: 'To Bank/Cash',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -1148,6 +1148,8 @@
   "select_src_wallet": "Select Source Wallet",
   "deposit_to_bank": "Deposit to Bank",
   "your_wallets": "Your Wallets",
+  "pause_wallet_toast": "This wallet will no longer synchronize with the blockchain and will not detect new transactions or balance changes",
+  "unpause_wallet_toast": "This wallet will now synchronize with the blockchain and detect new transactions and balance changes.",
   "coin_rank_price": "Price",
   "coin_rank_rank": "Rank",
   "coin_rank_title_market_cap": "Market Cap",


### PR DESCRIPTION
### CHANGELOG

- added: Toast message when pausing or unpausing wallets

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205591566453680