### PR TITLE
Don't start booting wallets until settings are loaded

### DIFF
--- a/src/__tests__/reducers/__snapshots__/RootReducer.test.ts.snap
+++ b/src/__tests__/reducers/__snapshots__/RootReducer.test.ts.snap
@@ -233,6 +233,7 @@ exports[`initialState 1`] = `
         },
       },
       "userPausedWallets": [],
+      "userPausedWalletsSet": null,
       "walletsSort": "manual",
     },
     "subcategories": [],

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -125,7 +125,7 @@ export function WalletListMenuModal(props: Props) {
 
   const dispatch = useDispatch()
   const account = useSelector(state => state.core.account)
-  const pausedWallets = useSelector(state => state.ui.settings.userPausedWallets)
+  const pausedWallets = useSelector(state => state.ui.settings.userPausedWalletsSet)
 
   const wallet = useWatch(account, 'currencyWallets')[walletId]
 
@@ -169,10 +169,12 @@ export function WalletListMenuModal(props: Props) {
     const result: Option[] = []
 
     const { pluginId } = wallet.currencyInfo
-    result.push({
-      label: pausedWallets.includes(walletId) ? lstrings.fragment_wallets_unpause_wallet : lstrings.fragment_wallets_pause_wallet,
-      value: 'togglePause'
-    })
+    if (pausedWallets != null) {
+      result.push({
+        label: pausedWallets.has(walletId) ? lstrings.fragment_wallets_unpause_wallet : lstrings.fragment_wallets_pause_wallet,
+        value: 'togglePause'
+      })
+    }
 
     for (const option of WALLET_LIST_MENU) {
       const { pluginIds, label, value } = option

--- a/src/components/services/WalletLifecycle.ts
+++ b/src/components/services/WalletLifecycle.ts
@@ -10,7 +10,7 @@ interface StateProps {
   account: EdgeAccount
   context: EdgeContext
   sortedWalletList: WalletListItem[]
-  userPausedWallets: string[]
+  userPausedWalletsSet: Set<string> | null
 }
 type Props = StateProps
 
@@ -58,7 +58,7 @@ export class WalletLifecycleComponent extends React.Component<Props> {
    * Figures out what has changed and adapts.
    */
   handleChange = () => {
-    const { account, context, sortedWalletList, userPausedWallets } = this.props
+    const { account, context, sortedWalletList, userPausedWalletsSet } = this.props
 
     // Check for login / logout:
     if (account !== this.edgeAccount || context !== this.edgeContext) {
@@ -88,7 +88,7 @@ export class WalletLifecycleComponent extends React.Component<Props> {
     this.paused = paused
 
     // The next steps only apply if we are active:
-    if (paused) return
+    if (paused || userPausedWalletsSet == null) return
 
     // Check for boots that have completed, and for deleted wallets:
     this.booting = this.booting.filter(boot => {
@@ -114,7 +114,7 @@ export class WalletLifecycleComponent extends React.Component<Props> {
       if (token != null || tokenId != null || wallet == null) continue
       if (!wallet.paused) continue
       if (this.booting.find(boot => boot.walletId === walletId) != null) continue
-      if (userPausedWallets.includes(walletId)) continue
+      if (userPausedWalletsSet.has(walletId)) continue
 
       this.booting.push(bootWallet(wallet, this.handleChange))
     }
@@ -192,7 +192,7 @@ export const WalletLifecycle = connect<StateProps, {}, {}>(
     account: state.core.account,
     context: state.core.context,
     sortedWalletList: state.sortedWalletList,
-    userPausedWallets: state.ui.settings.userPausedWallets
+    userPausedWalletsSet: state.ui.settings.userPausedWalletsSet
   }),
   dispatch => ({})
 )(WalletLifecycleComponent)

--- a/src/reducers/scenes/SettingsReducer.ts
+++ b/src/reducers/scenes/SettingsReducer.ts
@@ -13,7 +13,8 @@ export const initialState: SettingsState = {
   isTouchEnabled: false,
   isTouchSupported: false,
   pinLoginEnabled: false,
-  settingsLoaded: null
+  settingsLoaded: null,
+  userPausedWalletsSet: null
 }
 
 export interface SettingsState extends LocalAccountSettings, SyncedAccountSettings {
@@ -22,6 +23,10 @@ export interface SettingsState extends LocalAccountSettings, SyncedAccountSettin
   isTouchSupported: boolean
   pinLoginEnabled: boolean
   settingsLoaded: boolean | null
+
+  // A copy of `userPausedWallets`, but as a set.
+  // This is `null` until we load the setting from disk.
+  userPausedWalletsSet: Set<string> | null
 }
 
 export interface AccountInitPayload extends SettingsState {
@@ -94,6 +99,7 @@ export const settingsLegacy = (state: SettingsState = initialState, action: Acti
         mostRecentWallets,
         passwordRecoveryRemindersShown,
         userPausedWallets,
+        userPausedWalletsSet: new Set(userPausedWallets),
         pinLoginEnabled,
         preferredSwapPluginId: preferredSwapPluginId === '' ? undefined : preferredSwapPluginId,
         preferredSwapPluginType,
@@ -206,9 +212,11 @@ export const settingsLegacy = (state: SettingsState = initialState, action: Acti
     }
 
     case 'UI/SETTINGS/SET_USER_PAUSED_WALLETS': {
+      const { userPausedWallets } = action.data
       return {
         ...state,
-        userPausedWallets: action.data.userPausedWallets
+        userPausedWallets,
+        userPausedWalletsSet: new Set(userPausedWallets)
       }
     }
 


### PR DESCRIPTION
Otherwise we might boot wallets that should stay paused.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205605002662319