### PR TITLE
Set autoCapitalize to 'none' by default for secureTextEntry inputs

### DIFF
--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -114,7 +114,7 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
     onSubmitEditing,
 
     // TextInput:
-    autoCapitalize,
+    autoCapitalize = props.secureTextEntry === true ? 'none' : undefined,
     autoCorrect,
     autoFocus = false,
     blurOnClear = false,

--- a/src/components/themed/SimpleTextInput.tsx
+++ b/src/components/themed/SimpleTextInput.tsx
@@ -91,7 +91,7 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
     onSubmitEditing,
 
     // TextInput:
-    autoCapitalize,
+    autoCapitalize = props.secureTextEntry === true ? 'none' : undefined,
     autoCorrect,
     autoFocus = false,
     blurOnClear = false,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206379497162078
  - https://app.asana.com/0/0/1206379497162105