### PR TITLE
UI4: Fix Nugget Styling

### DIFF
--- a/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
@@ -183,8 +183,9 @@ exports[`BalanceCard should render with loading props 1`] = `
     layout="row"
     style={
       {
-        "flex": 1,
         "flexDirection": "row-reverse",
+        "flexGrow": 1,
+        "flexShrink": 1,
         "justifyContent": "center",
         "margin": 11,
       }
@@ -222,10 +223,11 @@ exports[`BalanceCard should render with loading props 1`] = `
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
           "flex": 1,
           "justifyContent": "center",
+          "margin": -11,
           "opacity": 1,
+          "padding": 11,
         }
       }
     >
@@ -253,36 +255,23 @@ exports[`BalanceCard should render with loading props 1`] = `
           [
             {
               "alignItems": "center",
+              "borderRadius": 34,
               "flexDirection": "row",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
             },
             {
-              "alignSelf": "auto",
-              "opacity": 1,
+              "alignSelf": "stretch",
             },
             {
               "height": 67,
-              "paddingHorizontal": 45,
+              "paddingHorizontal": 34,
             },
+            {},
             {
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "borderRadius": 34,
-              "justifyContent": "center",
+              "opacity": 1,
             },
-            [
-              {
-                "alignItems": "center",
-                "alignSelf": "stretch",
-                "borderRadius": 34,
-                "justifyContent": "center",
-              },
-              {
-                "flex": 1,
-              },
-            ],
-            undefined,
-            undefined,
           ]
         }
       >
@@ -363,10 +352,11 @@ exports[`BalanceCard should render with loading props 1`] = `
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
           "flex": 1,
           "justifyContent": "center",
+          "margin": -11,
           "opacity": 1,
+          "padding": 11,
         }
       }
     >
@@ -394,36 +384,23 @@ exports[`BalanceCard should render with loading props 1`] = `
           [
             {
               "alignItems": "center",
+              "borderRadius": 34,
               "flexDirection": "row",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
             },
             {
-              "alignSelf": "auto",
-              "opacity": 1,
+              "alignSelf": "stretch",
             },
             {
               "height": 67,
-              "paddingHorizontal": 45,
+              "paddingHorizontal": 34,
             },
+            {},
             {
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "borderRadius": 34,
-              "justifyContent": "center",
+              "opacity": 1,
             },
-            [
-              {
-                "alignItems": "center",
-                "alignSelf": "stretch",
-                "borderRadius": 34,
-                "justifyContent": "center",
-              },
-              {
-                "flex": 1,
-              },
-            ],
-            undefined,
-            undefined,
           ]
         }
       >

--- a/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
@@ -268,7 +268,6 @@ exports[`BalanceCard should render with loading props 1`] = `
               "height": 67,
               "paddingHorizontal": 34,
             },
-            {},
             {
               "opacity": 1,
             },
@@ -397,7 +396,6 @@ exports[`BalanceCard should render with loading props 1`] = `
               "height": 67,
               "paddingHorizontal": 34,
             },
-            {},
             {
               "opacity": 1,
             },

--- a/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
@@ -63,8 +63,9 @@ exports[`TransactionListRow should render with loading props 1`] = `
     style={
       {
         "alignItems": "center",
-        "flex": 1,
         "flexDirection": "row",
+        "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
   >
@@ -142,8 +143,9 @@ exports[`TransactionListRow should render with loading props 1`] = `
       style={
         [
           {
-            "flex": 1,
             "flexDirection": "column",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           {
             "marginBottom": 6,

--- a/src/__tests__/modals/__snapshots__/AdvancedDetailsCard.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AdvancedDetailsCard.test.tsx.snap
@@ -42,8 +42,9 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
     style={
       [
         {
-          "flex": 1,
           "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
         },
         {
           "marginVertical": 0,

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -754,10 +754,10 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             "flexShrink": 1,
             "justifyContent": "center",
             "opacity": 1,
-            "paddingBottom": 11,
-            "paddingLeft": 11,
-            "paddingRight": 11,
-            "paddingTop": 11,
+            "paddingBottom": 22,
+            "paddingLeft": 22,
+            "paddingRight": 22,
+            "paddingTop": 22,
           }
         }
       >
@@ -798,7 +798,6 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                 "height": 67,
                 "paddingHorizontal": 34,
               },
-              {},
               {
                 "opacity": 0.3,
               },

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -749,13 +749,15 @@ exports[`CreateWalletAccountSelect renders 1`] = `
           {
             "alignItems": "center",
             "alignSelf": "center",
-            "borderRadius": 34,
+            "flexBasis": "auto",
+            "flexGrow": 0,
+            "flexShrink": 1,
             "justifyContent": "center",
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
             "opacity": 1,
+            "paddingBottom": 11,
+            "paddingLeft": 11,
+            "paddingRight": 11,
+            "paddingTop": 11,
           }
         }
       >
@@ -783,41 +785,23 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             [
               {
                 "alignItems": "center",
+                "borderRadius": 34,
                 "flexDirection": "row",
+                "flexGrow": 0,
+                "flexShrink": 1,
                 "justifyContent": "center",
               },
               {
                 "alignSelf": "center",
-                "opacity": 0.3,
               },
               {
                 "height": 67,
-                "paddingHorizontal": 45,
+                "paddingHorizontal": 34,
               },
+              {},
               {
-                "alignItems": "center",
-                "alignSelf": "stretch",
-                "borderRadius": 34,
-                "justifyContent": "center",
+                "opacity": 0.3,
               },
-              [
-                {
-                  "alignItems": "center",
-                  "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "justifyContent": "center",
-                },
-                {
-                  "alignSelf": "center",
-                },
-              ],
-              {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
-              },
-              undefined,
             ]
           }
         >

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -676,10 +676,10 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
         "flexShrink": 1,
         "justifyContent": "center",
         "opacity": 1,
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 22,
+        "paddingLeft": 22,
+        "paddingRight": 22,
+        "paddingTop": 22,
       }
     }
   >
@@ -720,7 +720,6 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
             "height": 67,
             "paddingHorizontal": 34,
           },
-          {},
           {
             "opacity": 1,
           },

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -671,13 +671,15 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
       {
         "alignItems": "center",
         "alignSelf": "center",
-        "borderRadius": 34,
+        "flexBasis": "auto",
+        "flexGrow": 0,
+        "flexShrink": 1,
         "justifyContent": "center",
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
         "opacity": 1,
+        "paddingBottom": 11,
+        "paddingLeft": 11,
+        "paddingRight": 11,
+        "paddingTop": 11,
       }
     }
   >
@@ -705,41 +707,23 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
         [
           {
             "alignItems": "center",
+            "borderRadius": 34,
             "flexDirection": "row",
+            "flexGrow": 0,
+            "flexShrink": 1,
             "justifyContent": "center",
           },
           {
             "alignSelf": "center",
-            "opacity": 1,
           },
           {
             "height": 67,
-            "paddingHorizontal": 45,
+            "paddingHorizontal": 34,
           },
+          {},
           {
-            "alignItems": "center",
-            "alignSelf": "stretch",
-            "borderRadius": 34,
-            "justifyContent": "center",
+            "opacity": 1,
           },
-          [
-            {
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "borderRadius": 34,
-              "justifyContent": "center",
-            },
-            {
-              "alignSelf": "center",
-            },
-          ],
-          {
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
-          },
-          undefined,
         ]
       }
     >

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -1831,13 +1831,15 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             {
               "alignItems": "center",
               "alignSelf": "center",
-              "borderRadius": 34,
+              "flexBasis": "auto",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
-              "marginBottom": 11,
-              "marginLeft": -11,
-              "marginRight": -11,
-              "marginTop": 0,
               "opacity": 1,
+              "paddingBottom": 11,
+              "paddingLeft": -11,
+              "paddingRight": -11,
+              "paddingTop": 0,
             }
           }
         >
@@ -1865,41 +1867,23 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
               [
                 {
                   "alignItems": "center",
+                  "borderRadius": 34,
                   "flexDirection": "row",
+                  "flexGrow": 0,
+                  "flexShrink": 1,
                   "justifyContent": "center",
                 },
                 {
                   "alignSelf": "center",
-                  "opacity": 1,
                 },
                 {
                   "height": 67,
-                  "paddingHorizontal": 45,
+                  "paddingHorizontal": 34,
                 },
+                {},
                 {
-                  "alignItems": "center",
-                  "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "justifyContent": "center",
+                  "opacity": 1,
                 },
-                [
-                  {
-                    "alignItems": "center",
-                    "alignSelf": "stretch",
-                    "borderRadius": 34,
-                    "justifyContent": "center",
-                  },
-                  {
-                    "alignSelf": "center",
-                  },
-                ],
-                {
-                  "marginBottom": 11,
-                  "marginLeft": -11,
-                  "marginRight": -11,
-                  "marginTop": 0,
-                },
-                undefined,
               ]
             }
           >

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -1836,9 +1836,9 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
               "flexShrink": 1,
               "justifyContent": "center",
               "opacity": 1,
-              "paddingBottom": 11,
-              "paddingLeft": -11,
-              "paddingRight": -11,
+              "paddingBottom": 22,
+              "paddingLeft": 0,
+              "paddingRight": 0,
               "paddingTop": 0,
             }
           }
@@ -1880,7 +1880,6 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "height": 67,
                   "paddingHorizontal": 34,
                 },
-                {},
                 {
                   "opacity": 1,
                 },

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
@@ -283,6 +283,7 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
     style={
       {
         "flex": 1,
+        "margin": 11,
         "paddingTop": 11,
       }
     }
@@ -1190,10 +1191,10 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
           "flexShrink": 1,
           "justifyContent": "center",
           "opacity": 1,
-          "paddingBottom": 0,
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "paddingTop": 11,
+          "paddingBottom": 11,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 22,
         }
       }
     >
@@ -1234,7 +1235,6 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
               "height": 67,
               "paddingHorizontal": 34,
             },
-            {},
             {
               "opacity": 1,
             },
@@ -1307,8 +1307,8 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
           "justifyContent": "center",
           "opacity": 1,
           "paddingBottom": 22,
-          "paddingLeft": 11,
-          "paddingRight": 11,
+          "paddingLeft": 0,
+          "paddingRight": 0,
           "paddingTop": 11,
         }
       }
@@ -1353,7 +1353,6 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
               "height": undefined,
               "padding": 0,
             },
-            {},
             {
               "opacity": 1,
             },

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
@@ -1185,13 +1185,15 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
         {
           "alignItems": "center",
           "alignSelf": "center",
-          "borderRadius": 34,
+          "flexBasis": "auto",
+          "flexGrow": 0,
+          "flexShrink": 1,
           "justifyContent": "center",
-          "marginBottom": 0,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
           "opacity": 1,
+          "paddingBottom": 0,
+          "paddingLeft": 11,
+          "paddingRight": 11,
+          "paddingTop": 11,
         }
       }
     >
