### PR TITLE
Fix ENS Name Resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed: Various margin styling alignments
 - fixed: Long delay updating exchange rates after login
 - fixed: Do not count paused wallets for progress ratio
+- fixed: ENS name resolution intermittently failing
 
 ## 3.22.0
 

--- a/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
@@ -220,7 +220,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
               style={
                 [
                   {
-                    "color": "#E85466",
+                    "color": "#00f1a2",
                     "fontFamily": "Quicksand-Regular",
                     "fontSize": 17,
                   },
@@ -1325,7 +1325,7 @@ exports[`TransactionListTop should render 1`] = `
               style={
                 [
                   {
-                    "color": "#E85466",
+                    "color": "#00f1a2",
                     "fontFamily": "Quicksand-Regular",
                     "fontSize": 17,
                   },

--- a/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
       onChangeText={[Function]}
       onSubmitEditing={[Function]}
       returnKeyType="search"
+      showSpinner={false}
       value=""
     />
     <View

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -571,7 +571,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           style={
             [
               {
-                "color": "#E85466",
+                "color": "#00f1a2",
                 "fontFamily": "Quicksand-Regular",
                 "fontSize": 17,
               },
@@ -1656,7 +1656,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           style={
             [
               {
-                "color": "#E85466",
+                "color": "#00f1a2",
                 "fontFamily": "Quicksand-Regular",
                 "fontSize": 17,
               },

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -311,7 +311,7 @@ exports[`WalletListModal should render with loading props 1`] = `
           style={
             [
               {
-                "color": "#E85466",
+                "color": "#00f1a2",
                 "fontFamily": "Quicksand-Regular",
                 "fontSize": 17,
               },

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -306,7 +306,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             style={
               [
                 {
-                  "color": "#E85466",
+                  "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
                   "fontSize": 17,
                 },

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
           style={
             [
               {
-                "color": "#E85466",
+                "color": "#00f1a2",
                 "fontFamily": "Quicksand-Regular",
                 "fontSize": 17,
               },

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             style={
               [
                 {
-                  "color": "#E85466",
+                  "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
                   "fontSize": 17,
                 },

--- a/src/components/modals/AddressModal.tsx
+++ b/src/components/modals/AddressModal.tsx
@@ -1,6 +1,5 @@
 import { FlashList } from '@shopify/flash-list'
 import { EdgeAccount, EdgeCurrencyConfig, EdgeCurrencyWallet } from 'edge-core-js'
-import { ethers } from 'ethers'
 import * as React from 'react'
 import { ActivityIndicator, Image, TouchableWithoutFeedback, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
@@ -166,13 +165,8 @@ export class AddressModalComponent extends React.Component<Props, State> {
   }
 
   fetchEnsAddress = async (domain: string): Promise<string> => {
-    const chainId = 1 // Hard-coded to Ethereum mainnet
-    const network = ethers.providers.getNetwork(chainId)
-    if (network.name === 'unknown') {
-      throw new ResolutionError('UnsupportedDomain', { domain })
-    }
-    const ethersProvider = ethers.getDefaultProvider(network)
-    const address = await ethersProvider.resolveName(domain)
+    const ethPlugin: EdgeCurrencyConfig = this.props.account.currencyConfig.ethereum
+    const address = await ethPlugin.otherMethods.resolveEnsName(domain)
     if (address == null) throw new ResolutionError('UnregisteredDomain', { domain })
     return address
   }


### PR DESCRIPTION
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/3327eb73-fc8f-4701-9708-ae38afdd129f)
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/12fccca0-8550-41c4-968d-80d5bce3d52e)

ENS name resolution only works on Ethereum network. 
`ethers.getDefaultProvider` does not reliably succeed in resolving ENS names.

- Port over `validText` from loginUI's implementation of `OutlinedTextInput` and fix styling on the modal. This change caused differences in unit test colors. **The original implementation rendered red in tests for some reason while the new one renders mint, as expected.**
- Rely on accountbased to multicast `ethers` `JsonRpcProviders` instead to reliably resolve ENS names.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-currency-accountbased/pull/666

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205732732237945