### PR TITLE
Make FilledTextInput take up constant space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - changed: Upgrade to Android NDK version 26.1.10909125.
 - changed: Re-enable fake signup captcha experiment at 50%
 - fixed: Show a useful, localized error message when device doesn't have an email account
+- fixed: Make FilledTextInputs take up constant vertical space
 
 ## 4.0.1
 

--- a/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
@@ -169,7 +169,9 @@ exports[`FilledTextInput should render with some props 1`] = `
       </TouchableOpacity>
     </StyledComponent(View)>
   </TouchableWithoutFeedback>
-  <StyledComponent(View)>
+  <StyledComponent(View)
+    noLayoutFlow={false}
+  >
     <StyledComponent(Text)
       danger={true}
     >

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -670,12 +670,17 @@ exports[`CreateWalletAccountSelect renders 1`] = `
           </View>
         </View>
         <View
+          noLayoutFlow={false}
           style={
-            {
-              "flexDirection": "row",
-              "justifyContent": "space-between",
-              "paddingHorizontal": 11,
-            }
+            [
+              {
+                "flexDirection": "row",
+                "height": 22,
+                "justifyContent": "space-between",
+                "paddingHorizontal": 11,
+              },
+              {},
+            ]
           }
         >
           <Text

--- a/src/components/scenes/DevTestScene.tsx
+++ b/src/components/scenes/DevTestScene.tsx
@@ -45,6 +45,7 @@ export function DevTestScene(props: Props) {
   const [filledTextInputValue5, setFilledTextInputValue5] = useState<string>('')
   const [filledTextInputValue6, setFilledTextInputValue6] = useState<string>('')
   const [filledTextInputValue7, setFilledTextInputValue7] = useState<string>('')
+  const [filledTextInputValue8, setFilledTextInputValue8] = useState<string>('')
   const walletId = selectedWallet?.wallet.id ?? ''
   const tokenId = selectedWallet?.tokenId ?? null
   const exchangedFlipInputRef = React.useRef<ExchangedFlipInputRef>(null)
@@ -164,6 +165,17 @@ export function DevTestScene(props: Props) {
           error="Error"
           maxLength={100}
         />
+        <>
+          <FilledTextInput
+            vertical={1}
+            value={filledTextInputValue8}
+            onChangeText={setFilledTextInputValue8}
+            autoFocus={false}
+            placeholder="Test FilledTextInput Custom Error"
+            error={filledTextInputValue8 === '' ? undefined : filledTextInputValue8}
+          />
+          <EdgeText>Ensure errors above don't push me down</EdgeText>
+        </>
         <CardUi4>
           <ExchangedFlipInput2
             ref={exchangedFlipInputRef}

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -1,3 +1,8 @@
+/**
+ * IMPORTANT: Changes in this file MUST be synced between edge-react-gui and
+ * edge-login-ui-rn!
+ */
+
 import * as React from 'react'
 import { useMemo } from 'react'
 import { ActivityIndicator, Platform, Text, TextInput, TouchableOpacity, TouchableWithoutFeedback, View } from 'react-native'
@@ -278,7 +283,7 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
         </Container>
       </TouchableWithoutFeedback>
       {valid != null || error != null || charactersLeft !== '' ? (
-        <MessagesContainer>
+        <MessagesContainer noLayoutFlow={charactersLeft === ''}>
           <Message danger={error != null}>{valid ?? error ?? null}</Message>
           <Message>{charactersLeft}</Message>
         </MessagesContainer>
@@ -516,11 +521,24 @@ const StyledNumericInput = styledWithRef(NumericInput)<{
   ]
 })
 
-const MessagesContainer = styled(Animated.View)(theme => ({
-  flexDirection: 'row',
-  justifyContent: 'space-between',
-  paddingHorizontal: theme.rem(0.5)
-}))
+const MessagesContainer = styled(Animated.View)<{ noLayoutFlow?: boolean }>(theme => props => [
+  {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: theme.rem(0.5),
+    height: theme.rem(1)
+  },
+  props.noLayoutFlow
+    ? {
+        // HACK: If this field has a potential error message, counter-act the
+        // layout flow to avoid the effect of the error message's appearance
+        // pushing components below the this text field down.
+        // If there's a counter, this field is already taking up the maximum
+        // amount of vertical space, so the above is not an issue.
+        marginBottom: -theme.rem(1)
+      }
+    : {}
+])
 
 const Message = styled(Text)<{ danger?: boolean }>(theme => props => [
   {


### PR DESCRIPTION
<img width="751" alt="Screenshot 2024-02-09 at 3 25 24 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/0fa23f50-2e89-4702-b277-6fd0b6157843">

- Used negative margins. Not ideal, but a lower impact change to avoid affecting the layouts app-wide.
- Only apply this special styling if there is no counter, since we already styled the app according to visibility of counters.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206471966737303