@@ -1219,41 +1221,23 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
           [
             {
               "alignItems": "center",
+              "borderRadius": 34,
               "flexDirection": "row",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
             },
             {
               "alignSelf": "center",
-              "opacity": 1,
             },
             {
               "height": 67,
-              "paddingHorizontal": 45,
+              "paddingHorizontal": 34,
             },
+            {},
             {
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "borderRadius": 34,
-              "justifyContent": "center",
+              "opacity": 1,
             },
-            [
-              {
-                "alignItems": "center",
-                "alignSelf": "stretch",
-                "borderRadius": 34,
-                "justifyContent": "center",
-              },
-              {
-                "alignSelf": "center",
-              },
-            ],
-            {
-              "marginBottom": 0,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
-            },
-            undefined,
           ]
         }
       >
@@ -1317,16 +1301,15 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
         {
           "alignItems": "center",
           "alignSelf": "center",
-          "borderRadius": 34,
-          "height": undefined,
+          "flexBasis": "auto",
+          "flexGrow": 0,
+          "flexShrink": 1,
           "justifyContent": "center",
-          "marginBottom": 22,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
           "opacity": 1,
-          "paddingHorizontal": 0,
-          "paddingVertical": 0,
+          "paddingBottom": 22,
+          "paddingLeft": 11,
+          "paddingRight": 11,
+          "paddingTop": 11,
         }
       }
     >
@@ -1354,47 +1337,26 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
           [
             {
               "alignItems": "center",
+              "borderRadius": 34,
               "flexDirection": "row",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
             },
             {
               "alignSelf": "center",
+            },
+            {
+              "alignSelf": "center",
+            },
+            {
+              "height": undefined,
+              "padding": 0,
+            },
+            {},
+            {
               "opacity": 1,
             },
-            {
-              "height": 67,
-              "paddingHorizontal": 45,
-            },
-            {
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "borderRadius": 34,
-              "justifyContent": "center",
-            },
-            [
-              {
-                "alignItems": "center",
-                "alignSelf": "stretch",
-                "borderRadius": 34,
-                "justifyContent": "center",
-              },
-              {
-                "alignSelf": "center",
-              },
-              {
-                "alignSelf": "center",
-                "height": undefined,
-                "paddingHorizontal": 0,
-                "paddingVertical": 0,
-              },
-            ],
-            {
-              "marginBottom": 22,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
-            },
-            undefined,
           ]
         }
       >

--- a/src/__tests__/scenes/__snapshots__/CryptoExchangeScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CryptoExchangeScene.test.tsx.snap
@@ -1,14 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CryptoExchangeComponent should render with loading props 1`] = `
-<View
-  style={
-    {
-      "flex": 1,
-      "marginHorizontal": 11,
-    }
-  }
->
+<React.Fragment>
   <Memo(EdgeAnimInner)
     enter={
       {
@@ -55,7 +48,6 @@ exports[`CryptoExchangeComponent should render with loading props 1`] = `
       walletId=""
     >
       <MiniButton
-        alignSelf="center"
         label="MAX"
         marginRem={
           [
@@ -124,5 +116,5 @@ exports[`CryptoExchangeComponent should render with loading props 1`] = `
       }
     }
   />
-</View>
+</React.Fragment>
 `;

--- a/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
@@ -477,7 +477,6 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
               "height": 67,
               "paddingHorizontal": 34,
             },
-            {},
             {
               "opacity": 1,
             },
@@ -597,7 +596,6 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
             "height": undefined,
             "padding": 0,
           },
-          {},
           {
             "opacity": 1,
           },

--- a/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
@@ -428,13 +428,15 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
         {
           "alignItems": "center",
           "alignSelf": "center",
-          "borderRadius": 34,
+          "flexBasis": "auto",
+          "flexGrow": 0,
+          "flexShrink": 1,
           "justifyContent": "center",
-          "marginBottom": 22,
-          "marginLeft": 22,
-          "marginRight": 22,
-          "marginTop": 22,
           "opacity": 1,
+          "paddingBottom": 22,
+          "paddingLeft": 22,
+          "paddingRight": 22,
+          "paddingTop": 22,
         }
       }
     >
@@ -462,41 +464,23 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
           [
             {
               "alignItems": "center",
+              "borderRadius": 34,
               "flexDirection": "row",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
             },
             {
-              "alignSelf": "auto",
-              "opacity": 1,
+              "alignSelf": "center",
             },
             {
               "height": 67,
-              "paddingHorizontal": 45,
+              "paddingHorizontal": 34,
             },
+            {},
             {
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "borderRadius": 34,
-              "justifyContent": "center",
+              "opacity": 1,
             },
-            [
-              {
-                "alignItems": "center",
-                "alignSelf": "stretch",
-                "borderRadius": 34,
-                "justifyContent": "center",
-              },
-              {
-                "alignSelf": "center",
-              },
-            ],
-            {
-              "marginBottom": 22,
-              "marginLeft": 22,
-              "marginRight": 22,
-              "marginTop": 22,
-            },
-            undefined,
           ]
         }
       >
@@ -561,16 +545,15 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
       {
         "alignItems": "center",
         "alignSelf": "center",
-        "borderRadius": 34,
-        "height": undefined,
+        "flexBasis": "auto",
+        "flexGrow": 0,
+        "flexShrink": 1,
         "justifyContent": "center",
-        "marginBottom": 22,
-        "marginLeft": 22,
-        "marginRight": 22,
-        "marginTop": 0,
         "opacity": 1,
-        "paddingHorizontal": 0,
-        "paddingVertical": 0,
+        "paddingBottom": 22,
+        "paddingLeft": 22,
+        "paddingRight": 22,
+        "paddingTop": 0,
       }
     }
   >
@@ -598,47 +581,26 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
         [
           {
             "alignItems": "center",
+            "borderRadius": 34,
             "flexDirection": "row",
+            "flexGrow": 0,
+            "flexShrink": 1,
             "justifyContent": "center",
           },
           {
-            "alignSelf": "auto",
+            "alignSelf": "center",
+          },
+          {
+            "alignSelf": "center",
+          },
+          {
+            "height": undefined,
+            "padding": 0,
+          },
+          {},
+          {
             "opacity": 1,
           },
-          {
-            "height": 67,
-            "paddingHorizontal": 45,
-          },
-          {
-            "alignItems": "center",
-            "alignSelf": "stretch",
-            "borderRadius": 34,
-            "justifyContent": "center",
-          },
-          [
-            {
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "borderRadius": 34,
-              "justifyContent": "center",
-            },
-            {
-              "alignSelf": "center",
-            },
-            {
-              "alignSelf": "center",
-              "height": undefined,
-              "paddingHorizontal": 0,
-              "paddingVertical": 0,
-            },
-          ],
-          {
-            "marginBottom": 22,
-            "marginLeft": 22,
-            "marginRight": 22,
-            "marginTop": 0,
-          },
-          undefined,
         ]
       }
     >

--- a/src/__tests__/scenes/__snapshots__/FioAddressRegisterSelectWalletScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressRegisterSelectWalletScene.test.tsx.snap
@@ -65,7 +65,13 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
     </View>
     <MainButton
       label="FIO Names"
-      marginRem={2}
+      marginRem={
+        [
+          4,
+          0,
+          2,
+        ]
+      }
       onPress={[Function]}
     />
   </View>

--- a/src/__tests__/scenes/__snapshots__/FioAddressRegisteredScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressRegisteredScene.test.tsx.snap
@@ -65,7 +65,13 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
     </View>
     <MainButton
       label="FIO Names"
-      marginRem={2}
+      marginRem={
+        [
+          4,
+          0,
+          2,
+        ]
+      }
       onPress={[Function]}
     />
   </View>

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -470,8 +470,9 @@ exports[`SendScene2 1 spendTarget 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -997,8 +998,9 @@ exports[`SendScene2 1 spendTarget 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -1814,8 +1816,9 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -2341,8 +2344,9 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -3346,8 +3350,9 @@ exports[`SendScene2 2 spendTargets 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -4038,8 +4043,9 @@ exports[`SendScene2 2 spendTargets 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -4855,8 +4861,9 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -5248,8 +5255,9 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -6065,8 +6073,9 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -6434,8 +6443,9 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -7251,8 +7261,9 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -7459,8 +7470,9 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -8276,8 +8288,9 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -8789,8 +8802,9 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -9606,8 +9620,9 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -10054,8 +10069,9 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -10871,8 +10887,9 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -11278,8 +11295,9 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,
@@ -12095,8 +12113,9 @@ exports[`SendScene2 Render SendScene 1`] = `
               style={
                 [
                   {
-                    "flex": 1,
                     "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                   {
                     "marginVertical": 0,

--- a/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
@@ -239,8 +239,9 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
         style={
           [
             {
-              "flex": 1,
               "flexDirection": "column",
+              "flexGrow": 1,
+              "flexShrink": 1,
             },
             {
               "marginBottom": 11,
@@ -356,8 +357,9 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -1204,8 +1206,9 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -3328,9 +3331,13 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
             {
               "alignItems": "center",
               "alignSelf": "stretch",
-              "borderRadius": 34,
+              "flexBasis": "auto",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
+              "margin": -11,
               "opacity": 1,
+              "padding": 11,
             }
           }
         >
@@ -3358,36 +3365,23 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               [
                 {
                   "alignItems": "center",
+                  "borderRadius": 34,
                   "flexDirection": "row",
+                  "flexGrow": 0,
+                  "flexShrink": 1,
                   "justifyContent": "center",
                 },
                 {
-                  "alignSelf": "auto",
-                  "opacity": 1,
+                  "alignSelf": "stretch",
                 },
                 {
                   "height": 67,
-                  "paddingHorizontal": 45,
+                  "paddingHorizontal": 34,
                 },
+                {},
                 {
-                  "alignItems": "center",
-                  "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "justifyContent": "center",
+                  "opacity": 1,
                 },
-                [
-                  {
-                    "alignItems": "center",
-                    "alignSelf": "stretch",
-                    "borderRadius": 34,
-                    "justifyContent": "center",
-                  },
-                  {
-                    "alignSelf": "stretch",
-                  },
-                ],
-                undefined,
-                undefined,
               ]
             }
           >
@@ -3468,9 +3462,13 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
             {
               "alignItems": "center",
               "alignSelf": "stretch",
-              "borderRadius": 34,
+              "flexBasis": "auto",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
+              "margin": -11,
               "opacity": 1,
+              "padding": 11,
             }
           }
         >
@@ -3498,36 +3496,23 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               [
                 {
                   "alignItems": "center",
+                  "borderRadius": 34,
                   "flexDirection": "row",
+                  "flexGrow": 0,
+                  "flexShrink": 1,
                   "justifyContent": "center",
                 },
                 {
-                  "alignSelf": "auto",
-                  "opacity": 1,
+                  "alignSelf": "stretch",
                 },
                 {
                   "height": 67,
-                  "paddingHorizontal": 45,
+                  "paddingHorizontal": 34,
                 },
+                {},
                 {
-                  "alignItems": "center",
-                  "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "justifyContent": "center",
+                  "opacity": 1,
                 },
-                [
-                  {
-                    "alignItems": "center",
-                    "alignSelf": "stretch",
-                    "borderRadius": 34,
-                    "justifyContent": "center",
-                  },
-                  {
-                    "alignSelf": "stretch",
-                  },
-                ],
-                undefined,
-                undefined,
               ]
             }
           >
@@ -3804,8 +3789,9 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
         style={
           [
             {
-              "flex": 1,
               "flexDirection": "column",
+              "flexGrow": 1,
+              "flexShrink": 1,
             },
             {
               "marginBottom": 11,
@@ -3921,8 +3907,9 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -4769,8 +4756,9 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -6893,9 +6881,13 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
             {
               "alignItems": "center",
               "alignSelf": "stretch",
-              "borderRadius": 34,
+              "flexBasis": "auto",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
+              "margin": -11,
               "opacity": 1,
+              "padding": 11,
             }
           }
         >
@@ -6923,36 +6915,23 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               [
                 {
                   "alignItems": "center",
+                  "borderRadius": 34,
                   "flexDirection": "row",
+                  "flexGrow": 0,
+                  "flexShrink": 1,
                   "justifyContent": "center",
                 },
                 {
-                  "alignSelf": "auto",
-                  "opacity": 1,
+                  "alignSelf": "stretch",
                 },
                 {
                   "height": 67,
-                  "paddingHorizontal": 45,
+                  "paddingHorizontal": 34,
                 },
+                {},
                 {
-                  "alignItems": "center",
-                  "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "justifyContent": "center",
+                  "opacity": 1,
                 },
-                [
-                  {
-                    "alignItems": "center",
-                    "alignSelf": "stretch",
-                    "borderRadius": 34,
-                    "justifyContent": "center",
-                  },
-                  {
-                    "alignSelf": "stretch",
-                  },
-                ],
-                undefined,
-                undefined,
               ]
             }
           >
@@ -7033,9 +7012,13 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
             {
               "alignItems": "center",
               "alignSelf": "stretch",
-              "borderRadius": 34,
+              "flexBasis": "auto",
+              "flexGrow": 0,
+              "flexShrink": 1,
               "justifyContent": "center",
+              "margin": -11,
               "opacity": 1,
+              "padding": 11,
             }
           }
         >
@@ -7063,36 +7046,23 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               [
                 {
                   "alignItems": "center",
+                  "borderRadius": 34,
                   "flexDirection": "row",
+                  "flexGrow": 0,
+                  "flexShrink": 1,
                   "justifyContent": "center",
                 },
                 {
-                  "alignSelf": "auto",
-                  "opacity": 1,
+                  "alignSelf": "stretch",
                 },
                 {
                   "height": 67,
-                  "paddingHorizontal": 45,
+                  "paddingHorizontal": 34,
                 },
+                {},
                 {
-                  "alignItems": "center",
-                  "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "justifyContent": "center",
+                  "opacity": 1,
                 },
-                [
-                  {
-                    "alignItems": "center",
-                    "alignSelf": "stretch",
-                    "borderRadius": 34,
-                    "justifyContent": "center",
-                  },
-                  {
-                    "alignSelf": "stretch",
-                  },
-                ],
-                undefined,
-                undefined,
               ]
             }
           >

--- a/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
@@ -3378,7 +3378,6 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
                   "height": 67,
                   "paddingHorizontal": 34,
                 },
-                {},
                 {
                   "opacity": 1,
                 },
@@ -3509,7 +3508,6 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
                   "height": 67,
                   "paddingHorizontal": 34,
                 },
-                {},
                 {
                   "opacity": 1,
                 },
@@ -6928,7 +6926,6 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
                   "height": 67,
                   "paddingHorizontal": 34,
                 },
