### PR TITLE
UI4: Modal Fixes 2

### DIFF
--- a/src/__tests__/components/__snapshots__/SelectableRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/SelectableRow.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`SelectableRow should render with loading props 1`] = `
       }
     >
       <WithTheme(EdgeTextComponent)
-        disableFontScaling={true}
         numberOfLines={1}
       >
         title

--- a/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
@@ -12,47 +12,41 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
     }
   }
   onCancel={[Function]}
-  paddingRem={1}
   title="string"
 >
+  <ForwardRef
+    around={0.5}
+    autoCapitalize="none"
+    autoCorrect={false}
+    bottom={1}
+    onChangeText={[Function]}
+    onSubmitEditing={[Function]}
+    placeholder="Address"
+    returnKeyType="search"
+    showSpinner={false}
+    value=""
+  />
   <View
     style={
       {
+        "alignItems": "center",
         "flex": 1,
-        "flexDirection": "column",
-        "width": "100%",
+        "justifyContent": "center",
       }
     }
   >
-    <ForwardRef
-      autoCapitalize="none"
-      autoCorrect={false}
-      horizontal={1}
-      onChangeText={[Function]}
-      onSubmitEditing={[Function]}
-      placeholder="Address"
-      returnKeyType="search"
-      showSpinner={false}
-      value=""
-    />
-    <View
-      style={
-        {
-          "alignItems": "center",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    >
-      <ActivityIndicator
-        color="#00f1a2"
-      />
-    </View>
-    <MainButton
-      label="Submit"
-      onPress={[Function]}
-      type="primary"
+    <ActivityIndicator
+      color="#00f1a2"
     />
   </View>
+  <Memo
+    primary={
+      {
+        "label": "Next",
+        "onPress": [Function],
+      }
+    }
+    sceneMargin={true}
+  />
 </ModalUi4>
 `;

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -134,6 +134,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
               "includeFontPadding": false,
             },
             {
+              "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
               "fontSize": 27,
               "marginHorizontal": 11,
@@ -178,7 +179,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             "alignSelf": "flex-start",
             "flexGrow": 1,
             "justifyContent": "flex-start",
-            "marginRight": 11,
+            "marginRight": 6,
             "opacity": 1,
             "paddingTop": 3,
           }
@@ -1549,6 +1550,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
               "includeFontPadding": false,
             },
             {
+              "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
               "fontSize": 27,
               "marginHorizontal": 11,
@@ -1593,7 +1595,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             "alignSelf": "flex-start",
             "flexGrow": 1,
             "justifyContent": "flex-start",
-            "marginRight": 11,
+            "marginRight": 6,
             "opacity": 1,
             "paddingTop": 3,
           }

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -48,6 +48,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           "borderTopRightRadius": 22,
           "flexShrink": 1,
           "overflow": "hidden",
+          "paddingLeft": 11,
+          "paddingRight": 11,
           "width": 674,
         },
         {
@@ -62,8 +64,6 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           "borderWidth": 0,
           "marginBottom": -86,
           "paddingBottom": 97,
-          "paddingLeft": 11,
-          "paddingRight": 11,
           "paddingTop": 0,
         },
       ]
@@ -98,10 +98,10 @@ exports[`CategoryModal should render with a subcategory 1`] = `
       <View
         style={
           {
-            "backgroundColor": "#888888",
+            "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
             "borderRadius": 3,
             "height": 6,
-            "marginTop": 11,
+            "marginTop": 6,
             "width": 67,
           }
         }
@@ -109,16 +109,12 @@ exports[`CategoryModal should render with a subcategory 1`] = `
     </View>
     <View
       style={
-        [
-          {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "marginTop": 28,
-          },
-          {
-            "marginBottom": 11,
-          },
-        ]
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "marginBottom": 11,
+          "marginTop": 28,
+        }
       }
     >
       <Text
@@ -213,8 +209,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           "alignItems": "center",
           "flexDirection": "row",
           "justifyContent": "space-between",
-          "marginBottom": 22,
-          "marginHorizontal": 22,
+          "margin": 11,
         }
       }
     >
@@ -474,10 +469,10 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           "flex": undefined,
           "flexDirection": "column",
           "justifyContent": undefined,
-          "marginBottom": 0,
-          "marginLeft": 0,
-          "marginRight": 0,
-          "marginTop": 0,
+          "marginBottom": 11,
+          "marginLeft": 11,
+          "marginRight": 11,
+          "marginTop": 11,
         }
       }
     >
@@ -1464,6 +1459,8 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           "borderTopRightRadius": 22,
           "flexShrink": 1,
           "overflow": "hidden",
+          "paddingLeft": 11,
+          "paddingRight": 11,
           "width": 674,
         },
         {
@@ -1478,8 +1475,6 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           "borderWidth": 0,
           "marginBottom": -86,
           "paddingBottom": 97,
-          "paddingLeft": 11,
-          "paddingRight": 11,
           "paddingTop": 0,
         },
       ]
@@ -1514,10 +1509,10 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
       <View
         style={
           {
-            "backgroundColor": "#888888",
+            "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
             "borderRadius": 3,
             "height": 6,
-            "marginTop": 11,
+            "marginTop": 6,
             "width": 67,
           }
         }
