### PR TITLE
Move the developer-mode plugin URI to DeviceSettings

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -86,8 +86,6 @@ jest.mock('rn-qr-generator', () => ({
   }
 }))
 
-jest.mock('@react-native-async-storage/async-storage', () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'))
-
 // force timezone to UTC
 jest.mock('dateformat', () => (number, format) => require('dateformat')(number, format, true))
 

--- a/src/actions/DeviceSettingsActions.ts
+++ b/src/actions/DeviceSettingsActions.ts
@@ -11,6 +11,18 @@ export const initDeviceSettings = async () => {
   deviceSettings = await readDeviceSettings()
 }
 
+export const writeDeveloperPluginUri = async (developerPluginUri: string) => {
+  try {
+    const raw = await disklet.getText(DEVICE_SETTINGS_FILENAME)
+    const json = JSON.parse(raw)
+    deviceSettings = asDeviceSettings(json)
+  } catch (e) {
+    console.log(e)
+  }
+  const updatedSettings = { ...deviceSettings, developerPluginUri }
+  return await writeDeviceSettings(updatedSettings)
+}
+
 export const writeDisableAnimations = async (disableAnimations: boolean) => {
   try {
     const raw = await disklet.getText(DEVICE_SETTINGS_FILENAME)

--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -1,5 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
-import { asObject, asString } from 'cleaners'
 import { Disklet } from 'disklet'
 import { EdgeAccount } from 'edge-core-js/types'
 import * as React from 'react'
@@ -8,6 +6,7 @@ import FastImage from 'react-native-fast-image'
 import Animated from 'react-native-reanimated'
 
 import { showBackupForTransferModal } from '../../actions/BackupModalActions'
+import { getDeviceSettings, writeDeveloperPluginUri } from '../../actions/DeviceSettingsActions'
 import { NestedDisableMap } from '../../actions/ExchangeInfoActions'
 import { readSyncedSettings, updateOneSetting, writeSyncedSettings } from '../../actions/SettingsActions'
 import { FLAG_LOGO_URL } from '../../constants/CdnConstants'
@@ -104,9 +103,7 @@ interface State {
 }
 
 const BUY_SELL_PLUGIN_REFRESH_INTERVAL = 60000
-const DEVELOPER_PLUGIN_KEY = 'developerPlugin'
 const PLUGIN_LIST_FILE = 'buySellPlugins.json'
-const asDeveloperUri = asObject({ uri: asString })
 
 class GuiPluginList extends React.PureComponent<Props, State> {
   componentMounted: boolean
@@ -124,10 +121,9 @@ class GuiPluginList extends React.PureComponent<Props, State> {
   async componentDidMount() {
     this.updatePlugins().catch(err => showError(err))
     this.checkCountry()
-    const text = await AsyncStorage.getItem(DEVELOPER_PLUGIN_KEY)
-    if (text != null) {
-      const clean = asDeveloperUri(JSON.parse(text))
-      this.setState({ developerUri: clean.uri })
+    const { developerPluginUri } = getDeviceSettings()
+    if (developerPluginUri != null) {
+      this.setState({ developerUri: developerPluginUri })
     }
   }
 
@@ -266,7 +262,7 @@ class GuiPluginList extends React.PureComponent<Props, State> {
         this.setState({ developerUri: deepPath })
 
         // Write to disk lazily:
-        AsyncStorage.setItem(DEVELOPER_PLUGIN_KEY, JSON.stringify({ uri: deepPath })).catch(showError)
+        writeDeveloperPluginUri(deepPath).catch(error => showError(error))
       }
     }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -167,6 +167,7 @@ const asLocalAccountSettingsInner = asObject({
   spendingLimits: asMaybe(asSpendingLimits, () => asSpendingLimits({}))
 })
 const asDeviceSettingsInner = asObject({
+  developerPluginUri: asMaybe(asString),
   disableAnimations: asMaybe(asBoolean, false),
   hasInteractedWithBackupModal: asMaybe(asBoolean, false)
 })


### PR DESCRIPTION
This is the last thing we use the old async-storage module for. However, some WalletConnect dependencies still need it, so we leave it in package.json.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206453986039455