### PR TITLE
Analytics: Fix isFirstOpen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@
 - changed: Disable max-spend for Filecoin wallets
 - changed: Don't show recovery, password, or otp reminders in Maestro
 - fixed: Incorrectly filtering out transactions due to spam/dust filter
-- fixed: Performance issue from LoanManagerService running while not in beta mode
+- fixed: Performance issue from LoanManagerService running while not in beta
+  mode
+- fixed: isFirstOpen analytics param reporting the previously saved value
+  instead of forcing to false after first open
 
 ## 3.21.0
 

--- a/src/actions/FirstOpenActions.tsx
+++ b/src/actions/FirstOpenActions.tsx
@@ -26,6 +26,7 @@ export const getFirstOpenInfo = async (): Promise<FirstOpenInfo> => {
     try {
       firstOpenText = await firstOpenDisklet.getText(FIRST_OPEN)
       firstOpenInfo = asFirstOpenInfo(JSON.parse(firstOpenText))
+      firstOpenInfo.isFirstOpen = 'false'
     } catch (error: any) {
       // Generate new values.
       firstOpenInfo = {


### PR DESCRIPTION
Add special handling to properly force this value to false if the experiment config validation succeeds

Not deprecating the existing var for clean data because we are moving to Posthog and a self hosted solution, which are new to this release.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205981666228532