### PR TITLE
Fix TransactionListRow Styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed: Show a useful, localized error message when device doesn't have an email account
 - fixed: Make FilledTextInputs take up constant vertical space
 - fixed: Send Recipient Address Modal styling when saved recipients are shown
+- fixed: Minor Transaction List spacing adjustments
 - removed: swipeLastUsp experiment (always allow swipes on the last USP)
 
 ## 4.0.2 (2024-02-13)

--- a/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
@@ -159,6 +159,7 @@ exports[`TransactionListRow should render with loading props 1`] = `
       <View
         style={
           {
+            "alignItems": "center",
             "flexDirection": "row",
             "justifyContent": "space-between",
             "marginHorizontal": 11,
@@ -217,6 +218,7 @@ exports[`TransactionListRow should render with loading props 1`] = `
       <View
         style={
           {
+            "alignItems": "center",
             "flexDirection": "row",
             "justifyContent": "space-between",
             "marginHorizontal": 11,
@@ -240,6 +242,7 @@ exports[`TransactionListRow should render with loading props 1`] = `
                 "color": "#F1AA19",
                 "flexShrink": 1,
                 "fontSize": 17,
+                "marginRight": 22,
               },
               null,
             ]

--- a/src/components/themed/TransactionListRow.tsx
+++ b/src/components/themed/TransactionListRow.tsx
@@ -276,6 +276,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   },
   row: {
     flexDirection: 'row',
+    alignItems: 'center',
     justifyContent: 'space-between',
     marginHorizontal: theme.rem(0.5)
   },
@@ -303,6 +304,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   unconfirmedText: {
     flexShrink: 1,
     fontSize: theme.rem(0.75),
-    color: theme.warningText
+    color: theme.warningText,
+    marginRight: theme.rem(1)
   }
 }))


### PR DESCRIPTION
<img width="500" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/8a6350b0-260f-44e5-ba95-a997f308f803">

Fix the 2nd line of text in tx list card rows:
- Center align text
- Add a right margin

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206512051627949