### PR TITLE
Retry failed wallet connect initializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - changed: Use new EdgeTransaction.savedAction to show extended transaction info in tx list and tx details
 - changed: Use new EdgeTxAction data for Thorchain and Tron stake plugins
 - changed: Make useAsyncEffect tags required
+- changed: Rettry failed WalletConnect initializations
 - fixed: USP vs legacy landing experiment distribution
 - fixed: Paybis sell from Tron USDT
 - fixed: Remove `minWidth` style from stake option card

--- a/src/components/scenes/WcConnectionsScene.tsx
+++ b/src/components/scenes/WcConnectionsScene.tsx
@@ -5,12 +5,13 @@ import * as React from 'react'
 import { ScrollView, TouchableOpacity, View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
+import { sprintf } from 'sprintf-js'
 
 import { showBackupForTransferModal } from '../../actions/BackupModalActions'
 import { SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { useMount } from '../../hooks/useMount'
-import { useWalletConnect } from '../../hooks/useWalletConnect'
+import { useWalletConnect, walletConnectClient } from '../../hooks/useWalletConnect'
 import { lstrings } from '../../locales/strings'
 import { useSelector } from '../../types/reactRedux'
 import { EdgeSceneProps } from '../../types/routerTypes'
@@ -106,6 +107,11 @@ export const WcConnectionsScene = (props: Props) => {
           spinner={connecting}
         />
         <EdgeText style={styles.listTitle}>{lstrings.wc_walletconnect_active_connections}</EdgeText>
+        {walletConnectClient.client != null ? null : (
+          <EdgeText style={{ ...styles.listTitle, color: theme.dangerText }}>
+            {sprintf(lstrings.wc_dapp_disconnected, lstrings.wc_walletconnect_title)}
+          </EdgeText>
+        )}
         <View style={styles.list}>
           {connections.map((dAppConnection: WcConnectionInfo, index) => (
             <TouchableOpacity key={index} style={styles.listRow} onPress={() => handleActiveConnectionPress(dAppConnection)}>


### PR DESCRIPTION
This retries the initialization of the WalletConnect client if it fails. Also, a small red text was added to the connections scene to indicate if the app hasn't connect yet

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206080746926242