### PR TITLE
AssetStatusCard and PromoCard Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@
 - changed: Enable max spend for Filecoin
 - changed: Move asset-specific settings into their own settings page
 - changed: Experiment config probability distribution support percentage based values
+- changed: Added border to Promo Card
 - fixed: Write updated experiment configs to disk
 - fixed: Auto Logoff picker text color for Android Light OS theme
+- fixed: Fallback language selection for Asset Status Card
 - removed: Moonpay sell via ACH
 - removed: Banxa buy via Pix
 

--- a/src/__tests__/components/__snapshots__/PromoCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/PromoCard.test.tsx.snap
@@ -31,10 +31,10 @@ exports[`PromoCard should render 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     {
-      "marginBottom": 22,
-      "marginLeft": 22,
-      "marginRight": 22,
-      "marginTop": 22,
+      "marginBottom": 11,
+      "marginLeft": 11,
+      "marginRight": 11,
+      "marginTop": 11,
       "opacity": 1,
       "paddingBottom": 11,
       "paddingLeft": 11,
@@ -46,10 +46,7 @@ exports[`PromoCard should render 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
-        "backgroundColor": "rgba(255, 255, 255, 0)",
-        "flexDirection": "row",
-        "padding": 11,
+        "width": "100%",
       }
     }
   >