-                {},
                 {
                   "opacity": 1,
                 },
@@ -7059,7 +7056,6 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
                   "height": 67,
                   "paddingHorizontal": 34,
                 },
-                {},
                 {
                   "opacity": 1,
                 },

--- a/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
@@ -1793,7 +1793,6 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "height": 67,
                     "paddingHorizontal": 34,
                   },
-                  {},
                   {
                     "opacity": 1,
                   },
@@ -3656,7 +3655,6 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "height": 67,
                     "paddingHorizontal": 34,
                   },
-                  {},
                   {
                     "opacity": 1,
                   },

--- a/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
@@ -452,8 +452,9 @@ exports[`TransactionDetailsScene should render 1`] = `
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -1070,8 +1071,9 @@ exports[`TransactionDetailsScene should render 1`] = `
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -1439,8 +1441,9 @@ exports[`TransactionDetailsScene should render 1`] = `
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -1701,7 +1704,8 @@ exports[`TransactionDetailsScene should render 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "margin": 11,
               "marginBottom": 67,
@@ -1742,9 +1746,13 @@ exports[`TransactionDetailsScene should render 1`] = `
               {
                 "alignItems": "center",
                 "alignSelf": "center",
-                "borderRadius": 34,
+                "flexBasis": "auto",
+                "flexGrow": 0,
+                "flexShrink": 1,
                 "justifyContent": "center",
+                "margin": -11,
                 "opacity": 1,
+                "padding": 11,
               }
             }
           >
@@ -1772,36 +1780,23 @@ exports[`TransactionDetailsScene should render 1`] = `
                 [
                   {
                     "alignItems": "center",
+                    "borderRadius": 34,
                     "flexDirection": "row",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
                     "justifyContent": "center",
                   },
                   {
-                    "alignSelf": "auto",
-                    "opacity": 1,
+                    "alignSelf": "center",
                   },
                   {
                     "height": 67,
-                    "paddingHorizontal": 45,
+                    "paddingHorizontal": 34,
                   },
+                  {},
                   {
-                    "alignItems": "center",
-                    "alignSelf": "stretch",
-                    "borderRadius": 34,
-                    "justifyContent": "center",
+                    "opacity": 1,
                   },
-                  [
-                    {
-                      "alignItems": "center",
-                      "alignSelf": "stretch",
-                      "borderRadius": 34,
-                      "justifyContent": "center",
-                    },
-                    {
-                      "alignSelf": "center",
-                    },
-                  ],
-                  undefined,
-                  undefined,
                 ]
               }
             >
@@ -2320,8 +2315,9 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -2938,8 +2934,9 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -3307,8 +3304,9 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
             style={
               [
                 {
-                  "flex": 1,
                   "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 {
                   "marginVertical": 0,
@@ -3569,7 +3567,8 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "margin": 11,
               "marginBottom": 67,
@@ -3610,9 +3609,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               {
                 "alignItems": "center",
                 "alignSelf": "center",
-                "borderRadius": 34,
+                "flexBasis": "auto",
+                "flexGrow": 0,
+                "flexShrink": 1,
                 "justifyContent": "center",
+                "margin": -11,
                 "opacity": 1,
+                "padding": 11,
               }
             }
           >
@@ -3640,36 +3643,23 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 [
                   {
                     "alignItems": "center",
+                    "borderRadius": 34,
                     "flexDirection": "row",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
                     "justifyContent": "center",
                   },
                   {
-                    "alignSelf": "auto",
-                    "opacity": 1,
+                    "alignSelf": "center",
                   },
                   {
                     "height": 67,
-                    "paddingHorizontal": 45,
+                    "paddingHorizontal": 34,
                   },
+                  {},
                   {
-                    "alignItems": "center",
-                    "alignSelf": "stretch",
-                    "borderRadius": 34,
-                    "justifyContent": "center",
+                    "opacity": 1,
                   },
-                  [
-                    {
-                      "alignItems": "center",
-                      "alignSelf": "stretch",
-                      "borderRadius": 34,
-                      "justifyContent": "center",
-                    },
-                    {
-                      "alignSelf": "center",
-                    },
-                  ],
-                  undefined,
-                  undefined,
                 ]
               }
             >

--- a/src/components/modals/ButtonsModal.tsx
+++ b/src/components/modals/ButtonsModal.tsx
@@ -109,7 +109,7 @@ export function ButtonsModal<Buttons extends { [key: string]: ButtonInfo }>(prop
               )
             }
 
-            return <MainButton key={key} label={label} marginRem={0.25} type={type} onPress={handlePress} layout="column" />
+            return <MainButton key={key} label={label} marginRem={0.5} type={type} onPress={handlePress} layout="column" />
           })}
         </View>
       </View>

--- a/src/components/modals/ConfirmContinueModal.tsx
+++ b/src/components/modals/ConfirmContinueModal.tsx
@@ -72,7 +72,7 @@ export function ConfirmContinueModal(props: Props) {
         </View>
       </TouchableWithoutFeedback>
       <Fade visible={isAgreed}>
-        <MainButton alignSelf="center" label={lstrings.confirm_finish} marginRem={0.5} type="primary" onPress={handleAgreed} />
+        <MainButton label={lstrings.confirm_finish} marginRem={0.5} type="primary" onPress={handleAgreed} />
       </Fade>
     </ModalUi4>
   )

--- a/src/components/modals/ConfirmContinueModal.tsx
+++ b/src/components/modals/ConfirmContinueModal.tsx
@@ -72,7 +72,7 @@ export function ConfirmContinueModal(props: Props) {
         </View>
       </TouchableWithoutFeedback>
       <Fade visible={isAgreed}>
-        <MainButton label={lstrings.confirm_finish} marginRem={0.5} type="primary" onPress={handleAgreed} />
+        <MainButton label={lstrings.confirm_finish} marginRem={1} type="primary" onPress={handleAgreed} />
       </Fade>
     </ModalUi4>
   )

--- a/src/components/modals/FioExpiredModal.tsx
+++ b/src/components/modals/FioExpiredModal.tsx
@@ -14,7 +14,7 @@ export function FioExpiredModal(props: { bridge: AirshipBridge<boolean>; fioName
     <ModalUi4 bridge={bridge} title={title} onCancel={() => bridge.resolve(false)}>
       <ModalMessage>{lstrings.fio_domain_details_expired_soon}</ModalMessage>
       <ModalMessage>{fioName}</ModalMessage>
-      <MainButton label={lstrings.title_fio_renew} marginRem={[1, 0.5, 0.5]} type="secondary" onPress={() => bridge.resolve(true)} />
+      <MainButton label={lstrings.title_fio_renew} marginRem={1} type="secondary" onPress={() => bridge.resolve(true)} />
     </ModalUi4>
   )
 }