@@ -1525,16 +1520,12 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
     </View>
     <View
       style={
-        [
-          {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "marginTop": 28,
-          },
-          {
-            "marginBottom": 11,
-          },
-        ]
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "marginBottom": 11,
+          "marginTop": 28,
+        }
       }
     >
       <Text
@@ -1629,8 +1620,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           "alignItems": "center",
           "flexDirection": "row",
           "justifyContent": "space-between",
-          "marginBottom": 22,
-          "marginHorizontal": 22,
+          "margin": 11,
         }
       }
     >
@@ -1890,10 +1880,10 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           "flex": undefined,
           "flexDirection": "column",
           "justifyContent": undefined,
-          "marginBottom": 0,
-          "marginLeft": 0,
-          "marginRight": 0,
-          "marginTop": 0,
+          "marginBottom": 11,
+          "marginLeft": 11,
+          "marginRight": 11,
+          "marginTop": 11,
         }
       }
     >

--- a/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
@@ -62,8 +62,8 @@ exports[`HelpModal should render with loading props 1`] = `
           "borderWidth": 0,
           "marginBottom": -86,
           "paddingBottom": 86,
-          "paddingLeft": 0,
-          "paddingRight": 0,
+          "paddingLeft": 11,
+          "paddingRight": 11,
           "paddingTop": 0,
         },
       ]
@@ -116,7 +116,7 @@ exports[`HelpModal should render with loading props 1`] = `
             "marginTop": 28,
           },
           {
-            "marginBottom": 22,
+            "marginBottom": 11,
           },
         ]
       }
@@ -128,6 +128,7 @@ exports[`HelpModal should render with loading props 1`] = `
             "flexDirection": "column",
             "flexGrow": 1,
             "justifyContent": "center",
+            "marginTop": 6,
           }
         }
       >
@@ -154,22 +155,35 @@ exports[`HelpModal should render with loading props 1`] = `
           }
         >
           <Text
+            adjustsFontSizeToFit={false}
+            minimumFontScale={0.65}
+            numberOfLines={0}
             style={
               [
                 {
                   "color": "#FFFFFF",
-                  "fontFamily": "Quicksand-Medium",
-                  "fontSize": 27,
+                  "fontFamily": "Quicksand-Regular",
+                  "fontSize": 22,
+                  "includeFontPadding": false,
                 },
-                {
-                  "textAlign": "center",
-                },
-                {
-                  "paddingBottom": 0,
-                  "paddingLeft": 0,
-                  "paddingRight": 0,
-                  "paddingTop": 0,
-                },
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "Quicksand-Medium",
+                    "fontSize": 27,
+                  },
+                  {
+                    "flexGrow": 1,
+                    "textAlign": "center",
+                  },
+                  {
+                    "marginBottom": 0,
+                    "marginLeft": 0,
+                    "marginRight": 0,
+                    "marginTop": 0,
+                  },
+                ],
+                null,
               ]
             }
           >
@@ -209,7 +223,7 @@ exports[`HelpModal should render with loading props 1`] = `
           {
             "opacity": 1,
             "position": "absolute",
-            "right": 11,
+            "right": 6,
             "top": 3,
           }
         }

--- a/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
@@ -48,6 +48,8 @@ exports[`HelpModal should render with loading props 1`] = `
           "borderTopRightRadius": 22,
           "flexShrink": 1,
           "overflow": "hidden",
+          "paddingLeft": 11,
+          "paddingRight": 11,
           "width": 674,
         },
         {
@@ -62,8 +64,6 @@ exports[`HelpModal should render with loading props 1`] = `
           "borderWidth": 0,
           "marginBottom": -86,
           "paddingBottom": 86,
-          "paddingLeft": 11,
-          "paddingRight": 11,
           "paddingTop": 0,
         },
       ]
@@ -98,10 +98,10 @@ exports[`HelpModal should render with loading props 1`] = `
       <View
         style={
           {
-            "backgroundColor": "#888888",
+            "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
             "borderRadius": 3,
             "height": 6,
-            "marginTop": 11,
+            "marginTop": 6,
             "width": 67,
           }
         }
@@ -109,16 +109,12 @@ exports[`HelpModal should render with loading props 1`] = `
     </View>
     <View
       style={
-        [
-          {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "marginTop": 28,
-          },
-          {
-            "marginBottom": 11,
-          },
-        ]
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "marginBottom": 11,
+          "marginTop": 28,
+        }
       }
     >
       <View
@@ -155,34 +151,23 @@ exports[`HelpModal should render with loading props 1`] = `
           }
         >
           <Text
-            adjustsFontSizeToFit={false}
-            minimumFontScale={0.65}
-            numberOfLines={0}
             style={
               [
                 {
                   "color": "#FFFFFF",
-                  "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "includeFontPadding": false,
+                  "fontFamily": "Quicksand-Medium",
+                  "fontSize": 27,
                 },
-                [
-                  {
-                    "color": "#FFFFFF",
-                    "fontFamily": "Quicksand-Medium",
-                    "fontSize": 27,
-                  },
-                  {
-                    "flexGrow": 1,
-                    "textAlign": "center",
-                  },
-                  {
-                    "marginBottom": 0,
-                    "marginLeft": 0,
-                    "marginRight": 0,
-                    "marginTop": 0,
-                  },
-                ],
+                {
+                  "flexGrow": 1,
+                  "textAlign": "center",
+                },
+                {
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                },
                 null,
               ]
             }
