### PR TITLE
Prevent crash when tx has no spendTargets

### DIFF
--- a/src/components/tiles/SwapDetailsTiles.tsx
+++ b/src/components/tiles/SwapDetailsTiles.tsx
@@ -1,3 +1,4 @@
+import { abs, sub } from 'biggystring'
 import { EdgeCurrencyWallet, EdgeTransaction, EdgeTxSwap } from 'edge-core-js'
 import * as React from 'react'
 import { Linking, Platform, View } from 'react-native'
@@ -89,7 +90,8 @@ export function SwapDetailsTiles(props: Props) {
   )
   if (destinationDenomination == null) return null
 
-  const sourceAmount = convertNativeToDisplay(walletDefaultDenom.multiplier)(spendTargets[0].nativeAmount)
+  const sourceNativeAmount = sub(abs(transaction.nativeAmount), transaction.networkFee)
+  const sourceAmount = convertNativeToDisplay(walletDefaultDenom.multiplier)(sourceNativeAmount)
   const destinationAmount = convertNativeToDisplay(destinationDenomination.multiplier)(swapData.payoutNativeAmount)
   const destinationCurrencyCode = destinationDenomination.name
 


### PR DESCRIPTION
A tx created by makeTx that also has swapData  will crash since it is assume to be created by makeSpend where core always adds the spendTargets.

In the case of a makeTx there are no spendTargets so use tx.nativeAmount instead.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205930491280477