### PR TITLE
Fix tappability for non 'touchable' tappable modes

### DIFF
--- a/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`TransactionListRow should render with loading props 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
+            "flex": 1,
             "flexDirection": "row",
             "paddingHorizontal": 11,
             "paddingVertical": 6,
@@ -283,14 +284,6 @@ exports[`TransactionListRow should render with loading props 1`] = `
             </Text>
           </View>
         </View>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "justifyContent": "center",
-            }
-          }
-        />
       </View>
     </View>
   </View>

--- a/src/__tests__/modals/__snapshots__/AdvancedDetailsCard.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AdvancedDetailsCard.test.tsx.snap
@@ -63,6 +63,7 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
         {
           "alignItems": "center",
           "backgroundColor": "rgba(255, 255, 255, 0)",
+          "flex": 1,
           "flexDirection": "row",
           "paddingHorizontal": 11,
           "paddingVertical": 6,
@@ -125,14 +126,6 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
           123123123
         </Text>
       </View>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "justifyContent": "center",
-          }
-        }
-      />
     </View>
   </View>
 </View>

--- a/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`TransactionDetailsScene should render 1`] = `
             {
               "alignItems": "center",
               "backgroundColor": "rgba(255, 255, 255, 0)",
+              "flex": 1,
               "flexDirection": "row",
               "paddingHorizontal": 11,
               "paddingVertical": 6,
@@ -112,7 +113,7 @@ exports[`TransactionDetailsScene should render 1`] = `
           <View
             style={
               {
-                "marginRight": 11,
+                "marginRight": 6,
               }
             }
           >
