### PR TITLE
Move CurrencySettings into new "Asset Settings" Scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - changed: Change FlipInput styling to make the edit functionality more obvious
+- changed: Move asset-specific settings into their own settings page
 
 ## 3.20.0
 

--- a/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
@@ -1737,6 +1737,114 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             }
           >
+            Asset Settings
+          </Text>
+          <View>
+            <View
+              pending={false}
+              style={
+                [
+                  {
+                    "aspectRatio": 1,
+                    "position": "absolute",
+                    "width": "100%",
+                    "zIndex": 1,
+                  },
+                  {
+                    "opacity": 0,
+                  },
+                ]
+              }
+            >
+              <ActivityIndicator
+                color="#00f1a2"
+                style={
+                  {
+                    "height": 34,
+                    "marginHorizontal": 11,
+                  }
+                }
+              />
+            </View>
+            <View
+              pending={false}
+              style={
+                {
+                  "opacity": 1,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 12,
+                    },
+                    {
+                      "color": "#00f1a2",
+                      "fontSize": 22,
+                      "marginHorizontal": 11,
+                    },
+                    {
+                      "fontFamily": "FontAwesome5Free-Solid",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {
+                      "fontWeight": "900",
+                    },
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "rgba(255, 255, 255, 0)",
+              "flexDirection": "row",
+              "marginBottom": 1,
+              "minHeight": 67,
+              "padding": 11,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "#FFFFFF",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "fontFamily": "Quicksand-Regular",
+                "fontSize": 22,
+                "paddingHorizontal": 11,
+                "textAlign": "left",
+              }
+            }
+          >
             Promotion Settings
           </Text>
           <View>
@@ -4350,6 +4458,114 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
             }
           >
             Notifications
+          </Text>
+          <View>
+            <View
+              pending={false}
+              style={
+                [
+                  {
+                    "aspectRatio": 1,
+                    "position": "absolute",
+                    "width": "100%",
+                    "zIndex": 1,
+                  },
+                  {
+                    "opacity": 0,
+                  },
+                ]
+              }
+            >
+              <ActivityIndicator
+                color="#00f1a2"
+                style={
+                  {
+                    "height": 34,
+                    "marginHorizontal": 11,
+                  }
+                }
+              />
+            </View>
+            <View
+              pending={false}
+              style={
+                {
+                  "opacity": 1,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 12,
+                    },
+                    {
+                      "color": "#00f1a2",
+                      "fontSize": 22,
+                      "marginHorizontal": 11,
+                    },
+                    {
+                      "fontFamily": "FontAwesome5Free-Solid",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {
+                      "fontWeight": "900",
+                    },
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "rgba(255, 255, 255, 0)",
+              "flexDirection": "row",
+              "marginBottom": 1,
+              "minHeight": 67,
+              "padding": 11,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "#FFFFFF",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "fontFamily": "Quicksand-Regular",
+                "fontSize": 22,
+                "paddingHorizontal": 11,
+                "textAlign": "left",
+              }
+            }
+          >
+            Asset Settings
           </Text>
           <View>
             <View

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -38,6 +38,7 @@ import { HeaderTitle } from './navigation/HeaderTitle'
 import { ParamHeaderTitle } from './navigation/ParamHeaderTitle'
 import { SideMenuButton } from './navigation/SideMenuButton'
 import { TransactionDetailsTitle } from './navigation/TransactionDetailsTitle'
+import { AssetSettingsScene as AssetSettingsSceneComponent } from './scenes/AssetSettingsScene'
 import { ChangeMiningFeeScene as ChangeMiningFeeSceneComponent } from './scenes/ChangeMiningFeeScene'
 import { ChangeMiningFeeScene2 as ChangeMiningFeeScene2Component } from './scenes/ChangeMiningFeeScene2'
 import { ChangePasswordScene as ChangePasswordSceneComponent } from './scenes/ChangePasswordScene'
