### PR TITLE
Fix MiniButton alignSelf on FlipInputModal2

### DIFF
--- a/src/__tests__/scenes/__snapshots__/CryptoExchangeScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CryptoExchangeScene.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`CryptoExchangeComponent should render with loading props 1`] = `
           [
             0.5,
             0,
-            1,
+            0.75,
           ]
         }
         onPress={[Function]}

--- a/src/components/modals/FlipInputModal2.tsx
+++ b/src/components/modals/FlipInputModal2.tsx
@@ -200,7 +200,7 @@ const FlipInputModal2Component = React.forwardRef<FlipInputModalRef, Props>((pro
           onNext={handleCloseModal}
         />
         {getSpecialCurrencyInfo(pluginId).noMaxSpend !== true && hideMaxButton !== true ? (
-          <MiniButton label={lstrings.string_max_cap} marginRem={[1.2, 0, 0]} onPress={handleSendMaxAmount} />
+          <MiniButton label={lstrings.string_max_cap} marginRem={[1, 0, 1]} alignSelf="center" onPress={handleSendMaxAmount} />
         ) : null}
       </CardUi4>
     )

--- a/src/components/scenes/CryptoExchangeScene.tsx
+++ b/src/components/scenes/CryptoExchangeScene.tsx
@@ -310,7 +310,9 @@ export class CryptoExchangeComponent extends React.Component<Props, State> {
             focusMe={this.focusFromWallet}
             onNext={this.handleNext}
           >
-            {this.props.hasMaxSpend ? <MiniButton label={lstrings.string_max_cap} marginRem={[0.5, 0, 1]} onPress={this.handleMax} alignSelf="center" /> : null}
+            {this.props.hasMaxSpend ? (
+              <MiniButton label={lstrings.string_max_cap} marginRem={[0.5, 0, 0.75]} onPress={this.handleMax} alignSelf="center" />
+            ) : null}
           </CryptoExchangeFlipInputWrapper>
         </EdgeAnim>
         <EdgeAnim>


### PR DESCRIPTION
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/c9ff8c4a-4bed-4fb7-99e5-f7a467c3bc3d)
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/b8d84d22-7294-4680-a73b-fa4e76574f52)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206656306638757