@@ -378,7 +363,7 @@ exports[`HelpModal should render with loading props 1`] = `
               }
             >
               <Text
-                adjustsFontSizeToFit={false}
+                adjustsFontSizeToFit={true}
                 minimumFontScale={0.65}
                 numberOfLines={1}
                 style={
@@ -529,7 +514,7 @@ exports[`HelpModal should render with loading props 1`] = `
               }
             >
               <Text
-                adjustsFontSizeToFit={false}
+                adjustsFontSizeToFit={true}
                 minimumFontScale={0.65}
                 numberOfLines={1}
                 style={
@@ -680,7 +665,7 @@ exports[`HelpModal should render with loading props 1`] = `
               }
             >
               <Text
-                adjustsFontSizeToFit={false}
+                adjustsFontSizeToFit={true}
                 minimumFontScale={0.65}
                 numberOfLines={1}
                 style={
@@ -831,7 +816,7 @@ exports[`HelpModal should render with loading props 1`] = `
               }
             >
               <Text
-                adjustsFontSizeToFit={false}
+                adjustsFontSizeToFit={true}
                 minimumFontScale={0.65}
                 numberOfLines={1}
                 style={
@@ -982,7 +967,7 @@ exports[`HelpModal should render with loading props 1`] = `
               }
             >
               <Text
-                adjustsFontSizeToFit={false}
+                adjustsFontSizeToFit={true}
                 minimumFontScale={0.65}
                 numberOfLines={1}
                 style={

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -48,6 +48,8 @@ exports[`WalletListModal should render with loading props 1`] = `
           "borderTopRightRadius": 22,
           "flexShrink": 1,
           "overflow": "hidden",
+          "paddingLeft": 11,
+          "paddingRight": 11,
           "width": 674,
         },
         {
@@ -62,8 +64,6 @@ exports[`WalletListModal should render with loading props 1`] = `
           "borderWidth": 0,
           "marginBottom": -86,
           "paddingBottom": 86,
-          "paddingLeft": 11,
-          "paddingRight": 11,
           "paddingTop": 0,
         },
       ]
@@ -98,10 +98,10 @@ exports[`WalletListModal should render with loading props 1`] = `
       <View
         style={
           {
-            "backgroundColor": "#888888",
+            "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
             "borderRadius": 3,
             "height": 6,
-            "marginTop": 11,
+            "marginTop": 6,
             "width": 67,
           }
         }
@@ -109,16 +109,12 @@ exports[`WalletListModal should render with loading props 1`] = `
     </View>
     <View
       style={
-        [
-          {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "marginTop": 28,
-          },
-          {
-            "marginBottom": 11,
-          },
-        ]
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "marginBottom": 11,
+          "marginTop": 28,
+        }
       }
     >
       <View
@@ -138,31 +134,20 @@ exports[`WalletListModal should render with loading props 1`] = `
           }
         >
           <Text
-            adjustsFontSizeToFit={false}
-            minimumFontScale={0.65}
-            numberOfLines={0}
             style={
               [
                 {
                   "color": "#FFFFFF",
-                  "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "includeFontPadding": false,
+                  "fontFamily": "Quicksand-Medium",
+                  "fontSize": 27,
                 },
-                [
-                  {
-                    "color": "#FFFFFF",
-                    "fontFamily": "Quicksand-Medium",
-                    "fontSize": 27,
-                  },
-                  null,
-                  {
-                    "marginBottom": 0,
-                    "marginLeft": 0,
-                    "marginRight": 0,
-                    "marginTop": 0,
-                  },
-                ],
+                null,
+                {
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                },
                 null,
               ]
             }

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -138,20 +138,32 @@ exports[`WalletListModal should render with loading props 1`] = `
           }
         >
           <Text
+            adjustsFontSizeToFit={false}
+            minimumFontScale={0.65}
+            numberOfLines={0}
             style={
               [
                 {
                   "color": "#FFFFFF",
-                  "fontFamily": "Quicksand-Medium",
-                  "fontSize": 27,
+                  "fontFamily": "Quicksand-Regular",
+                  "fontSize": 22,
+                  "includeFontPadding": false,
                 },
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "Quicksand-Medium",
+                    "fontSize": 27,
+                  },
+                  null,
+                  {
+                    "marginBottom": 0,
+                    "marginLeft": 0,
+                    "marginRight": 0,
+                    "marginTop": 0,
+                  },
+                ],
                 null,
-                {
-                  "paddingBottom": 0,
-                  "paddingLeft": 0,
-                  "paddingRight": 0,
-                  "paddingTop": 0,
-                },
               ]
             }
           >
@@ -467,7 +479,7 @@ exports[`WalletListModal should render with loading props 1`] = `
           {
             "opacity": 1,
             "position": "absolute",
-            "right": 11,
+            "right": 6,
             "top": 3,
           }
         }

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -309,44 +309,68 @@ exports[`CreateWalletAccountSelect renders 1`] = `
         </View>
       </View>
       <Text
+        adjustsFontSizeToFit={false}
+        minimumFontScale={0.65}
+        numberOfLines={0}
         style={
           [
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
               "fontSize": 22,
-              "margin": 11,
-              "textAlign": "left",
+              "includeFontPadding": false,
             },
-            {
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-            },
-            undefined,
+            [
+              {
+                "color": "#FFFFFF",
+                "fontFamily": "Quicksand-Regular",
+                "fontSize": 22,
+                "margin": 11,
+                "textAlign": "left",
+              },
+              {
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+              },
+              undefined,
+            ],
+            null,
           ]
         }
       >
         Create a unique account handle, this will also be the name of your BTC wallet:
       </Text>
       <Text
+        adjustsFontSizeToFit={false}
+        minimumFontScale={0.65}
+        numberOfLines={0}
         style={
           [
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
               "fontSize": 22,
-              "margin": 11,
-              "textAlign": "left",
+              "includeFontPadding": false,
             },
-            {
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-            },
-            undefined,
+            [
+              {
+                "color": "#FFFFFF",
+                "fontFamily": "Quicksand-Regular",
+                "fontSize": 22,
+                "margin": 11,
+                "textAlign": "left",
+              },
+              {
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+              },
+              undefined,
+            ],
+            null,
           ]
         }
       >

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -309,33 +309,22 @@ exports[`CreateWalletAccountSelect renders 1`] = `
         </View>
       </View>
       <Text
