### PR TITLE
Remove ModalFooter from FlashNotification

### DIFF
--- a/src/components/navigation/FlashNotification.tsx
+++ b/src/components/navigation/FlashNotification.tsx
@@ -3,11 +3,9 @@ import { Text, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
-import { useHandler } from '../../hooks/useHandler'
 import { THEME } from '../../theme/variables/airbitz'
 import { AirshipDropdown } from '../common/AirshipDropdown'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
-import { ModalFooter } from '../themed/ModalParts'
 
 interface Props {
   bridge: AirshipBridge<void>
@@ -20,14 +18,11 @@ export function FlashNotification(props: Props) {
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const handleClose = useHandler(() => bridge.resolve())
-
   return (
     <AirshipDropdown bridge={bridge} backgroundColor={theme.modal} onPress={onPress}>
       <View style={styles.container}>
         <AntDesignIcon name="checkcircle" size={theme.rem(2)} style={styles.icon} />
         <Text style={styles.text}>{message}</Text>
-        <ModalFooter onPress={handleClose} />
       </View>
     </AirshipDropdown>
   )


### PR DESCRIPTION
This is UI3 paradigm. Now that we have dismiss-able airship dropdowns,
we no longer need the footer and the included X button.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206539946111764

# Before

<img src=https://github.com/EdgeApp/edge-react-gui/assets/517469/410edf92-120f-4c93-b1c9-75e17cb9c3d5 width=300>

# After

<img src=https://github.com/EdgeApp/edge-react-gui/assets/517469/60fe287b-3fe0-41a4-9229-548f0c12d9aa width=300>
<img src=https://github.com/EdgeApp/edge-react-gui/assets/517469/86f44d61-0aa8-4c16-800c-44769020213d width=300>