--- a/src/components/modals/FioExpiredModal.tsx
+++ b/src/components/modals/FioExpiredModal.tsx
@@ -14,7 +14,7 @@ export function FioExpiredModal(props: { bridge: AirshipBridge<boolean>; fioName
     <ModalUi4 bridge={bridge} title={title} onCancel={() => bridge.resolve(false)}>
       <ModalMessage>{lstrings.fio_domain_details_expired_soon}</ModalMessage>
       <ModalMessage>{fioName}</ModalMessage>
-      <MainButton alignSelf="center" label={lstrings.title_fio_renew} marginRem={[1, 0.5, 0.5]} type="secondary" onPress={() => bridge.resolve(true)} />
+      <MainButton label={lstrings.title_fio_renew} marginRem={[1, 0.5, 0.5]} type="secondary" onPress={() => bridge.resolve(true)} />
     </ModalUi4>
   )
 }

--- a/src/components/modals/FlipInputModal2.tsx
+++ b/src/components/modals/FlipInputModal2.tsx
@@ -203,7 +203,7 @@ const FlipInputModal2Component = React.forwardRef<FlipInputModalRef, Props>((pro
           onNext={handleCloseModal}
         />
         {getSpecialCurrencyInfo(pluginId).noMaxSpend !== true && hideMaxButton !== true ? (
-          <MiniButton alignSelf="center" label={lstrings.string_max_cap} marginRem={[1.2, 0, 0]} onPress={handleSendMaxAmount} />
+          <MiniButton label={lstrings.string_max_cap} marginRem={[1.2, 0, 0]} onPress={handleSendMaxAmount} />
         ) : null}
       </CardUi4>
     )

--- a/src/components/modals/LogsModal.tsx
+++ b/src/components/modals/LogsModal.tsx
@@ -87,7 +87,7 @@ export const LogsModal = (props: Props) => {
       {isDangerous ? null : (
         <MainButton label={lstrings.settings_button_send_logs} marginRem={0.5} type="primary" onPress={handleSend} disabled={isDangerous} />
       )}
-      <MainButton label={lstrings.settings_button_export_logs} marginRem={0.5} type="secondary" onPress={handleShare} />
+      <MainButton label={lstrings.settings_button_export_logs} marginRem={[0.5, 0, 1]} type="secondary" onPress={handleShare} />
     </ModalUi4>
   )
 }

--- a/src/components/modals/PermissionsSettingModal.tsx
+++ b/src/components/modals/PermissionsSettingModal.tsx
@@ -47,7 +47,7 @@ export function PermissionsSettingModal(props: {
   return (
     <ModalUi4 bridge={bridge} onCancel={handleClose}>
       <ModalMessage>{message}</ModalMessage>
-      <MainButton label={lstrings.string_ok_cap} marginRem={0.5} type="primary" onPress={handlePress} />
+      <MainButton label={lstrings.string_ok_cap} marginRem={1} type="primary" onPress={handlePress} />
     </ModalUi4>
   )
 }

--- a/src/components/modals/RawTextModal.tsx
+++ b/src/components/modals/RawTextModal.tsx
@@ -32,7 +32,7 @@ export function RawTextModal(props: Props) {
       <ScrollView scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}>
         <ModalMessage>{body}</ModalMessage>
       </ScrollView>
-      {disableCopy ? null : <MainButton label={lstrings.fragment_request_copy_title} marginRem={0.5} onPress={handleCopy} type="secondary" />}
+      {disableCopy ? null : <MainButton label={lstrings.fragment_request_copy_title} marginRem={1} onPress={handleCopy} type="secondary" />}
     </ModalUi4>
   )
 }

--- a/src/components/modals/RawTextModal.tsx
+++ b/src/components/modals/RawTextModal.tsx
@@ -32,9 +32,7 @@ export function RawTextModal(props: Props) {
       <ScrollView scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}>
         <ModalMessage>{body}</ModalMessage>
       </ScrollView>
-      {disableCopy ? null : (
-        <MainButton alignSelf="center" label={lstrings.fragment_request_copy_title} marginRem={0.5} onPress={handleCopy} type="secondary" />
-      )}
+      {disableCopy ? null : <MainButton label={lstrings.fragment_request_copy_title} marginRem={0.5} onPress={handleCopy} type="secondary" />}
     </ModalUi4>
   )
 }

--- a/src/components/modals/ScanModal.tsx
+++ b/src/components/modals/ScanModal.tsx
@@ -191,7 +191,7 @@ export const ScanModal = (props: Props) => {
     return (
       <View style={styles.cameraPermissionContainer}>
         <ModalMessage>{lstrings.scan_camera_permission_denied}</ModalMessage>
-        <MainButton onPress={handleSettings} label={lstrings.open_settings} marginRem={0.5} />
+        <MainButton onPress={handleSettings} label={lstrings.open_settings} marginRem={1} />
       </View>
     )
   }

--- a/src/components/modals/SwapVerifyTermsModal.tsx
+++ b/src/components/modals/SwapVerifyTermsModal.tsx
@@ -70,8 +70,8 @@ function SwapVerifyTermsModal(props: Props) {
       onCancel={() => bridge.resolve(false)}
     >
       <ModalMessage>{lstrings.swap_terms_statement}</ModalMessage>
-      <MainButton label={lstrings.swap_terms_accept_button} marginRem={0.5} onPress={() => bridge.resolve(true)} />
-      <MainButton label={lstrings.swap_terms_reject_button} marginRem={0.5} type="secondary" onPress={() => bridge.resolve(false)} />
+      <MainButton label={lstrings.swap_terms_accept_button} marginRem={1} onPress={() => bridge.resolve(true)} />
+      <MainButton label={lstrings.swap_terms_reject_button} marginRem={1} type="secondary" onPress={() => bridge.resolve(false)} />
       <View style={styles.linkContainer}>
         {termsUri == null ? null : (
           <Text style={styles.linkText} onPress={async () => await Linking.openURL(termsUri)}>

--- a/src/components/modals/TextInputModal.tsx
+++ b/src/components/modals/TextInputModal.tsx
@@ -92,7 +92,7 @@ export function TextInputModal(props: Props) {
 
   const isAndroid = Platform.OS === 'android'
   // TODO: Address this in ButtonsViewUi4
-  const androidButtonMargin = isAndroid ? [0.5, 0.5, 2, 0.5] : 0.5
+  const androidButtonMargin = isAndroid ? [1, 1, 2, 1] : 1
 
   return (
     <ModalUi4 warning={warning} bridge={bridge} title={title} onCancel={() => bridge.resolve(undefined)}>

--- a/src/components/modals/UpdateModal.tsx
+++ b/src/components/modals/UpdateModal.tsx
@@ -43,7 +43,7 @@ export function UpdateModal(props: Props) {
     >
       <ModalMessage>{message}</ModalMessage>
       <MainButton label={lstrings.update_now} marginRem={0.5} type="primary" onPress={handleUpdate} />
-      <MainButton label={lstrings.update_later} marginRem={0.5} type="secondary" onPress={onSkip} />
+      <MainButton label={lstrings.update_later} marginRem={[0.5, 0, 1]} type="secondary" onPress={onSkip} />
     </ModalUi4>
   )
 }

--- a/src/components/scenes/ChangeMiningFeeScene.tsx
+++ b/src/components/scenes/ChangeMiningFeeScene.tsx
@@ -152,7 +152,7 @@ export class ChangeMiningFeeComponent extends React.PureComponent<Props & HookPr
           ) : null}
           {customFormat != null ? this.renderCustomFeeTextInput(customFormat) : null}
           {this.renderFeeWarning()}
-          <MainButton alignSelf="center" label={lstrings.string_done_cap} marginRem={2} type="secondary" onPress={this.onSubmit} />
+          <MainButton label={lstrings.string_done_cap} marginRem={2} type="secondary" onPress={this.onSubmit} />
         </ScrollView>
       </SceneWrapper>
     )

--- a/src/components/scenes/ChangeMiningFeeScene.tsx
+++ b/src/components/scenes/ChangeMiningFeeScene.tsx
@@ -152,7 +152,7 @@ export class ChangeMiningFeeComponent extends React.PureComponent<Props & HookPr
           ) : null}
           {customFormat != null ? this.renderCustomFeeTextInput(customFormat) : null}
           {this.renderFeeWarning()}
-          <MainButton label={lstrings.string_done_cap} marginRem={2} type="secondary" onPress={this.onSubmit} />
+          <MainButton label={lstrings.string_done_cap} marginRem={[4, 0, 2]} type="secondary" onPress={this.onSubmit} />
         </ScrollView>
       </SceneWrapper>
     )