@@ -57,115 +54,156 @@ exports[`PromoCard should render 1`] = `
       style={
         [
           {
-            "overflow": "hidden",
-          },
-          {
-            "height": 45,
-            "margin": 11,
-            "width": 45,
-          },
-        ]
-      }
-    >
-      <FastImageView
-        resizeMode="contain"
-        source={
-          {
-            "uri": "https://edge.app/favicon.ico",
-          }
-        }
-        style={
-          {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          }
-        }
-      />
-    </View>
-    <Text
-      adjustsFontSizeToFit={true}
-      minimumFontScale={0.65}
-      numberOfLines={0}
-      style={
-        [
-          {
-            "color": "#FFFFFF",
-            "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
-            "includeFontPadding": false,
-          },
-          {
-            "flex": 1,
-            "margin": 11,
+            "borderColor": "rgba(255, 255, 255, .1)",
+            "borderRadius": 4,
+            "borderWidth": 1,
           },
           null,
+          {
+            "marginBottom": 0,
+            "marginLeft": 0,
+            "marginRight": 0,
+            "marginTop": 0,
+          },
+          {
+            "paddingBottom": 22,
+            "paddingLeft": 22,
+            "paddingRight": 22,
+            "paddingTop": 22,
+          },
         ]
       }
-      testID="promoCard"
     >
-      Show me
-    </Text>
-    <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={false}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "opacity": 1,
-        }
-      }
-    >
-      <Text
-        accessibilityHint="Close"
-        allowFontScaling={false}
+      <View
         style={
-          [
-            {
-              "color": "#00f1a2",
-              "fontSize": 22,
-            },
-            {
-              "padding": 11,
-            },
-            {
-              "fontFamily": "anticon",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            {},
-          ]
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+          }
         }
-        testID="closePromo"
       >
-        
-      </Text>
+        <View
+          style={
+            [
+              {
+                "overflow": "hidden",
+              },
+              {
+                "height": 45,
+                "marginHorizontal": 11,
+                "width": 45,
+              },
+            ]
+          }
+        >
+          <FastImageView
+            resizeMode="contain"
+            source={
+              {
+                "uri": "https://edge.app/favicon.ico",
+              }
+            }
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            {
+              "flex": 1,
+              "flexDirection": "column",
+              "padding": 11,
+            }
+          }
+        >
+          <Text
+            adjustsFontSizeToFit={true}
+            minimumFontScale={0.65}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "Quicksand-Regular",
+                  "fontSize": 22,
+                  "includeFontPadding": false,
+                },
+                undefined,
+                null,
+              ]
+            }
+            testID="promoCard"
+          >
+            Show me
+          </Text>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={false}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "opacity": 1,
+            }
+          }
+        >
+          <Text
+            accessibilityHint="Close"
+            allowFontScaling={false}
+            style={
+              [
+                {
+                  "color": "#00f1a2",
+                  "fontSize": 22,
+                },
+                {
+                  "padding": 11,
+                },
+                {
+                  "fontFamily": "anticon",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+            testID="closePromo"
+          >
+            
+          </Text>
+        </View>
+      </View>
     </View>
   </View>
 </View>

--- a/src/components/cards/AssetStatusCard.tsx
+++ b/src/components/cards/AssetStatusCard.tsx
@@ -30,6 +30,7 @@ export const AssetStatusCard = (props: { assetStatus: AssetStatus }) => {
     <StatusCard
       message={message}
       title={title}
+      testIds={{ title: 'statusCardTitle', message: 'statusCardMessage', close: 'statusCardClose' }}
       iconOrUri={
         // If not explicitly set, auto-fill if warning status.
         iconUrl == null ? (
@@ -57,7 +58,6 @@ const getStyles = cacheStyles((theme: Theme) => ({
   icon: {
     width: theme.rem(3),
     height: theme.rem(3),
-    marginRight: theme.rem(0.75),
-    marginLeft: theme.rem(-0.25)
+    marginRight: theme.rem(0.5)
   }
 }))

--- a/src/components/cards/AssetStatusCard.tsx
+++ b/src/components/cards/AssetStatusCard.tsx
@@ -9,6 +9,8 @@ import { openBrowserUri } from '../../util/WebUtils'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { StatusCard } from './StatusCard'
 
+const DEFAULT_LANGUAGE = 'en_US'
+
 export const AssetStatusCard = (props: { assetStatus: AssetStatus }) => {
   const { statusType, localeStatusTitle, localeStatusBody, iconUrl, statusUrl, statusStartIsoDate, statusEndIsoDate } = props.assetStatus
   const theme = useTheme()
@@ -17,10 +19,10 @@ export const AssetStatusCard = (props: { assetStatus: AssetStatus }) => {
   const curDate = new Date().toISOString()
   const isWithinDate = statusStartIsoDate != null && statusEndIsoDate != null && statusStartIsoDate <= curDate && statusEndIsoDate >= curDate
 
-  const [firstLocale = { languageTag: 'en_US' }] = getLocales()
+  const [firstLocale = { languageTag: DEFAULT_LANGUAGE }] = getLocales()
   const { languageTag } = firstLocale
-  const titleLocale = pickLanguage(languageTag, Object.keys(localeStatusTitle))
-  const messageLocale = pickLanguage(languageTag, Object.keys(localeStatusBody))
+  const titleLocale = pickLanguage(languageTag, Object.keys(localeStatusTitle)) ?? pickLanguage(DEFAULT_LANGUAGE, Object.keys(localeStatusTitle))
+  const messageLocale = pickLanguage(languageTag, Object.keys(localeStatusBody)) ?? pickLanguage(DEFAULT_LANGUAGE, Object.keys(localeStatusBody))
   const title = localeStatusTitle[titleLocale ?? 0]
   const message = localeStatusBody[messageLocale ?? 0]
 

--- a/src/components/cards/AssetStatusCard.tsx
+++ b/src/components/cards/AssetStatusCard.tsx
@@ -7,7 +7,7 @@ import IonIcon from 'react-native-vector-icons/Ionicons'
 import { pickLanguage } from '../../locales/intl'
 import { openBrowserUri } from '../../util/WebUtils'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
-import { StatusCard } from './StatusCard'
+import { IconMessageCard } from './IconMessageCard'
 
 const DEFAULT_LANGUAGE = 'en_US'
 
@@ -27,7 +27,7 @@ export const AssetStatusCard = (props: { assetStatus: AssetStatus }) => {
   const message = localeStatusBody[messageLocale ?? 0]
 
   return isWithinDate ? (
-    <StatusCard
+    <IconMessageCard
       message={message}
       title={title}
       testIds={{ title: 'statusCardTitle', message: 'statusCardMessage', close: 'statusCardClose' }}

--- a/src/components/cards/IconMessageCard.tsx
+++ b/src/components/cards/IconMessageCard.tsx
@@ -18,7 +18,7 @@ interface Props {
   onPress?: () => void
 }
 
-export function StatusCard(props: Props) {
+export function IconMessageCard(props: Props) {
   const { iconOrUri, message, title, testIds, onPress = () => {}, onClose } = props
   const theme = useTheme()
   const styles = getStyles(theme)

--- a/src/components/cards/PromoCard.tsx
+++ b/src/components/cards/PromoCard.tsx
@@ -9,7 +9,7 @@ import { NavigationBase } from '../../types/routerTypes'
 import { bestOfMessages } from '../../util/ReferralHelpers'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
-import { StatusCard } from './StatusCard'
+import { IconMessageCard } from './IconMessageCard'
 
 interface Props {
   navigation: NavigationBase
@@ -39,7 +39,7 @@ export function PromoCard(props: Props) {
   if (messageSummary == null) return null
   const { message } = messageSummary
   return (
-    <StatusCard
+    <IconMessageCard
       message={message.message}
       testIds={{ message: 'promoCard', close: 'closePromo' }}
       iconOrUri={message.iconUri != null ? <FastImage resizeMode="contain" source={{ uri: message.iconUri }} style={styles.icon} /> : null}

--- a/src/components/cards/PromoCard.tsx
+++ b/src/components/cards/PromoCard.tsx
@@ -1,19 +1,15 @@
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
 import FastImage from 'react-native-fast-image'
-import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
 import { hideMessageTweak } from '../../actions/AccountReferralActions'
 import { linkReferralWithCurrencies } from '../../actions/WalletListActions'
 import { useHandler } from '../../hooks/useHandler'
-import { lstrings } from '../../locales/strings'
 import { useDispatch, useSelector } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
 import { bestOfMessages } from '../../util/ReferralHelpers'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
-import { EdgeText } from '../themed/EdgeText'
-import { ButtonBox } from '../themed/ThemedButtons'
+import { StatusCard } from './StatusCard'
 
 interface Props {
   navigation: NavigationBase
@@ -43,44 +39,20 @@ export function PromoCard(props: Props) {
   if (messageSummary == null) return null
   const { message } = messageSummary
   return (
-    <ButtonBox marginRem={1} onPress={handlePress}>
-      <View style={styles.container}>
-        {message.iconUri != null ? <FastImage resizeMode="contain" source={{ uri: message.iconUri }} style={styles.icon} /> : null}
-        <EdgeText testID="promoCard" numberOfLines={0} style={styles.text}>
-          {message.message}
-        </EdgeText>
-        <TouchableOpacity accessible={false} onPress={handleClose}>
-          <AntDesignIcon
-            testID="closePromo"
-            name="close"
-            color={theme.iconTappable}
-            size={theme.rem(1)}
-            style={styles.close}
-            accessibilityHint={lstrings.close_hint}
-          />
-        </TouchableOpacity>
-      </View>
-    </ButtonBox>
+    <StatusCard
+      message={message.message}
+      testIds={{ message: 'promoCard', close: 'closePromo' }}
+      iconOrUri={message.iconUri != null ? <FastImage resizeMode="contain" source={{ uri: message.iconUri }} style={styles.icon} /> : null}
+      onPress={handlePress}
+      onClose={handleClose}
+    />
   )
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: theme.tileBackground,
-    padding: theme.rem(0.5)
-  },
   icon: {
     width: theme.rem(2),
     height: theme.rem(2),
-    margin: theme.rem(0.5)
-  },
-  text: {
-    flex: 1,
-    margin: theme.rem(0.5)
-  },
-  close: {
-    padding: theme.rem(0.5)
+    marginHorizontal: theme.rem(0.5)
   }
 }))

--- a/src/components/cards/StatusCard.tsx
+++ b/src/components/cards/StatusCard.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
-import { View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
 import FastImage from 'react-native-fast-image'
+import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
+import { lstrings } from '../../locales/strings'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { ButtonBox } from '../themed/ThemedButtons'
@@ -9,29 +11,45 @@ import { Card } from './Card'
 
 interface Props {
   message: string
-  title: string
+  testIds: { title?: string; message: string; close: string }
   iconOrUri?: string | React.ReactNode
+  title?: string
+  onClose?: () => void
   onPress?: () => void
 }
 
 export function StatusCard(props: Props) {
-  const { iconOrUri, message, title, onPress = () => {} } = props
+  const { iconOrUri, message, title, testIds, onPress = () => {}, onClose } = props
   const theme = useTheme()
   const styles = getStyles(theme)
 
   return (
-    <ButtonBox marginRem={[0, 0.5, 0, 0.5]} onPress={onPress}>
+    <ButtonBox marginRem={0.5} onPress={onPress}>
       <Card>
         <View style={styles.cardContainer}>
           {typeof iconOrUri === 'string' ? <FastImage resizeMode="contain" source={{ uri: iconOrUri }} style={styles.icon} /> : iconOrUri}
           <View style={styles.textContainer}>
-            <EdgeText testID="statusCardTitle" numberOfLines={0} style={styles.title}>
-              {title}
-            </EdgeText>
-            <EdgeText testID="statusCardMessage" numberOfLines={0}>
+            {title == null ? null : (
+              <EdgeText testID={testIds.title} numberOfLines={0} style={styles.title}>
+                {title}
+              </EdgeText>
+            )}
+            <EdgeText testID={testIds.message} numberOfLines={0}>
               {message}
             </EdgeText>
           </View>
+          {onClose == null ? null : (
+            <TouchableOpacity accessible={false} onPress={onClose}>
+              <AntDesignIcon
+                testID={testIds.close}
+                name="close"
+                color={theme.iconTappable}
+                size={theme.rem(1)}
+                style={styles.close}
+                accessibilityHint={lstrings.close_hint}
+              />
+            </TouchableOpacity>
+          )}
         </View>
       </Card>
     </ButtonBox>
@@ -46,7 +64,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   textContainer: {
     flexDirection: 'column',
     flex: 1,
-    paddingRight: theme.rem(0.25)
+    padding: theme.rem(0.5)
   },
   icon: {
     width: theme.rem(3),
@@ -57,5 +75,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     fontFamily: theme.fontFaceMedium,
     marginBottom: theme.rem(0.25),
     marginRight: theme.rem(0.5)
+  },
+  close: {
+    padding: theme.rem(0.5)
   }
 }))


### PR DESCRIPTION
- Fix fallback language in AssetStatusCard
- Unify PromoCard and AssetStatusCard styling. PromoCard wasn't even visually a card to begin with.

![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/a8a2fc4b-a7b3-4071-8402-a62ab3b4a62b)
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/eaa0af56-29c5-4810-b396-bd74cf060963)


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205822925785320