### PR TITLE
Rename assetStatus -> assetStatusCards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed: Write updated experiment configs to disk
 - fixed: Auto Logoff picker text color for Android Light OS theme
 - fixed: Fallback language selection for Asset Status Card
+- fixed: Version-specific targetting for Asset Status Card
 - removed: Moonpay sell via ACH
 - removed: Banxa buy via Pix
 

--- a/src/components/scenes/TransactionListScene.tsx
+++ b/src/components/scenes/TransactionListScene.tsx
@@ -145,7 +145,7 @@ function TransactionListComponent(props: Props) {
 
   // Check for AssetStatuses from info server (known sync issues, etc):
   React.useEffect(() => {
-    fetchInfo(`v1/assetStatus/${pluginId}${tokenId == null ? '' : `_${tokenId}`}`)
+    fetchInfo(`v1/assetStatusCards/${pluginId}${tokenId == null ? '' : `_${tokenId}`}`)
       .then(async res => {
         const allAssetStatuses: AssetStatus[] = asArray(asAssetStatus)(await res.json())
         const version = getVersion()


### PR DESCRIPTION
For fixing appVersion targeting after this release. 

assetStatus endpoint will now be reserved for 3.20 messaging, and assetStatusCards for 3.21+

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205865322432429