### PR TITLE
Remove extra close button on FIO modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - changed: Tweak the boot background color on Android.
 - changed: Include stake plugin display name in error message on transaction list scene
 - changed: Include stake plugin display name in error message on transaction
+- fixed: Extra close (x) button on FIO modal
 - fixed: Deposit/Send footer buttons for native currencies
 - fixed: Error showing in some cases during auto logout
   list scene

--- a/src/components/modals/FioCreateHandleModal.tsx
+++ b/src/components/modals/FioCreateHandleModal.tsx
@@ -38,7 +38,7 @@ export const FioCreateHandleModal = (props: Props) => {
   })
 
   return (
-    <ThemedModal bridge={bridge} onCancel={handleCancel}>
+    <ThemedModal bridge={bridge} closeButton={false} onCancel={handleCancel}>
       <View style={styles.container}>
         <FastImage source={{ uri: getFioNewHandleImage(theme) }} style={styles.icon} />
         <GetFioHandleTitle>{parseMarkedText(lstrings.fio_free_handle_title_m)}</GetFioHandleTitle>
@@ -55,7 +55,7 @@ export const FioCreateHandleModal = (props: Props) => {
         </EdgeText>
       ) : null}
       <MainButton type="primary" label={lstrings.get_started_button} onPress={handleConfirm} marginRem={[1, 1, 0.5, 1]} />
-      <MainButton type="escape" label={lstrings.not_now_button} onPress={handleCancel} marginRem={[0.5, 1, 1, 1]} />
+      <MainButton type="escape" label={lstrings.not_now_button} onPress={handleCancel} marginRem={[0.5, 1, 0.5, 1]} />
     </ThemedModal>
   )
 }


### PR DESCRIPTION
### CHANGELOG

- fixed: Extra close (x) button on FIO modal

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205533593327784