### PR TITLE
Revert Newly Added Font Scaling From UI4

### DIFF
--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -378,7 +378,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                     layout={BaseAnimationMock {}}
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       minimumFontScale={0.65}
                       numberOfLines={3}
                       style={
@@ -1565,7 +1565,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                     layout={BaseAnimationMock {}}
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       minimumFontScale={0.65}
                       numberOfLines={3}
                       style={
@@ -3105,7 +3105,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                     layout={BaseAnimationMock {}}
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       minimumFontScale={0.65}
                       numberOfLines={3}
                       style={
@@ -5510,7 +5510,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                     layout={BaseAnimationMock {}}
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       minimumFontScale={0.65}
                       numberOfLines={3}
                       style={
@@ -7431,7 +7431,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                     layout={BaseAnimationMock {}}
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       minimumFontScale={0.65}
                       numberOfLines={3}
                       style={
@@ -8539,7 +8539,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                     layout={BaseAnimationMock {}}
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       minimumFontScale={0.65}
                       numberOfLines={3}
                       style={
@@ -9671,7 +9671,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                     layout={BaseAnimationMock {}}
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       minimumFontScale={0.65}
                       numberOfLines={3}
                       style={

--- a/src/components/tiles/AddressTile2.tsx
+++ b/src/components/tiles/AddressTile2.tsx
@@ -288,9 +288,7 @@ export const AddressTile2 = React.forwardRef((props: Props, ref: React.Forwarded
       {recipientAddress == null || recipientAddress === '' ? null : (
         <EdgeAnim enter={{ type: 'stretchInY' }} exit={{ type: 'stretchOutY' }}>
           {fioToAddress == null ? null : <EdgeText>{fioToAddress + '\n'}</EdgeText>}
-          <EdgeText numberOfLines={3} disableFontScaling>
-            {recipientAddress}
-          </EdgeText>
+          <EdgeText numberOfLines={3}>{recipientAddress}</EdgeText>
         </EdgeAnim>
       )}
     </RowUi4>


### PR DESCRIPTION
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/b62c762c-0f37-4044-aa4c-d63c36e1b77d)

This scene below was unchanged, just showing that it is working despite the reported issue in the task
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/f3442b70-dbb3-45f7-8d66-604c2e54d395)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206319183602848