### PR TITLE
Remove animated PlaceholderText for SimpleTextInput

### DIFF
--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -264,53 +264,6 @@ exports[`WalletListModal should render with loading props 1`] = `
               }
             }
           >
-            <Text
-              disableAnimation={
-                {
-                  "value": 0,
-                }
-              }
-              focusAnimation={
-                {
-                  "value": 0,
-                }
-              }
-              hasValueAnimation={
-                {
-                  "value": 0,
-                }
-              }
-              scale={
-                {
-                  "value": 1,
-                }
-              }
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "justifyContent": "center",
-                    "margin": 0,
-                    "paddingHorizontal": 11,
-                    "paddingVertical": 0,
-                    "position": "absolute",
-                    "top": 0,
-                  },
-                  {
-                    "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "includeFontPadding": false,
-                  },
-                  {
-                    "color": undefined,
-                    "fontSize": 22,
-                    "opacity": undefined,
-                  },
-                ]
-              }
-            >
-              Search Wallets
-            </Text>
             <TextInput
               accessibilityState={
                 {
@@ -333,6 +286,8 @@ exports[`WalletListModal should render with loading props 1`] = `
               onChangeText={[Function]}
               onFocus={[Function]}
               onSubmitEditing={[Function]}
+              placeholder="Search Wallets"
+              placeholderTextColor="rgba(255, 255, 255, .5)"
               returnKeyType="search"
               scale={
                 {

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -400,53 +400,6 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             }
           }
         >
-          <Text
-            disableAnimation={
-              {
-                "value": 0,
-              }
-            }
-            focusAnimation={
-              {
-                "value": 0,
-              }
-            }
-            hasValueAnimation={
-              {
-                "value": 0,
-              }
-            }
-            scale={
-              {
-                "value": 1,
-              }
-            }
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                  "margin": 0,
-                  "paddingHorizontal": 11,
-                  "paddingVertical": 0,
-                  "position": "absolute",
-                  "top": 0,
-                },
-                {
-                  "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "includeFontPadding": false,
-                },
-                {
-                  "color": undefined,
-                  "fontSize": 22,
-                  "opacity": undefined,
-                },
-              ]
-            }
-          >
-            Search Wallets
-          </Text>
           <TextInput
             accessibilityState={
               {
@@ -471,6 +424,8 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             onChangeText={[Function]}
             onFocus={[Function]}
             onSubmitEditing={[Function]}
+            placeholder="Search Wallets"
+            placeholderTextColor="rgba(255, 255, 255, .5)"
             scale={
               {
                 "value": 1,


### PR DESCRIPTION
Use regular placeholder props instead of a separate element because
the delay between entering text and animating the placeholder away
is too noticeable that it looks bad.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206421724981295