--- a/src/components/scenes/ConfirmScene.tsx
+++ b/src/components/scenes/ConfirmScene.tsx
@@ -63,7 +63,7 @@ const ConfirmComponent = (props: Props) => {
         {renderInfoTiles()}
         <View style={styles.footer}>
           <SafeSlider disabled={false} onSlidingComplete={handleSliderComplete} />
-          <MainButton label={lstrings.string_cancel_cap} type="escape" marginRem={[1]} onPress={handleBackButton} />
+          <MainButton label={lstrings.string_cancel_cap} type="escape" marginRem={0.5} onPress={handleBackButton} />
         </View>
       </KeyboardAwareScrollView>
     </SceneWrapper>

--- a/src/components/scenes/ConfirmScene.tsx
+++ b/src/components/scenes/ConfirmScene.tsx
@@ -63,7 +63,7 @@ const ConfirmComponent = (props: Props) => {
         {renderInfoTiles()}
         <View style={styles.footer}>
           <SafeSlider disabled={false} onSlidingComplete={handleSliderComplete} />
-          <MainButton label={lstrings.string_cancel_cap} type="escape" marginRem={[1]} onPress={handleBackButton} alignSelf="center" />
+          <MainButton label={lstrings.string_cancel_cap} type="escape" marginRem={[1]} onPress={handleBackButton} />
         </View>
       </KeyboardAwareScrollView>
     </SceneWrapper>

--- a/src/components/scenes/CreateWalletAccountSetupScene.tsx
+++ b/src/components/scenes/CreateWalletAccountSetupScene.tsx
@@ -103,7 +103,6 @@ export const CreateWalletAccountSetupScene = withWallet((props: Props) => {
         onSubmitEditing={handleSubmit}
       />
       <MainButton
-        alignSelf="center"
         disabled={spinning || text.length !== 12}
         label={spinning ? undefined : lstrings.string_next_capitalized}
         marginRem={0.5}

--- a/src/components/scenes/CreateWalletAccountSetupScene.tsx
+++ b/src/components/scenes/CreateWalletAccountSetupScene.tsx
@@ -105,7 +105,7 @@ export const CreateWalletAccountSetupScene = withWallet((props: Props) => {
       <MainButton
         disabled={spinning || text.length !== 12}
         label={spinning ? undefined : lstrings.string_next_capitalized}
-        marginRem={0.5}
+        marginRem={1}
         spinner={spinning}
         type="primary"
         onPress={handleSubmit}

--- a/src/components/scenes/CreateWalletCompletionScene.tsx
+++ b/src/components/scenes/CreateWalletCompletionScene.tsx
@@ -156,7 +156,7 @@ const CreateWalletCompletionComponent = (props: Props) => {
           disabled={!done}
           label={!done ? undefined : lstrings.string_done_cap}
           type="secondary"
-          marginRem={[0, 0, 0.5]}
+          marginRem={[0, 0, 1]}
           onPress={() => navigation.navigate('walletsTab', { screen: 'walletList' })}
         />
       </View>

--- a/src/components/scenes/CreateWalletCompletionScene.tsx
+++ b/src/components/scenes/CreateWalletCompletionScene.tsx
@@ -158,7 +158,6 @@ const CreateWalletCompletionComponent = (props: Props) => {
           type="secondary"
           marginRem={[0, 0, 0.5]}
           onPress={() => navigation.navigate('walletsTab', { screen: 'walletList' })}
-          alignSelf="center"
         />
       </View>
     )

--- a/src/components/scenes/CreateWalletImportOptionsScene.tsx
+++ b/src/components/scenes/CreateWalletImportOptionsScene.tsx
@@ -224,7 +224,7 @@ const CreateWalletImportOptionsComponent = (props: Props) => {
           renderItem={renderOptions}
           scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
         />
-        <MainButton disabled={disableNextButton} label={lstrings.string_next_capitalized} type="secondary" marginRem={[1, 1]} onPress={handleNext} />
+        <MainButton disabled={disableNextButton} label={lstrings.string_next_capitalized} marginRem={[2, 0, 1]} onPress={handleNext} />
       </View>
     </SceneWrapper>
   )

--- a/src/components/scenes/CreateWalletImportOptionsScene.tsx
+++ b/src/components/scenes/CreateWalletImportOptionsScene.tsx
@@ -224,14 +224,7 @@ const CreateWalletImportOptionsComponent = (props: Props) => {
           renderItem={renderOptions}
           scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
         />
-        <MainButton
-          disabled={disableNextButton}
-          label={lstrings.string_next_capitalized}
-          type="secondary"
-          marginRem={[1, 1]}
-          onPress={handleNext}
-          alignSelf="center"
-        />
+        <MainButton disabled={disableNextButton} label={lstrings.string_next_capitalized} type="secondary" marginRem={[1, 1]} onPress={handleNext} />
       </View>
     </SceneWrapper>
   )

--- a/src/components/scenes/CreateWalletImportScene.tsx
+++ b/src/components/scenes/CreateWalletImportScene.tsx
@@ -165,7 +165,7 @@ const CreateWalletImportComponent = (props: Props) => {
           onSubmitEditing={handleNext}
           ref={textInputRef}
         />
-        <MainButton label={lstrings.string_next_capitalized} type="secondary" marginRem={[0.5, 0.5]} onPress={handleNext} alignSelf="center" />
+        <MainButton label={lstrings.string_next_capitalized} type="secondary" marginRem={[0.5, 0.5]} onPress={handleNext} />
       </KeyboardAwareScrollView>
     </SceneWrapper>
   )

--- a/src/components/scenes/CreateWalletImportScene.tsx
+++ b/src/components/scenes/CreateWalletImportScene.tsx
@@ -165,7 +165,7 @@ const CreateWalletImportComponent = (props: Props) => {
           onSubmitEditing={handleNext}
           ref={textInputRef}
         />
-        <MainButton label={lstrings.string_next_capitalized} type="secondary" marginRem={[0.5, 0.5]} onPress={handleNext} />
+        <MainButton label={lstrings.string_next_capitalized} type="secondary" marginRem={1} onPress={handleNext} />
       </KeyboardAwareScrollView>
     </SceneWrapper>
   )

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -243,7 +243,7 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
     () => (
       <Fade noFadeIn={defaultSelection.length > 0} visible={numSelected > 0} duration={300}>
         <View style={styles.bottomButton}>
-          <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, -0.5, 0.5]} onPress={handleNextPress} />
+          <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, 0, 1]} onPress={handleNextPress} />
         </View>
       </Fade>
     ),

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -243,7 +243,7 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
     () => (
       <Fade noFadeIn={defaultSelection.length > 0} visible={numSelected > 0} duration={300}>
         <View style={styles.bottomButton}>
-          <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, -0.5, 0.5]} onPress={handleNextPress} alignSelf="center" />
+          <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, -0.5, 0.5]} onPress={handleNextPress} />
         </View>
       </Fade>
     ),

--- a/src/components/scenes/CreateWalletSelectFiatScene.tsx
+++ b/src/components/scenes/CreateWalletSelectFiatScene.tsx
@@ -224,8 +224,8 @@ const CreateWalletSelectFiatComponent = (props: Props) => {
           renderItem={renderCurrencyRow}
           scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
         />
-        <MainButton label={lstrings.title_create_wallets} type="secondary" marginRem={[0.5, 0.5, 0]} onPress={handleCreate} />
-        <MainButton label={lstrings.create_wallet_imports_title} type="escape" marginRem={[0.5, 0.5, 1]} onPress={handleImport} />
+        <MainButton label={lstrings.title_create_wallets} type="secondary" marginRem={[1, 0, 0.5]} onPress={handleCreate} />
+        <MainButton label={lstrings.create_wallet_imports_title} type="escape" marginRem={[0.5, 0, 1]} onPress={handleImport} />
       </View>
     </SceneWrapper>
   )
