### PR TITLE
UI4: Narrow Device Scaling

### DIFF
--- a/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`BalanceCard should render with loading props 1`] = `
         }
       >
         <Text
-          adjustsFontSizeToFit={false}
+          adjustsFontSizeToFit={true}
           minimumFontScale={0.65}
           numberOfLines={1}
           style={
@@ -436,7 +436,7 @@ exports[`BalanceCard should render with loading props 1`] = `
         }
       >
         <Text
-          adjustsFontSizeToFit={false}
+          adjustsFontSizeToFit={true}
           minimumFontScale={0.65}
           numberOfLines={1}
           style={

--- a/src/__tests__/modals/__snapshots__/AdvancedDetailsCard.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AdvancedDetailsCard.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
         }
       >
         <Text
-          adjustsFontSizeToFit={false}
+          adjustsFontSizeToFit={true}
           ellipsizeMode="tail"
           minimumFontScale={0.65}
           numberOfLines={1}

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -604,7 +604,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
         }
       >
         <Text
-          adjustsFontSizeToFit={false}
+          adjustsFontSizeToFit={true}
           minimumFontScale={0.65}
           numberOfLines={1}
           style={

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -533,7 +533,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
       }
     >
       <Text
-        adjustsFontSizeToFit={false}
+        adjustsFontSizeToFit={true}
         minimumFontScale={0.65}
         numberOfLines={1}
         style={

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -1696,7 +1696,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             }
           >
             <Text
-              adjustsFontSizeToFit={false}
+              adjustsFontSizeToFit={true}
               minimumFontScale={0.65}
               numberOfLines={1}
               style={

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
@@ -1052,7 +1052,7 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
         }
       >
         <Text
-          adjustsFontSizeToFit={false}
+          adjustsFontSizeToFit={true}
           minimumFontScale={0.65}
           numberOfLines={1}
           style={
@@ -1193,7 +1193,7 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
         }
       >
         <Text
-          adjustsFontSizeToFit={false}
+          adjustsFontSizeToFit={true}
           minimumFontScale={0.65}
           numberOfLines={1}
           style={

--- a/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
         }
       >
         <Text
-          adjustsFontSizeToFit={false}
+          adjustsFontSizeToFit={true}
           minimumFontScale={0.65}
           numberOfLines={1}
           style={
@@ -437,7 +437,7 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
       }
     >
       <Text
-        adjustsFontSizeToFit={false}
+        adjustsFontSizeToFit={true}
         minimumFontScale={0.65}
         numberOfLines={1}
         style={

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -350,7 +350,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -516,7 +516,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -696,7 +696,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -877,7 +877,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -1332,7 +1332,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -1533,7 +1533,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -1699,7 +1699,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -1879,7 +1879,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -2060,7 +2060,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -2219,7 +2219,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -2313,7 +2313,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -2703,7 +2703,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -2909,7 +2909,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -3069,7 +3069,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -3235,7 +3235,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -3415,7 +3415,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -3596,7 +3596,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -4051,7 +4051,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -4257,7 +4257,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -4422,7 +4422,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -4645,7 +4645,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -5100,7 +5100,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -5306,7 +5306,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -5466,7 +5466,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -5670,7 +5670,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -6125,7 +6125,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -6331,7 +6331,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -6534,7 +6534,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -6989,7 +6989,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -7195,7 +7195,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -7379,7 +7379,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -7480,7 +7480,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -7703,7 +7703,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -8158,7 +8158,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -8388,7 +8388,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -8483,7 +8483,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -8649,7 +8649,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -8807,7 +8807,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -9262,7 +9262,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -9492,7 +9492,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -9611,7 +9611,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -9712,7 +9712,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                     }
                   >
                     <Text
-                      adjustsFontSizeToFit={false}
+                      adjustsFontSizeToFit={true}
                       ellipsizeMode="tail"
                       minimumFontScale={0.65}
                       numberOfLines={1}
@@ -9870,7 +9870,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}
@@ -10325,7 +10325,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -10550,7 +10550,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                   }
                 >
                   <Text
-                    adjustsFontSizeToFit={false}
+                    adjustsFontSizeToFit={true}
                     ellipsizeMode="tail"
                     minimumFontScale={0.65}
                     numberOfLines={1}

--- a/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
@@ -3184,7 +3184,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
           }
         >
           <Text
-            adjustsFontSizeToFit={false}
+            adjustsFontSizeToFit={true}
             minimumFontScale={0.65}
             numberOfLines={1}
             style={
@@ -3324,7 +3324,7 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
           }
         >
           <Text
-            adjustsFontSizeToFit={false}
+            adjustsFontSizeToFit={true}
             minimumFontScale={0.65}
             numberOfLines={1}
             style={
@@ -6540,7 +6540,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
           }
         >
           <Text
-            adjustsFontSizeToFit={false}
+            adjustsFontSizeToFit={true}
             minimumFontScale={0.65}
             numberOfLines={1}
             style={
@@ -6680,7 +6680,7 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
           }
         >
           <Text
-            adjustsFontSizeToFit={false}
+            adjustsFontSizeToFit={true}
             minimumFontScale={0.65}
             numberOfLines={1}
             style={

--- a/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
@@ -1640,7 +1640,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               }
             >
               <Text
-                adjustsFontSizeToFit={false}
+                adjustsFontSizeToFit={true}
                 minimumFontScale={0.65}
                 numberOfLines={1}
                 style={
@@ -3342,7 +3342,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               }
             >
               <Text
-                adjustsFontSizeToFit={false}
+                adjustsFontSizeToFit={true}
                 minimumFontScale={0.65}
                 numberOfLines={1}
                 style={

--- a/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               }
             >
               <Text