@@ -205,8 +206,49 @@ exports[`TransactionDetailsScene should render 1`] = `
           <View
             style={
               {
-                "alignItems": "center",
+                "height": "100%",
+                "width": 34,
+              }
+            }
+          />
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "flex-end",
+                "height": "100%",
                 "justifyContent": "center",
+                "opacity": 1,
+                "paddingRight": 11,
+                "position": "absolute",
+                "right": 0,
+                "width": 67,
               }
             }
           >
@@ -299,6 +341,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -361,14 +404,6 @@ exports[`TransactionDetailsScene should render 1`] = `
                 ₿ 0.123
               </Text>
             </View>
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                }
-              }
-            />
           </View>
           <View
             style={
@@ -377,6 +412,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -385,6 +421,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -474,8 +511,49 @@ exports[`TransactionDetailsScene should render 1`] = `
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >
@@ -512,6 +590,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -520,6 +599,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -631,14 +711,6 @@ exports[`TransactionDetailsScene should render 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                }
-              }
-            />
           </View>
           <View
             style={
@@ -647,6 +719,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -655,6 +728,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -720,8 +794,49 @@ exports[`TransactionDetailsScene should render 1`] = `
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >
@@ -815,6 +930,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -879,8 +995,49 @@ exports[`TransactionDetailsScene should render 1`] = `
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >
@@ -917,6 +1074,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -925,6 +1083,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -990,8 +1149,49 @@ exports[`TransactionDetailsScene should render 1`] = `
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >
@@ -1085,6 +1285,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -1147,14 +1348,6 @@ exports[`TransactionDetailsScene should render 1`] = `
                 this is an address
               </Text>
             </View>
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                }
-              }
-            />
           </View>
           <View
             style={
@@ -1163,6 +1356,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -1171,6 +1365,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -1236,8 +1431,49 @@ exports[`TransactionDetailsScene should render 1`] = `
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >
@@ -1691,6 +1927,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
             {
               "alignItems": "center",
               "backgroundColor": "rgba(255, 255, 255, 0)",
+              "flex": 1,
               "flexDirection": "row",
               "paddingHorizontal": 11,
               "paddingVertical": 6,
@@ -1700,7 +1937,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
           <View
             style={
               {
-                "marginRight": 11,
+                "marginRight": 6,
               }
             }
           >
@@ -1793,8 +2030,49 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
           <View
             style={
               {
-                "alignItems": "center",
+                "height": "100%",
+                "width": 34,
+              }
+            }
+          />
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "flex-end",
+                "height": "100%",
                 "justifyContent": "center",
+                "opacity": 1,
+                "paddingRight": 11,
+                "position": "absolute",
+                "right": 0,
+                "width": 67,
               }
             }
           >
@@ -1887,6 +2165,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -1949,14 +2228,6 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 ₿ 0.12299999 (+0 fee)
               </Text>
             </View>
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                }
-              }
-            />
           </View>
           <View
             style={
@@ -1965,6 +2236,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -1973,6 +2245,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -2062,8 +2335,49 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >
@@ -2100,6 +2414,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -2108,6 +2423,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -2219,14 +2535,6 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 </Text>
               </View>
             </View>
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                }
-              }
-            />
           </View>
           <View
             style={
@@ -2235,6 +2543,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -2243,6 +2552,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -2308,8 +2618,49 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >
@@ -2403,6 +2754,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -2467,8 +2819,49 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >
@@ -2505,6 +2898,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -2513,6 +2907,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -2578,8 +2973,49 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >
@@ -2673,6 +3109,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -2735,14 +3172,6 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 this is an address
               </Text>
             </View>
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                }
-              }
-            />
           </View>
           <View
             style={
@@ -2751,6 +3180,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderBottomWidth": 1,
                 "height": 1,
                 "marginHorizontal": 11,
+                "marginVertical": 11,
               }
             }
           />
@@ -2759,6 +3189,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               {
                 "alignItems": "center",
                 "backgroundColor": "rgba(255, 255, 255, 0)",
+                "flex": 1,
                 "flexDirection": "row",
                 "paddingHorizontal": 11,
                 "paddingVertical": 6,
@@ -2824,8 +3255,49 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
             <View
               style={
                 {
-                  "alignItems": "center",
+                  "height": "100%",
+                  "width": 34,
+                }
+              }
+            />
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingRight": 11,
+                  "position": "absolute",
+                  "right": 0,
+                  "width": 67,
                 }
               }
             >

--- a/src/components/ui4/RowUi4.tsx
+++ b/src/components/ui4/RowUi4.tsx
@@ -67,6 +67,8 @@ export const RowUi4 = (props: Props) => {
     }
   })
 
+  const isTouchable = type !== 'default' && type !== 'loading'
+
   const content = (
     <View style={styles.container}>
       {icon == null ? null : <View style={styles.iconContainer}>{icon}</View>}
@@ -86,13 +88,18 @@ export const RowUi4 = (props: Props) => {
           children
         )}
       </View>
-      <View style={styles.rightButtonContainer}>
-        {type === 'touchable' && <FontAwesome5 name="chevron-right" style={styles.tappableIcon} size={theme.rem(1)} />}
-        {type === 'editable' && <FontAwesomeIcon name="edit" style={styles.tappableIcon} size={theme.rem(1)} />}
-        {type === 'copy' && <FontAwesomeIcon name="copy" style={styles.tappableIcon} size={theme.rem(1)} />}
-        {type === 'delete' && <FontAwesomeIcon name="times" style={styles.tappableIcon} size={theme.rem(1)} />}
-        {type === 'questionable' && <SimpleLineIcons name="question" style={styles.tappableIcon} size={theme.rem(1)} />}
-      </View>
+      {isTouchable ? (
+        <>
+          <View style={styles.tappableIconMargin} />
+          <TouchableOpacity style={styles.tappableIconContainer} accessible={false} onPress={handlePress} onLongPress={handleLongPress}>
+            {type === 'touchable' ? <FontAwesome5 name="chevron-right" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
+            {type === 'editable' ? <FontAwesomeIcon name="edit" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
+            {type === 'copy' ? <FontAwesomeIcon name="copy" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
+            {type === 'delete' ? <FontAwesomeIcon name="times" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
+            {type === 'questionable' ? <SimpleLineIcons name="question" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
+          </TouchableOpacity>
+        </>
+      ) : null}
     </View>
   )
 
@@ -103,10 +110,6 @@ export const RowUi4 = (props: Props) => {
         <ActivityIndicator style={styles.loader} color={theme.primaryText} size="large" />
       </View>
     </View>
-  ) : type === 'touchable' ? (
-    <TouchableOpacity accessible={false} onPress={handlePress} onLongPress={handleLongPress} disabled={handlePress == null && handleLongPress == null}>
-      {content}
-    </TouchableOpacity>
   ) : (
     content
   )
@@ -120,22 +123,40 @@ const getStyles = cacheStyles((theme: Theme) => ({
     paddingHorizontal: theme.rem(0.5),
     paddingVertical: theme.rem(0.25),
     flexDirection: 'row',
-    alignItems: 'center'
+    alignItems: 'center',
+    flex: 1
   },
   content: {
     flex: 1
   },
   iconContainer: {
-    marginRight: theme.rem(0.5)
-  },
-  rightButtonContainer: {
-    justifyContent: 'center',
-    alignItems: 'center'
+    marginRight: theme.rem(0.25)
   },
   tappableIcon: {
     color: theme.iconTappable,
     marginLeft: theme.rem(0.5),
     textAlign: 'center'
+  },
+  tappableIconContainer: {
+    // Positioned absolutely with constant width to increase tappable area
+    // overlapping the content, improving ease of tappability.
+    position: 'absolute',
+    right: 0,
+    width: theme.rem(3),
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    paddingRight: theme.rem(0.5)
+  },
+  tappableIconMargin: {
+    // Extra invisible space to align the content when the right tappable icon
+    // is visible, since the right tappable icon + TouchableOpaicty is
+    // positioned absolutely.
+    // Using this instead of negative margins on tappableIconContainer to make
+    // it more clear what the spacing is without taking into account the
+    // children styling of tappableIconContainer.
+    width: theme.rem(1.5),
+    height: '100%'
   },
   textHeader: {
     color: theme.secondaryText,

--- a/src/components/ui4/SectionView.tsx
+++ b/src/components/ui4/SectionView.tsx
@@ -53,6 +53,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   divider: {
     height: theme.thinLineWidth,
     marginHorizontal: theme.rem(0.5),
+    marginVertical: theme.rem(0.5),
     borderBottomWidth: theme.thinLineWidth,
     borderBottomColor: theme.lineDivider
   }


### PR DESCRIPTION
Fix tappability for non 'touchable' tappable modes. Previously only 'touchable' was tappable, but did not include 'copy,' 'editable,' etc.

Also increase tappable area beyond the bounds of the right icon to
improve ease of use.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206210011193789