### PR TITLE
Fix Receive QR Style

### DIFF
--- a/src/components/scenes/RequestScene.tsx
+++ b/src/components/scenes/RequestScene.tsx
@@ -551,10 +551,10 @@ const getStyles = cacheStyles((theme: Theme) => ({
     fontFamily: theme.fontFaceBold
   },
   qrContainer: {
-    margin: theme.rem(0.5),
+    margin: theme.rem(1),
     alignSelf: 'center',
     flex: 1,
-    flexDirection: 'row'
+    flexDirection: 'column'
   },
   title: {
     fontFamily: theme.fontFaceMedium,


### PR DESCRIPTION
The combination of styles across the scene, single `qrContainer` style, `QrCode`, and `AddressQr` was allowing the QR code to overflow beyond its container bounds. 

![oldQr](https://github.com/EdgeApp/edge-react-gui/assets/90650827/069b703a-bb57-40ed-87e4-87b0225b361a)

Modifying `QrCode` and/or `AddressQr` styles was fragile and fixing single QR would break multi-QR and vice versa.
Ultimately, the simplest fix found was to change `flexDirection` for the single QR case.

![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/2ce83a1c-ded2-4b5b-b9a9-a2f047026fbd) 
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/71abc98a-242f-4a63-a111-87241c2a660b)
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/23ab4926-f723-48e8-9a9b-772a2316e227)
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/ab51616e-e6a4-4b90-99af-1b1f6b20e89d)

iOS:
<img width="1008" alt="Screenshot 2024-02-01 at 2 33 34 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/701ad453-2c23-4067-9466-aef4bd43c126">
<img width="1007" alt="Screenshot 2024-02-01 at 2 33 58 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/d80ad7b6-0698-4efd-b9f6-6cb5e04b5349">
<img width="731" alt="Screenshot 2024-02-01 at 2 33 17 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/3ada7aba-913e-4673-9e08-98b68577b28b">
<img width="1004" alt="Screenshot 2024-02-01 at 2 33 45 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/d0c9c875-4eb4-479c-b8c3-3ebf009bc7e8">


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [x] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206493350744524