### PR TITLE
GUI: Fix Back Routing for Legacy Landing Variant

### DIFF
--- a/src/components/scenes/LoginScene.tsx
+++ b/src/components/scenes/LoginScene.tsx
@@ -4,7 +4,6 @@ import { NotificationPermissionsInfo } from 'edge-login-ui-rn/lib/types/ReduxTyp
 import * as React from 'react'
 import { Keyboard, StatusBar, View } from 'react-native'
 import { checkVersion } from 'react-native-check-version'
-import { isMaestro } from 'react-native-is-maestro'
 import { BlurView } from 'rn-id-blurview'
 
 import { showSendLogsModal } from '../../actions/LogActions'
@@ -61,7 +60,6 @@ export function LoginSceneComponent(props: Props) {
   const [counter, setCounter] = React.useState<number>(0)
   const [notificationPermissionsInfo, setNotificationPermissionsInfo] = React.useState<NotificationPermissionsInfo | undefined>()
   const [passwordRecoveryKey, setPasswordRecoveryKey] = React.useState<string | undefined>()
-  const [legacyLanding, setLegacyLanding] = React.useState<boolean | undefined>(isMaestro() ? false : undefined)
   const [experimentConfig, setExperimentConfig] = React.useState<ExperimentConfig>()
 
   const fontDescription = React.useMemo(
@@ -156,7 +154,7 @@ export function LoginSceneComponent(props: Props) {
   )
 
   const maybeHandleComplete =
-    ENV.USE_WELCOME_SCREENS && !legacyLanding
+    ENV.USE_WELCOME_SCREENS && experimentConfig != null && !experimentConfig.legacyLanding
       ? () => {
           navigation.navigate('gettingStarted', {})
         }
@@ -188,7 +186,6 @@ export function LoginSceneComponent(props: Props) {
   useAsyncEffect(async () => {
     const experimentConfig = await getExperimentConfig()
     setExperimentConfig(experimentConfig)
-    setLegacyLanding(experimentConfig.legacyLanding === 'legacyLanding')
   }, [])
 
   return loggedIn || experimentConfig == null ? (

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -196,7 +196,7 @@ export const asEnvConfig = asObject({
   KEYS_ONLY_PLUGINS: asOptional(asObject(asBoolean), {}),
   USE_FAKE_CORE: asOptional(asBoolean, false),
   USE_FIREBASE: asOptional(asBoolean, true),
-  USE_WELCOME_SCREENS: asOptional(asBoolean, true),
+  USE_WELCOME_SCREENS: asOptional(asBoolean, true), // Used by whitelabels
 
   YOLO_DEEP_LINK: asNullable(asString),
   YOLO_PASSWORD: asNullable(asString),


### PR DESCRIPTION
Bug steps:
1. Press Sign Up
2. Press Get Started
3. Go Back 2x (new username, password login)
4. Observe the wrong scene: GettingStarted USPs instead of legacy landing

legacyLanding being undefined at the end of the steps to produce the bug was causing incorrect maybeHandleComplete routing to be returned

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205586035325311