### PR TITLE
Cache the footer render in MenuTabs and give it a unique key

### DIFF
--- a/src/components/scenes/CoinRankingScene.tsx
+++ b/src/components/scenes/CoinRankingScene.tsx
@@ -212,6 +212,7 @@ const CoinRankingComponent = (props: Props) => {
     sceneWrapperInfo => {
       return (
         <SearchFooter
+          key="CoinRankingScene-SearchFooter"
           placeholder={lstrings.search_assets}
           isSearching={isSearching}
           searchText={searchText}

--- a/src/components/scenes/TransactionListScene.tsx
+++ b/src/components/scenes/TransactionListScene.tsx
@@ -258,6 +258,7 @@ function TransactionListComponent(props: Props) {
     sceneWrapperInfo => {
       return (
         <SearchFooter
+          key="TransactionListScene-SearchFooter"
           placeholder={lstrings.transaction_list_search}
           isSearching={isSearching}
           searchText={searchText}

--- a/src/components/scenes/WalletListScene.tsx
+++ b/src/components/scenes/WalletListScene.tsx
@@ -95,14 +95,16 @@ export function WalletListScene(props: Props) {
 
   const renderFooter: FooterRender = React.useCallback(
     sceneWrapperInfo => {
+      const key = 'WalletListScene-SearchFooter'
       return sorting ? (
-        <SceneFooterWrapper noBackgroundBlur sceneWrapperInfo={sceneWrapperInfo} onLayoutHeight={handleFooterLayoutHeight}>
+        <SceneFooterWrapper key={key} noBackgroundBlur sceneWrapperInfo={sceneWrapperInfo} onLayoutHeight={handleFooterLayoutHeight}>
           <View style={styles.sortFooterContainer}>
             <ButtonUi4 key="doneButton" mini type="primary" label={lstrings.string_done_cap} onPress={handlePressDone} />
           </View>
         </SceneFooterWrapper>
       ) : (
         <SearchFooter
+          key={key}
           placeholder={lstrings.wallet_list_wallet_search}
           isSearching={isSearching}
           searchText={searchText}

--- a/src/components/themed/SceneFooterWrapper.tsx
+++ b/src/components/themed/SceneFooterWrapper.tsx
@@ -9,6 +9,9 @@ import { styled } from '../hoc/styled'
 import { BlurBackground } from '../ui4/BlurBackground'
 
 export interface SceneFooterProps {
+  // This component requires a key for the onLayoutHeight prop
+  key: string
+
   children: React.ReactNode
   sceneWrapperInfo?: SceneWrapperInfo
 
@@ -19,7 +22,7 @@ export interface SceneFooterProps {
 }
 
 export const SceneFooterWrapper = (props: SceneFooterProps) => {
-  const { children, noBackgroundBlur = false, sceneWrapperInfo, onLayoutHeight } = props
+  const { key, children, noBackgroundBlur = false, sceneWrapperInfo, onLayoutHeight } = props
   const { hasTabs = true, isKeyboardOpen = false } = sceneWrapperInfo ?? {}
   const footerOpenRatio = useSceneFooterState(state => state.footerOpenRatio)
 
@@ -49,6 +52,7 @@ export const SceneFooterWrapper = (props: SceneFooterProps) => {
 
   return (
     <ContainerAnimatedView
+      key={`${key}-ContainerAnimatedView`}
       containerHeight={layout?.height}
       footerOpenRatio={footerOpenRatio}
       isKeyboardOpen={isKeyboardOpen}

--- a/src/components/themed/SceneFooterWrapper.tsx
+++ b/src/components/themed/SceneFooterWrapper.tsx
@@ -1,4 +1,3 @@
-import { useIsFocused } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 import Animated, { interpolate, SharedValue, useAnimatedStyle } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -23,7 +22,6 @@ export const SceneFooterWrapper = (props: SceneFooterProps) => {
   const { children, noBackgroundBlur = false, sceneWrapperInfo, onLayoutHeight } = props
   const { hasTabs = true, isKeyboardOpen = false } = sceneWrapperInfo ?? {}
   const footerOpenRatio = useSceneFooterState(state => state.footerOpenRatio)
-  const footerHeightShared = useSceneFooterState(state => state.footerHeight)
 
   const safeAreaInsets = useSafeAreaInsets()
   const maybeInsetBottom = !hasTabs ? safeAreaInsets.bottom : 0
@@ -44,18 +42,6 @@ export const SceneFooterWrapper = (props: SceneFooterProps) => {
     const footerHeight = layout.height - maybeInsetBottom
     onLayoutHeight(footerHeight)
   }, [layout, maybeInsetBottom, onLayoutHeight])
-
-  // Set the global shared value for the footerHeight so that way the
-  // background in the MenuTabs can translate accordingly
-  const isFocused = useIsFocused()
-  useEffect(() => {
-    if (isFocused) {
-      footerHeightShared.value = layout?.height ?? 0
-      return () => {
-        footerHeightShared.value = 0
-      }
-    }
-  }, [footerHeightShared, isFocused, layout?.height])
 
   //
   // Render

--- a/src/components/themed/SearchFooter.tsx
+++ b/src/components/themed/SearchFooter.tsx
@@ -9,6 +9,9 @@ import { SceneFooterWrapper } from './SceneFooterWrapper'
 import { SimpleTextInput, SimpleTextInputRef } from './SimpleTextInput'
 
 interface SearchFooterProps {
+  // This component requires a key for the onLayoutHeight prop
+  key: string
+
   placeholder: string
 
   isSearching: boolean
@@ -24,7 +27,7 @@ interface SearchFooterProps {
 }
 
 export const SearchFooter = (props: SearchFooterProps) => {
-  const { placeholder, isSearching, searchText, noBackground, sceneWrapperInfo, onChangeText, onDoneSearching, onLayoutHeight, onStartSearching } = props
+  const { key, placeholder, isSearching, searchText, noBackground, sceneWrapperInfo, onChangeText, onDoneSearching, onLayoutHeight, onStartSearching } = props
 
   const textInputRef = React.useRef<SimpleTextInputRef>(null)
 
@@ -80,7 +83,12 @@ export const SearchFooter = (props: SearchFooterProps) => {
   //
 
   return (
-    <SceneFooterWrapper noBackgroundBlur={noBackground} sceneWrapperInfo={sceneWrapperInfo} onLayoutHeight={handleFooterLayoutHeight}>
+    <SceneFooterWrapper
+      key={`${key}-SceneFooterWrapper`}
+      noBackgroundBlur={noBackground}
+      sceneWrapperInfo={sceneWrapperInfo}
+      onLayoutHeight={handleFooterLayoutHeight}
+    >
       <Space expand horizontal={1} vertical={0.5}>
         <SimpleTextInput
           returnKeyType="search"


### PR DESCRIPTION
The unique key ensures that we always render a new component when the
render function changes and this in-turn triggers onLayout.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206481495752132

# Before

<img alt="Simulator Screenshot - iPhone 14 - 2024-02-02 at 12 53 55" src="https://github.com/EdgeApp/edge-react-gui/assets/517469/fc85a0c4-eb50-4a72-95e4-5dcbc69a5639" width="300" />


# After

<img alt="Simulator Screenshot - iPhone 14 - 2024-02-02 at 12 51 50" src="https://github.com/EdgeApp/edge-react-gui/assets/517469/525afc93-1e7f-40d0-8880-a8295f4559fe" width="300" />
