### PR TITLE
Jon/fix/retention-analytics

### DIFF
--- a/src/actions/FirstOpenActions.tsx
+++ b/src/actions/FirstOpenActions.tsx
@@ -1,25 +1,46 @@
+import { asNumber, asObject, asString, asValue } from 'cleaners'
 import { makeReactNativeDisklet } from 'disklet'
 
 import { FIRST_OPEN } from '../constants/constantSettings'
+import { makeUuid } from '../util/utils'
 
 const firstOpenDisklet = makeReactNativeDisklet()
 
-let isFirstOpen: 'true' | 'false'
+const asFirstOpenInfo = asObject({
+  isFirstOpen: asValue('true', 'false'),
+  deviceId: asString,
+  firstOpenEpoch: asNumber
+})
+type FirstOpenInfo = ReturnType<typeof asFirstOpenInfo>
+
+let firstOpenInfo: FirstOpenInfo
 
 /**
  * Returns whether this session was the first time the user opened the app.
- * Repeated calls will return the same result.
+ * Repeated calls will return the same result. Also sets the deviceId &
+ * firstOpenEpoch
  */
-export const getIsFirstOpen = async () => {
-  if (isFirstOpen != null) return isFirstOpen
-  else {
+export const getFirstOpenInfo = async (): Promise<FirstOpenInfo> => {
+  if (firstOpenInfo == null) {
+    let firstOpenText
     try {
-      await firstOpenDisklet.getText(FIRST_OPEN)
-      isFirstOpen = 'false'
+      firstOpenText = await firstOpenDisklet.getText(FIRST_OPEN)
+      firstOpenInfo = asFirstOpenInfo(JSON.parse(firstOpenText))
     } catch (error: any) {
-      await firstOpenDisklet.setText(FIRST_OPEN, '')
-      isFirstOpen = 'true'
+      // Generate new values.
+      firstOpenInfo = {
+        deviceId: makeUuid(),
+        firstOpenEpoch: Date.now(),
+        // If firstOpen != null: This is not the first time they opened the app,
+        // but with an older version that didn't set a deviceId and firstOpen
+        // date, just created an empty file.
+        // Note that 'firstOpenEpoch' won't be accurate in this case, but at
+        // least make a starting point.
+        isFirstOpen: firstOpenText != null ? 'false' : 'true'
+      }
+      await firstOpenDisklet.setText(FIRST_OPEN, JSON.stringify(firstOpenInfo))
     }
-    return isFirstOpen
   }
+
+  return firstOpenInfo
 }

--- a/src/constants/constantSettings.ts
+++ b/src/constants/constantSettings.ts
@@ -1,5 +1,5 @@
 export const AAVE_WELCOME = 'aaveWelcome.json'
-export const FIRST_OPEN = 'firstOpen.json'
+export const FIRST_OPEN = 'firstOpen3.json'
 export const SCAM_WARNING = 'scamWarning.json'
 export const SETTINGS_PERMISSION_LIMITS = 'SETTINGS_PERMISSION_LIMIT'
 export const SETTINGS_PERMISSION_QUANTITY = 3

--- a/src/util/tracking.ts
+++ b/src/util/tracking.ts
@@ -122,6 +122,9 @@ export function logEvent(event: TrackingEventName, values: TrackingValues = {}) 
       // Add all 'sticky' remote config variant values:
       for (const key of Object.keys(experimentConfig)) params[`svar_${key}`] = experimentConfig[key as keyof ExperimentConfig]
 
+      // TEMP HACK: Add renamed var for legacyLanding
+      params.svar_newLegacyLanding = experimentConfig.legacyLanding
+
       consify({ logEvent: { event, params } })
 
       Promise.all([logToFirebase(event, params), logToUtilServer(event, params)]).catch(error => console.warn(error))

--- a/src/util/tracking.ts
+++ b/src/util/tracking.ts
@@ -3,7 +3,7 @@ import analytics from '@react-native-firebase/analytics'
 import { TrackingEventName as LoginTrackingEventName, TrackingValues as LoginTrackingValues } from 'edge-login-ui-rn/lib/util/analytics'
 import { getUniqueId, getVersion } from 'react-native-device-info'
 
-import { getIsFirstOpen } from '../actions/FirstOpenActions'
+import { getFirstOpenInfo } from '../actions/FirstOpenActions'
 import { ENV } from '../env'
 import { ExperimentConfig, getExperimentConfig } from '../experimentConfig'
 import { fetchReferral } from './network'
@@ -105,7 +105,8 @@ export function logEvent(event: TrackingEventName, values: TrackingValues = {}) 
   getExperimentConfig()
     .then(async (experimentConfig: ExperimentConfig) => {
       // Persistent & Unchanged params:
-      const params: any = { edgeVersion: getVersion(), isFirstOpen: await getIsFirstOpen(), ...values }
+      const { isFirstOpen, deviceId, firstOpenEpoch } = await getFirstOpenInfo()
+      const params: any = { edgeVersion: getVersion(), isFirstOpen, deviceId, firstOpenEpoch, ...values }
 
       // Adjust params:
       if (accountDate != null) params.adate = accountDate


### PR DESCRIPTION
Background
Changing svar_legacyLanding's type from boolean to string might have broken retention report views in Firebase, since it was already a tracked boolean dimension. The numbers don't make sense in the retention reports.

It was also discovered that it was misguided to continue to try to augment reported Firebase data to try to more accurately capture first open, because first open is exactly the time where we know it's unlikely Firebase will be working correctly.

Task
Rename legacyLanding to start capturing a fresh dimension.
This is a quick trial fix in hopes of fixing the retention report in firebase
Add new tracking params: firstOpenEpoch, deviceId
firstOpenEpochis a fallback solution in case 1. doesn't work, and will also be useful in moving towards our own reporting solution in general. We need this regardless due to analytics reliability issues for new installs.
Will allow us to create our own retention report with data on our util/referral server.

### CHANGELOG

- added: New analytics for first open epoch and deviceId

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205619258271472