@@ -234,6 +234,7 @@ const CreateWalletSelectFiatComponent = (props: Props) => {
 const getStyles = cacheStyles((theme: Theme) => ({
   content: {
     flex: 1,
+    margin: theme.rem(0.5),
     paddingTop: theme.rem(0.5)
   },
   cryptoTypeLogo: {

--- a/src/components/scenes/CreateWalletSelectFiatScene.tsx
+++ b/src/components/scenes/CreateWalletSelectFiatScene.tsx
@@ -224,8 +224,8 @@ const CreateWalletSelectFiatComponent = (props: Props) => {
           renderItem={renderCurrencyRow}
           scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
         />
-        <MainButton label={lstrings.title_create_wallets} type="secondary" marginRem={[0.5, 0.5, 0]} onPress={handleCreate} alignSelf="center" />
-        <MainButton label={lstrings.create_wallet_imports_title} type="escape" marginRem={[0.5, 0.5, 1]} onPress={handleImport} alignSelf="center" />
+        <MainButton label={lstrings.title_create_wallets} type="secondary" marginRem={[0.5, 0.5, 0]} onPress={handleCreate} />
+        <MainButton label={lstrings.create_wallet_imports_title} type="escape" marginRem={[0.5, 0.5, 1]} onPress={handleImport} />
       </View>
     </SceneWrapper>
   )

--- a/src/components/scenes/CryptoExchangeScene.tsx
+++ b/src/components/scenes/CryptoExchangeScene.tsx
@@ -1,7 +1,7 @@
 import { div, gt, gte } from 'biggystring'
 import { EdgeAccount, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { Keyboard, View } from 'react-native'
+import { Keyboard } from 'react-native'
 import { sprintf } from 'sprintf-js'
 
 import { getQuoteForTransaction, selectWalletForExchange, SetNativeAmountInfo } from '../../actions/CryptoExchangeActions'
@@ -24,10 +24,10 @@ import { cacheStyles, Theme, ThemeProps, useTheme } from '../services/ThemeConte
 import { CryptoExchangeFlipInputWrapper } from '../themed/CryptoExchangeFlipInputWrapperComponent'
 import { ExchangedFlipInputAmounts } from '../themed/ExchangedFlipInput2'
 import { LineTextDivider } from '../themed/LineTextDivider'
-import { MainButton } from '../themed/MainButton'
 import { MiniButton } from '../themed/MiniButton'
 import { SceneHeader } from '../themed/SceneHeader'
 import { AlertCardUi4 } from '../ui4/AlertCardUi4'
+import { ButtonsViewUi4 } from '../ui4/ButtonsViewUi4'
 
 interface OwnProps extends EdgeSceneProps<'exchange'> {}
 
@@ -236,7 +236,7 @@ export class CryptoExchangeComponent extends React.Component<Props, State> {
     const showNext = this.props.fromCurrencyCode !== '' && this.props.toCurrencyCode !== '' && !!parseFloat(primaryNativeAmount)
     if (!showNext) return null
     if (this.checkExceedsAmount()) return null
-    return <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0.5, 0, 1]} paddingRem={[0.5, 2.3]} onPress={this.handleNext} />
+    return <ButtonsViewUi4 primary={{ label: lstrings.string_next_capitalized, onPress: this.handleNext }} sceneMargin />
   }
 
   renderAlert = () => {
@@ -293,7 +293,7 @@ export class CryptoExchangeComponent extends React.Component<Props, State> {
     const toHeaderText = sprintf(lstrings.exchange_to_wallet, toWalletName)
 
     return (
-      <View style={styles.sceneContainer}>
+      <>
         <EdgeAnim style={styles.header} enter={fadeInUp90}>
           <SceneHeader title={lstrings.title_exchange} underline />
         </EdgeAnim>
@@ -332,16 +332,12 @@ export class CryptoExchangeComponent extends React.Component<Props, State> {
         </EdgeAnim>
         <EdgeAnim enter={fadeInDown60}>{this.renderAlert()}</EdgeAnim>
         <EdgeAnim enter={fadeInDown90}>{this.renderButton()}</EdgeAnim>
-      </View>
+      </>
     )
   }
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
-  sceneContainer: {
-    marginHorizontal: theme.rem(0.5),
-    flex: 1
-  },
   mainScrollView: {
     flex: 1
   },
@@ -431,7 +427,7 @@ export const CryptoExchangeScene = (props: OwnProps) => {
   })
 
   return (
-    <SceneWrapper hasTabs hasNotifications scroll>
+    <SceneWrapper hasTabs hasNotifications scroll padding={theme.rem(0.5)}>
       <CryptoExchangeComponent
         route={route}
         onSelectWallet={handleSelectWallet}

--- a/src/components/scenes/CryptoExchangeScene.tsx
+++ b/src/components/scenes/CryptoExchangeScene.tsx
@@ -310,7 +310,7 @@ export class CryptoExchangeComponent extends React.Component<Props, State> {
             focusMe={this.focusFromWallet}
             onNext={this.handleNext}
           >
-            {this.props.hasMaxSpend ? <MiniButton alignSelf="center" label={lstrings.string_max_cap} marginRem={[0.5, 0, 1]} onPress={this.handleMax} /> : null}
+            {this.props.hasMaxSpend ? <MiniButton label={lstrings.string_max_cap} marginRem={[0.5, 0, 1]} onPress={this.handleMax} /> : null}
           </CryptoExchangeFlipInputWrapper>
         </EdgeAnim>
         <EdgeAnim>

--- a/src/components/scenes/DevTestScene.tsx
+++ b/src/components/scenes/DevTestScene.tsx
@@ -288,6 +288,7 @@ export function DevTestScene(props: Props) {
             <Fontello name="help_headset" color={theme.iconTappable} size={theme.rem(1.5)} />
           </ButtonUi4>
           <ButtonUi4 onPress={() => {}} label="Mini" marginRem={0.5} type="secondary" mini />
+          <EdgeText style={{ marginVertical: theme.rem(0.5) }}>ButtonsViews</EdgeText>
           <OutlinedView>
             <ButtonsViewUi4
               primary={{ label: 'Primary', onPress: () => {} }}
@@ -310,6 +311,17 @@ export function DevTestScene(props: Props) {
           <OutlinedView>
             <ButtonsViewUi4 secondary={{ label: 'Secondary', onPress: () => {} }} secondary2={{ label: 'Secondary', onPress: () => {} }} layout="row" />
           </OutlinedView>
+
+          <EdgeText style={{ marginVertical: theme.rem(0.5) }}>Loose Buttons (0.5rem margin)</EdgeText>
+          <OutlinedView>
+            <ButtonUi4 marginRem={0.5} onPress={() => {}} label="Mini" type="secondary" mini />
+            <ButtonUi4 marginRem={0.5} onPress={() => {}} label="Mini" type="secondary" mini />
+          </OutlinedView>
+          <OutlinedView>
+            <ButtonUi4 marginRem={0.5} onPress={() => {}} label="Primary" type="primary" />
+            <ButtonUi4 marginRem={0.5} onPress={() => {}} label="Secondary" type="secondary" />
+            <ButtonUi4 marginRem={0.5} onPress={() => {}} label="Tertiary" type="tertiary" />
+          </OutlinedView>
         </>
       </SectionView>
     </SceneWrapper>
@@ -318,5 +330,7 @@ export function DevTestScene(props: Props) {
 
 const OutlinedView = styled(View)({
   borderWidth: 1,
-  borderColor: 'white'
+  borderColor: 'white',
+  alignItems: 'center',
+  justifyContent: 'center'
 })

--- a/src/components/scenes/Fio/FioAddressRegisteredScene.tsx
+++ b/src/components/scenes/Fio/FioAddressRegisteredScene.tsx
@@ -46,7 +46,7 @@ export class FioAddressRegistered extends React.Component<Props> {
             <Text style={styles.title}>{fioName}</Text>
             {this.renderExpDate()}
           </View>
-          <MainButton marginRem={2} onPress={() => navigation.navigate('fioAddressList', {})} label={lstrings.title_fio_names} />
+          <MainButton marginRem={[4, 0, 2]} onPress={() => navigation.navigate('fioAddressList', {})} label={lstrings.title_fio_names} />
         </View>
       </SceneWrapper>
     )

--- a/src/components/scenes/Fio/FioDomainRegisterScene.tsx
+++ b/src/components/scenes/Fio/FioDomainRegisterScene.tsx
@@ -199,7 +199,7 @@ export class FioDomainRegister extends React.PureComponent<Props, LocalState> {
       return (
         <EdgeAnim enter={fadeIn} exit={fadeOut}>
           <MainButton
-            marginRem={1}
+            marginRem={[2, 0, 2]}
             label={walletLoading ? '' : lstrings.string_next_capitalized}
             disabled={!isAvailable || walletLoading}
             spinner={walletLoading}

--- a/src/components/scenes/Fio/FioDomainRegisterSelectWalletScene.tsx
+++ b/src/components/scenes/Fio/FioDomainRegisterSelectWalletScene.tsx
@@ -236,7 +236,7 @@ class FioDomainRegisterSelectWallet extends React.PureComponent<Props, LocalStat
             />
           </CardUi4>
           {!loading && paymentWallet && paymentWallet.id && (
-            <MainButton label={lstrings.string_next_capitalized} marginRem={1} onPress={this.onNextPress} type="primary" />
+            <MainButton label={lstrings.string_next_capitalized} marginRem={[2, 0, 2]} onPress={this.onNextPress} type="primary" />
           )}
           {errorMessage != null && <AlertCardUi4 title={lstrings.error_unexpected_title} body={errorMessage} type="error" />}
         </View>

--- a/src/components/scenes/Loans/LoanCreateScene.tsx
+++ b/src/components/scenes/Loans/LoanCreateScene.tsx
@@ -434,7 +434,6 @@ export const LoanCreateScene = (props: Props) => {
                     srcTokenId
                   })
                 }}
-                alignSelf="center"
               />
             </Space>
           )}

--- a/src/components/scenes/MigrateWalletCompletionScene.tsx
+++ b/src/components/scenes/MigrateWalletCompletionScene.tsx
@@ -238,7 +238,7 @@ const MigrateWalletCompletionComponent = (props: Props) => {
           disabled={!done}
           label={!done ? undefined : lstrings.string_done_cap}
           type="secondary"
-          marginRem={[0, 0, 0.5]}
+          marginRem={[0, 0, 1]}
           onPress={() => navigation.navigate('walletsTab', { screen: 'walletList' })}
         />
       </View>

--- a/src/components/scenes/MigrateWalletCompletionScene.tsx
+++ b/src/components/scenes/MigrateWalletCompletionScene.tsx
@@ -240,7 +240,6 @@ const MigrateWalletCompletionComponent = (props: Props) => {
           type="secondary"
           marginRem={[0, 0, 0.5]}
           onPress={() => navigation.navigate('walletsTab', { screen: 'walletList' })}
-          alignSelf="center"
         />
       </View>
     )

--- a/src/components/scenes/MigrateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/MigrateWalletSelectCryptoScene.tsx
@@ -132,7 +132,7 @@ const MigrateWalletSelectCryptoComponent = (props: Props) => {
     () => (
       <Fade noFadeIn={numSelected > 0} visible={numSelected > 0} duration={300}>
         <View style={styles.bottomButton}>
-          <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, -0.5, 0.5]} onPress={handleNext} />
+          <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, 0, 0.75]} onPress={handleNext} />
         </View>
       </Fade>
     ),

--- a/src/components/scenes/MigrateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/MigrateWalletSelectCryptoScene.tsx
@@ -132,7 +132,7 @@ const MigrateWalletSelectCryptoComponent = (props: Props) => {
     () => (
       <Fade noFadeIn={numSelected > 0} visible={numSelected > 0} duration={300}>
         <View style={styles.bottomButton}>
-          <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, -0.5, 0.5]} onPress={handleNext} alignSelf="center" />
+          <MainButton label={lstrings.string_next_capitalized} type="primary" marginRem={[0, -0.5, 0.5]} onPress={handleNext} />
         </View>
       </Fade>
     ),

--- a/src/components/scenes/OtpSettingsScene.tsx
+++ b/src/components/scenes/OtpSettingsScene.tsx
@@ -112,9 +112,9 @@ class OtpSettingsSceneComponent extends React.Component<Props, State> {
 
         {otpKey != null ? this.renderKey(otpKey) : null}
         {otpKey != null ? (
-          <MainButton label={lstrings.otp_disable} marginRem={0.5} type="secondary" onPress={this.handleDisable} />
+          <MainButton label={lstrings.otp_disable} marginRem={[1, 0, 0.5]} type="secondary" onPress={this.handleDisable} />
         ) : (
-          <MainButton label={lstrings.otp_enable} marginRem={0.5} type="secondary" onPress={this.handleEnable} />
+          <MainButton label={lstrings.otp_enable} marginRem={[0.5, 0, 1]} type="secondary" onPress={this.handleEnable} />
         )}
       </SceneWrapper>
     )

--- a/src/components/scenes/RequestScene.tsx
+++ b/src/components/scenes/RequestScene.tsx
@@ -279,7 +279,7 @@ export class RequestSceneComponent extends React.Component<Props & HookProps, St
       <SceneWrapper>
         <SceneHeader title={sprintf(lstrings.request_deprecated_header, this.props.wallet?.currencyInfo.displayName)} underline withTopMargin />
         <Text style={styles.keysOnlyModeText}>{sprintf(lstrings.request_deprecated_currency_code, this.props.primaryCurrencyInfo?.displayCurrencyCode)}</Text>
-        <MainButton onPress={this.handleKeysOnlyModePress} label={lstrings.help_support} marginRem={2} type="secondary">
+        <MainButton onPress={this.handleKeysOnlyModePress} label={lstrings.help_support} marginRem={[4, 0, 2]} type="secondary">
           <Fontello name="help_headset" color={this.props.theme.iconTappable} size={this.props.theme.rem(1.5)} />
         </MainButton>
       </SceneWrapper>

--- a/src/components/scenes/Staking/StakeOverviewScene.tsx
+++ b/src/components/scenes/Staking/StakeOverviewScene.tsx
@@ -174,21 +174,9 @@ const StakeOverviewSceneComponent = (props: Props) => {
         scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
       />
       <StyledButtonContainer layout="column">
-        <MainButton
-          label={lstrings.stake_stake_more_funds}
-          disabled={!canStake}
-          type="primary"
-          onPress={handleModifyPress('stake')}
-          marginRem={[0.5, 0.5, 0.25, 0.5]}
-        />
+        <MainButton label={lstrings.stake_stake_more_funds} disabled={!canStake} type="primary" onPress={handleModifyPress('stake')} marginRem={0.5} />
         {stakePolicy.hideClaimAction ? null : (
-          <MainButton
-            label={lstrings.stake_claim_rewards}
-            disabled={!canClaim}
-            type="secondary"
-            onPress={handleModifyPress('claim')}
-            marginRem={[0.25, 0.5, 0.25, 0.5]}
-          />
+          <MainButton label={lstrings.stake_claim_rewards} disabled={!canClaim} type="secondary" onPress={handleModifyPress('claim')} marginRem={0.5} />
         )}
         {stakePolicy.hideUnstakeAndClaimAction ? null : (
           <MainButton
@@ -196,17 +184,11 @@ const StakeOverviewSceneComponent = (props: Props) => {
             disabled={!canUnstakeAndClaim}
             type="escape"
             onPress={handleModifyPress('unstakeAndClaim')}
-            marginRem={[0.25, 0.5, 0.25, 0.5]}
+            marginRem={0.5}
           />
         )}
         {stakePolicy.hideUnstakeAction ? null : (
-          <MainButton
-            label={lstrings.stake_unstake}
-            disabled={!canUnstake}
-            type="escape"
-            onPress={handleModifyPress('unstake')}
-            marginRem={[0.25, 0.5, 0.25, 0.5]}
-          />
+          <MainButton label={lstrings.stake_unstake} disabled={!canUnstake} type="escape" onPress={handleModifyPress('unstake')} marginRem={0.5} />
         )}
       </StyledButtonContainer>
     </SceneWrapper>

--- a/src/components/scenes/TransactionsExportScene.tsx
+++ b/src/components/scenes/TransactionsExportScene.tsx
@@ -149,7 +149,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<Props, State>
         <SettingsLabelRow label={lstrings.string_end} right={endDateString} onPress={this.handleEndDate} />
         <SettingsHeaderRow icon={<EntypoIcon name="export" color={theme.icon} size={iconSize} />} label={lstrings.export_transaction_export_type} />
         {Platform.OS === 'android' ? this.renderAndroidSwitches() : this.renderIosSwitches()}
-        {disabledExport ? null : <MainButton label={lstrings.string_export} marginRem={1.5} onPress={this.handleSubmit} type="secondary" />}
+        {disabledExport ? null : <MainButton label={lstrings.string_export} marginRem={[3, 0, 1]} onPress={this.handleSubmit} type="secondary" />}
       </SceneWrapper>
     )
   }

--- a/src/components/scenes/WcConnectionsScene.tsx
+++ b/src/components/scenes/WcConnectionsScene.tsx
@@ -104,7 +104,6 @@ export const WcConnectionsScene = (props: Props) => {
           type="primary"
           marginRem={[1, 0.5]}
           onPress={async () => await handleNewConnectionPress()}
-          alignSelf="center"
           spinner={connecting}
         />
         <EdgeText style={styles.listTitle}>{lstrings.wc_walletconnect_active_connections}</EdgeText>

--- a/src/components/scenes/WcConnectionsScene.tsx
+++ b/src/components/scenes/WcConnectionsScene.tsx
@@ -102,7 +102,7 @@ export const WcConnectionsScene = (props: Props) => {
         <MainButton
           label={connecting ? undefined : lstrings.wc_walletconnect_new_connection_button}
           type="primary"
-          marginRem={[1, 0.5]}
+          marginRem={[2, 0]}
           onPress={async () => await handleNewConnectionPress()}
           spinner={connecting}
         />

--- a/src/components/scenes/WcDisconnectScene.tsx
+++ b/src/components/scenes/WcDisconnectScene.tsx
@@ -54,7 +54,7 @@ export const WcDisconnectScene = (props: Props) => {
       </View>
       <RowUi4 title={lstrings.string_expiration} body={wcConnectionInfo.expiration} />
       <RowUi4 title={lstrings.wc_details_connected_wallet} body={wcConnectionInfo.walletName} />
-      <MainButton label={lstrings.wc_details_disconnect_button} type="secondary" marginRem={[3.5, 0.5]} onPress={handleDisconnect} alignSelf="center" />
+      <MainButton label={lstrings.wc_details_disconnect_button} type="secondary" marginRem={[3.5, 0.5]} onPress={handleDisconnect} />
     </SceneWrapper>
   )
 }

--- a/src/components/scenes/WcDisconnectScene.tsx
+++ b/src/components/scenes/WcDisconnectScene.tsx
@@ -54,7 +54,7 @@ export const WcDisconnectScene = (props: Props) => {
       </View>
       <RowUi4 title={lstrings.string_expiration} body={wcConnectionInfo.expiration} />
       <RowUi4 title={lstrings.wc_details_connected_wallet} body={wcConnectionInfo.walletName} />
-      <MainButton label={lstrings.wc_details_disconnect_button} type="secondary" marginRem={[3.5, 0.5]} onPress={handleDisconnect} />
+      <MainButton label={lstrings.wc_details_disconnect_button} type="secondary" marginRem={[3.5, 0]} onPress={handleDisconnect} />
     </SceneWrapper>
   )
 }

--- a/src/components/themed/MainButton.tsx
+++ b/src/components/themed/MainButton.tsx
@@ -40,7 +40,7 @@ interface Props {
  * A stand-alone button to perform the primary action in a modal or scene.
  */
 export function MainButton(props: Props) {
-  const { children, disabled = false, label, marginRem = [0, 1, 0, 1], onPress, type = 'primary', paddingRem, layout, spinner = false } = props
+  const { children, disabled = false, label, marginRem, onPress, type = 'primary', paddingRem, layout, spinner = false } = props
 
   return (
     <ButtonUi4

--- a/src/components/themed/MainButton.tsx
+++ b/src/components/themed/MainButton.tsx
@@ -12,10 +12,6 @@ interface Props {
   // and show a spinner until the promise resolves.
   onPress?: () => void | Promise<void>
 
-  // Whether to center the button or stretch to fill the screen.
-  // Defaults to 'auto', letting the parent component be in charge:
-  alignSelf?: 'auto' | 'stretch' | 'center'
-
   // True to dim the button & prevent interactions:
   disabled?: boolean
 
@@ -44,22 +40,10 @@ interface Props {
  * A stand-alone button to perform the primary action in a modal or scene.
  */
 export function MainButton(props: Props) {
-  const {
-    alignSelf = 'auto',
-    children,
-    disabled = false,
-    label,
-    marginRem = [0, 1, 0, 1],
-    onPress,
-    type = 'primary',
-    paddingRem,
-    layout,
-    spinner = false
-  } = props
+  const { children, disabled = false, label, marginRem = [0, 1, 0, 1], onPress, type = 'primary', paddingRem, layout, spinner = false } = props
 
   return (
     <ButtonUi4
-      alignSelf={alignSelf}
       disabled={disabled}
       label={label}
       marginRem={marginRem}

--- a/src/components/ui4/ButtonUi4.tsx
+++ b/src/components/ui4/ButtonUi4.tsx
@@ -22,9 +22,7 @@ interface Props {
   // and show a spinner until the promise resolves.
   onPress?: () => void | Promise<void>
 
-  // Whether to center the button or stretch to fill the screen.
-  // Defaults to 'auto', letting the parent component be in charge:
-  alignSelf?: 'auto' | 'stretch' | 'center' // TODO: Maybe also remove this once column layout is restyled for UI4
+  alignSelf?: 'auto' | 'stretch' | 'center' // TODO: Remove
 
   // True to dim the button & prevent interactions:
   disabled?: boolean
@@ -59,20 +57,7 @@ interface Props {
  * - NOT meant to be used on its own outside of ButtonsViewUi4 unless layout='solo'
  */
 export function ButtonUi4(props: Props) {
-  const {
-    layout = 'solo',
-    alignSelf = 'auto',
-    children,
-    disabled = false,
-    label,
-    onPress,
-    type = 'primary',
-    spinner = false,
-    mini = false,
-    marginRem,
-    paddingRem,
-    testID
-  } = props
+  const { layout = 'solo', children, disabled = false, label, onPress, type = 'primary', spinner = false, mini = false, marginRem, paddingRem, testID } = props
 
   // `onPress` promise logic:
   const [pending, handlePress] = usePendingPress(onPress)
@@ -117,14 +102,6 @@ export function ButtonUi4(props: Props) {
   // manually enabled.
   const hideContent = pending || spinner
 
-  const dynamicGradientStyles = React.useMemo(
-    () => ({
-      alignSelf,
-      opacity: disabled ? 0.3 : hideContent ? 0.7 : 1
-    }),
-    [alignSelf, disabled, hideContent]
-  )
-
   const maybeText =
     label == null ? null : (
       <EdgeText numberOfLines={1} style={[textStyle, children == null ? null : styles.leftMarginedText]}>
@@ -132,32 +109,56 @@ export function ButtonUi4(props: Props) {
       </EdgeText>
     )
 
-  const containerStyle = React.useMemo(() => {
-    const retStyle: ViewStyle[] = [styles.containerCommon]
-    if (layout === 'column') retStyle.push(styles.containerColumn)
-    if (layout === 'row') retStyle.push(styles.containerRow)
-    if (layout === 'solo') retStyle.push(styles.containerSolo)
+  const touchContainerStyle = React.useMemo(() => {
+    const retStyle: ViewStyle[] = [styles.touchContainerCommon]
 
-    if (type === 'tertiary') retStyle.push(styles.containerTertiary)
+    if (layout === 'column') retStyle.push(styles.touchContainerColumn)
+    if (layout === 'row') retStyle.push(styles.touchContainerRow)
+    if (layout === 'solo') retStyle.push(styles.touchContainerSolo)
+
+    const customMargin = marginRem == null ? undefined : sidesToMargin(mapSides(fixSides(marginRem, 0), theme.rem))
+    retStyle.push(
+      customMargin != null
+        ? {
+            // Use margin as padding to increase tappable area
+            paddingLeft: customMargin.marginLeft,
+            paddingRight: customMargin.marginRight,
+            paddingTop: customMargin.marginTop,
+            paddingBottom: customMargin.marginBottom
+          }
+        : styles.touchContainerSpacing
+    )
+
     return retStyle
-  }, [layout, styles.containerColumn, styles.containerCommon, styles.containerRow, styles.containerSolo, styles.containerTertiary, type])
+  }, [layout, marginRem, styles, theme])
 
-  const customMargin = marginRem == null ? undefined : sidesToMargin(mapSides(fixSides(marginRem, 0), theme.rem))
-  const customPadding = paddingRem == null ? undefined : sidesToPadding(mapSides(fixSides(paddingRem, 0), theme.rem))
-  const finalContainerCommon = React.useMemo(
-    () => [styles.containerCommon, containerStyle, customMargin, customPadding],
-    [containerStyle, customMargin, customPadding, styles.containerCommon]
-  )
+  const visibleContainerStyle = React.useMemo(() => {
+    const retStyle: ViewStyle[] = [styles.visibleContainerCommon]
+
+    if (layout === 'column') retStyle.push(styles.visibleContainerColumn)
+    if (layout === 'row') retStyle.push(styles.visibleContainerRow)
+    if (layout === 'solo') retStyle.push(styles.visibleContainerSolo)
+    if (type === 'tertiary') retStyle.push(styles.visibleContainerTertiary)
+
+    retStyle.push(mini ? styles.visibleSizeMini : type === 'tertiary' ? styles.visibleSizeTertiary : styles.visibleSizeDefault)
+
+    if (paddingRem != null) {
+      retStyle.push(sidesToPadding(mapSides(fixSides(paddingRem, 0), theme.rem)))
+    }
+
+    retStyle.push({
+      opacity: disabled ? 0.3 : hideContent ? 0.7 : 1
+    })
+
+    return retStyle
+  }, [disabled, hideContent, layout, mini, paddingRem, styles, theme, type])
 
   return (
-    <TouchableOpacity disabled={disabled || pending || spinner} style={finalContainerCommon} onPress={handlePress} testID={testID}>
-      <LinearGradient
-        {...gradientProps}
-        style={[styles.contentCommon, dynamicGradientStyles, mini ? styles.contentSizeMini : styles.contentSizeDefault, ...finalContainerCommon]}
-      >
+    <TouchableOpacity disabled={disabled || pending || spinner} style={touchContainerStyle} onPress={handlePress} testID={testID}>
+      <LinearGradient {...gradientProps} style={visibleContainerStyle}>
         {hideContent ? null : children}
         {hideContent ? null : maybeText}
-        {!hideContent ? null : <ActivityIndicator color={spinnerColor} style={styles.spinnerCommon} />}
+        {!hideContent ? null : <ActivityIndicator color={spinnerColor} style={styles.spinner} />}
       </LinearGradient>
     </TouchableOpacity>
   )
@@ -165,48 +166,71 @@ export function ButtonUi4(props: Props) {
 
 const getStyles = cacheStyles((theme: Theme) => {
   return {
-    // Common styles:
-    spinnerCommon: {
-      height: theme.rem(2)
+    // Invisible Touchable Container Styles:
+    touchContainerCommon: {
+      alignItems: 'center',
+      justifyContent: 'center'
     },
-    containerCommon: {
-      borderRadius: theme.rem(theme.buttonBorderRadiusRem),
+    touchContainerSpacing: {
+      // Combination of negative margin and positive padding to increase
+      // invisible tappable area outside of the bounds of the visible button
+      margin: -theme.rem(0.5),
+      padding: theme.rem(0.5)
+    },
+    touchContainerRow: {
       alignSelf: 'stretch',
-      alignItems: 'center',
-      justifyContent: 'center'
+      flex: 1 // Size equally against other buttons in the row
     },
-    contentCommon: {
-      alignItems: 'center',
-      flexDirection: 'row',
-      justifyContent: 'center'
+    touchContainerColumn: {
+      alignSelf: 'stretch',
+      flexBasis: 'auto',
+      flexGrow: 0,
+      flexShrink: 1
     },
-
-    // Other styles:
-    contentSizeDefault: {
-      paddingHorizontal: theme.rem(2),
+    touchContainerSolo: {
+      alignSelf: 'center',
+      flexBasis: 'auto',
+      flexGrow: 0,
+      flexShrink: 1
+    },
+    // Visible Container Styles
+    visibleContainerCommon: {
+      borderRadius: theme.rem(theme.buttonBorderRadiusRem),
+      flexGrow: 0,
+      flexShrink: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'row'
+    },
+    visibleSizeDefault: {
+      paddingHorizontal: theme.rem(1.5),
       height: theme.rem(3)
     },
-    contentSizeMini: {
-      paddingHorizontal: theme.rem(1.5),
+    visibleSizeMini: {
+      alignSelf: 'center',
+      paddingHorizontal: theme.rem(1.25),
       height: theme.rem(2)
     },
-    containerColumn: {
-      alignSelf: 'stretch'
-    },
-    containerSolo: {
-      alignSelf: 'center'
-    },
-    containerRow: {
-      flex: 1 // Size equally with other buttons
-    },
-    containerTertiary: {
+    visibleSizeTertiary: {
       // Reduce the bounds of a tertiary button so it doesn't appear to be too
       // far from other buttons
-      alignSelf: 'center',
-      paddingHorizontal: 0,
-      paddingVertical: 0,
+      padding: 0,
       height: undefined
     },
+    visibleContainerColumn: {
+      alignSelf: 'stretch'
+    },
+    visibleContainerRow: {
+      alignSelf: 'stretch'
+    },
+    visibleContainerSolo: {
+      alignSelf: 'center'
+    },
+    visibleContainerTertiary: {
+      alignSelf: 'center'
+    },
+
+    // Content
     primaryText: {
       fontFamily: theme.primaryButtonFont,
       fontSize: theme.rem(theme.primaryButtonFontSizeRem),
@@ -224,6 +248,9 @@ const getStyles = cacheStyles((theme: Theme) => {
     },
     leftMarginedText: {
       marginLeft: theme.rem(0.5)
+    },
+    spinner: {
+      height: theme.rem(2)
     }
   }
 })

--- a/src/components/ui4/ButtonUi4.tsx
+++ b/src/components/ui4/ButtonUi4.tsx
@@ -22,8 +22,6 @@ interface Props {
   // and show a spinner until the promise resolves.
   onPress?: () => void | Promise<void>
 
-  alignSelf?: 'auto' | 'stretch' | 'center' // TODO: Remove
-
   // True to dim the button & prevent interactions:
   disabled?: boolean
 

--- a/src/components/ui4/ButtonUi4.tsx
+++ b/src/components/ui4/ButtonUi4.tsx
@@ -197,7 +197,7 @@ const getStyles = cacheStyles((theme: Theme) => {
       alignSelf: 'center'
     },
     containerRow: {
-      flex: 1
+      flex: 1 // Size equally with other buttons
     },
     containerTertiary: {
       // Reduce the bounds of a tertiary button so it doesn't appear to be too

--- a/src/components/ui4/ButtonsViewUi4.tsx
+++ b/src/components/ui4/ButtonsViewUi4.tsx
@@ -131,14 +131,16 @@ export const StyledButtonContainer = styled(View)<{ absolute?: boolean; layout: 
           justifyContent: 'center',
           marginHorizontal: theme.rem(0.5),
           alignItems: 'center',
-          flex: 1
+          flexGrow: 1,
+          flexShrink: 1
         }
       : {}
 
   const rowStyle: ViewStyle =
     layout === 'row'
       ? {
-          flex: 1,
+          flexGrow: 1,
+          flexShrink: 1,
           flexDirection: 'row-reverse',
           justifyContent: 'center'
         }

--- a/src/components/ui4/CardUi4.tsx
+++ b/src/components/ui4/CardUi4.tsx
@@ -177,7 +177,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     pointerEvents: 'none'
   },
   iconRowContainer: {
-    flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
     flexDirection: 'row',
     alignItems: 'center'
   },

--- a/src/components/ui4/CurrencyViewUi4.tsx
+++ b/src/components/ui4/CurrencyViewUi4.tsx
@@ -119,7 +119,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     alignItems: 'center',
     marginHorizontal: theme.rem(0.5),
     marginVertical: theme.rem(0.25),
-    flex: 1
+    flexGrow: 1,
+    flexShrink: 1
   },
   iconContainer: {
     marginRight: theme.rem(1)
@@ -127,7 +128,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
   innerContainer: {
     flexDirection: 'column',
     justifyContent: 'space-between',
-    flex: 1
+    flexGrow: 1,
+    flexShrink: 1
   },
   primaryText: {
     fontSize: theme.rem(0.75),

--- a/src/components/ui4/HomeCardUi4.tsx
+++ b/src/components/ui4/HomeCardUi4.tsx
@@ -46,7 +46,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
     ...theme.cardTextShadow
   },
   verticalSplitContainer: {
-    flex: 1, // Make sure the card fills the space
+    flex: 1, // Make sure the card fills the space evenly compared to the other HomeCards
     justifyContent: 'space-between', // Aligns title to the top, footer to the bottom
     margin: theme.rem(0.5)
   }

--- a/src/components/ui4/MarketsCardUi4.tsx
+++ b/src/components/ui4/MarketsCardUi4.tsx
@@ -167,7 +167,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
     marginHorizontal: theme.rem(0.5)
   },
   rowRight: {

--- a/src/components/ui4/SectionHeaderUi4.tsx
+++ b/src/components/ui4/SectionHeaderUi4.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 /**
  * A view representing rows of data split on the left and right edges of the
- * line. Neither side will exceed 50% of the width of the view.
+ * line.
  *
  * If the right side is a string and onRightPress handler is provided, it will
  * be rendered as green tappable text, else it's up to the caller to decide.
@@ -47,7 +47,8 @@ export const SectionHeaderUi4 = (props: Props) => {
 
 const getStyles = cacheStyles((theme: Theme) => ({
   rightTappableContainer: {
-    flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
     justifyContent: 'flex-end',
     // Increase tappable area with padding, while net 0 with negative margin to visually appear as if 0 margins/padding
     padding: theme.rem(0.75),

--- a/src/components/ui4/SectionView.tsx
+++ b/src/components/ui4/SectionView.tsx
@@ -72,7 +72,8 @@ export const SectionView = (props: Props): JSX.Element | null => {
 const getStyles = cacheStyles((theme: Theme) => ({
   container: {
     flexDirection: 'column',
-    flex: 1
+    flexGrow: 1,
+    flexShrink: 1
   },
   marginCard: {
     marginVertical: theme.rem(0)

--- a/src/plugins/gui/scenes/AddressFormScene.tsx
+++ b/src/plugins/gui/scenes/AddressFormScene.tsx
@@ -323,13 +323,7 @@ export const AddressFormScene = React.memo((props: Props) => {
                 onChangeText={handleChangePostalCode}
                 onBlur={handleHideAddressHints}
               />
-              <MainButton
-                label={lstrings.string_next_capitalized}
-                marginRem={[1, 0.5, 1, 0.5]}
-                type="secondary"
-                disabled={disableNextButton}
-                onPress={handleSubmit}
-              />
+              <MainButton label={lstrings.string_next_capitalized} marginRem={[2, 0, 1]} disabled={disableNextButton} onPress={handleSubmit} />
             </KeyboardAwareScrollView>
           </View>
         </>

--- a/src/plugins/gui/scenes/FiatPluginEnterAmountScene.tsx
+++ b/src/plugins/gui/scenes/FiatPluginEnterAmountScene.tsx
@@ -248,7 +248,7 @@ export const FiatPluginEnterAmountScene = React.memo((props: Props) => {
               <PoweredByCard iconUri={poweredByIconPath} poweredByText={poweredBy?.poweredByText ?? ''} onPress={handlePoweredByPress} />
             </EdgeAnim>
             <EdgeAnim enter={fadeInDown90}>
-              <MainButton disabled={spinner1 || spinner2} label={lstrings.string_next_capitalized} marginRem={[0.25, 0]} onPress={handleSubmit} />
+              <MainButton disabled={spinner1 || spinner2} label={lstrings.string_next_capitalized} marginRem={[0.5, 0]} onPress={handleSubmit} />
             </EdgeAnim>
           </>
         </View>

--- a/src/plugins/gui/scenes/InfoDisplayScene.tsx
+++ b/src/plugins/gui/scenes/InfoDisplayScene.tsx
@@ -128,7 +128,7 @@ export const InfoDisplayScene = React.memo((props: Props) => {
         <EdgeText numberOfLines={12}>{promptMessage}</EdgeText>
       </View>
       {renderGroups()}
-      <MainButton label={lstrings.string_done_cap} marginRem={[2, 1, 1.5, 1]} type="secondary" onPress={handleDone} />
+      <MainButton label={lstrings.string_done_cap} marginRem={[4, 0, 1]} type="secondary" onPress={handleDone} />
     </SceneWrapper>
   )
 })


### PR DESCRIPTION
- Remove 'flex: 1' where appropriate.
- Restyle ButtonUi4 and fix doubled custom margins.
- Increase ButtonUi4 tappable areas.
- MainButton: No callers directly called ButtonUi4 with custom margins.
  - Built-in horizontal margins removed. Remnant from when we had full width buttons.
  - Mostly doubled callers' custom margins to account for fix.
  - Removed custom horizontal margins and capped bottom margins for some users.

Red background fill shows increased tappable areas
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/3b515e7f-1db5-4376-a9d4-034b7eabdbfe)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206471966737297
  - https://app.asana.com/0/0/1206501486890527