-                adjustsFontSizeToFit={false}
+                adjustsFontSizeToFit={true}
                 ellipsizeMode="tail"
                 minimumFontScale={0.65}
                 numberOfLines={1}
@@ -331,7 +331,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -425,7 +425,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -608,7 +608,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -747,7 +747,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -949,7 +949,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -1108,7 +1108,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -1314,7 +1314,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -1408,7 +1408,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -1836,7 +1836,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               }
             >
               <Text
-                adjustsFontSizeToFit={false}
+                adjustsFontSizeToFit={true}
                 ellipsizeMode="tail"
                 minimumFontScale={0.65}
                 numberOfLines={1}
@@ -2033,7 +2033,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -2127,7 +2127,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -2310,7 +2310,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -2449,7 +2449,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -2651,7 +2651,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -2810,7 +2810,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -3016,7 +3016,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}
@@ -3110,7 +3110,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 }
               >
                 <Text
-                  adjustsFontSizeToFit={false}
+                  adjustsFontSizeToFit={true}
                   ellipsizeMode="tail"
                   minimumFontScale={0.65}
                   numberOfLines={1}

--- a/src/components/scenes/CoinRankingScene.tsx
+++ b/src/components/scenes/CoinRankingScene.tsx
@@ -304,7 +304,7 @@ const getStyles = cacheStyles((theme: Theme) => {
     percentChangeView: {
       ...baseTextView,
       justifyContent: 'center',
-      width: theme.rem(5)
+      width: theme.rem(4)
     },
     percentChangeText: {
       ...baseTextStyle,

--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -349,8 +349,10 @@ class GuiPluginList extends React.PureComponent<Props, State> {
         onLongPress={async () => await this.openPlugin(item, true).catch(showError)}
         paddingRem={[1, 0.5, 1, 0.5]}
       >
-        <View style={styles.rowContainer}>
-          <EdgeText style={styles.titleText}>{item.title}</EdgeText>
+        <View style={styles.cardContentContainer}>
+          <EdgeText style={styles.titleText} numberOfLines={1}>
+            {item.title}
+          </EdgeText>
           {item.description === '' ? null : <EdgeText style={styles.subtitleText}>{item.description}</EdgeText>}
           {poweredBy != null && item.partnerIconPath != null ? (
             <>
@@ -450,8 +452,10 @@ const getStyles = cacheStyles((theme: Theme) => ({
     marginLeft: -theme.rem(0.5),
     width: '100%'
   },
-  rowContainer: {
-    flexDirection: 'column'
+  cardContentContainer: {
+    flexDirection: 'column',
+    flexShrink: 1,
+    marginRight: theme.rem(0.5)
   },
   sceneContainer: {
     flex: 1,

--- a/src/components/ui4/ButtonUi4.tsx
+++ b/src/components/ui4/ButtonUi4.tsx
@@ -127,7 +127,7 @@ export function ButtonUi4(props: Props) {
 
   const maybeText =
     label == null ? null : (
-      <EdgeText numberOfLines={1} disableFontScaling style={[textStyle, children == null ? null : styles.leftMarginedText]}>
+      <EdgeText numberOfLines={1} style={[textStyle, children == null ? null : styles.leftMarginedText]}>
         {label}
       </EdgeText>
     )

--- a/src/components/ui4/RowUi4.tsx
+++ b/src/components/ui4/RowUi4.tsx
@@ -82,7 +82,7 @@ export const RowUi4 = (props: Props) => {
       {icon == null ? null : icon}
       <View style={[styles.content, rightButtonVisible ? styles.tappableIconMargin : styles.fullWidth]}>
         {title == null ? null : (
-          <EdgeText disableFontScaling ellipsizeMode="tail" style={error ? styles.textHeaderError : styles.textHeader}>
+          <EdgeText ellipsizeMode="tail" style={error ? styles.textHeaderError : styles.textHeader}>
             {title}
           </EdgeText>
         )}
@@ -163,7 +163,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   textHeader: {
     color: theme.secondaryText,
     fontSize: theme.rem(0.75),
-    paddingRight: theme.rem(1)
+    paddingRight: theme.rem(1) // TODO: Remove
   },
   textHeaderError: {
     color: theme.dangerText,


### PR DESCRIPTION
An Android emulator was set up to approximate the display of the Fold 3 device based on where the `PasswordReminderModal`'s text appeared to wrap in the bug report.

LoginUi 3.2.3 fixes the legacy landing scene in English:
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/2dae14f7-5f4a-41f0-8e93-14900137f69e)

The following is an artificially narrow appearance with the `ButtonUi4` changes mirrored to LoginUi:
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/3bcad859-db8e-4117-b5f2-32183e75936b)

Other screens:
![fio](https://github.com/EdgeApp/edge-react-gui/assets/90650827/25f5d64e-126d-437d-b8fc-a7a673f1df23)
![markets](https://github.com/EdgeApp/edge-react-gui/assets/90650827/59967434-a02c-45bd-9053-c86024362a51)
![assetList](https://github.com/EdgeApp/edge-react-gui/assets/90650827/e2e5fda5-385b-4d98-815a-bf2d9d27a826)
![pwModal](https://github.com/EdgeApp/edge-react-gui/assets/90650827/2e92a436-9fd6-47ff-bb25-403aee1155a4)
![exchangeScene](https://github.com/EdgeApp/edge-react-gui/assets/90650827/dc095143-049c-4baa-a092-048646f3abe9)
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/8037b13c-0171-4add-8399-3659fdb57075)


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206468789158141