### PR TITLE
Fix Exchange Scene "max" button width

### DIFF
--- a/src/__tests__/scenes/__snapshots__/CryptoExchangeScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CryptoExchangeScene.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`CryptoExchangeComponent should render with loading props 1`] = `
       walletId=""
     >
       <MiniButton
+        alignSelf="center"
         label="MAX"
         marginRem={
           [

--- a/src/components/scenes/CryptoExchangeScene.tsx
+++ b/src/components/scenes/CryptoExchangeScene.tsx
@@ -310,7 +310,7 @@ export class CryptoExchangeComponent extends React.Component<Props, State> {
             focusMe={this.focusFromWallet}
             onNext={this.handleNext}
           >
-            {this.props.hasMaxSpend ? <MiniButton label={lstrings.string_max_cap} marginRem={[0.5, 0, 1]} onPress={this.handleMax} /> : null}
+            {this.props.hasMaxSpend ? <MiniButton label={lstrings.string_max_cap} marginRem={[0.5, 0, 1]} onPress={this.handleMax} alignSelf="center" /> : null}
           </CryptoExchangeFlipInputWrapper>
         </EdgeAnim>
         <EdgeAnim>


### PR DESCRIPTION
<img width="416" alt="Screenshot 2024-02-20 at 4 04 04 PM" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/be306aed-a4e4-4b84-bbbf-d69c731e8f43">

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206638192938067