@@ -144,6 +145,7 @@ const CryptoExchangeQuoteProcessingScene = ifLoggedIn(CryptoExchangeQuoteProcess
 const CryptoExchangeScene = ifLoggedIn(CryptoExchangeSceneComponent)
 const CryptoExchangeSuccessScene = ifLoggedIn(CryptoExchangeSuccessSceneComponent)
 const CurrencyNotificationScene = ifLoggedIn(CurrencyNotificationSceneComponent)
+const AssetSettingsScene = ifLoggedIn(AssetSettingsSceneComponent)
 const CurrencySettingsScene = ifLoggedIn(CurrencySettingsSceneComponent)
 const DefaultFiatSettingScene = ifLoggedIn(DefaultFiatSettingSceneComponent)
 const EdgeLoginScene = ifLoggedIn(EdgeLoginSceneComponent)
@@ -422,6 +424,14 @@ const EdgeAppStack = () => {
         component={CurrencyNotificationScene}
         options={{
           headerTitle: props => <CurrencySettingsTitle />,
+          headerRight: () => null
+        }}
+      />
+      <Stack.Screen
+        name="assetSettings"
+        component={AssetSettingsScene}
+        options={{
+          title: lstrings.settings_asset_settings,
           headerRight: () => null
         }}
       />

--- a/src/components/scenes/AssetSettingsScene.tsx
+++ b/src/components/scenes/AssetSettingsScene.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { ScrollView } from 'react-native'
+
+import { CURRENCY_SETTINGS_KEYS } from '../../constants/WalletAndCurrencyConstants'
+import { useSelector } from '../../types/reactRedux'
+import { EdgeSceneProps } from '../../types/routerTypes'
+import { SceneWrapper } from '../common/SceneWrapper'
+import { CryptoIcon } from '../icons/CryptoIcon'
+import { SettingsTappableRow } from '../settings/SettingsTappableRow'
+
+interface Props extends EdgeSceneProps<'assetSettings'> {}
+
+export function AssetSettingsScene(props: Props) {
+  const { navigation } = props
+  const account = useSelector(state => state.core.account)
+
+  return (
+    <SceneWrapper background="theme" hasTabs={false}>
+      <ScrollView>
+        {CURRENCY_SETTINGS_KEYS.map(pluginId => {
+          if (account.currencyConfig[pluginId] == null) return null
+          const { currencyInfo } = account.currencyConfig[pluginId]
+          const { displayName } = currencyInfo
+          const onPress = () =>
+            navigation.navigate('currencySettings', {
+              currencyInfo
+            })
+
+          return (
+            <SettingsTappableRow key={pluginId} label={displayName} onPress={onPress}>
+              <CryptoIcon marginRem={[0.5, 0, 0.5, 0.5]} pluginId={pluginId} sizeRem={1.25} />
+            </SettingsTappableRow>
+          )
+        })}
+      </ScrollView>
+    </SceneWrapper>
+  )
+}

--- a/src/components/scenes/SettingsScene.tsx
+++ b/src/components/scenes/SettingsScene.tsx
@@ -29,7 +29,6 @@ import { EdgeSceneProps, NavigationBase } from '../../types/routerTypes'
 import { secondsToDisplay } from '../../util/displayTime'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { TextDropdown } from '../common/TextDropdown'
-import { CryptoIcon } from '../icons/CryptoIcon'
 import { Space } from '../layout/Space'
 import { AutoLogoutModal } from '../modals/AutoLogoutModal'
 import { ConfirmContinueModal } from '../modals/ConfirmContinueModal'
@@ -276,7 +275,7 @@ export class SettingsSceneComponent extends React.Component<Props, State> {
   }
 
   render() {
-    const { account, contactsPermissionOn, isLocked, navigation, theme, username, handleClearLogs, handleSendLogs } = this.props
+    const { contactsPermissionOn, isLocked, navigation, theme, username, handleClearLogs, handleSendLogs } = this.props
     const iconSize = theme.rem(1.25)
 
     const autoLogout = secondsToDisplay(this.props.autoLogoutTimeInSeconds)
@@ -338,22 +337,10 @@ export class SettingsSceneComponent extends React.Component<Props, State> {
             onPress={this.handleSpamToggle}
           />
           <SettingsTappableRow label={lstrings.settings_notifications} onPress={this.handleNotificationSettings} />
-          {CURRENCY_SETTINGS_KEYS.map(pluginId => {
-            if (account.currencyConfig[pluginId] == null) return null
-            const { currencyInfo } = account.currencyConfig[pluginId]
-            const { displayName } = currencyInfo
-            const onPress = () =>
-              navigation.navigate('currencySettings', {
-                currencyInfo
-              })
-
-            return (
-              <SettingsTappableRow key={pluginId} label={displayName} onPress={onPress}>
-                <CryptoIcon marginRem={[0.5, 0, 0.5, 0.5]} pluginId={pluginId} sizeRem={1.25} />
-              </SettingsTappableRow>
-            )
-          })}
-
+          <SettingsTappableRow
+            label={lstrings.settings_asset_settings}
+            onPress={() => navigation.push('assetSettings', { currencySettingsKeys: CURRENCY_SETTINGS_KEYS })}
+          />
           <SettingsTappableRow label={lstrings.title_promotion_settings} onPress={this.handlePromotionSettings} />
           {ENV.ALLOW_DEVELOPER_MODE && (
             <SettingsSwitchRow

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -390,6 +390,7 @@ const strings = {
   invalid_custom_fee: 'Minimum custom fee is',
   missing_username: '<No username>',
   settings_account_title_cap: 'Account',
+  settings_asset_settings: 'Asset Settings',
   settings_button_change_password: 'Change Password',
   settings_developer_mode: 'Developer Mode',
   settings_verbose_logging: 'Verbose Logging',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -324,6 +324,7 @@
   "invalid_custom_fee": "Minimum custom fee is",
   "missing_username": "<No username>",
   "settings_account_title_cap": "Account",
+  "settings_asset_settings": "Asset Settings",
   "settings_button_change_password": "Change Password",
   "settings_developer_mode": "Developer Mode",
   "settings_verbose_logging": "Verbose Logging",

--- a/src/types/routerTypes.tsx
+++ b/src/types/routerTypes.tsx
@@ -63,6 +63,7 @@ export interface RouteParamList {
   rewardsCardWelcome: RewardsCardWelcomeParams
 
   // Logged-in scenes:
+  assetSettings: {}
   changeMiningFee: {
     guiMakeSpendInfo: GuiMakeSpendInfo
     maxSpendSet: boolean


### PR DESCRIPTION
Move asset-specific settings into their own settings page

![Simulator Screenshot - iPhone 14 - 2023-10-19 at 18 03 14](https://github.com/EdgeApp/edge-react-gui/assets/90650827/5459cdd6-8e2c-4cd8-9315-4fea9247b5b8)

![Simulator Screenshot - iPhone 14 - 2023-10-19 at 18 03 18](https://github.com/EdgeApp/edge-react-gui/assets/90650827/2945f281-516b-4434-84e4-7c01ec7dd634)


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204864676553122