-        adjustsFontSizeToFit={false}
-        minimumFontScale={0.65}
-        numberOfLines={0}
         style={
           [
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
               "fontSize": 22,
-              "includeFontPadding": false,
+              "margin": 11,
+              "textAlign": "left",
             },
-            [
-              {
-                "color": "#FFFFFF",
-                "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
-                "margin": 11,
-                "textAlign": "left",
-              },
-              {
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-              },
-              undefined,
-            ],
+            {
+              "paddingBottom": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 0,
+            },
+            null,
             null,
           ]
         }
@@ -343,33 +332,22 @@ exports[`CreateWalletAccountSelect renders 1`] = `
         Create a unique account handle, this will also be the name of your BTC wallet:
       </Text>
       <Text
-        adjustsFontSizeToFit={false}
-        minimumFontScale={0.65}
-        numberOfLines={0}
         style={
           [
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
               "fontSize": 22,
-              "includeFontPadding": false,
+              "margin": 11,
+              "textAlign": "left",
             },
-            [
-              {
-                "color": "#FFFFFF",
-                "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
-                "margin": 11,
-                "textAlign": "left",
-              },
-              {
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-              },
-              undefined,
-            ],
+            {
+              "paddingBottom": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 0,
+            },
+            null,
             null,
           ]
         }

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
@@ -408,7 +408,7 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
             }
           >
             <Text
-              adjustsFontSizeToFit={false}
+              adjustsFontSizeToFit={true}
               minimumFontScale={0.65}
               numberOfLines={1}
               style={

--- a/src/components/FioAddress/DomainListModal.tsx
+++ b/src/components/FioAddress/DomainListModal.tsx
@@ -154,9 +154,9 @@ class DomainListModalComponent extends React.Component<Props, State> {
     const styles = getStyles(theme)
 
     return (
-      <ModalUi4 bridge={bridge} onCancel={() => bridge.resolve(undefined)} paddingRem={[1, 0]} title={lstrings.fio_address_choose_domain_label}>
+      <ModalUi4 bridge={bridge} onCancel={() => bridge.resolve(undefined)} title={lstrings.fio_address_choose_domain_label}>
         <SimpleTextInput
-          horizontal={0.75}
+          around={0.5}
           autoCorrect={false}
           returnKeyType="search"
           autoCapitalize="none"
@@ -174,7 +174,6 @@ class DomainListModalComponent extends React.Component<Props, State> {
           renderItem={this.renderItem}
           contentContainerStyle={styles.scrollPadding}
         />
-        {/* <ModalFooterFade /> */}
       </ModalUi4>
     )
   }

--- a/src/components/modals/AddressModal.tsx
+++ b/src/components/modals/AddressModal.tsx
@@ -18,7 +18,7 @@ import { FormattedText as Text } from '../legacy/FormattedText/FormattedText.ui'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
 import { FilledTextInput } from '../themed/FilledTextInput'
-import { MainButton } from '../themed/MainButton'
+import { ButtonsViewUi4 } from '../ui4/ButtonsViewUi4'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 interface OwnProps {
@@ -303,52 +303,45 @@ export class AddressModalComponent extends React.Component<Props, State> {
     const styles = getStyles(theme)
 
     return (
-      <ModalUi4 bridge={this.props.bridge} onCancel={this.handleClose} paddingRem={1} title={title ?? lstrings.address_modal_default_header}>
-        <View style={styles.container}>
-          <FilledTextInput
-            horizontal={1}
-            autoCorrect={false}
-            returnKeyType="search"
-            autoCapitalize="none"
-            placeholder={lstrings.fragment_send_address}
-            onChangeText={this.onChangeTextDelayed}
-            onSubmitEditing={this.handleSubmit}
-            value={uri}
-            error={errorLabel}
-            valid={validLabel}
-            showSpinner={showSpinner}
+      <ModalUi4 bridge={this.props.bridge} onCancel={this.handleClose} title={title ?? lstrings.address_modal_default_header}>
+        <FilledTextInput
+          around={0.5}
+          bottom={1}
+          autoCorrect={false}
+          returnKeyType="search"
+          autoCapitalize="none"
+          placeholder={lstrings.fragment_send_address}
+          onChangeText={this.onChangeTextDelayed}
+          onSubmitEditing={this.handleSubmit}
+          value={uri}
+          error={errorLabel}
+          valid={validLabel}
+          showSpinner={showSpinner}
+        />
+        {!userFioAddressesLoading ? (
+          <FlashList
+            data={filteredFioAddresses}
+            estimatedItemSize={theme.rem(4.25)}
+            keyboardShouldPersistTaps="handled"
+            keyExtractor={this.keyExtractor}
+            renderItem={this.renderFioAddressRow}
           />
-          {!userFioAddressesLoading ? (
-            <FlashList
-              data={filteredFioAddresses}
-              estimatedItemSize={theme.rem(4.25)}
-              keyboardShouldPersistTaps="handled"
-              keyExtractor={this.keyExtractor}
-              renderItem={this.renderFioAddressRow}
-            />
-          ) : (
-            <View style={styles.loaderContainer}>
-              <ActivityIndicator color={this.props.theme.iconTappable} />
-            </View>
-          )}
-          {/* TODO: Style ButtonsViewUi4 for Modals */}
-          <MainButton label={lstrings.submit} type="primary" onPress={this.handleSubmit} />
-        </View>
+        ) : (
+          <View style={styles.loaderContainer}>
+            <ActivityIndicator color={this.props.theme.iconTappable} />
+          </View>
+        )}
+        <ButtonsViewUi4 sceneMargin primary={{ label: lstrings.string_next_capitalized, onPress: this.handleSubmit }} />
       </ModalUi4>
     )
   }
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
-  container: {
-    flex: 1,
-    width: '100%',
-    flexDirection: 'column'
-  },
   rowContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginVertical: theme.rem(0.5)
+    margin: theme.rem(0.5)
   },
   fioAddressAvatarContainer: {
     width: theme.rem(1.25),

--- a/src/components/modals/ButtonsModal.tsx
+++ b/src/components/modals/ButtonsModal.tsx
@@ -78,7 +78,7 @@ export function ButtonsModal<Buttons extends { [key: string]: ButtonInfo }>(prop
   }
 
   return (
-    <ModalUi4 warning={warning} bridge={bridge} paddingRem={1} title={title} onCancel={disableCancel ? undefined : handleCancel}>
+    <ModalUi4 warning={warning} bridge={bridge} title={title} onCancel={disableCancel ? undefined : handleCancel}>
       <View style={containerStyle}>
         <View style={textStyle}>
           {message != null ? <ModalMessage>{message}</ModalMessage> : null}

--- a/src/components/modals/CategoryModal.tsx
+++ b/src/components/modals/CategoryModal.tsx
@@ -140,6 +140,7 @@ export function CategoryModal(props: Props) {
         ))}
       </View>
       <FilledTextInput
+        around={0.5}
         autoFocus
         returnKeyType="done"
         autoCapitalize="words"
@@ -171,8 +172,7 @@ const getStyle = cacheStyles((theme: Theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    marginHorizontal: theme.rem(1),
-    marginBottom: theme.rem(1)
+    margin: theme.rem(0.5)
   },
   categoryListContainer: {
     flex: 1

--- a/src/components/modals/CountryListModal.tsx
+++ b/src/components/modals/CountryListModal.tsx
@@ -70,7 +70,6 @@ export const CountryListModal = ({ countryCode: rawCountryCode, bridge }: Props)
       title={lstrings.buy_sell_crypto_select_country_button}
       label={lstrings.search_region}
       autoFocus
-      blurOnClear={false}
       rowsData={countryCodes}
       onSubmitEditing={handleSubmitEditing}
       rowComponent={rowComponent}

--- a/src/components/modals/FiatListModal.tsx
+++ b/src/components/modals/FiatListModal.tsx
@@ -80,7 +80,6 @@ export const FiatListModal = (props: Props) => {
       title={lstrings.title_create_wallet_select_fiat}
       label={lstrings.fragment_wallets_addwallet_fiat_hint}
       autoFocus
-      blurOnClear={false}
       rowsData={supportedFiats}
       onSubmitEditing={onSubmitEditing}
       rowComponent={item => renderFiatChoiceModalRow(item)}

--- a/src/components/modals/HelpModal.tsx
+++ b/src/components/modals/HelpModal.tsx
@@ -70,7 +70,6 @@ export const HelpModal = (props: Props) => {
         </View>
       }
       onCancel={handleClose}
-      paddingRem={[1, 0]}
       scroll
     >
       <SelectableRow
@@ -121,7 +120,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     flexGrow: 1,
     flexDirection: 'column',
     justifyContent: 'center',
-    alignItems: 'center'
+    alignItems: 'center',
+    marginTop: theme.rem(0.25)
   },
   logo: {
     height: theme.rem(2.25)

--- a/src/components/modals/ListModal.tsx
+++ b/src/components/modals/ListModal.tsx
@@ -29,7 +29,6 @@ interface Props<T> {
   onSubmitEditing?: (text: string) => void
   secureTextEntry?: boolean // Defaults to 'false'
   autoFocus?: boolean // Defaults to 'false'
-  blurOnClear?: boolean // Defaults to 'true'
   // List Props
   rowsData?: T[] // Defaults to []
   fullScreen?: boolean
@@ -72,13 +71,13 @@ export function ListModal<T>({
   return (
     <ModalUi4 title={title} bridge={bridge} onCancel={handleCancel}>
       {message == null ? null : <ModalMessage>{message}</ModalMessage>}
-      {textInput == null || !textInput ? null : (
+      {!textInput ? null : (
         <FilledTextInput
           vertical={1}
           horizontal={0.5}
           // Our props:
           searchIcon
-          blurOnClear
+          blurOnClear={false}
           autoCorrect={false}
           autoCapitalize="words"
           returnKeyType="done"

--- a/src/components/modals/PermissionsSettingModal.tsx
+++ b/src/components/modals/PermissionsSettingModal.tsx
@@ -45,7 +45,7 @@ export function PermissionsSettingModal(props: {
   const handleClose = () => bridge.resolve(mandatory)
 
   return (
-    <ModalUi4 bridge={bridge} paddingRem={1} onCancel={handleClose}>
+    <ModalUi4 bridge={bridge} onCancel={handleClose}>
       <ModalMessage>{message}</ModalMessage>
       <MainButton label={lstrings.string_ok_cap} marginRem={0.5} type="primary" onPress={handlePress} />
     </ModalUi4>

--- a/src/components/modals/TransferModal.tsx
+++ b/src/components/modals/TransferModal.tsx
@@ -160,7 +160,7 @@ export const TransferModal = ({ account, bridge, depositOrSend, navigation }: Pr
   )
 }
 
-export const styles = cacheStyles((theme: Theme) => ({
+const styles = cacheStyles((theme: Theme) => ({
   iconContainer: {
     flexDirection: 'row',
     paddingVertical: theme.rem(0.5),

--- a/src/components/modals/WcSmartContractModal.tsx
+++ b/src/components/modals/WcSmartContractModal.tsx
@@ -150,7 +150,6 @@ export const WcSmartContractModal = (props: Props) => {
           <ModalTitle>{lstrings.wc_smartcontract_title}</ModalTitle>
         </View>
       }
-      paddingRem={[1, 0]}
     >
       <ScrollView contentContainerStyle={styles.scrollPadding}>
         {renderWarning()}
@@ -192,7 +191,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
   title: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: theme.rem(1)
+    paddingHorizontal: theme.rem(1),
+    paddingTop: theme.rem(1)
   },
   logo: {
     height: theme.rem(2),

--- a/src/components/modals/WebViewModal.tsx
+++ b/src/components/modals/WebViewModal.tsx
@@ -3,6 +3,7 @@ import { AirshipBridge } from 'react-native-airship'
 import { WebView } from 'react-native-webview'
 
 import { Airship } from '../services/AirshipInstance'
+import { useTheme } from '../services/ThemeContext'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 export async function showWebViewModal(title: string, uri: string): Promise<void> {
@@ -18,14 +19,15 @@ interface Props {
 export const WebViewModal = (props: Props) => {
   const { bridge, title, uri } = props
   const webviewRef = React.useRef<WebView>(null)
+  const theme = useTheme()
 
   const handleClose = () => {
     props.bridge.resolve()
   }
 
   return (
-    <ModalUi4 bridge={bridge} onCancel={handleClose} title={title} paddingRem={[1, 0]}>
-      <WebView ref={webviewRef} allowsInlineMediaPlayback source={{ uri }} />
+    <ModalUi4 bridge={bridge} onCancel={handleClose} title={title}>
+      <WebView ref={webviewRef} allowsInlineMediaPlayback source={{ uri }} style={{ marginTop: theme.rem(0.5) }} />
     </ModalUi4>
   )
 }

--- a/src/components/scenes/CreateWalletImportScene.tsx
+++ b/src/components/scenes/CreateWalletImportScene.tsx
@@ -159,7 +159,6 @@ const CreateWalletImportComponent = (props: Props) => {
           placeholder={lstrings.create_wallet_import_input_key_or_seed_prompt}
           autoCapitalize="none"
           autoCorrect={false}
-          blurOnClear={false}
           onChangeText={setImportText}
           onSubmitEditing={handleNext}
           ref={textInputRef}

--- a/src/components/scenes/Fio/FioStakingChangeScene.tsx
+++ b/src/components/scenes/Fio/FioStakingChangeScene.tsx
@@ -193,7 +193,6 @@ export const FioStakingChangeScene = withWallet((props: Props) => {
               {lstrings.staking_change_unlock_explainer_title}
             </ModalTitle>
           }
-          paddingRem={1}
         >
           <ModalMessage>{lstrings.staking_change_unlock_explainer1}</ModalMessage>
           <ModalMessage>{lstrings.staking_change_unlock_explainer2}</ModalMessage>

--- a/src/components/themed/ModalParts.tsx
+++ b/src/components/themed/ModalParts.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ScrollView, Text, TouchableOpacity, View } from 'react-native'
+import { Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
@@ -24,11 +24,13 @@ export function ModalTitle(props: ModalTitleProps) {
   const theme = useTheme()
   const styles = getStyles(theme)
   const padding = sidesToPadding(mapSides(fixSides(paddingRem, 0), theme.rem))
+  const androidAdjust = Platform.OS === 'android' ? styles.androidAdjust : null
+  const centerStyle = center ? styles.titleCenter : null
 
   return (
     <View style={styles.titleContainer}>
       {icon ? <View style={styles.titleIconContainer}>{icon}</View> : null}
-      <Text style={[styles.titleText, center ? styles.titleCenter : null, padding]}>{children}</Text>
+      <Text style={[styles.titleText, centerStyle, padding, androidAdjust]}>{children}</Text>
     </View>
   )
 }
@@ -38,8 +40,10 @@ export function ModalMessage(props: { children: React.ReactNode; paddingRem?: nu
   const theme = useTheme()
   const styles = getStyles(theme)
   const padding = sidesToPadding(mapSides(fixSides(paddingRem, 0), theme.rem))
+  const warningStyle = isWarning ? styles.warningText : null
+  const androidAdjust = Platform.OS === 'android' ? styles.androidAdjust : null
 
-  return <Text style={[styles.messageText, padding, isWarning && styles.warningText]}>{children}</Text>
+  return <Text style={[styles.messageText, padding, warningStyle, androidAdjust]}>{children}</Text>
 }
 
 /**
@@ -91,6 +95,9 @@ export const ModalFooterFade = () => {
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
+  androidAdjust: {
+    top: -1
+  },
   closeContainer: {
     alignItems: 'center',
     padding: theme.rem(1),
@@ -116,7 +123,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     fontSize: theme.rem(1.2)
   },
   titleCenter: {
-    textAlign: 'center'
+    textAlign: 'center',
+    flexGrow: 1
   },
   warningText: {
     color: theme.warningText

--- a/src/components/themed/SelectableRow.tsx
+++ b/src/components/themed/SelectableRow.tsx
@@ -32,9 +32,7 @@ export const SelectableRow = (props: Props) => {
         {/* HACK: Keeping the iconContainer instead of CardUi4's built-in icon prop because the prop's behavior is inconsistent in legacy use cases */}
         <View style={styles.iconContainer}>{icon}</View>
         <View style={styles.textContainer}>
-          <EdgeText numberOfLines={1} disableFontScaling>
-            {title}
-          </EdgeText>
+          <EdgeText numberOfLines={1}>{title}</EdgeText>
           {subTitle ? (
             <EdgeText style={styles.subTitle} numberOfLines={2}>
               {subTitle}

--- a/src/components/ui4/ModalUi4.tsx
+++ b/src/components/ui4/ModalUi4.tsx
@@ -7,12 +7,12 @@ import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
 import { useHandler } from '../../hooks/useHandler'
-import { fixSides, mapSides, sidesToPadding } from '../../util/sides'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { BlurBackground } from './BlurBackground'
 
 const BACKGROUND_ALPHA = 0.7
+
 export interface ModalPropsUi4<T = unknown> {
   bridge: AirshipBridge<T>
 
@@ -21,9 +21,6 @@ export interface ModalPropsUi4<T = unknown> {
   title?: React.ReactNode
 
   children?: React.ReactNode
-
-  // Internal padding to place inside the component.
-  paddingRem?: number[] | number
 
   // Include a scroll area:
   scroll?: boolean
@@ -44,11 +41,11 @@ const duration = 300
  * and dims the rest of the app.
  */
 export function ModalUi4<T>(props: ModalPropsUi4<T>): JSX.Element {
-  const { bridge, title, children, paddingRem, scroll = false, warning = false, onCancel } = props
+  const { bridge, title, children, scroll = false, warning = false, onCancel } = props
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const customPadding = sidesToPadding(mapSides(fixSides(paddingRem, 0.5), theme.rem))
+  const halfRem = theme.rem(0.5)
   const closeThreshold = theme.rem(6)
   const dragSlop = theme.rem(1)
 
@@ -120,12 +117,8 @@ export function ModalUi4<T>(props: ModalPropsUi4<T>): JSX.Element {
     borderColor: warning ? theme.warningText : theme.modalBorderColor,
     borderWidth: warning ? 4 : theme.modalBorderWidth,
     marginBottom: -bottomGap,
-    paddingTop: isHeaderless ? customPadding.paddingTop : 0, // If there's a header; either close button or a title, the custom paddingTop will be added to the bottom of the title container.
-    paddingBottom: bottomGap + (scroll ? 0 : customPadding.paddingBottom), // Ignore custom padding on bottom for scrollable content so we don't have a cutoff gap when scrolling content
-
-    // No matter if we are scrollling or not, horizontal paddings are fixed
-    paddingLeft: customPadding.paddingLeft,
-    paddingRight: customPadding.paddingRight
+    paddingTop: isHeaderless ? halfRem : 0, // If there's a header; either close button or a title, the custom paddingTop will be added to the bottom of the title container.
+    paddingBottom: bottomGap + (scroll ? 0 : halfRem) // Ignore padding on bottom for scrollable content so we don't have a cutoff gap when scrolling content
   }
 
   return (
@@ -142,7 +135,7 @@ export function ModalUi4<T>(props: ModalPropsUi4<T>): JSX.Element {
           </View>
 
           {isHeaderless ? null : (
-            <View style={[styles.titleContainer, { marginBottom: customPadding.paddingTop }]}>
+            <View style={styles.titleContainer}>
               {typeof title === 'string' ? (
                 <EdgeText style={styles.titleText} numberOfLines={2}>
                   {title}
@@ -181,7 +174,9 @@ const getStyles = cacheStyles((theme: Theme) => ({
     borderTopRightRadius: theme.rem(1),
     flexShrink: 1,
     overflow: 'hidden',
-    width: theme.rem(30) // This works as a maxWidth because flexShrink is set
+    width: theme.rem(30), // This works as a maxWidth because flexShrink is set
+    paddingLeft: theme.rem(0.5),
+    paddingRight: theme.rem(0.5)
   },
   scroll: {
     // Only take up as much space as needed to display the contents
@@ -209,23 +204,25 @@ const getStyles = cacheStyles((theme: Theme) => ({
     alignItems: 'flex-end',
     justifyContent: 'flex-start',
     paddingTop: theme.rem(0.15), // Bake in margins to align with 1 line of text, no matter the number of lines
-    marginRight: theme.rem(0.5)
+    marginRight: theme.rem(0.25) // Less margins because the icon itself comes with whitespace
   },
   closeIconContainerAbsolute: {
     // Used when the caller passes a special title that may span the entire
     // width. It's up to the caller to ensure there's no overlap with the close button.
     position: 'absolute',
     top: theme.rem(0.15), // Bake in margins to align with 1 line of text, which is often supplied in custom headers.
-    right: theme.rem(0.5)
+    right: theme.rem(0.25)
   },
   titleContainer: {
     flexDirection: 'row',
     alignItems: 'flex-start',
-    marginTop: theme.rem(1.25) // Ensure the top drag bar is not overlapped
+    marginTop: theme.rem(1.25), // Ensure the top drag bar is not overlapped
+    marginBottom: theme.rem(0.5)
   },
   titleText: {
     fontFamily: theme.fontFaceMedium,
     fontSize: theme.rem(1.2),
-    marginHorizontal: theme.rem(0.5)
+    marginHorizontal: theme.rem(0.5),
+    flexShrink: 1
   }
 }))

--- a/src/components/ui4/ModalUi4.tsx
+++ b/src/components/ui4/ModalUi4.tsx
@@ -194,7 +194,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
     backgroundColor: theme.modalDragbarColor,
     borderRadius: theme.rem(0.125),
     height: theme.rem(0.25),
-    marginTop: theme.rem(0.5),
+    marginTop: theme.rem(0.25),
     width: theme.rem(3)
   },
   closeIconContainer: {

--- a/src/theme/variables/edgeDark.ts
+++ b/src/theme/variables/edgeDark.ts
@@ -49,6 +49,8 @@ const palette = {
   blackOp50: 'rgba(0, 0, 0, .5)',
   blackOp70: 'rgba(0, 0, 0, .7)',
 
+  darkGreyOp30: 'hsla(0, 0%, 53%, 0.3)',
+
   whiteOp05: 'rgba(255, 255, 255, .05)',
   whiteOp10: 'rgba(255, 255, 255, .1)',
   whiteOp37: 'rgba(255, 255, 255, .37)',
@@ -178,7 +180,7 @@ export const edgeDark: Theme = {
   modalBorderRadiusRem: 1,
   modalBackgroundUi4: palette.whiteOp37,
   modalSceneOverlayColor: palette.black,
-  modalDragbarColor: palette.gray,
+  modalDragbarColor: palette.darkGreyOp30,
 
   sideMenuBorderColor: palette.backgroundBlack,
   sideMenuBorderWidth: 0,


### PR DESCRIPTION
- Remove blurOnClear from ListModal altogether
- Fix ModalUi4 title handling, small X button adjustment
- **Remove custom padding altogether from ModalUi4.** 
-- This is less risky than trying to change ModalUi4 to support legacy + UI4 styling patterns.
- Misc restyling: AddressModal, SelectableRow (used on TransferModal)

<img width="1341" alt="Screenshot 2024-01-18 at 5 46 34 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/1b149632-7f8b-4b20-8c2e-d088073871df">
<img width="1330" alt="Screenshot 2024-01-18 at 5 40 26 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/e979fe24-745f-4be6-9c79-9dbaa17c5ec5">
<img width="1330" alt="Screenshot 2024-01-18 at 5 39 57 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/12f79db6-af30-4fde-a48f-8f0c0d0a9999">
<img width="1337" alt="Screenshot 2024-01-18 at 6 33 07 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/0799f17e-e022-4b15-bbc9-181a9453bc41">
<img width="1335" alt="Screenshot 2024-01-18 at 6 33 40 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/7875539b-f555-4800-bc68-26011553bda2">
<img width="1344" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/f6969d54-5b06-46a9-a9b2-d22495175425">

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206379497162045