### PR TITLE
Use "modalLikeBackground" in GettingStartedScene

### DIFF
--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -399,7 +399,7 @@ const SectionCoverAnimated = styled(Animated.View)<{ swipeOffset: SharedValue<nu
       marginBottom: -insets.bottom
     },
     useAnimatedStyle(() => {
-      const backgroundColor = interpolateColor(props.swipeOffset.value, [0, 1], [`${theme.modal}00`, theme.modalBackground])
+      const backgroundColor = interpolateColor(props.swipeOffset.value, [0, 1], [`${theme.modal}00`, theme.modalLikeBackground])
       const paddingVertical = interpolate(props.swipeOffset.value, [0, 1], [0, themeRem], Extrapolation.CLAMP)
       const flexGrow = interpolate(props.swipeOffset.value, [0, 1], [0, 1.2], Extrapolation.CLAMP)
       return {

--- a/src/theme/variables/edgeDark.ts
+++ b/src/theme/variables/edgeDark.ts
@@ -182,6 +182,8 @@ export const edgeDark: Theme = {
   modalSceneOverlayColor: palette.black,
   modalDragbarColor: palette.darkGreyOp30,
 
+  modalLikeBackground: '#333232',
+
   sideMenuBorderColor: palette.backgroundBlack,
   sideMenuBorderWidth: 0,
   sideMenuFont: palette.QuicksandMedium,

--- a/src/theme/variables/edgeLight.ts
+++ b/src/theme/variables/edgeLight.ts
@@ -156,6 +156,8 @@ export const edgeLight: Theme = {
   modalSceneOverlayColor: palette.black,
   modalDragbarColor: palette.gray,
 
+  modalLikeBackground: '#333232',
+
   sideMenuBorderColor: palette.transparent,
   sideMenuBorderWidth: 0,
   sideMenuFont: palette.QuicksandMedium,

--- a/src/theme/variables/testDark.ts
+++ b/src/theme/variables/testDark.ts
@@ -181,6 +181,8 @@ export const testDark: Theme = {
   modalSceneOverlayColor: palette.black,
   modalDragbarColor: palette.gray,
 
+  modalLikeBackground: '#333232',
+
   sideMenuBorderColor: palette.navyAqua,
   sideMenuBorderWidth: 0,
   sideMenuFont: palette.QuicksandMedium,

--- a/src/theme/variables/testLight.ts
+++ b/src/theme/variables/testLight.ts
@@ -156,6 +156,8 @@ export const testLight: Theme = {
   modalSceneOverlayColor: palette.black,
   modalDragbarColor: palette.gray,
 
+  modalLikeBackground: '#333232',
+
   sideMenuBorderColor: palette.transparent,
   sideMenuBorderWidth: 0,
   sideMenuFont: palette.QuicksandMedium,

--- a/src/types/Theme.ts
+++ b/src/types/Theme.ts
@@ -125,6 +125,11 @@ export interface Theme {
   modalSceneOverlayColor: string
   modalDragbarColor: string
 
+  // Modal content backgrounds have a number of dynamic layers that affect the
+  // resulting color.
+  // This color represents an approximation of a modal's background color
+  modalLikeBackground: string
+
   sideMenuBorderColor: string
   sideMenuBorderWidth: number
   sideMenuFont: string


### PR DESCRIPTION
This color is an opaque representation of a real modal's complex background.

<img width="851" alt="Screenshot 2024-01-31 at 12 45 49 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/3cb158d9-8833-4693-adaf-65f3f4fc2d79">

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206471773351597