### PR TITLE
Enable Light Account 2.0 + experimentConfig fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## Unreleased
 
 - added: `minerTip` to `feeRateUsed` processing
+- changed: Update various scenes with UI4 components
+- changed: Light account re-enabled at 50% distribution
+- fixed: USP vs legacy landing experiment distribution
 - fixed: Paybis sell from Tron USDT
 - fixed: Remove `minWidth` style from stake option card
 - fixed: Send scene no-longer accesses clipboard immediately
-- changed: Update various scenes with UI4 components
 
 ## 3.23.0
 

--- a/src/experimentConfig.ts
+++ b/src/experimentConfig.ts
@@ -1,4 +1,4 @@
-import { asMaybe, asObject, asOptional, asValue, Cleaner } from 'cleaners'
+import { asMaybe, asObject, asValue, Cleaner } from 'cleaners'
 import { makeReactNativeDisklet } from 'disklet'
 import { CreateAccountType } from 'edge-login-ui-rn'
 import { isMaestro } from 'react-native-is-maestro'
@@ -74,9 +74,9 @@ const generateExperimentConfigVal = <T>(key: keyof typeof experimentDistribution
 // behavior/appearance, while the last value represents unchanged
 // behavior/appearance.
 const asExperimentConfig: Cleaner<ExperimentConfig> = asObject({
-  swipeLastUsp: asOptional(asValue('true', 'false'), generateExperimentConfigVal('swipeLastUsp', ['true', 'false'])),
+  swipeLastUsp: asMaybe(asValue('true', 'false'), generateExperimentConfigVal('swipeLastUsp', ['true', 'false'])),
   createAccountType: asMaybe(asValue('full', 'light'), generateExperimentConfigVal('createAccountType', ['full', 'light'])),
-  legacyLanding: asMaybe(asValue('uspLanding'), generateExperimentConfigVal('legacyLanding', ['legacyLanding', 'uspLanding'])),
+  legacyLanding: asMaybe(asValue('uspLanding', 'legacyLanding'), generateExperimentConfigVal('legacyLanding', ['legacyLanding', 'uspLanding'])),
   signupCaptcha: asMaybe(asValue('withoutCaptcha'), 'withoutCaptcha')
 })
 

--- a/src/experimentConfig.ts
+++ b/src/experimentConfig.ts
@@ -75,7 +75,7 @@ const generateExperimentConfigVal = <T>(key: keyof typeof experimentDistribution
 // behavior/appearance.
 const asExperimentConfig: Cleaner<ExperimentConfig> = asObject({
   swipeLastUsp: asOptional(asValue('true', 'false'), generateExperimentConfigVal('swipeLastUsp', ['true', 'false'])),
-  createAccountType: asMaybe(asValue('full'), 'full'),
+  createAccountType: asMaybe(asValue('full', 'light'), generateExperimentConfigVal('createAccountType', ['full', 'light'])),
   legacyLanding: asMaybe(asValue('uspLanding'), generateExperimentConfigVal('legacyLanding', ['legacyLanding', 'uspLanding'])),
   signupCaptcha: asMaybe(asValue('withoutCaptcha'), 'withoutCaptcha')
 })


### PR DESCRIPTION
Enable Light Account 2.0 in experiment config

Other minor fixes: 
- We don't want to regenerate the entire experiment config if some var fails cleaning.
- Don't regenerate `legacyLanding` if the value saved is not `uspLanding`

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206225857137542