### PR TITLE
Change header/tabbar background color to match app background color

### DIFF
--- a/src/components/themed/MenuTabs.tsx
+++ b/src/components/themed/MenuTabs.tsx
@@ -2,7 +2,7 @@ import { BottomTabBarProps, BottomTabNavigationEventMap } from '@react-navigatio
 import { NavigationHelpers, ParamListBase } from '@react-navigation/native'
 import * as React from 'react'
 import { useMemo } from 'react'
-import { Platform, TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import Animated, { SharedValue, useAnimatedStyle } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -42,9 +42,6 @@ export const MenuTabs = (props: BottomTabBarProps) => {
   const { navigation, state } = props
   const theme = useTheme()
   const activeTabFullIndex = state.index
-  const colors = Platform.OS === 'ios' ? theme.tabBarBackgroundIos : theme.tabBarBackground
-  const start = theme.tabBarBackgroundStart
-  const end = theme.tabBarBackgroundEnd
   const routes = useMemo(
     () =>
       state.routes.filter(route => {
@@ -70,7 +67,7 @@ export const MenuTabs = (props: BottomTabBarProps) => {
   return (
     <Container>
       <BlurBackground />
-      <LinearGradient colors={colors} start={start} end={end}>
+      <LinearGradient colors={theme.tabBarBackground} start={theme.tabBarBackgroundStart} end={theme.tabBarBackgroundEnd}>
         <Tabs>
           {routes.map((route, index: number) => (
             <Tab

--- a/src/theme/variables/edgeDark.ts
+++ b/src/theme/variables/edgeDark.ts
@@ -309,8 +309,7 @@ export const edgeDark: Theme = {
     textShadowRadius: 3
   },
 
-  tabBarBackground: [palette.blackOp35, palette.blackOp70],
-  tabBarBackgroundIos: [palette.blackOp10, palette.blackOp70],
+  tabBarBackground: [palette.blackOp10, palette.blackOp70],
   tabBarBackgroundStart: { x: 0, y: 0.5 },
   tabBarBackgroundEnd: { x: 0, y: 1 },
   tabBarTopOutlineColors: [`${palette.white}22`, `${palette.white}22`],

--- a/src/theme/variables/edgeLight.ts
+++ b/src/theme/variables/edgeLight.ts
@@ -269,7 +269,6 @@ export const edgeLight: Theme = {
   },
 
   tabBarBackground: [palette.white, palette.white],
-  tabBarBackgroundIos: [palette.white, palette.white],
   tabBarBackgroundStart: { x: 0, y: 0 },
   tabBarBackgroundEnd: { x: 1, y: 1 },
   tabBarTopOutlineColors: [palette.white, palette.white],

--- a/src/theme/variables/testDark.ts
+++ b/src/theme/variables/testDark.ts
@@ -309,8 +309,7 @@ export const testDark: Theme = {
     textShadowRadius: 3
   },
 
-  tabBarBackground: [palette.black, palette.black],
-  tabBarBackgroundIos: [palette.blackOp25, palette.blackOp50],
+  tabBarBackground: [palette.blackOp25, palette.blackOp50],
   tabBarBackgroundStart: { x: 0, y: 0.5 },
   tabBarBackgroundEnd: { x: 0, y: 1 },
   tabBarTopOutlineColors: [`${palette.white}22`, `${palette.white}22`],

--- a/src/theme/variables/testLight.ts
+++ b/src/theme/variables/testLight.ts
@@ -269,7 +269,6 @@ export const testLight: Theme = {
   },
 
   tabBarBackground: [palette.white, palette.white],
-  tabBarBackgroundIos: [palette.white, palette.white],
   tabBarBackgroundStart: { x: 0, y: 0 },
   tabBarBackgroundEnd: { x: 1, y: 1 },
   tabBarTopOutlineColors: [palette.white, palette.white],

--- a/src/types/Theme.ts
+++ b/src/types/Theme.ts
@@ -263,9 +263,6 @@ export interface Theme {
   cardTextShadow: TextShadowParams // For added contrast against complex card backgrounds
 
   tabBarBackground: string[]
-  // IOS has a forced darkening and lightening of blurviews so we need
-  // a different color to compensate
-  tabBarBackgroundIos: string[]
   tabBarBackgroundStart: GradientCoords
   tabBarBackgroundEnd: GradientCoords
   tabBarTopOutlineColors: string[]


### PR DESCRIPTION
This makes the app feel more pro.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

iOS:

https://github.com/EdgeApp/edge-react-gui/assets/517469/d634c3a5-291a-4172-b611-4a3abda2a917

Android Before:
[before.webm](https://github.com/EdgeApp/edge-react-gui/assets/517469/9d209605-62db-4549-960f-930e90c9b36b)

Android After:
[after.webm](https://github.com/EdgeApp/edge-react-gui/assets/517469/c5588fff-ce97-4704-bc34-d75772c0c9c2)
