### PR TITLE
Fix visuals for missing contact thumbnails

### DIFF
--- a/src/components/themed/TransactionListRow.tsx
+++ b/src/components/themed/TransactionListRow.tsx
@@ -135,14 +135,15 @@ export function TransactionListRow(props: Props) {
     </ShadowedView>
   )
 
-  const icon = thumbnailPath ? (
-    <ShadowedView style={styles.contactContainer}>
-      <FastImage style={styles.contactImage} source={{ uri: thumbnailPath }} />
-      {arrowIcon}
-    </ShadowedView>
-  ) : (
-    arrowIcon
-  )
+  const icon =
+    thumbnailPath != null ? (
+      <ShadowedView style={styles.contactContainer}>
+        <FastImage style={styles.contactImage} source={{ uri: thumbnailPath }} />
+        {arrowIcon}
+      </ShadowedView>
+    ) : (
+      arrowIcon
+    )
 
   // Pending Text and Style
   const currentConfirmations = transaction.confirmations

--- a/src/hooks/redux/useContactThumbnail.ts
+++ b/src/hooks/redux/useContactThumbnail.ts
@@ -45,7 +45,7 @@ export const useContactThumbnail = (name?: string): string | undefined => {
     for (const contact of contacts) {
       const { givenName, familyName } = contact
       const contactName = normalizeForSearch(`${givenName}${familyName ?? ''}`)
-      if (contact.thumbnailPath != null && contactName === searchName) {
+      if (contactName === searchName && contact.thumbnailPath != null && contact.thumbnailPath !== '') {
         return contact.thumbnailPath
       }
     }


### PR DESCRIPTION
We were using inconsistent checks, so in one place "" would be a missing icon, but in another place only `undefined` would count.

Standardize on checking for `!= null` everywhere, but also filter out "" in the `useContactThumbnail` hook to get the best of both worlds.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206227157907408