### PR TITLE
Don't pass pendingTxs with spendInfo in migrate flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed: Paybis sell from Tron USDT
 - fixed: Remove `minWidth` style from stake option card
 - fixed: Send scene no-longer accesses clipboard immediately
+- fixed: Don't pass pendingTxs with spendInfo in migrate flow
 
 ## 3.23.0
 

--- a/src/components/scenes/MigrateWalletCompletionScene.tsx
+++ b/src/components/scenes/MigrateWalletCompletionScene.tsx
@@ -137,13 +137,11 @@ const MigrateWalletCompletionComponent = (props: Props) => {
         // Send tokens
         let feeTotal = '0'
         const hasError = false
-        const pendingTxs: EdgeTransaction[] = []
         const successfullyTransferredTokenIds: string[] = []
         for (const item of tokenItems) {
           let tokenSpendInfo: EdgeSpendInfo = {
             currencyCode: item.currencyCode,
             spendTargets: [{ publicAddress: newPublicAddress }],
-            pendingTxs,
             networkFeeOption: 'standard'
           }
           try {
@@ -153,7 +151,6 @@ const MigrateWalletCompletionComponent = (props: Props) => {
             successfullyTransferredTokenIds.push(item.tokenId)
             const txFee = tx.parentNetworkFee ?? tx.networkFee
             feeTotal = add(feeTotal, txFee)
-            pendingTxs.push(tx)
 
             handleItemStatus(item, 'complete')
           } catch (e: any) {
@@ -174,7 +171,6 @@ const MigrateWalletCompletionComponent = (props: Props) => {
               name: newWalletName,
               notes: sprintf(lstrings.migrate_wallet_tx_notes, newWalletName)
             },
-            pendingTxs,
             networkFeeOption: 'standard'
           }
           try {


### PR DESCRIPTION
Since we're broadcasting and saving the tx, the engine should adjust the nonce accordingly and we shouldn't pass this array.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206116889339878