### PR TITLE
Update device-specific bottom padding to MenuTabs

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -125,6 +125,9 @@ jest.mock('react-native-device-info', () => ({
   },
   getVersion() {
     return '1.2.3'
+  },
+  hasNotch() {
+    return false
   }
 }))
 

--- a/src/__tests__/scenes/__snapshots__/CryptoExchangeQuoteScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CryptoExchangeQuoteScene.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CryptoExchangeQuoteScreenComponent should render with loading props 1`]
     collapsable={false}
     contentContainerStyle={
       {
-        "paddingBottom": 58,
+        "paddingBottom": 74.85492957746479,
         "paddingLeft": 0,
         "paddingRight": 0,
         "paddingTop": 64,

--- a/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TransactionDetailsScene should render 1`] = `
     collapsable={false}
     contentContainerStyle={
       {
-        "paddingBottom": 58,
+        "paddingBottom": 74.85492957746479,
         "paddingLeft": 0,
         "paddingRight": 0,
         "paddingTop": 64,
@@ -1703,7 +1703,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
     collapsable={false}
     contentContainerStyle={
       {
-        "paddingBottom": 58,
+        "paddingBottom": 74.85492957746479,
         "paddingLeft": 0,
         "paddingRight": 0,
         "paddingTop": 64,

--- a/src/components/themed/MenuTabs.tsx
+++ b/src/components/themed/MenuTabs.tsx
@@ -3,6 +3,7 @@ import { NavigationHelpers, ParamListBase } from '@react-navigation/native'
 import * as React from 'react'
 import { useMemo } from 'react'
 import { Platform, TouchableOpacity, View } from 'react-native'
+import DeviceInfo from 'react-native-device-info'
 import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller'
 import LinearGradient from 'react-native-linear-gradient'
 import Animated, { interpolate, SharedValue, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated'
@@ -27,12 +28,15 @@ import { VectorIcon } from './VectorIcon'
 
 const extraTabString: LocaleStringKey = config.extraTab?.tabTitleKey ?? 'title_map'
 
-// Android doesn't include extra space from the nav-bar like iOS does, so we
-// add 0.75 rem to the bottom padding of the MenuTab's container:
-const ANDROID_MENU_TAB_BAR_EXTRA_PADDING = Platform.OS === 'android' ? scale(16) * 0.75 : 0
+// Include the correct bottom padding to the menu bar for all devices accept for
+// iOS devices with a nav bar (has a notch). This is because iOS devices with a
+// nav-bar and notch include extra space according to the Apple style-guide.
+// react-native-safe-area-context incorrectly applies no extra padding to iPad
+// devices with a notch.
+const MAYBE_BOTTOM_PADDING = Platform.OS === 'ios' && !Platform.isPad && DeviceInfo.hasNotch() ? 0 : scale(16) * 0.75
 
-export const MAX_TAB_BAR_HEIGHT = 58 + ANDROID_MENU_TAB_BAR_EXTRA_PADDING
-export const MIN_TAB_BAR_HEIGHT = 40 + ANDROID_MENU_TAB_BAR_EXTRA_PADDING
+export const MAX_TAB_BAR_HEIGHT = 58 + MAYBE_BOTTOM_PADDING
+export const MIN_TAB_BAR_HEIGHT = 40 + MAYBE_BOTTOM_PADDING
 
 const title: { readonly [key: string]: string } = {
   homeTab: lstrings.title_home,
@@ -196,7 +200,8 @@ const Tab = ({
 const TabContainer = styled(TouchableOpacity)<{ insetBottom: number }>(theme => ({ insetBottom }) => ({
   flex: 1,
   paddingTop: theme.rem(0.75),
-  paddingBottom: insetBottom + ANDROID_MENU_TAB_BAR_EXTRA_PADDING,
+  paddingBottom: MAYBE_BOTTOM_PADDING,
+  marginBottom: insetBottom,
   justifyContent: 'center',
   alignItems: 'center'
 }))


### PR DESCRIPTION
We include padding on all devices with the exception of iPhone's with
a notch (and therefore with extra inset padding). This means we include
equal top and bottom padding to the MenuTabs for iPads in addition to
Android devices.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [x] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206455300465101

# Before
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-01-30 at 15 48 01](https://github.com/EdgeApp/edge-react-gui/assets/517469/4f4f1b53-2940-4024-bde4-ce6c1bf6b20d)

# After
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-01-30 at 15 47 48](https://github.com/EdgeApp/edge-react-gui/assets/517469/7e91b3bf-93ca-4928-9a72-72a4c7b5ad97)
