### PR TITLE
Jon/edge-wrapped-touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: Wrapped Touchable* components to consolidate tap debounce logic
 - changed: Remove extra spaces and normal capitalization of mnemonic seed input
 - changed: 2FA/otp modals moved behind a notification card instead of showing instantly on login
 - changed: Password reminder modal only shows after tapping new persistent notification

--- a/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`BalanceCard should render with loading props 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": undefined,
+        "disabled": false,
         "expanded": undefined,
         "selected": undefined,
       }

--- a/src/__tests__/components/__snapshots__/BuyCrypto.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/BuyCrypto.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`BuyCrypto should render with some props 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": undefined,
+        "disabled": false,
         "expanded": undefined,
         "selected": undefined,
       }

--- a/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`FilledTextInput should render with some props 1`] = `
     }
   }
 >
-  <TouchableWithoutFeedback
+  <ExtendedTouchable
     accessible={false}
     onPress={[Function]}
     testID="string"
@@ -170,7 +170,7 @@ exports[`FilledTextInput should render with some props 1`] = `
         </StyledComponent(View)>
       </StyledComponent(TouchableOpacity)>
     </StyledComponent(View)>
-  </TouchableWithoutFeedback>
+  </ExtendedTouchable>
   <StyledComponent(View)
     noLayoutFlow={false}
   >

--- a/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TransactionListRow should render with loading props 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }

--- a/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
@@ -610,7 +610,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": undefined,
+          "disabled": false,
           "expanded": undefined,
           "selected": undefined,
         }

--- a/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -284,7 +284,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -343,7 +343,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": undefined,
+          "disabled": false,
           "expanded": undefined,
           "selected": undefined,
         }
@@ -434,7 +434,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -497,7 +497,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -797,7 +797,7 @@ exports[`TransactionListTop should render 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -1028,7 +1028,7 @@ exports[`TransactionListTop should render 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -1087,7 +1087,7 @@ exports[`TransactionListTop should render 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": undefined,
+          "disabled": false,
           "expanded": undefined,
           "selected": undefined,
         }
@@ -1178,7 +1178,7 @@ exports[`TransactionListTop should render 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -1241,7 +1241,7 @@ exports[`TransactionListTop should render 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }

--- a/src/__tests__/components/__snapshots__/WalletListSortableRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/WalletListSortableRow.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -21,7 +21,7 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
   }
   accessible={true}
   collapsable={false}
-  focusable={false}
+  focusable={true}
   onClick={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
@@ -282,7 +282,7 @@ exports[`WalletListSortableRow should render with loading wallet 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -297,7 +297,7 @@ exports[`WalletListSortableRow should render with loading wallet 1`] = `
   }
   accessible={true}
   collapsable={false}
-  focusable={false}
+  focusable={true}
   onClick={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": undefined,
+        "disabled": false,
         "expanded": undefined,
         "selected": undefined,
       }
@@ -485,7 +485,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -1452,7 +1452,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": undefined,
+        "disabled": false,
         "expanded": undefined,
         "selected": undefined,
       }
@@ -1930,7 +1930,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -1591,7 +1591,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -868,6 +868,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             style={null}
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1007,6 +1012,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             style={null}
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1146,6 +1156,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             style={null}
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1285,6 +1300,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             style={null}
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2293,6 +2313,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             style={null}
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2403,6 +2428,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             style={null}
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2513,6 +2543,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             style={null}
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2623,6 +2658,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             style={null}
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,

--- a/src/__tests__/modals/__snapshots__/DateModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/DateModal.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`DateModalIos should render with loading props 1`] = `
   }
   onCancel={[Function]}
 >
-  <TouchableOpacity
+  <ExtendedTouchable
     onPress={[Function]}
   >
     <Text
@@ -31,7 +31,7 @@ exports[`DateModalIos should render with loading props 1`] = `
     >
       Done
     </Text>
-  </TouchableOpacity>
+  </ExtendedTouchable>
   <Picker
     display="spinner"
     mode="date"

--- a/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`HelpModal should render with loading props 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": undefined,
+        "disabled": false,
         "expanded": undefined,
         "selected": undefined,
       }

--- a/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`HelpModal should render with loading props 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -275,7 +275,7 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }
@@ -426,7 +426,7 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }
@@ -577,7 +577,7 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }
@@ -728,7 +728,7 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }
@@ -879,7 +879,7 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`WalletListModal should render with loading props 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": undefined,
+        "disabled": false,
         "expanded": undefined,
         "selected": undefined,
       }
@@ -160,7 +160,7 @@ exports[`WalletListModal should render with loading props 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -393,7 +393,7 @@ exports[`WalletListModal should render with loading props 1`] = `
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -376,7 +376,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -341,7 +341,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": undefined,
+          "disabled": false,
           "expanded": undefined,
           "selected": undefined,
         }

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": undefined,
+          "disabled": false,
           "expanded": undefined,
           "selected": undefined,
         }

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectFiatScene.test.tsx.snap
@@ -293,7 +293,7 @@ exports[`CreateWalletSelectFiatComponent should render with loading props 1`] = 
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": undefined,
+          "disabled": false,
           "expanded": undefined,
           "selected": undefined,
         }

--- a/src/__tests__/scenes/__snapshots__/CryptoExchangeQuoteScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CryptoExchangeQuoteScene.test.tsx.snap
@@ -1292,7 +1292,7 @@ exports[`CryptoExchangeQuoteScreenComponent should render with loading props 1`]
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": undefined,
+                  "disabled": false,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -1473,7 +1473,7 @@ exports[`CryptoExchangeQuoteScreenComponent should render with loading props 1`]
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": undefined,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }

--- a/src/__tests__/scenes/__snapshots__/CurrencyNotificationScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CurrencyNotificationScene.test.tsx.snap
@@ -236,6 +236,11 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
   >
     <View>
       <View
+        accessibilityState={
+          {
+            "disabled": false,
+          }
+        }
         accessibilityValue={
           {
             "max": undefined,
@@ -349,6 +354,11 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
         </View>
       </View>
       <View
+        accessibilityState={
+          {
+            "disabled": false,
+          }
+        }
         accessibilityValue={
           {
             "max": undefined,

--- a/src/__tests__/scenes/__snapshots__/CurrencySettings.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CurrencySettings.ui.test.tsx.snap
@@ -272,6 +272,11 @@ exports[`CurrencySettings should render 1`] = `
         </Text>
       </View>
       <View
+        accessibilityState={
+          {
+            "disabled": false,
+          }
+        }
         accessibilityValue={
           {
             "max": undefined,
@@ -401,6 +406,11 @@ exports[`CurrencySettings should render 1`] = `
         </View>
       </View>
       <View
+        accessibilityState={
+          {
+            "disabled": false,
+          }
+        }
         accessibilityValue={
           {
             "max": undefined,
@@ -530,6 +540,11 @@ exports[`CurrencySettings should render 1`] = `
         </View>
       </View>
       <View
+        accessibilityState={
+          {
+            "disabled": false,
+          }
+        }
         accessibilityValue={
           {
             "max": undefined,

--- a/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
@@ -138,7 +138,7 @@ exports[`Request should render with loaded props 1`] = `
         }
       }
     >
-      <TouchableOpacity
+      <ExtendedTouchable
         onPress={[Function]}
         style={
           {
@@ -151,7 +151,7 @@ exports[`Request should render with loaded props 1`] = `
         <EdgeText>
           You have 0.000012 undefined
         </EdgeText>
-      </TouchableOpacity>
+      </ExtendedTouchable>
       <EdgeText
         style={
           {
@@ -226,7 +226,7 @@ exports[`Request should render with loaded props 1`] = `
         }
       }
     >
-      <TouchableOpacity
+      <ExtendedTouchable
         accessible={false}
         disabled={false}
         onPress={[Function]}
@@ -258,7 +258,7 @@ exports[`Request should render with loaded props 1`] = `
         >
           Loading…
         </EdgeText>
-      </TouchableOpacity>
+      </ExtendedTouchable>
     </Memo(EdgeAnimInner)>
   </View>
   <Memo(EdgeAnimInner)

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -362,7 +362,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -750,7 +750,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -887,7 +887,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1090,7 +1090,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1708,7 +1708,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -2096,7 +2096,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -2233,7 +2233,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -2436,7 +2436,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -3242,7 +3242,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -3449,7 +3449,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -3795,7 +3795,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -3932,7 +3932,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -4135,7 +4135,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -4753,7 +4753,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -4960,7 +4960,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -5145,7 +5145,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -5347,7 +5347,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -5965,7 +5965,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -6172,7 +6172,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -6535,7 +6535,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -7153,7 +7153,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -7360,7 +7360,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -7562,7 +7562,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -8180,7 +8180,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -8387,7 +8387,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -8692,7 +8692,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": false,
+                        "disabled": undefined,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -8894,7 +8894,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -9512,7 +9512,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -9640,7 +9640,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -10161,7 +10161,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -10779,7 +10779,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -10907,7 +10907,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -11387,7 +11387,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": false,
+                      "disabled": undefined,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -12005,7 +12005,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -12221,7 +12221,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "busy": undefined,
                           "checked": undefined,
-                          "disabled": undefined,
+                          "disabled": false,
                           "expanded": undefined,
                           "selected": undefined,
                         }
@@ -12305,7 +12305,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "busy": undefined,
                           "checked": undefined,
-                          "disabled": undefined,
+                          "disabled": false,
                           "expanded": undefined,
                           "selected": undefined,
                         }
@@ -12391,7 +12391,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "busy": undefined,
                           "checked": undefined,
-                          "disabled": undefined,
+                          "disabled": false,
                           "expanded": undefined,
                           "selected": undefined,
                         }

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -362,7 +362,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -750,7 +750,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -887,7 +887,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1090,7 +1090,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1708,7 +1708,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -2096,7 +2096,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -2233,7 +2233,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -2436,7 +2436,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -3242,7 +3242,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -3449,7 +3449,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -3795,7 +3795,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -3932,7 +3932,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -4135,7 +4135,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -4753,7 +4753,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -4960,7 +4960,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -5145,7 +5145,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -5347,7 +5347,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -5965,7 +5965,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -6172,7 +6172,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -6535,7 +6535,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -7153,7 +7153,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -7360,7 +7360,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -7562,7 +7562,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -8180,7 +8180,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -8387,7 +8387,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -8692,7 +8692,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       {
                         "busy": undefined,
                         "checked": undefined,
-                        "disabled": undefined,
+                        "disabled": false,
                         "expanded": undefined,
                         "selected": undefined,
                       }
@@ -8894,7 +8894,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -9512,7 +9512,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -9640,7 +9640,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -10161,7 +10161,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -10779,7 +10779,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -10907,7 +10907,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -11387,7 +11387,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                     {
                       "busy": undefined,
                       "checked": undefined,
-                      "disabled": undefined,
+                      "disabled": false,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -12005,7 +12005,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }

--- a/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
@@ -368,6 +368,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
             }
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -488,6 +493,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -610,6 +620,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -732,6 +747,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -854,6 +874,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -976,6 +1001,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1217,6 +1247,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
             }
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1339,6 +1374,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1461,6 +1501,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1569,6 +1614,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1677,6 +1727,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1804,6 +1859,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -1931,6 +1991,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2058,6 +2123,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2180,6 +2250,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2302,6 +2377,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2424,6 +2504,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2551,6 +2636,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2678,6 +2768,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2805,6 +2900,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -2927,6 +3027,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -3049,6 +3154,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -3171,6 +3281,11 @@ exports[`MyComponent should render Locked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -3916,6 +4031,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
             }
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -4036,6 +4156,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -4158,6 +4283,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -4280,6 +4410,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -4402,6 +4537,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -4524,6 +4664,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -4765,6 +4910,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
             }
           >
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -4887,6 +5037,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -5009,6 +5164,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -5117,6 +5277,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -5225,6 +5390,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -5352,6 +5522,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -5479,6 +5654,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -5606,6 +5786,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -5728,6 +5913,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -5850,6 +6040,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -5972,6 +6167,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -6099,6 +6299,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -6226,6 +6431,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -6353,6 +6563,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -6475,6 +6690,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -6597,6 +6817,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,
@@ -6719,6 +6944,11 @@ exports[`MyComponent should render UnLocked SettingsOverview 1`] = `
               }
             />
             <View
+              accessibilityState={
+                {
+                  "disabled": false,
+                }
+              }
               accessibilityValue={
                 {
                   "max": undefined,

--- a/src/components/FioAddress/DomainListModal.tsx
+++ b/src/components/FioAddress/DomainListModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { FlatList } from 'react-native-gesture-handler'
 
@@ -9,6 +9,7 @@ import { lstrings } from '../../locales/strings'
 import { connect } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
 import { FioDomain, FlatListItem } from '../../types/types'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SearchIconAnimated } from '../icons/ThemedIcons'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
@@ -134,12 +135,12 @@ class DomainListModalComponent extends React.Component<Props, State> {
     }
     if (value) {
       return (
-        <TouchableOpacity onPress={() => this.selectItem(value)}>
+        <EdgeTouchableOpacity onPress={() => this.selectItem(value)}>
           <View style={styles.rowContainerTop}>
             <EdgeText style={styles.domainListRowName}>{label}</EdgeText>
             <EdgeText style={styles.domainListRowFree}>{value.isFree ? lstrings.fio_domain_free : ''}</EdgeText>
           </View>
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
       )
     }
     return null

--- a/src/components/buttons/MinimalButton.tsx
+++ b/src/components/buttons/MinimalButton.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
-import { ActivityIndicator, Text, TextStyle, TouchableOpacity, ViewStyle } from 'react-native'
+import { ActivityIndicator, Text, TextStyle, ViewStyle } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 
 import { usePendingPress } from '../../hooks/usePendingPress'
 import { fixSides, mapSides, sidesToMargin } from '../../util/sides'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { Theme, useTheme } from '../services/ThemeContext'
 
 interface Props {
@@ -49,14 +50,14 @@ const MinimalButtonComponent = (props: Props) => {
   )
 
   return (
-    <TouchableOpacity disabled={disabled || pending} style={memoizedStyle} onPress={handlePress}>
+    <EdgeTouchableOpacity disabled={disabled || pending} style={memoizedStyle} onPress={handlePress}>
       {pending ? null : (
         <Text adjustsFontSizeToFit minimumFontScale={0.25} numberOfLines={1} style={highlighted ? styles.labelSelected : styles.label}>
           {label}
         </Text>
       )}
       {!pending ? null : <ActivityIndicator color={theme.secondaryButtonText} style={styles.spinner} />}
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/cards/IconMessageCard.tsx
+++ b/src/components/cards/IconMessageCard.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
 import { lstrings } from '../../locales/strings'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { ButtonBox } from '../themed/ThemedButtons'
@@ -42,7 +43,7 @@ export function IconMessageCard(props: Props) {
             </EdgeText>
           </View>
           {onClose == null ? null : (
-            <TouchableOpacity accessible={false} onPress={onClose}>
+            <EdgeTouchableOpacity accessible={false} onPress={onClose}>
               <AntDesignIcon
                 testID={testIds.close}
                 name="close"
@@ -51,7 +52,7 @@ export function IconMessageCard(props: Props) {
                 style={styles.close}
                 accessibilityHint={lstrings.close_hint}
               />
-            </TouchableOpacity>
+            </EdgeTouchableOpacity>
           )}
         </View>
       </CardUi4>

--- a/src/components/cards/LoanSummaryCard.tsx
+++ b/src/components/cards/LoanSummaryCard.tsx
@@ -21,7 +21,7 @@ import { Alert } from '../themed/Alert'
 import { EdgeText } from '../themed/EdgeText'
 import { TappableCard } from './TappableCard'
 
-const LoanSummaryCardComponent = ({ borrowEngine, iconUri, onPress }: { borrowEngine: BorrowEngine; iconUri: string; onPress: (() => void) | undefined }) => {
+const LoanSummaryCardComponent = ({ borrowEngine, iconUri, onPress }: { borrowEngine: BorrowEngine; iconUri: string; onPress: () => void }) => {
   const theme = useTheme()
   const styles = getStyles(theme)
 

--- a/src/components/cards/TappableCard.tsx
+++ b/src/components/cards/TappableCard.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react'
 import { View } from 'react-native'
-import { TouchableOpacity } from 'react-native-gesture-handler'
 import FontAwesome5 from 'react-native-vector-icons/FontAwesome5'
 
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { CardUi4 } from '../ui4/CardUi4'
 
 interface Props {
   children: React.ReactNode
   disabled?: boolean
-  onPress?: () => void
+  onPress: () => void
   warning?: boolean
   marginRem?: number[] | number
   paddingRem?: number[] | number
@@ -34,7 +34,7 @@ const TappableCardComponent = ({ children, disabled = false, onPress, ...cardPro
 
   return (
     <CardUi4 {...cardProps}>
-      {disabled ? renderTouchableChildren() : <TouchableOpacity onPress={disabled ? undefined : onPress}>{renderTouchableChildren()}</TouchableOpacity>}
+      {disabled ? renderTouchableChildren() : <EdgeTouchableOpacity onPress={onPress}>{renderTouchableChildren()}</EdgeTouchableOpacity>}
     </CardUi4>
   )
 }

--- a/src/components/cards/UnderlinedNumInputCard.tsx
+++ b/src/components/cards/UnderlinedNumInputCard.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 
 import { useHandler } from '../../hooks/useHandler'
 import { useLayout } from '../../hooks/useLayout'
 import { lstrings } from '../../locales/strings'
 import { zeroString } from '../../util/utils'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
@@ -33,7 +34,7 @@ const UnderlinedNumInputCardComponent = (props: {
   }
 
   const handlePress = useHandler(async () => {
-    if (onPress == null) return null
+    if (onPress == null) return
     try {
       await onPress()
     } catch (err) {
@@ -43,7 +44,7 @@ const UnderlinedNumInputCardComponent = (props: {
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity onPress={handlePress}>
+      <EdgeTouchableOpacity onPress={handlePress}>
         <CardUi4>
           <View style={styles.cardContainer}>
             <View style={styles.leftContainer}>
@@ -70,7 +71,7 @@ const UnderlinedNumInputCardComponent = (props: {
             <FastImage style={styles.icon} source={{ uri: iconUri }} />
           </View>
         </CardUi4>
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     </View>
   )
 }

--- a/src/components/cards/VisaCardCard.tsx
+++ b/src/components/cards/VisaCardCard.tsx
@@ -1,6 +1,5 @@
 import { EdgeCurrencyWallet, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { TouchableOpacity } from 'react-native'
 import FastImage from 'react-native-fast-image'
 
 import { executePluginAction } from '../../actions/PluginActions'
@@ -13,6 +12,7 @@ import { useDispatch, useSelector } from '../../types/reactRedux'
 import { NavigationProp } from '../../types/routerTypes'
 import { getCurrencyIconUris } from '../../util/CdnUris'
 import { logEvent } from '../../util/tracking'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
@@ -53,12 +53,12 @@ export const VisaCardCard = (props: Props) => {
     <>
       {ioniaPluginIds.includes(pluginId) && tokenId == null && (
         <CardUi4 paddingRem={0}>
-          <TouchableOpacity onPress={handlePress} style={styles.container}>
+          <EdgeTouchableOpacity onPress={handlePress} style={styles.container}>
             <FastImage resizeMode="contain" source={{ uri: icon.symbolImage }} style={styles.icon} />
             <EdgeText numberOfLines={0} style={styles.text}>
               {lstrings.rewards_card_call_to_action}
             </EdgeText>
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         </CardUi4>
       )}
     </>

--- a/src/components/common/EdgeTouchableHighlight.ts
+++ b/src/components/common/EdgeTouchableHighlight.ts
@@ -1,0 +1,5 @@
+import { TouchableHighlight } from 'react-native'
+
+import { withExtendedTouchable } from '../hoc/withExtendedTouchable'
+
+export const EdgeTouchableHighlight = withExtendedTouchable(TouchableHighlight)

--- a/src/components/common/EdgeTouchableOpacity.ts
+++ b/src/components/common/EdgeTouchableOpacity.ts
@@ -1,0 +1,5 @@
+import { TouchableOpacity } from 'react-native'
+
+import { withExtendedTouchable } from '../hoc/withExtendedTouchable'
+
+export const EdgeTouchableOpacity = withExtendedTouchable(TouchableOpacity)

--- a/src/components/common/EdgeTouchableWithoutFeedback.ts
+++ b/src/components/common/EdgeTouchableWithoutFeedback.ts
@@ -1,0 +1,5 @@
+import { TouchableWithoutFeedback } from 'react-native'
+
+import { withExtendedTouchable } from '../hoc/withExtendedTouchable'
+
+export const EdgeTouchableWithoutFeedback = withExtendedTouchable(TouchableWithoutFeedback)

--- a/src/components/data/row/CoinRankRow.tsx
+++ b/src/components/data/row/CoinRankRow.tsx
@@ -1,6 +1,6 @@
 import { div, lt, round } from 'biggystring'
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import { cacheStyles } from 'react-native-patina'
 
@@ -16,6 +16,7 @@ import { NavigationProp } from '../../../types/routerTypes'
 import { triggerHaptic } from '../../../util/haptic'
 import { debugLog, LOG_COINRANK } from '../../../util/logger'
 import { DECIMAL_PRECISION } from '../../../util/utils'
+import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { Theme, useTheme } from '../../services/ThemeContext'
 import { EdgeText } from '../../themed/EdgeText'
 
@@ -144,7 +145,7 @@ const CoinRankRowComponent = (props: Props) => {
   const percentString = `${plusMinus}${percentChangeString}`
 
   return (
-    <TouchableOpacity accessible={false} style={styles.container} onPress={handlePress}>
+    <EdgeTouchableOpacity accessible={false} style={styles.container} onPress={handlePress}>
       <View style={styles.rank}>
         <EdgeText accessible numberOfLines={1} disableFontScaling>
           {rank}
@@ -163,7 +164,7 @@ const CoinRankRowComponent = (props: Props) => {
           <EdgeText style={priceStyle}>{priceString}</EdgeText>
         </View>
       </View>
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/hoc/withExtendedTouchable.tsx
+++ b/src/components/hoc/withExtendedTouchable.tsx
@@ -1,0 +1,89 @@
+import React, { ComponentType, ReactNode, useEffect, useRef, useState } from 'react'
+import { GestureResponderEvent, TouchableHighlightProps, TouchableOpacityProps, TouchableWithoutFeedbackProps } from 'react-native'
+
+import { useHandler } from '../../hooks/useHandler'
+import { showError } from '../services/AirshipInstance'
+
+type PressFn = (event: GestureResponderEvent) => void | Promise<void>
+
+interface ExtendedProps {
+  onPress?: PressFn
+  onLongPress?: PressFn
+  awaitChild?: ReactNode // What to render during async await, if different from children. This does not get rendered while debounce is in effect, only while awaiting the onPress.
+  debounce?: boolean // Enforce a strict 500ms debounce delay for synchronous press handlers.
+}
+
+type PropsWithOptionalChildren<P = unknown> = P & { children?: ReactNode }
+
+const DEBOUNCE_DELAY = 500
+
+export function withExtendedTouchable<T extends TouchableOpacityProps | TouchableWithoutFeedbackProps | TouchableHighlightProps>(
+  WrappedComponent: ComponentType<PropsWithOptionalChildren<T>>
+): React.FC<PropsWithOptionalChildren<T> & ExtendedProps> {
+  const ExtendedTouchable: React.FC<PropsWithOptionalChildren<T> & ExtendedProps> = ({
+    children,
+    onPress,
+    onLongPress,
+    awaitChild,
+    debounce = false,
+    ...restProps
+  }) => {
+    const [isDebouncing, setIsDebouncing] = useState<boolean>(false)
+    const [isAwaiting, setIsAwaiting] = useState<boolean>(false)
+    const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+    useEffect(() => {
+      return () => {
+        if (timeoutRef.current !== null) {
+          clearTimeout(timeoutRef.current)
+        }
+      }
+    }, [])
+
+    const runPress = (event: GestureResponderEvent, pressFn?: PressFn) => {
+      if (pressFn == null) return
+      if (isDebouncing || isAwaiting) return
+
+      // Set debounce state before we even know if onPress is async or not to
+      // guarantee we cannot call onPress twice in quick succession.
+      if (debounce) setIsDebouncing(true)
+
+      try {
+        const result = pressFn(event)
+        // Async onPress. Always show busy form until promise resolves
+        if (typeof result?.then === 'function') {
+          setIsAwaiting(true)
+          result.catch(e => showError(e)).finally(() => setIsAwaiting(false))
+        }
+
+        // Also layer on debounce state toggling if enabled
+        if (debounce) {
+          timeoutRef.current = setTimeout(() => setIsDebouncing(false), DEBOUNCE_DELAY)
+        }
+      } catch (err) {
+        showError(err)
+
+        // Always reset the busy state no matter what
+        setIsDebouncing(false)
+        setIsAwaiting(false)
+      }
+    }
+
+    const handlePress = useHandler((event: GestureResponderEvent) => {
+      runPress(event, onPress)
+    })
+
+    const handleLongPress = useHandler((event: GestureResponderEvent) => {
+      runPress(event, onLongPress)
+    })
+
+    // HACK: Can't get typescript to not complain when defining restProps as T
+    return children == null ? null : (
+      <WrappedComponent disabled={isDebouncing || isAwaiting} onPress={handlePress} onLongPress={handleLongPress} {...(restProps as any)}>
+        {isAwaiting && awaitChild != null ? awaitChild : children}
+      </WrappedComponent>
+    )
+  }
+
+  return ExtendedTouchable
+}

--- a/src/components/modals/AddressModal.tsx
+++ b/src/components/modals/AddressModal.tsx
@@ -1,6 +1,6 @@
 import { EdgeAccount, EdgeCurrencyConfig, EdgeCurrencyWallet } from 'edge-core-js'
 import * as React from 'react'
-import { ActivityIndicator, FlatList, Image, Text, TouchableWithoutFeedback, View } from 'react-native'
+import { ActivityIndicator, FlatList, Image, Text, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { sprintf } from 'sprintf-js'
 
@@ -13,6 +13,7 @@ import { connect } from '../../types/reactRedux'
 import { ResolutionError } from '../../types/ResolutionError'
 import { FioAddress, FlatListItem } from '../../types/types'
 import { checkPubAddress, FioAddresses, getFioAddressCache } from '../../util/FioAddressUtils'
+import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
 import { FilledTextInput } from '../themed/FilledTextInput'
@@ -276,12 +277,12 @@ export class AddressModalComponent extends React.Component<Props, State> {
       return null
     }
     return (
-      <TouchableWithoutFeedback onPress={() => this.onPressFioAddress(item)}>
+      <EdgeTouchableWithoutFeedback onPress={() => this.onPressFioAddress(item)}>
         <View style={styles.rowContainer}>
           <Image source={addressType} style={styles.fioAddressAvatarContainer} resizeMode="cover" />
           <Text style={styles.fioAddressText}>{item}</Text>
         </View>
-      </TouchableWithoutFeedback>
+      </EdgeTouchableWithoutFeedback>
     )
   }
 

--- a/src/components/modals/CategoryModal.tsx
+++ b/src/components/modals/CategoryModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ListRenderItem, TouchableHighlight, View } from 'react-native'
+import { ListRenderItem, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { FlatList } from 'react-native-gesture-handler'
 
@@ -11,6 +11,7 @@ import { lstrings } from '../../locales/strings'
 import { useDispatch, useSelector } from '../../types/reactRedux'
 import { scale } from '../../util/scaling'
 import { MinimalButton } from '../buttons/MinimalButton'
+import { EdgeTouchableHighlight } from '../common/EdgeTouchableHighlight'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { DividerLine } from '../themed/DividerLine'
 import { EdgeText } from '../themed/EdgeText'
@@ -116,7 +117,7 @@ export function CategoryModal(props: Props) {
   const keyExtractor = useHandler((row: CategoryRow) => row.raw)
 
   const renderRow: ListRenderItem<CategoryRow> = useHandler(({ item }) => (
-    <TouchableHighlight delayPressIn={60} style={styles.rowContainer} onPress={async () => await handleCategoryUpdate(item.raw)}>
+    <EdgeTouchableHighlight delayPressIn={60} style={styles.rowContainer} onPress={async () => await handleCategoryUpdate(item.raw)}>
       <>
         <View style={styles.rowContent}>
           <View style={styles.rowCategoryTextWrap}>
@@ -130,7 +131,7 @@ export function CategoryModal(props: Props) {
         </View>
         <DividerLine marginRem={[0, 0]} />
       </>
-    </TouchableHighlight>
+    </EdgeTouchableHighlight>
   ))
 
   return (

--- a/src/components/modals/ConfirmContinueModal.tsx
+++ b/src/components/modals/ConfirmContinueModal.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
-import { TouchableWithoutFeedback, View } from 'react-native'
+import { View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import Feather from 'react-native-vector-icons/Feather'
 import Ionicons from 'react-native-vector-icons/Ionicons'
 
 import { lstrings } from '../../locales/strings'
+import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { Fade } from '../themed/Fade'
@@ -63,14 +64,14 @@ export function ConfirmContinueModal(props: Props) {
       {children}
       {body != null ? <ModalMessage>{body}</ModalMessage> : null}
       <ModalMessage>{lstrings.confirm_continue_modal_body}</ModalMessage>
-      <TouchableWithoutFeedback onPress={handleTogggle}>
+      <EdgeTouchableWithoutFeedback onPress={handleTogggle}>
         <View style={styles.checkBoxContainer}>
           <EdgeText style={styles.checkboxText}>{lstrings.confirm_continue_modal_button_text}</EdgeText>
           <View style={[styles.checkCircleContainer, isAgreed ? styles.checkCircleContainerAgreed : undefined]}>
             {isAgreed && <Feather name="check" color={theme.iconTappable} size={theme.rem(0.75)} accessibilityHint={lstrings.check_icon_hint} />}
           </View>
         </View>
-      </TouchableWithoutFeedback>
+      </EdgeTouchableWithoutFeedback>
       <Fade visible={isAgreed}>
         <MainButton label={lstrings.confirm_finish} marginRem={1} type="primary" onPress={handleAgreed} />
       </Fade>

--- a/src/components/modals/DateModal.tsx
+++ b/src/components/modals/DateModal.tsx
@@ -1,9 +1,10 @@
 import DateTimePicker from '@react-native-community/datetimepicker'
 import * as React from 'react'
-import { Appearance, Platform, Text, TextStyle, TouchableOpacity } from 'react-native'
+import { Appearance, Platform, Text, TextStyle } from 'react-native'
 import { AirshipBridge, AirshipModal } from 'react-native-airship'
 
 import { lstrings } from '../../locales/strings'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { ThemeProps, withTheme } from '../services/ThemeContext'
 
 export interface Props {
@@ -64,9 +65,9 @@ export class DateModalIos extends React.Component<Props & ThemeProps, State> {
         borderRadius={0}
         backgroundColor={darkMode ? theme.dateModalBackgroundDark : theme.dateModalBackgroundLight}
       >
-        <TouchableOpacity onPress={this.handleDone}>
+        <EdgeTouchableOpacity onPress={this.handleDone}>
           <Text style={textStyle}>{lstrings.string_done_cap}</Text>
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
         <DateTimePicker display="spinner" mode="date" onChange={this.handleChange} value={date} />
       </AirshipModal>
     )

--- a/src/components/modals/FlipInputModal2.tsx
+++ b/src/components/modals/FlipInputModal2.tsx
@@ -2,7 +2,7 @@ import { div, log10, toFixed } from 'biggystring'
 import { EdgeCurrencyWallet, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
 import { memo, useState } from 'react'
-import { TouchableWithoutFeedback, View } from 'react-native'
+import { View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome'
 import { sprintf } from 'sprintf-js'
@@ -15,6 +15,7 @@ import { useWatch } from '../../hooks/useWatch'
 import { formatNumber } from '../../locales/intl'
 import { lstrings } from '../../locales/strings'
 import { DECIMAL_PRECISION } from '../../util/utils'
+import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { ExchangeRate2 } from '../common/ExchangeRate2'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { FiatText } from '../text/FiatText'
@@ -218,14 +219,14 @@ const FlipInputModal2Component = React.forwardRef<FlipInputModalRef, Props>((pro
   return (
     <ModalUi4 bridge={bridge} onCancel={handleCloseModal}>
       <View style={styles.flipInput}>{renderFlipInput()}</View>
-      <TouchableWithoutFeedback onPress={handleFeesChange}>
+      <EdgeTouchableWithoutFeedback onPress={handleFeesChange}>
         <View style={styles.fees}>
           {renderFees()}
           {renderExchangeRates()}
           {renderBalance()}
           {renderErrorMessage()}
         </View>
-      </TouchableWithoutFeedback>
+      </EdgeTouchableWithoutFeedback>
     </ModalUi4>
   )
 })

--- a/src/components/modals/RadioListModal.tsx
+++ b/src/components/modals/RadioListModal.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
-import { Image, Text, TouchableOpacity, View } from 'react-native'
+import { Image, Text, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import IonIcon from 'react-native-vector-icons/Ionicons'
 
 import { useHandler } from '../../hooks/useHandler'
 import { lstrings } from '../../locales/strings'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { ListModal } from './ListModal'
@@ -46,7 +47,7 @@ export function RadioListModal(props: Props) {
       )
 
     return (
-      <TouchableOpacity onPress={() => bridge.resolve(name)}>
+      <EdgeTouchableOpacity onPress={() => bridge.resolve(name)}>
         <View style={styles.row}>
           <View style={styles.iconContainer}>{iconElement}</View>
           <EdgeText style={styles.rowText}>{name}</EdgeText>
@@ -61,7 +62,7 @@ export function RadioListModal(props: Props) {
             size={theme.rem(1.25)}
           />
         </View>
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     )
   })
 

--- a/src/components/modals/ScanModal.tsx
+++ b/src/components/modals/ScanModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Linking, TouchableOpacity, View } from 'react-native'
+import { Linking, View } from 'react-native'
 import { AirshipBridge, AirshipModal } from 'react-native-airship'
 import { RNCamera } from 'react-native-camera'
 import { launchImageLibrary } from 'react-native-image-picker'
@@ -13,6 +13,7 @@ import { lstrings } from '../../locales/strings'
 import { useSelector } from '../../types/reactRedux'
 import { triggerHaptic } from '../../util/haptic'
 import { logActivity } from '../../util/logger'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { QrPeephole } from '../common/QrPeephole'
 import { TextInputModal } from '../modals/TextInputModal'
 import { Airship, showError, showWarning } from '../services/AirshipInstance'
@@ -181,18 +182,18 @@ export const ScanModal = (props: Props) => {
             <View style={[styles.inner, { flexDirection: isLandscape ? 'row' : 'column' }]}>
               <View style={styles.peepholeSpace} onLayout={handleLayoutPeepholeSpace} />
               <View style={[styles.buttonsContainer, { flexDirection: isLandscape ? 'column-reverse' : 'row' }]}>
-                <TouchableOpacity style={styles.iconButton} onPress={handleFlash}>
+                <EdgeTouchableOpacity style={styles.iconButton} onPress={handleFlash}>
                   <Ionicon style={styles.icon} name={flashMode ? 'flash' : 'flash-outline'} />
                   <EdgeText>{lstrings.fragment_send_flash}</EdgeText>
-                </TouchableOpacity>
-                <TouchableOpacity style={styles.iconButton} onPress={handleAlbum}>
+                </EdgeTouchableOpacity>
+                <EdgeTouchableOpacity style={styles.iconButton} onPress={handleAlbum}>
                   <Ionicon style={styles.icon} name="albums-outline" />
                   <EdgeText>{lstrings.fragment_send_album}</EdgeText>
-                </TouchableOpacity>
-                <TouchableOpacity style={styles.iconButton} onPress={handleTextInput}>
+                </EdgeTouchableOpacity>
+                <EdgeTouchableOpacity style={styles.iconButton} onPress={handleTextInput}>
                   <Ionicon style={styles.icon} name="pencil-outline" />
                   <EdgeText>{lstrings.enter_as_in_enter_address_with_keyboard}</EdgeText>
-                </TouchableOpacity>
+                </EdgeTouchableOpacity>
               </View>
             </View>
           </View>

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -1,6 +1,6 @@
 import { EdgeTokenId } from 'edge-core-js'
 import React from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
+import { Text, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { sprintf } from 'sprintf-js'
@@ -15,6 +15,7 @@ import { useDispatch, useSelector } from '../../types/reactRedux'
 import { NavigationProp } from '../../types/routerTypes'
 import { getCurrencyCode, getCurrencyInfos, isKeysOnlyPlugin } from '../../util/CurrencyInfoHelpers'
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { ModalTitle } from '../themed/ModalParts'
@@ -229,7 +230,7 @@ export function WalletListMenuModal(props: Props) {
       scroll
     >
       {options.map((option: Option) => (
-        <TouchableOpacity key={option.value} onPress={() => optionAction(option.value)} style={styles.row}>
+        <EdgeTouchableOpacity key={option.value} onPress={() => optionAction(option.value)} style={styles.row}>
           <AntDesignIcon
             // @ts-expect-error
             name={icons[option.value] ?? 'arrowsalt'} // for split keys like splitBCH, splitETH, etc.
@@ -237,7 +238,7 @@ export function WalletListMenuModal(props: Props) {
             style={option.value === 'delete' ? [styles.optionIcon, styles.warningColor] : styles.optionIcon}
           />
           <Text style={option.value === 'delete' ? [styles.optionText, styles.warningColor] : styles.optionText}>{option.label}</Text>
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
       ))}
     </ModalUi4>
   )

--- a/src/components/modals/WalletListModal.tsx
+++ b/src/components/modals/WalletListModal.tsx
@@ -1,7 +1,7 @@
 import { FlashList, ListRenderItem } from '@shopify/flash-list'
 import { EdgeAccount, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { sprintf } from 'sprintf-js'
 
@@ -15,6 +15,7 @@ import { useSelector } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
 import { EdgeAsset } from '../../types/types'
 import { getCurrencyCode, isKeysOnlyPlugin } from '../../util/CurrencyInfoHelpers'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { CustomAsset } from '../data/row/CustomAssetRow'
 import { PaymentMethodRow } from '../data/row/PaymentMethodRow'
 import { SearchIconAnimated } from '../icons/ThemedIcons'
@@ -174,9 +175,9 @@ export function WalletListModal(props: Props) {
 
   const renderPaymentMethod: ListRenderItem<PaymentMethod> = useHandler(item => {
     return (
-      <TouchableOpacity onPress={handlePaymentMethodPress(item.item.id)}>
+      <EdgeTouchableOpacity onPress={handlePaymentMethodPress(item.item.id)}>
         <PaymentMethodRow paymentMethod={item.item} pluginId="wyre" key={item.item.id} />
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     )
   })
 

--- a/src/components/navigation/NavigationButton.tsx
+++ b/src/components/navigation/NavigationButton.tsx
@@ -1,9 +1,10 @@
 import { getDefaultHeaderHeight } from '@react-navigation/elements'
 import * as React from 'react'
-import { TouchableOpacity, ViewStyle } from 'react-native'
+import { ViewStyle } from 'react-native'
 import { useSafeAreaFrame } from 'react-native-safe-area-context'
 
 import { fixSides, mapSides, sidesToPadding } from '../../util/sides'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { useTheme } from '../services/ThemeContext'
 
 interface Props {
@@ -33,8 +34,8 @@ export const NavigationButton = (props: Props) => {
   )
 
   return (
-    <TouchableOpacity accessible={false} style={touchableStyle} onPress={onPress}>
+    <EdgeTouchableOpacity accessible={false} style={touchableStyle} onPress={onPress}>
       {children}
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }

--- a/src/components/scenes/CoinRankingScene.tsx
+++ b/src/components/scenes/CoinRankingScene.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ListRenderItemInfo, TouchableOpacity, View } from 'react-native'
+import { ListRenderItemInfo, View } from 'react-native'
 import Animated from 'react-native-reanimated'
 
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
@@ -16,6 +16,7 @@ import { EdgeSceneProps } from '../../types/routerTypes'
 import { debugLog, enableDebugLogType, LOG_COINRANK } from '../../util/logger'
 import { fetchRates } from '../../util/network'
 import { EdgeAnim, MAX_LIST_ITEMS_ANIM } from '../common/EdgeAnim'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { CoinRankRow } from '../data/row/CoinRankRow'
 import { showError } from '../services/AirshipInstance'
@@ -235,12 +236,12 @@ const CoinRankingComponent = (props: Props) => {
             <View style={styles.rankView}>
               <EdgeText style={styles.rankText}>{lstrings.coin_rank_rank}</EdgeText>
             </View>
-            <TouchableOpacity style={styles.assetView} onPress={handlePriceSubText}>
+            <EdgeTouchableOpacity style={styles.assetView} onPress={handlePriceSubText}>
               <EdgeText style={styles.assetText}>{assetSubTextString}</EdgeText>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.percentChangeView} onPress={handlePercentChange}>
+            </EdgeTouchableOpacity>
+            <EdgeTouchableOpacity style={styles.percentChangeView} onPress={handlePercentChange}>
               <EdgeText style={styles.percentChangeText}>{timeFrameString}</EdgeText>
-            </TouchableOpacity>
+            </EdgeTouchableOpacity>
             <View style={styles.priceView}>
               <EdgeText style={styles.priceText}>{lstrings.coin_rank_price}</EdgeText>
             </View>

--- a/src/components/scenes/CreateWalletImportOptionsScene.tsx
+++ b/src/components/scenes/CreateWalletImportOptionsScene.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Linking, TouchableOpacity, View } from 'react-native'
+import { Linking, View } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import Ionicon from 'react-native-vector-icons/Ionicons'
 
@@ -11,6 +11,7 @@ import { WalletCreateItem } from '../../selectors/getCreateWalletList'
 import { useSelector } from '../../types/reactRedux'
 import { EdgeSceneProps } from '../../types/routerTypes'
 import { FlatListItem } from '../../types/types'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { TextInputModal } from '../modals/TextInputModal'
 import { Airship, showError } from '../services/AirshipInstance'
@@ -112,9 +113,9 @@ const CreateWalletImportOptionsComponent = (props: Props) => {
         description = (
           <ModalMessage>
             {message}
-            <TouchableOpacity onPress={onPress}>
+            <EdgeTouchableOpacity onPress={onPress}>
               <Ionicon name="help-circle-outline" size={theme.rem(1)} color={theme.iconTappable} />
-            </TouchableOpacity>
+            </EdgeTouchableOpacity>
           </ModalMessage>
         )
       } else {

--- a/src/components/scenes/CryptoExchangeQuoteScene.tsx
+++ b/src/components/scenes/CryptoExchangeQuoteScene.tsx
@@ -1,7 +1,7 @@
 import { div, gte } from 'biggystring'
 import { EdgeSwapQuote } from 'edge-core-js'
 import React, { useEffect, useState } from 'react'
-import { SectionList, TouchableOpacity, View, ViewStyle } from 'react-native'
+import { SectionList, View, ViewStyle } from 'react-native'
 import { sprintf } from 'sprintf-js'
 
 import { exchangeTimerExpired, shiftCryptoCurrency } from '../../actions/CryptoExchangeActions'
@@ -14,6 +14,7 @@ import { getSwapPluginIconUri } from '../../util/CdnUris'
 import { logEvent } from '../../util/tracking'
 import { PoweredByCard } from '../cards/PoweredByCard'
 import { EdgeAnim, fadeInDown30, fadeInDown60, fadeInDown90, fadeInDown120, fadeInUp30, fadeInUp60, fadeInUp90 } from '../common/EdgeAnim'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { SwapProviderRow } from '../data/row/SwapProviderRow'
 import { ButtonsModal } from '../modals/ButtonsModal'
@@ -122,14 +123,14 @@ export const CryptoExchangeQuoteScene = (props: Props) => {
   const renderRow = useHandler((item: { item: EdgeSwapQuote; section: Section; index: number }) => {
     const quote = item.item
     return (
-      <TouchableOpacity
+      <EdgeTouchableOpacity
         onPress={() => {
           setSelectedQuote(quote)
           Airship.clear()
         }}
       >
         <SwapProviderRow quote={quote} />
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     )
   })
 

--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -2,7 +2,7 @@ import { InitialRouteName } from 'edge-login-ui-rn'
 import * as React from 'react'
 import { useEffect } from 'react'
 import { Image, Pressable, Text, View } from 'react-native'
-import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler'
+import { ScrollView } from 'react-native-gesture-handler'
 import Animated, {
   Extrapolation,
   interpolate,
@@ -32,6 +32,7 @@ import { ImageProp } from '../../types/Theme'
 import { parseMarkedText } from '../../util/parseMarkedText'
 import { logEvent } from '../../util/tracking'
 import { EdgeAnim } from '../common/EdgeAnim'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { styled } from '../hoc/styled'
 import { SwipeOffsetDetector } from '../interactions/SwipeOffsetDetector'
@@ -176,9 +177,9 @@ export const GettingStartedScene = (props: Props) => {
     <SceneWrapper hasHeader={false}>
       <SkipButton swipeOffset={swipeOffset}>
         <Space left horizontal={1} vertical={0.5}>
-          <TouchableOpacity onPress={handlePressSkip}>
+          <EdgeTouchableOpacity onPress={handlePressSkip}>
             <EdgeText>{lstrings.skip}</EdgeText>
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         </Space>
       </SkipButton>
       <SwipeOffsetDetector swipeOffset={swipeOffset} minOffset={0} maxOffset={paginationCount}>

--- a/src/components/scenes/Loans/LoanCloseScene.tsx
+++ b/src/components/scenes/Loans/LoanCloseScene.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { TouchableOpacity } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import Ionicon from 'react-native-vector-icons/Ionicons'
 import { sprintf } from 'sprintf-js'
@@ -24,6 +23,7 @@ import { getExecutionNetworkFees } from '../../../util/networkFeeUtils'
 import { filterNull } from '../../../util/safeFilters'
 import { translateError } from '../../../util/translateError'
 import { zeroString } from '../../../util/utils'
+import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { CryptoFiatAmountRow } from '../../data/row/CryptoFiatAmountRow'
 import { withLoanAccount } from '../../hoc/withLoanAccount'
@@ -131,9 +131,9 @@ export const LoanCloseSceneComponent = (props: Props) => {
     <SceneWrapper>
       <SceneHeader
         tertiary={
-          <TouchableOpacity onPress={handleInfoIconPress}>
+          <EdgeTouchableOpacity onPress={handleInfoIconPress}>
             <Ionicon name="information-circle-outline" size={theme.rem(1.25)} color={theme.iconTappable} />
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         }
         title={lstrings.loan_close_loan_title}
         underline

--- a/src/components/scenes/Loans/LoanCreateScene.tsx
+++ b/src/components/scenes/Loans/LoanCreateScene.tsx
@@ -1,7 +1,7 @@
 import { div, lt, max, mul } from 'biggystring'
 import { EdgeCurrencyWallet, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { ActivityIndicator, TouchableOpacity } from 'react-native'
+import { ActivityIndicator } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import Ionicon from 'react-native-vector-icons/Ionicons'
@@ -33,6 +33,7 @@ import { enableToken } from '../../../util/CurrencyWalletHelpers'
 import { DECIMAL_PRECISION, truncateDecimals, zeroString } from '../../../util/utils'
 import { FiatAmountInputCard } from '../../cards/FiatAmountInputCard'
 import { TappableAccountCard } from '../../cards/TappableAccountCard'
+import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { CryptoFiatAmountRow } from '../../data/row/CryptoFiatAmountRow'
 import { Space } from '../../layout/Space'
@@ -349,9 +350,9 @@ export const LoanCreateScene = (props: Props) => {
     <SceneWrapper>
       <SceneHeader
         tertiary={
-          <TouchableOpacity onPress={handleInfoIconPress}>
+          <EdgeTouchableOpacity onPress={handleInfoIconPress}>
             <Ionicon name="information-circle-outline" size={theme.rem(1.25)} color={theme.iconTappable} />
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         }
         title={lstrings.loan_create_title}
         underline

--- a/src/components/scenes/Loans/LoanDashboardScene.tsx
+++ b/src/components/scenes/Loans/LoanDashboardScene.tsx
@@ -1,6 +1,6 @@
 import { EdgeCurrencyInfo } from 'edge-core-js'
 import * as React from 'react'
-import { ListRenderItemInfo, TouchableOpacity, View } from 'react-native'
+import { ListRenderItemInfo, View } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import Ionicon from 'react-native-vector-icons/Ionicons'
 import { sprintf } from 'sprintf-js'
@@ -23,6 +23,7 @@ import { Theme } from '../../../types/Theme'
 import { getBorrowPluginIconUri } from '../../../util/CdnUris'
 import { getCurrencyInfos } from '../../../util/CurrencyInfoHelpers'
 import { LoanSummaryCard } from '../../cards/LoanSummaryCard'
+import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { Space } from '../../layout/Space'
 import { LoanWelcomeModal } from '../../modals/LoanWelcomeModal'
@@ -185,10 +186,10 @@ export const LoanDashboardScene = (props: Props) => {
             <FillLoader />
           </Space>
         ) : (
-          <TouchableOpacity onPress={handleAddLoan} style={styles.addButtonsContainer}>
+          <EdgeTouchableOpacity onPress={handleAddLoan} style={styles.addButtonsContainer}>
             <Ionicon name="md-add" style={styles.addItem} size={theme.rem(1.5)} color={theme.iconTappable} />
             <EdgeText style={[styles.addItem, styles.addItemText]}>{lstrings.loan_new_loan}</EdgeText>
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         )}
       </>
     )
@@ -207,9 +208,9 @@ export const LoanDashboardScene = (props: Props) => {
     <SceneWrapper>
       <SceneHeader
         tertiary={
-          <TouchableOpacity onPress={handleInfoIconPress}>
+          <EdgeTouchableOpacity onPress={handleInfoIconPress}>
             <Ionicon name="information-circle-outline" size={theme.rem(1.25)} color={theme.iconTappable} />
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         }
         title={lstrings.loan_dashboard_title}
         underline

--- a/src/components/scenes/Loans/LoanDetailsScene.tsx
+++ b/src/components/scenes/Loans/LoanDetailsScene.tsx
@@ -1,7 +1,7 @@
 import { add, div, gt, max, mul, sub } from 'biggystring'
 import { EdgeCurrencyWallet, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { ActivityIndicator, TouchableOpacity } from 'react-native'
+import { ActivityIndicator } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import Ionicon from 'react-native-vector-icons/Ionicons'
 import { sprintf } from 'sprintf-js'
@@ -28,6 +28,7 @@ import { getToken } from '../../../util/CurrencyInfoHelpers'
 import { DECIMAL_PRECISION, zeroString } from '../../../util/utils'
 import { LoanDetailsSummaryCard } from '../../cards/LoanDetailsSummaryCard'
 import { TappableCard } from '../../cards/TappableCard'
+import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { withLoanAccount } from '../../hoc/withLoanAccount'
 import { FiatIcon } from '../../icons/FiatIcon'
@@ -116,7 +117,7 @@ export const LoanDetailsSceneComponent = (props: Props) => {
   const renderProgramStatusCard = () => {
     if (runningProgramMessage != null && runningProgramEdge != null) {
       return (
-        <TouchableOpacity onPress={() => handleProgramStatusCardPress(runningProgramEdge)}>
+        <EdgeTouchableOpacity onPress={() => handleProgramStatusCardPress(runningProgramEdge)}>
           <CardUi4 marginRem={[0, 0, 1]}>
             <Space sideways>
               <ActivityIndicator color={theme.iconTappable} style={styles.activityIndicator} />
@@ -125,7 +126,7 @@ export const LoanDetailsSceneComponent = (props: Props) => {
               </EdgeText>
             </Space>
           </CardUi4>
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
       )
     } else return null
   }
@@ -221,9 +222,9 @@ export const LoanDetailsSceneComponent = (props: Props) => {
     <SceneWrapper>
       <SceneHeader
         tertiary={
-          <TouchableOpacity onPress={handleInfoIconPress}>
+          <EdgeTouchableOpacity onPress={handleInfoIconPress}>
             <Ionicon name="information-circle-outline" size={theme.rem(1.25)} color={theme.iconTappable} />
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         }
         title={`${lstrings.loan_details_title}${isDevMode ? ` (${wallet.name})` : ''}`}
         underline

--- a/src/components/scenes/Loans/LoanManageScene.tsx
+++ b/src/components/scenes/Loans/LoanManageScene.tsx
@@ -1,6 +1,5 @@
 import { add, gt, max, mul } from 'biggystring'
 import * as React from 'react'
-import { TouchableOpacity } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { cacheStyles } from 'react-native-patina'
 import Ionicon from 'react-native-vector-icons/Ionicons'
@@ -35,6 +34,7 @@ import { getExecutionNetworkFees } from '../../../util/networkFeeUtils'
 import { zeroString } from '../../../util/utils'
 import { FiatAmountInputCard } from '../../cards/FiatAmountInputCard'
 import { SelectableAsset, TappableAccountCard } from '../../cards/TappableAccountCard'
+import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { withLoanAccount } from '../../hoc/withLoanAccount'
 import { Peek } from '../../layout/Peek'
 import { Space } from '../../layout/Space'
@@ -420,9 +420,9 @@ export const LoanManageSceneComponent = (props: Props) => {
       onSliderComplete={handleSliderComplete}
       sliderDisabled={actionProgram == null}
       headerTertiary={
-        <TouchableOpacity onPress={handleInfoIconPress}>
+        <EdgeTouchableOpacity onPress={handleInfoIconPress}>
           <Ionicon name="information-circle-outline" size={theme.rem(1.25)} color={theme.iconTappable} />
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
       }
     >
       <Space vertical={1} around={0.5}>

--- a/src/components/scenes/Loans/LoanStatusScene.tsx
+++ b/src/components/scenes/Loans/LoanStatusScene.tsx
@@ -1,6 +1,6 @@
 import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 import ConfettiCannon from 'react-native-confetti-cannon'
 import { ScrollView } from 'react-native-gesture-handler'
 import Ionicon from 'react-native-vector-icons/Ionicons'
@@ -20,6 +20,7 @@ import { config } from '../../../theme/appConfig'
 import { useDispatch, useSelector } from '../../../types/reactRedux'
 import { EdgeSceneProps } from '../../../types/routerTypes'
 import { Theme } from '../../../types/Theme'
+import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { withLoanAccount } from '../../hoc/withLoanAccount'
 import { ConfirmContinueModal } from '../../modals/ConfirmContinueModal'
@@ -102,9 +103,9 @@ export const LoanStatusSceneComponent = (props: Props) => {
     <SceneWrapper>
       <SceneHeader
         tertiary={
-          <TouchableOpacity onPress={handleInfoIconPress}>
+          <EdgeTouchableOpacity onPress={handleInfoIconPress}>
             <Ionicon name="information-circle-outline" size={theme.rem(1.25)} color={theme.iconTappable} />
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         }
         title={lstrings.loan_status_title}
         underline

--- a/src/components/scenes/OtpSettingsScene.tsx
+++ b/src/components/scenes/OtpSettingsScene.tsx
@@ -1,7 +1,7 @@
 import Clipboard from '@react-native-clipboard/clipboard'
 import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
+import { Text, View } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { sprintf } from 'sprintf-js'
@@ -12,6 +12,7 @@ import { config } from '../../theme/appConfig'
 import { connect } from '../../types/reactRedux'
 import { EdgeSceneProps } from '../../types/routerTypes'
 import { logActivity } from '../../util/logger'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { Airship, showError, showToast } from '../services/AirshipInstance'
@@ -127,14 +128,14 @@ class OtpSettingsSceneComponent extends React.Component<Props, State> {
 
     return (
       <View style={styles.keyArea}>
-        <TouchableOpacity style={styles.keyToggle} onPress={this.handleToggleKey}>
+        <EdgeTouchableOpacity style={styles.keyToggle} onPress={this.handleToggleKey}>
           <Text style={styles.keyToggleText}>{showKey ? lstrings.otp_hide_code : lstrings.otp_show_code}</Text>
           <AntDesignIcon name={showKey ? 'up' : 'down'} style={styles.keyToggleIcon} />
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
         {showKey ? (
-          <TouchableOpacity onPress={this.handleCopyKey}>
+          <EdgeTouchableOpacity onPress={this.handleCopyKey}>
             <Text style={styles.keyText}>{otpKey}</Text>
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         ) : null}
       </View>
     )

--- a/src/components/scenes/RequestScene.tsx
+++ b/src/components/scenes/RequestScene.tsx
@@ -2,7 +2,7 @@ import Clipboard from '@react-native-clipboard/clipboard'
 import { lt } from 'biggystring'
 import { EdgeCurrencyWallet, EdgeEncodeUri, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { ActivityIndicator, Linking, Platform, Text, TouchableOpacity, View } from 'react-native'
+import { ActivityIndicator, Linking, Platform, Text, View } from 'react-native'
 import Share, { ShareOptions } from 'react-native-share'
 import IonIcon from 'react-native-vector-icons/Ionicons'
 import { sprintf } from 'sprintf-js'
@@ -25,6 +25,7 @@ import { getAvailableBalance, getWalletName } from '../../util/CurrencyWalletHel
 import { triggerHaptic } from '../../util/haptic'
 import { convertNativeToDenomination, darkenHexColor, truncateDecimals, zeroString } from '../../util/utils'
 import { EdgeAnim, fadeInDown50, fadeInDown75, fadeInUp25, fadeInUp50, fadeInUp80 } from '../common/EdgeAnim'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { withWallet } from '../hoc/withWallet'
 import { AddressModal } from '../modals/AddressModal'
@@ -370,9 +371,9 @@ export class RequestSceneComponent extends React.Component<Props & HookProps, St
             <EdgeText style={styles.exchangeRate}>{denomString}</EdgeText>
           </EdgeAnim>
           <EdgeAnim style={styles.balanceContainer} enter={fadeInUp50}>
-            <TouchableOpacity onPress={this.toggleBalanceVisibility} style={styles.balanceAmountContainer}>
+            <EdgeTouchableOpacity onPress={this.toggleBalanceVisibility} style={styles.balanceAmountContainer}>
               {this.props.showBalance ? <EdgeText>{displayBalanceString}</EdgeText> : <EdgeText>{lstrings.string_show_balance}</EdgeText>}
-            </TouchableOpacity>
+            </EdgeTouchableOpacity>
             <EdgeText style={styles.exchangeRate}>
               <FiatText
                 appendFiatCurrencyCode
@@ -429,13 +430,13 @@ export class RequestSceneComponent extends React.Component<Props & HookProps, St
           )}
 
           <EdgeAnim enter={fadeInDown50}>
-            <TouchableOpacity accessible={false} disabled={addressExplorerDisabled} onPress={this.handleAddressBlockExplorer}>
+            <EdgeTouchableOpacity accessible={false} disabled={addressExplorerDisabled} onPress={this.handleAddressBlockExplorer}>
               <View style={styles.rightChevronContainer}>
                 <EdgeText>{selectedAddress?.label ?? lstrings.request_qr_your_wallet_address}</EdgeText>
                 {addressExplorerDisabled ? null : <IonIcon name="chevron-forward" size={theme.rem(1.5)} color={theme.iconTappable} />}
               </View>
               <EdgeText style={styles.publicAddressText}>{requestAddress}</EdgeText>
-            </TouchableOpacity>
+            </EdgeTouchableOpacity>
           </EdgeAnim>
         </View>
 

--- a/src/components/scenes/Staking/StakeOptionsScene.tsx
+++ b/src/components/scenes/Staking/StakeOptionsScene.tsx
@@ -1,7 +1,7 @@
 import { EdgeCurrencyWallet } from 'edge-core-js'
 import * as React from 'react'
 import { View } from 'react-native'
-import { FlatList, TouchableOpacity } from 'react-native-gesture-handler'
+import { FlatList } from 'react-native-gesture-handler'
 import { sprintf } from 'sprintf-js'
 
 import { SCROLL_INDICATOR_INSET_FIX } from '../../../constants/constantSettings'
@@ -14,6 +14,7 @@ import { getTokenIdForced } from '../../../util/CurrencyInfoHelpers'
 import { getPluginFromPolicy, getPolicyAssetName, getPolicyIconUris, getPolicyTitleName } from '../../../util/stakeUtils'
 import { darkenHexColor } from '../../../util/utils'
 import { StakingOptionCard } from '../../cards/StakingOptionCard'
+import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { withWallet } from '../../hoc/withWallet'
 import { cacheStyles, Theme, useTheme } from '../../services/ThemeContext'
@@ -68,14 +69,14 @@ const StakeOptionsSceneComponent = (props: Props) => {
     const policyIcons = getPolicyIconUris(wallet.currencyInfo, item)
     return (
       <View key={key} style={styles.optionContainer}>
-        <TouchableOpacity onPress={() => handleStakeOptionPress(item)}>
+        <EdgeTouchableOpacity onPress={() => handleStakeOptionPress(item)}>
           <StakingOptionCard
             currencyLogos={policyIcons.stakeAssetUris}
             primaryText={primaryText}
             secondaryText={secondaryText}
             stakeProviderInfo={item.stakeProviderInfo}
           />
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
       </View>
     )
   }

--- a/src/components/scenes/WcConnectionsScene.tsx
+++ b/src/components/scenes/WcConnectionsScene.tsx
@@ -2,7 +2,7 @@ import { ProposalTypes } from '@walletconnect/types'
 import { Web3WalletTypes } from '@walletconnect/web3wallet'
 import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
-import { ScrollView, TouchableOpacity, View } from 'react-native'
+import { ScrollView, View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { sprintf } from 'sprintf-js'
@@ -17,6 +17,7 @@ import { lstrings } from '../../locales/strings'
 import { useSelector } from '../../types/reactRedux'
 import { EdgeSceneProps } from '../../types/routerTypes'
 import { EdgeAsset, WcConnectionInfo } from '../../types/types'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { ScanModal } from '../modals/ScanModal'
 import { Airship, showError } from '../services/AirshipInstance'
@@ -110,7 +111,7 @@ export const WcConnectionsScene = (props: Props) => {
         )}
         <View style={styles.list}>
           {connections.map((dAppConnection: WcConnectionInfo, index) => (
-            <TouchableOpacity key={index} style={styles.listRow} onPress={() => handleActiveConnectionPress(dAppConnection)}>
+            <EdgeTouchableOpacity key={index} style={styles.listRow} onPress={() => handleActiveConnectionPress(dAppConnection)}>
               <FastImage resizeMode="contain" style={styles.currencyLogo} source={{ uri: dAppConnection.icon }} />
               <View style={styles.info}>
                 <EdgeText style={styles.infoTitle}>{dAppConnection.dAppName}</EdgeText>
@@ -120,7 +121,7 @@ export const WcConnectionsScene = (props: Props) => {
               <View style={styles.arrow}>
                 <AntDesignIcon name="right" size={theme.rem(1)} color={theme.icon} />
               </View>
-            </TouchableOpacity>
+            </EdgeTouchableOpacity>
           ))}
         </View>
       </ScrollView>

--- a/src/components/settings/SettingsRow.tsx
+++ b/src/components/settings/SettingsRow.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import { ActivityIndicator, Text, TextStyle, TouchableHighlight, View } from 'react-native'
+import { ActivityIndicator, Text, TextStyle, View } from 'react-native'
 import Animated, { useAnimatedStyle, withDelay, withTiming } from 'react-native-reanimated'
 
 import { usePendingPress } from '../../hooks/usePendingPress'
+import { EdgeTouchableHighlight } from '../common/EdgeTouchableHighlight'
 import { styled } from '../hoc/styled'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 
@@ -42,7 +43,7 @@ const SettingsRowComponent = (props: Props) => {
   const [pending, handlePress] = usePendingPress(onPress)
 
   return (
-    <TouchableHighlight accessible={false} underlayColor={theme.settingsRowPressed} style={styles.row} onPress={handlePress}>
+    <EdgeTouchableHighlight accessible={false} underlayColor={theme.settingsRowPressed} style={styles.row} onPress={handlePress}>
       <>
         {children}
         <Text style={disabled ? styles.disabledText : dangerous ? styles.dangerText : styles.text}>{label}</Text>
@@ -53,7 +54,7 @@ const SettingsRowComponent = (props: Props) => {
           <RightContainer pending={pending}>{right}</RightContainer>
         </View>
       </>
-    </TouchableHighlight>
+    </EdgeTouchableHighlight>
   )
 }
 

--- a/src/components/themed/Alert.tsx
+++ b/src/components/themed/Alert.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
-import { Platform, TouchableOpacity, View } from 'react-native'
+import { Platform, View } from 'react-native'
 import IonIcon from 'react-native-vector-icons/Ionicons'
 
 import { useHandler } from '../../hooks/useHandler'
 import { fixSides, mapSides, sidesToMargin, sidesToPadding } from '../../util/sides'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
@@ -57,7 +58,7 @@ export function Alert(props: Props) {
     </View>
   )
 
-  return onPress ? <TouchableOpacity onPress={handlePress}>{result}</TouchableOpacity> : result
+  return onPress ? <EdgeTouchableOpacity onPress={handlePress}>{result}</EdgeTouchableOpacity> : result
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({

--- a/src/components/themed/ClickableText.tsx
+++ b/src/components/themed/ClickableText.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import { ActivityIndicator, Text, TouchableOpacity } from 'react-native'
+import { ActivityIndicator, Text } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 
 import { fixSides, mapSides, sidesToMargin, sidesToPadding } from '../../util/sides'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { showError } from '../services/AirshipInstance'
 import { Theme, useTheme } from '../services/ThemeContext'
 
@@ -68,12 +69,12 @@ export function ClickableText(props: Props) {
   }
 
   return (
-    <TouchableOpacity disabled={disabled || pending} style={[styles.buttonContainer, dynamicStyles]} onPress={handlePress}>
+    <EdgeTouchableOpacity disabled={disabled || pending} style={[styles.buttonContainer, dynamicStyles]} onPress={handlePress}>
       {icon != null ? icon : null}
       {label != null && !pending ? <Text style={styles.buttonText}>{label}</Text> : null}
       {!pending ? children : null}
       {spinner || pending ? <ActivityIndicator color={theme.secondaryButtonText} style={styles.spinner} /> : null}
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/CreateWalletSelectCryptoRow.tsx
+++ b/src/components/themed/CreateWalletSelectCryptoRow.tsx
@@ -1,10 +1,11 @@
 import { EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 
 import { useHandler } from '../../hooks/useHandler'
 import { useWatch } from '../../hooks/useWatch'
 import { useSelector } from '../../types/reactRedux'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { CryptoIconUi4 } from '../ui4/CryptoIconUi4'
@@ -48,14 +49,14 @@ export const CreateWalletSelectCryptoRowComponent = (props: Props) => {
   })
 
   return (
-    <TouchableOpacity style={styles.container} disabled={onPress == null} onPress={handlePress}>
+    <EdgeTouchableOpacity style={styles.container} disabled={onPress == null} onPress={handlePress}>
       <CryptoIconUi4 marginRem={1} pluginId={pluginId} sizeRem={2} tokenId={tokenId} />
       <View style={styles.detailsContainer}>
         <EdgeText style={styles.detailsCurrency}>{`${tokenOrCurrencyInfo == null ? '' : tokenOrCurrencyInfo.currencyCode}${networkName}`}</EdgeText>
         <EdgeText style={styles.detailsName}>{walletName}</EdgeText>
       </View>
       <View style={styles.childrenContainer}>{rightSide}</View>
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -5,7 +5,7 @@
 
 import * as React from 'react'
 import { useMemo } from 'react'
-import { ActivityIndicator, Platform, Text, TextInput, TouchableOpacity, TouchableWithoutFeedback, View } from 'react-native'
+import { ActivityIndicator, Platform, Text, TextInput, TouchableOpacity, View } from 'react-native'
 import Animated, {
   interpolate,
   interpolateColor,
@@ -20,6 +20,7 @@ import Animated, {
 
 import { useHandler } from '../../hooks/useHandler'
 import { SpaceProps, useSpaceStyle } from '../../hooks/useSpaceStyle'
+import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { styled, styledWithRef } from '../hoc/styled'
 import { AnimatedIconComponent, CloseIconAnimated, EyeIconAnimated } from '../icons/ThemedIcons'
 import { useTheme } from '../services/ThemeContext'
@@ -223,7 +224,7 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
 
   return (
     <View style={spaceStyle}>
-      <TouchableWithoutFeedback accessible={false} testID={testID} onPress={() => focus()}>
+      <EdgeTouchableWithoutFeedback accessible={false} testID={testID} onPress={() => focus()}>
         <Container disableAnimation={disableAnimation} focusAnimation={focusAnimation} multiline={multiline} scale={scale}>
           <SideContainer scale={leftIconSize}>{LeftIcon == null ? null : <LeftIcon color={iconColor} size={leftIconSize} />}</SideContainer>
 
@@ -288,7 +289,7 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
             </SideContainer>
           </TouchContainer>
         </Container>
-      </TouchableWithoutFeedback>
+      </EdgeTouchableWithoutFeedback>
       {valid != null || error != null || charactersLeft !== '' ? (
         <MessagesContainer noLayoutFlow={charactersLeft === ''}>
           <Message danger={error != null}>{valid ?? error ?? null}</Message>

--- a/src/components/themed/FioRequestRow.tsx
+++ b/src/components/themed/FioRequestRow.tsx
@@ -1,7 +1,7 @@
 import { mul, toFixed } from 'biggystring'
 import { EdgeDenomination } from 'edge-core-js'
 import * as React from 'react'
-import { StyleSheet, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import { SharedValue } from 'react-native-reanimated'
 import FontAwesome from 'react-native-vector-icons/FontAwesome'
 
@@ -14,6 +14,7 @@ import { connect } from '../../types/reactRedux'
 import { FioRequest, FioRequestStatus } from '../../types/types'
 import { getCryptoText } from '../../util/cryptoTextUtils'
 import { convertEdgeToFIOCodes, convertFIOToEdgeCodes } from '../../util/FioAddressUtils'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SwipeableRowIcon } from '../icons/SwipeableRowIcon'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
@@ -104,11 +105,11 @@ class FioRequestRowComponent extends React.PureComponent<Props> {
           fioRequest.status === 'sent_to_blockchain' || fioRequest.status === 'rejected'
             ? undefined
             : (isActive: SharedValue<boolean>) => (
-                <TouchableOpacity style={styles.underlay} onPress={this.onSwipe}>
+                <EdgeTouchableOpacity style={styles.underlay} onPress={this.onSwipe}>
                   <SwipeableRowIcon isActive={isActive} minWidth={theme.rem(7)}>
                     <EdgeText>{isSent ? lstrings.string_cancel_cap : lstrings.swap_terms_reject_button}</EdgeText>
                   </SwipeableRowIcon>
-                </TouchableOpacity>
+                </EdgeTouchableOpacity>
               )
         }
         rightDetent={theme.rem(7)}

--- a/src/components/themed/FlipInput2.tsx
+++ b/src/components/themed/FlipInput2.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useMemo } from 'react'
-import { Platform, ReturnKeyType, Text, TextInput, TouchableWithoutFeedback, View } from 'react-native'
+import { Platform, ReturnKeyType, Text, TextInput, View } from 'react-native'
 import Animated, {
   AnimationCallback,
   Easing,
@@ -19,6 +19,7 @@ import { formatNumberInput, isValidInput } from '../../locales/intl'
 import { lstrings } from '../../locales/strings'
 import { useState } from '../../types/reactHooks'
 import { zeroString } from '../../util/utils'
+import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { styled, styledWithRef } from '../hoc/styled'
 import { FlipIcon } from '../icons/ThemedIcons'
 import { showError } from '../services/AirshipInstance'
@@ -171,11 +172,11 @@ export const FlipInput2 = React.forwardRef<FlipInputRef, Props>((props: Props, r
     const fieldInfo = fieldInfos[fieldNum]
     topText = `${topText} ${fieldInfo.currencyName}`
     return (
-      <TouchableWithoutFeedback onPress={onToggleFlipInput} key="top">
+      <EdgeTouchableWithoutFeedback onPress={onToggleFlipInput} key="top">
         <TopAmountText numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.65}>
           {topText}
         </TopAmountText>
-      </TouchableWithoutFeedback>
+      </EdgeTouchableWithoutFeedback>
     )
   }
 
@@ -331,7 +332,7 @@ const CurrencySymbolAnimatedText = styled(Animated.Text)<{ focusAnimation: Share
   ]
 })
 
-const AmountFieldContainerTouchable = styled(TouchableWithoutFeedback)(theme => {
+const AmountFieldContainerTouchable = styled(EdgeTouchableWithoutFeedback)(theme => {
   return {
     marginRight: theme.rem(1.5),
     minHeight: theme.rem(2)

--- a/src/components/themed/ManageTokensRow.tsx
+++ b/src/components/themed/ManageTokensRow.tsx
@@ -1,6 +1,6 @@
 import { EdgeCurrencyWallet, EdgeToken } from 'edge-core-js'
 import * as React from 'react'
-import { ActivityIndicator, Pressable, Switch, TouchableOpacity, View } from 'react-native'
+import { ActivityIndicator, Pressable, Switch, View } from 'react-native'
 import Animated, { useAnimatedStyle } from 'react-native-reanimated'
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome'
 
@@ -11,6 +11,7 @@ import { lstrings } from '../../locales/strings'
 import { NavigationProp } from '../../types/routerTypes'
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import { logActivity } from '../../util/logger'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { CryptoIconUi4 } from '../ui4/CryptoIconUi4'
 import { EdgeText } from './EdgeText'
@@ -84,9 +85,9 @@ export const ManageTokensRowComponent = (props: Props) => {
         <EdgeText style={styles.displayName}>{token.displayName}</EdgeText>
       </View>
       {!isCustom ? null : (
-        <TouchableOpacity style={styles.editIcon} onPress={handleEdit}>
+        <EdgeTouchableOpacity style={styles.editIcon} onPress={handleEdit}>
           <FontAwesomeIcon color={theme.iconTappable} name="edit" size={theme.rem(1)} accessibilityHint={lstrings.edit_icon_hint} accessibilityRole="button" />
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
       )}
       <View pointerEvents="none" style={styles.switchBox}>
         <AnimatedSpinner color={theme.iconTappable} style={[styles.spinner, spinnerStyle]} accessibilityHint={lstrings.spinner_hint} />

--- a/src/components/themed/MaybeCustomServersSetting.tsx
+++ b/src/components/themed/MaybeCustomServersSetting.tsx
@@ -1,11 +1,12 @@
 import { asArray, asBoolean, asCodec, asObject, asOptional, asString, Cleaner, uncleaner } from 'cleaners'
 import * as React from 'react'
-import { Text, TouchableOpacity } from 'react-native'
+import { Text } from 'react-native'
 import { sprintf } from 'sprintf-js'
 
 import { useHandler } from '../../hooks/useHandler'
 import { lstrings } from '../../locales/strings'
 import { logActivity } from '../../util/logger'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { CurrencySettingProps, maybeCurrencySetting } from '../hoc/MaybeCurrencySetting'
 import { TextInputModal } from '../modals/TextInputModal'
 import { Airship, showError } from '../services/AirshipInstance'
@@ -76,9 +77,9 @@ function CustomServersSettingComponent(props: Props) {
         <>
           {Array.from(customServerSet).map(server => (
             <SettingsTappableRow key={server} action="delete" onPress={async () => await handleDeleteNode(server)}>
-              <TouchableOpacity onPress={() => handleEditNode(server)} style={styles.labelContainer}>
+              <EdgeTouchableOpacity onPress={() => handleEditNode(server)} style={styles.labelContainer}>
                 <Text style={styles.labelText}>{server}</Text>
-              </TouchableOpacity>
+              </EdgeTouchableOpacity>
             </SettingsTappableRow>
           ))}
           <SettingsTappableRow action="add" label={lstrings.settings_add_custom_node} onPress={handleEditNode} />

--- a/src/components/themed/MiniButton.tsx
+++ b/src/components/themed/MiniButton.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
-import { ActivityIndicator, Text, TouchableOpacity } from 'react-native'
+import { ActivityIndicator, Text } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 
 import { usePendingPress } from '../../hooks/usePendingPress'
 import { fixSides, mapSides, sidesToMargin } from '../../util/sides'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { Theme, useTheme } from '../services/ThemeContext'
 
 interface Props {
@@ -47,14 +48,14 @@ export function MiniButton(props: Props) {
   }
 
   return (
-    <TouchableOpacity disabled={disabled || pending} style={[styles.button, dynamicStyles]} onPress={handlePress}>
+    <EdgeTouchableOpacity disabled={disabled || pending} style={[styles.button, dynamicStyles]} onPress={handlePress}>
       {pending ? null : (
         <Text adjustsFontSizeToFit minimumFontScale={0.75} numberOfLines={1} style={styles.label}>
           {label}
         </Text>
       )}
       {!pending ? null : <ActivityIndicator color={theme.secondaryButtonText} style={styles.spinner} />}
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/ModalParts.tsx
+++ b/src/components/themed/ModalParts.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
-import { Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native'
+import { Platform, ScrollView, Text, View } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
 import { lstrings } from '../../locales/strings'
 import { fixSides, mapSides, sidesToPadding } from '../../util/sides'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { GradientFadeOut } from '../modals/GradientFadeout'
 import { Theme, useTheme } from '../services/ThemeContext'
 
@@ -55,9 +56,9 @@ export function ModalFooter(props: ModalFooterProps) {
   const styles = getStyles(theme)
 
   return (
-    <TouchableOpacity onPress={props.onPress} style={styles.closeContainer}>
+    <EdgeTouchableOpacity onPress={props.onPress} style={styles.closeContainer}>
       <AntDesignIcon accessibilityHint={lstrings.modal_close_hint} color={theme.iconTappable} name="close" size={theme.rem(1.25)} />
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/QrCode.tsx
+++ b/src/components/themed/QrCode.tsx
@@ -1,10 +1,11 @@
 import qrcodeGenerator from 'qrcode-generator'
 import * as React from 'react'
-import { ActivityIndicator, TouchableWithoutFeedback, View } from 'react-native'
+import { ActivityIndicator, View } from 'react-native'
 import Animated, { useAnimatedStyle, useDerivedValue, withTiming } from 'react-native-reanimated'
 import Svg, { Path } from 'react-native-svg'
 
 import { fixSides, mapSides, sidesToMargin } from '../../util/sides'
+import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 
 interface Props {
@@ -46,7 +47,7 @@ export function QrCode(props: Props) {
   const viewBox = `0 0 ${sizeInCells} ${sizeInCells}`
 
   return (
-    <TouchableWithoutFeedback onPress={onPress}>
+    <EdgeTouchableWithoutFeedback onPress={onPress}>
       <View style={[styles.container, margin]} onLayout={handleLayout}>
         <ActivityIndicator color={theme.iconTappable} />
         <Animated.View style={[styles.whiteBox, fadeStyle]}>
@@ -57,7 +58,7 @@ export function QrCode(props: Props) {
           )}
         </Animated.View>
       </View>
-    </TouchableWithoutFeedback>
+    </EdgeTouchableWithoutFeedback>
   )
 }
 

--- a/src/components/themed/ShareButtons.tsx
+++ b/src/components/themed/ShareButtons.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 
 import { Fontello } from '../../assets/vector/index'
-import { usePendingPress } from '../../hooks/usePendingPress'
 import { lstrings } from '../../locales/strings'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 
@@ -31,13 +31,12 @@ function ShareButton(props: { text: string; onPress: () => Promise<void>; icon: 
   const { icon, text, onPress } = props
   const theme = useTheme()
   const styles = getStyles(theme)
-  const [pending, handlePress] = usePendingPress(onPress)
 
   return (
-    <TouchableOpacity accessible={false} style={styles.button} onPress={handlePress} disabled={pending}>
+    <EdgeTouchableOpacity accessible={false} style={styles.button} onPress={onPress}>
       <Fontello name={icon} size={theme.rem(1.5)} style={styles.image} color={theme.iconTappable} />
       <EdgeText style={styles.text}>{text}</EdgeText>
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/SideMenu.tsx
+++ b/src/components/themed/SideMenu.tsx
@@ -3,7 +3,7 @@ import { DrawerContentComponentProps, useDrawerStatus } from '@react-navigation/
 import { DrawerActions } from '@react-navigation/native'
 import { EdgeAccount, EdgeUserInfo } from 'edge-core-js'
 import * as React from 'react'
-import { Image, Platform, Pressable, ScrollView, TouchableOpacity, View } from 'react-native'
+import { Image, Platform, Pressable, ScrollView, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import Animated, { Easing, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -30,6 +30,7 @@ import { NavigationBase } from '../../types/routerTypes'
 import { parseDeepLink } from '../../util/DeepLinkParser'
 import { base58ToUuid } from '../../util/utils'
 import { IONIA_SUPPORTED_FIATS } from '../cards/VisaCardCard'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { ScanModal } from '../modals/ScanModal'
 import { LoadingSplashScreen } from '../progress-indicators/LoadingSplashScreen'
@@ -310,12 +311,12 @@ export function SideMenuComponent(props: DrawerContentComponentProps) {
               <View key={userInfo.loginId} style={styles.rowContainer}>
                 {/* This empty container is required to align the row contents properly */}
                 <View style={styles.rowIconContainer} />
-                <TouchableOpacity style={styles.rowBodyContainer} onPress={handleSwitchAccount(userInfo)}>
+                <EdgeTouchableOpacity style={styles.rowBodyContainer} onPress={handleSwitchAccount(userInfo)}>
                   <TitleText style={styles.text}>{userInfo.username ?? lstrings.missing_username}</TitleText>
-                </TouchableOpacity>
-                <TouchableOpacity style={styles.rowIconContainer} onPress={handleDeleteAccount(userInfo)}>
+                </EdgeTouchableOpacity>
+                <EdgeTouchableOpacity style={styles.rowIconContainer} onPress={handleDeleteAccount(userInfo)}>
                   <MaterialIcon accessibilityHint={lstrings.close_control_panel_hint} color={theme.iconTappable} name="close" size={theme.rem(1.5)} />
-                </TouchableOpacity>
+                </EdgeTouchableOpacity>
               </View>
             ))}
           </ScrollView>
@@ -327,7 +328,7 @@ export function SideMenuComponent(props: DrawerContentComponentProps) {
         <View style={styles.rowsContainer}>
           <ScrollView overScrollMode="always" scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}>
             {rowDatas.map(rowData => (
-              <TouchableOpacity accessible={false} onPress={rowData.pressHandler} key={rowData.title} style={styles.rowContainer}>
+              <EdgeTouchableOpacity accessible={false} onPress={rowData.pressHandler} key={rowData.title} style={styles.rowContainer}>
                 <View style={styles.rowIconContainer}>
                   {rowData.iconName != null ? <Fontello name={rowData.iconName} style={styles.icon} size={theme.rem(1.5)} color={theme.iconTappable} /> : null}
                   {rowData.iconNameFontAwesome != null ? (
@@ -337,14 +338,14 @@ export function SideMenuComponent(props: DrawerContentComponentProps) {
                 <View style={styles.rowBodyContainer}>
                   <TitleText style={styles.text}>{rowData.title}</TitleText>
                 </View>
-              </TouchableOpacity>
+              </EdgeTouchableOpacity>
             ))}
           </ScrollView>
           {/* === Navigation Rows End === */}
         </View>
         {/* === Translucent X Close Button Start === */}
         <LinearGradient colors={[xButtonTopColor, xButtonBottomColor]} style={closeButtonContainerStyle} start={xButtonGradientStart} end={xButtonGradientEnd}>
-          <TouchableOpacity onPress={handlePressClose}>
+          <EdgeTouchableOpacity onPress={handlePressClose}>
             <AntDesignIcon
               testID="closeX"
               name="close"
@@ -352,7 +353,7 @@ export function SideMenuComponent(props: DrawerContentComponentProps) {
               color={theme.iconTappable}
               accessibilityHint={lstrings.close_control_panel_hint}
             />
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         </LinearGradient>
         {/* === Translucent X Close Button End === */}
       </View>

--- a/src/components/themed/SimpleTextInput.tsx
+++ b/src/components/themed/SimpleTextInput.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useMemo } from 'react'
-import { TextInput, TouchableOpacity, TouchableWithoutFeedback, View } from 'react-native'
+import { TextInput, TouchableOpacity, View } from 'react-native'
 import Animated, {
   interpolate,
   interpolateColor,
@@ -15,6 +15,7 @@ import Animated, {
 
 import { useHandler } from '../../hooks/useHandler'
 import { SpaceProps, useSpaceStyle } from '../../hooks/useSpaceStyle'
+import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { styled, styledWithRef } from '../hoc/styled'
 import { AnimatedIconComponent, CloseIconAnimated } from '../icons/ThemedIcons'
 import { useTheme } from '../services/ThemeContext'
@@ -178,7 +179,7 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
   }, [disabled, isFocused, theme.textInputPlaceholderColor, theme.textInputPlaceholderColorDisabled, theme.textInputPlaceholderColorFocused])
 
   return (
-    <TouchableWithoutFeedback accessible={false} testID={testID} onPress={() => focus()}>
+    <EdgeTouchableWithoutFeedback accessible={false} testID={testID} onPress={() => focus()}>
       <Container disableAnimation={disableAnimation} focusAnimation={focusAnimation} scale={scale} spaceProps={spaceProps}>
         <SideContainer size={leftIconSize}>{Icon == null ? null : <Icon color={iconColor} size={leftIconSize} />}</SideContainer>
 
@@ -219,7 +220,7 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
           </SideContainer>
         </TouchContainer>
       </Container>
-    </TouchableWithoutFeedback>
+    </EdgeTouchableWithoutFeedback>
   )
 })
 

--- a/src/components/themed/ThemedButtons.tsx
+++ b/src/components/themed/ThemedButtons.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
-import { TouchableHighlight, TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 import IonIcon from 'react-native-vector-icons/Ionicons'
 
 import { useHandler } from '../../hooks/useHandler'
 import { fixSides, mapSides, sidesToMargin, sidesToPadding } from '../../util/sides'
+import { EdgeTouchableHighlight } from '../common/EdgeTouchableHighlight'
 import { showError } from '../services/AirshipInstance'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from './EdgeText'
@@ -57,7 +58,7 @@ export function Radio(props: RadioButtonProps) {
 
   return (
     <View style={[margin, padding]}>
-      <TouchableHighlight
+      <EdgeTouchableHighlight
         activeOpacity={theme.underlayOpacity}
         // @ts-expect-error
         underlayColor={theme.secondaryButton}
@@ -67,7 +68,7 @@ export function Radio(props: RadioButtonProps) {
           <RadioIcon value={value} />
           {children}
         </View>
-      </TouchableHighlight>
+      </EdgeTouchableHighlight>
     </View>
   )
 }

--- a/src/components/themed/ThemedButtons.tsx
+++ b/src/components/themed/ThemedButtons.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 import IonIcon from 'react-native-vector-icons/Ionicons'
 
 import { useHandler } from '../../hooks/useHandler'
 import { fixSides, mapSides, sidesToMargin, sidesToPadding } from '../../util/sides'
 import { EdgeTouchableHighlight } from '../common/EdgeTouchableHighlight'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { showError } from '../services/AirshipInstance'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from './EdgeText'
@@ -43,9 +44,9 @@ export function ButtonBox(props: Props) {
   })
 
   return (
-    <TouchableOpacity accessible={false} onPress={handlePress} style={[margin, padding]}>
+    <EdgeTouchableOpacity accessible={false} onPress={handlePress} style={[margin, padding]}>
       {children}
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 
@@ -93,12 +94,12 @@ export function RightChevronButton(props: { text: string; onPress: () => void; p
   const padding = sidesToPadding(mapSides(fixSides(paddingRem, 0), theme.rem))
 
   return (
-    <TouchableOpacity accessible={false} onPress={onPress}>
+    <EdgeTouchableOpacity accessible={false} onPress={onPress}>
       <View style={[padding, styles.rightChevronContainer]}>
         <EdgeText style={styles.rightChevronText}>{text}</EdgeText>
         <IonIcon name="chevron-forward" size={theme.rem(1.5)} color={theme.iconTappable} />
       </View>
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/TransactionListTop.tsx
+++ b/src/components/themed/TransactionListTop.tsx
@@ -1,7 +1,7 @@
 import { add, gt, mul, round } from 'biggystring'
 import { EdgeAccount, EdgeBalanceMap, EdgeCurrencyWallet, EdgeDenomination, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { ActivityIndicator, TouchableOpacity, View } from 'react-native'
+import { ActivityIndicator, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import Ionicons from 'react-native-vector-icons/Ionicons'
 import { sprintf } from 'sprintf-js'
@@ -26,6 +26,7 @@ import { triggerHaptic } from '../../util/haptic'
 import { getFioStakingBalances, getPluginFromPolicy, getPositionAllocations } from '../../util/stakeUtils'
 import { convertNativeToDenomination, datelog } from '../../util/utils'
 import { VisaCardCard } from '../cards/VisaCardCard'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { BackupForTransferModal, BackupForTransferModalResult } from '../modals/BackupForTransferModal'
 import { WalletListMenuModal } from '../modals/WalletListMenuModal'
 import { WalletListModal, WalletListResult } from '../modals/WalletListModal'
@@ -199,18 +200,18 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
     return (
       <>
         <View style={styles.balanceBoxWalletNameCurrencyContainer}>
-          <TouchableOpacity accessible={false} style={styles.balanceBoxWalletNameContainer} onPress={this.handleOpenWalletListModal}>
+          <EdgeTouchableOpacity accessible={false} style={styles.balanceBoxWalletNameContainer} onPress={this.handleOpenWalletListModal}>
             <CryptoIconUi4 sizeRem={1.5} tokenId={tokenId} walletId={wallet.id} />
             <EdgeText accessible style={styles.balanceBoxWalletName}>
               {walletName}
             </EdgeText>
             <Ionicons name="chevron-forward" size={theme.rem(1.5)} color={theme.iconTappable} />
-          </TouchableOpacity>
-          <TouchableOpacity testID="gearIcon" onPress={this.handleMenu} style={styles.settingsIcon}>
+          </EdgeTouchableOpacity>
+          <EdgeTouchableOpacity testID="gearIcon" onPress={this.handleMenu} style={styles.settingsIcon}>
             <Fontello accessibilityHint={lstrings.wallet_settings_label} color={theme.iconTappable} name="control-panel-settings" size={theme.rem(1.5)} />
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         </View>
-        <TouchableOpacity accessible={false} onPress={this.props.toggleBalanceVisibility}>
+        <EdgeTouchableOpacity accessible={false} onPress={this.props.toggleBalanceVisibility}>
           {isAccountBalanceVisible ? (
             <>
               <EdgeText accessible style={styles.balanceBoxCurrency} minimumFontScale={0.3}>
@@ -225,7 +226,7 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
               {lstrings.string_show_balance}
             </EdgeText>
           )}
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
       </>
     )
   }
@@ -378,24 +379,24 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
             {this.renderBalanceBox()}
             {isStakingAvailable && this.renderStakedBalance()}
             <View style={styles.buttonsContainer}>
-              <TouchableOpacity accessible={false} onPress={this.handleRequest} style={styles.buttons}>
+              <EdgeTouchableOpacity accessible={false} onPress={this.handleRequest} style={styles.buttons}>
                 <EdgeText accessible style={styles.buttonsText}>
                   {lstrings.fragment_request_subtitle}
                 </EdgeText>
-              </TouchableOpacity>
-              <TouchableOpacity accessible={false} onPress={this.handleSend} style={styles.buttons}>
+              </EdgeTouchableOpacity>
+              <EdgeTouchableOpacity accessible={false} onPress={this.handleSend} style={styles.buttons}>
                 <EdgeText accessible style={styles.buttonsText}>
                   {lstrings.fragment_send_subtitle}
                 </EdgeText>
-              </TouchableOpacity>
+              </EdgeTouchableOpacity>
               {!isStakePoliciesLoaded ? (
                 <ActivityIndicator color={theme.textLink} style={styles.stakingButton} />
               ) : (
                 isStakingAvailable && (
-                  <TouchableOpacity onPress={this.handleStakePress} style={styles.buttons}>
+                  <EdgeTouchableOpacity onPress={this.handleStakePress} style={styles.buttons}>
                     <EdgeText style={styles.buttonsText}>{lstrings.stake_earn_button_label}</EdgeText>
                     {bestApy != null ? <EdgeText style={styles.apyText}>{bestApy}</EdgeText> : null}
-                  </TouchableOpacity>
+                  </EdgeTouchableOpacity>
                 )
               )}
             </View>

--- a/src/components/themed/WalletListCreateRow.tsx
+++ b/src/components/themed/WalletListCreateRow.tsx
@@ -1,7 +1,6 @@
 import { EdgeCurrencyWallet, EdgeTokenId, JsonObject } from 'edge-core-js'
 import * as React from 'react'
 import { View } from 'react-native'
-import { TouchableOpacity } from 'react-native-gesture-handler'
 
 import { createWallet, getUniqueWalletName } from '../../actions/CreateWalletActions'
 import { approveTokenTerms } from '../../actions/TokenTermsActions'
@@ -15,6 +14,7 @@ import { useDispatch, useSelector } from '../../types/reactRedux'
 import { ThunkAction } from '../../types/reduxTypes'
 import { getTokenIdForced } from '../../util/CurrencyInfoHelpers'
 import { logEvent, TrackingEventName } from '../../util/tracking'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { ListModal } from '../modals/ListModal'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { CryptoIconUi4 } from '../ui4/CryptoIconUi4'
@@ -127,7 +127,7 @@ export const WalletListCreateRowComponent = (props: WalletListCreateRowProps) =>
   })
 
   return (
-    <TouchableOpacity style={styles.row} onPress={handlePress}>
+    <EdgeTouchableOpacity style={styles.row} onPress={handlePress}>
       <CryptoIconUi4 marginRem={1} pluginId={pluginId} sizeRem={2} tokenId={tokenId} />
       <View style={styles.nameColumn}>
         <EdgeText style={styles.currencyText}>{`${currencyCode}${networkName}`}</EdgeText>
@@ -136,7 +136,7 @@ export const WalletListCreateRowComponent = (props: WalletListCreateRowProps) =>
       <View style={styles.labelColumn}>
         <EdgeText style={styles.labelText}>{walletType != null ? lstrings.fragment_create_wallet_create_wallet : lstrings.wallet_list_add_token}</EdgeText>
       </View>
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/WalletListCurrencyRow.tsx
+++ b/src/components/themed/WalletListCurrencyRow.tsx
@@ -1,6 +1,5 @@
 import { EdgeCurrencyWallet, EdgeToken, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { TouchableOpacity } from 'react-native'
 
 import { useHandler } from '../../hooks/useHandler'
 import { useIconColor } from '../../hooks/useIconColor'
@@ -8,6 +7,7 @@ import { lstrings } from '../../locales/strings'
 import { useSelector } from '../../types/reactRedux'
 import { isKeysOnlyPlugin } from '../../util/CurrencyInfoHelpers'
 import { triggerHaptic } from '../../util/haptic'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { CustomAsset, CustomAssetRow } from '../data/row/CustomAssetRow'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { CardUi4 } from '../ui4/CardUi4'
@@ -63,9 +63,9 @@ const WalletListCurrencyRowComponent = (props: Props) => {
 
   return customAsset != null ? (
     // TODO: Update to UI4
-    <TouchableOpacity accessible={false} style={styles.row} onLongPress={handleLongPress} onPress={handlePress}>
+    <EdgeTouchableOpacity accessible={false} style={styles.row} onLongPress={handleLongPress} onPress={handlePress}>
       <CustomAssetRow customAsset={customAsset} />
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   ) : (
     <CardUi4
       overlay={isPaused ? <EdgeText style={styles.overlayLabel}>{lstrings.fragment_wallets_wallet_paused}</EdgeText> : null}

--- a/src/components/themed/WalletListErrorRow.tsx
+++ b/src/components/themed/WalletListErrorRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { TouchableOpacity } from 'react-native'
 import EntypoIcon from 'react-native-vector-icons/Entypo'
 
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from './EdgeText'
 
@@ -16,10 +16,10 @@ function WalletListErrorRowComponent(props: Props) {
   const styles = getStyles(theme)
 
   return (
-    <TouchableOpacity style={styles.container} onLongPress={onLongPress}>
+    <EdgeTouchableOpacity style={styles.container} onLongPress={onLongPress}>
       <EntypoIcon name="warning" size={theme.rem(1)} style={styles.icon} />
       <EdgeText>{error.message}</EdgeText>
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/WalletListHeader.tsx
+++ b/src/components/themed/WalletListHeader.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 import Ionicon from 'react-native-vector-icons/Ionicons'
 
 import { Fontello } from '../../assets/vector/index'
 import { lstrings } from '../../locales/strings'
 import { NavigationBase } from '../../types/routerTypes'
 import { EdgeAnim, fadeInUp40, fadeInUp60 } from '../common/EdgeAnim'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
 import { BalanceCardUi4 } from '../ui4/BalanceCardUi4'
 import { SectionHeaderUi4 } from '../ui4/SectionHeaderUi4'
@@ -26,12 +27,12 @@ export class WalletListHeaderComponent extends React.PureComponent<Props> {
 
     const addSortButtons = (
       <View key="defaultButtons" style={styles.buttonsContainer}>
-        <TouchableOpacity accessible={false} style={styles.addButton} onPress={() => navigation.push('createWalletSelectCrypto', {})}>
+        <EdgeTouchableOpacity accessible={false} style={styles.addButton} onPress={() => navigation.push('createWalletSelectCrypto', {})}>
           <Ionicon testID="addButton" accessibilityHint={lstrings.wallet_list_add_wallet} color={theme.iconTappable} name="md-add" size={theme.rem(1.5)} />
-        </TouchableOpacity>
-        <TouchableOpacity accessible={false} onPress={this.props.openSortModal}>
+        </EdgeTouchableOpacity>
+        <EdgeTouchableOpacity accessible={false} onPress={this.props.openSortModal}>
           <Fontello testID="sortButton" accessibilityHint={lstrings.sort_wallets_hint} color={theme.iconTappable} name="sort" size={theme.rem(1.5)} />
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
       </View>
     )
 

--- a/src/components/themed/WalletListLoadingRow.tsx
+++ b/src/components/themed/WalletListLoadingRow.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import { ActivityIndicator, TouchableOpacity } from 'react-native'
+import { ActivityIndicator } from 'react-native'
 
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 
 interface Props {
@@ -14,9 +15,9 @@ function WalletListLoadingRowComponent(props: Props) {
   const styles = getStyles(theme)
 
   return (
-    <TouchableOpacity style={styles.container} onLongPress={onLongPress} onPress={onPress}>
+    <EdgeTouchableOpacity style={styles.container} onLongPress={onLongPress} onPress={onPress}>
       <ActivityIndicator color={theme.primaryText} size="large" />
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/WalletListSortableRow.tsx
+++ b/src/components/themed/WalletListSortableRow.tsx
@@ -1,7 +1,7 @@
 import { div, gt } from 'biggystring'
 import { EdgeCurrencyWallet } from 'edge-core-js'
 import * as React from 'react'
-import { ActivityIndicator, TouchableOpacity, View } from 'react-native'
+import { ActivityIndicator, View } from 'react-native'
 import Ionicon from 'react-native-vector-icons/Ionicons'
 
 import { FIAT_PRECISION, getSymbolFromCurrency } from '../../constants/WalletAndCurrencyConstants'
@@ -12,6 +12,7 @@ import { useDispatch, useSelector } from '../../types/reactRedux'
 import { getWalletTokenId } from '../../util/CurrencyInfoHelpers'
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import { DECIMAL_PRECISION, decimalOrZero, truncateDecimals } from '../../util/utils'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { CryptoIconUi4 } from '../ui4/CryptoIconUi4'
 import { EdgeText } from './EdgeText'
@@ -34,11 +35,11 @@ function WalletListSortableRowComponent(props: Props) {
 
   if (wallet == null || exchangeDenomination == null) {
     return (
-      <TouchableOpacity style={styles.container} activeOpacity={0.95} onLongPress={onDrag}>
+      <EdgeTouchableOpacity style={styles.container} activeOpacity={0.95} onLongPress={onDrag}>
         <View style={[styles.rowContainer, styles.loaderContainer]}>
           <ActivityIndicator color={theme.primaryText} size="small" />
         </View>
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     )
   }
 
@@ -60,7 +61,7 @@ function WalletListSortableRowComponent(props: Props) {
   const fiatBalanceString = showBalance ? formatNumber(fiatBalanceFormat, { toFixed: FIAT_PRECISION }) : ''
 
   return (
-    <TouchableOpacity style={styles.container} onLongPress={onDrag}>
+    <EdgeTouchableOpacity style={styles.container} onLongPress={onDrag}>
       <View style={styles.rowContainer}>
         <View style={styles.iconContainer}>
           <Ionicon name="ios-menu" size={theme.rem(1.25)} color={theme.icon} />
@@ -79,7 +80,7 @@ function WalletListSortableRowComponent(props: Props) {
           </View>
         </View>
       </View>
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/themed/WalletListSwipeableCurrencyRow.tsx
+++ b/src/components/themed/WalletListSwipeableCurrencyRow.tsx
@@ -1,6 +1,6 @@
 import { EdgeCurrencyWallet, EdgeToken, EdgeTokenId } from 'edge-core-js'
 import * as React from 'react'
-import { Text, TouchableOpacity } from 'react-native'
+import { Text } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { SharedValue } from 'react-native-reanimated'
 
@@ -9,6 +9,7 @@ import { Fontello } from '../../assets/vector/index'
 import { useHandler } from '../../hooks/useHandler'
 import { useDispatch, useSelector } from '../../types/reactRedux'
 import { NavigationProp } from '../../types/routerTypes'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SwipeableRowIcon } from '../icons/SwipeableRowIcon'
 import { BackupForTransferModal, BackupForTransferModalResult } from '../modals/BackupForTransferModal'
 import { WalletListMenuModal } from '../modals/WalletListMenuModal'
@@ -111,27 +112,27 @@ function WalletListSwipeableCurrencyRowComponent(props: Props) {
 
   const renderRequestUnderlay = (isActive: SharedValue<boolean>) => (
     <>
-      <TouchableOpacity style={styles.menuButton} onPress={handleMenu}>
+      <EdgeTouchableOpacity style={styles.menuButton} onPress={handleMenu}>
         <Text style={styles.menuIcon}>…</Text>
-      </TouchableOpacity>
-      <TouchableOpacity style={styles.requestUnderlay} onPress={handleRequest}>
+      </EdgeTouchableOpacity>
+      <EdgeTouchableOpacity style={styles.requestUnderlay} onPress={handleRequest}>
         <SwipeableRowIcon isActive={isActive} minWidth={iconWidth}>
           <Fontello name="request" color={theme.icon} size={theme.rem(1)} />
         </SwipeableRowIcon>
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     </>
   )
 
   const renderSendUnderlay = (isActive: SharedValue<boolean>) => (
     <>
-      <TouchableOpacity style={styles.sendUnderlay} onPress={handleSend}>
+      <EdgeTouchableOpacity style={styles.sendUnderlay} onPress={handleSend}>
         <SwipeableRowIcon isActive={isActive} minWidth={iconWidth}>
           <Fontello name="send" color={theme.icon} size={theme.rem(1)} />
         </SwipeableRowIcon>
-      </TouchableOpacity>
-      <TouchableOpacity style={styles.menuButton} onPress={handleMenu}>
+      </EdgeTouchableOpacity>
+      <EdgeTouchableOpacity style={styles.menuButton} onPress={handleMenu}>
         <Text style={styles.menuIcon}>…</Text>
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     </>
   )
 

--- a/src/components/themed/WalletListSwipeableLoadingRow.tsx
+++ b/src/components/themed/WalletListSwipeableLoadingRow.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
-import { Text, TouchableOpacity } from 'react-native'
+import { Text } from 'react-native'
 import { SharedValue } from 'react-native-reanimated'
 
 import { useHandler } from '../../hooks/useHandler'
 import { useWatch } from '../../hooks/useWatch'
 import { useSelector } from '../../types/reactRedux'
 import { NavigationProp } from '../../types/routerTypes'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SwipeableRowIcon } from '../icons/SwipeableRowIcon'
 import { WalletListMenuModal } from '../modals/WalletListMenuModal'
 import { Airship, showError } from '../services/AirshipInstance'
@@ -47,11 +48,11 @@ function WalletListSwipeableLoadingRowComponent(props: Props) {
 
   const renderMenuUnderlay = (isActive: SharedValue<boolean>) => {
     return (
-      <TouchableOpacity style={styles.menuUnderlay} onPress={handleMenu}>
+      <EdgeTouchableOpacity style={styles.menuUnderlay} onPress={handleMenu}>
         <SwipeableRowIcon isActive={isActive} minWidth={iconWidth}>
           <Text style={styles.menuIcon}>…</Text>
         </SwipeableRowIcon>
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     )
   }
 

--- a/src/components/tiles/AddressTile2.tsx
+++ b/src/components/tiles/AddressTile2.tsx
@@ -2,7 +2,6 @@ import Clipboard from '@react-native-clipboard/clipboard'
 import { EdgeCurrencyWallet, EdgeParsedUri } from 'edge-core-js'
 import { ethers } from 'ethers'
 import * as React from 'react'
-import { TouchableOpacity } from 'react-native'
 import AntDesign from 'react-native-vector-icons/AntDesign'
 import FontAwesome from 'react-native-vector-icons/FontAwesome'
 import FontAwesome5 from 'react-native-vector-icons/FontAwesome5'
@@ -20,6 +19,7 @@ import { getTokenId, getTokenIdForced } from '../../util/CurrencyInfoHelpers'
 import { parseDeepLink } from '../../util/DeepLinkParser'
 import { checkPubAddress } from '../../util/FioAddressUtils'
 import { EdgeAnim } from '../common/EdgeAnim'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { AddressModal } from '../modals/AddressModal'
 import { ScanModal } from '../modals/ScanModal'
 import { WalletListModal, WalletListResult } from '../modals/WalletListModal'
@@ -265,24 +265,24 @@ export const AddressTile2 = React.forwardRef((props: Props, ref: React.Forwarded
     <RowUi4 rightButtonType={tileType} loading={loading} title={title} onPress={handleTilePress}>
       {!recipientAddress && (
         <EdgeAnim style={styles.buttonsContainer} enter={{ type: 'stretchInY' }} exit={{ type: 'stretchOutY' }}>
-          <TouchableOpacity style={styles.buttonContainer} onPress={handleChangeAddress}>
+          <EdgeTouchableOpacity style={styles.buttonContainer} onPress={handleChangeAddress}>
             <FontAwesome name="edit" size={theme.rem(2)} color={theme.iconTappable} />
             <EdgeText style={styles.buttonText}>{lstrings.enter_as_in_enter_address_with_keyboard}</EdgeText>
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
           {canSelfTransfer ? (
-            <TouchableOpacity style={styles.buttonContainer} onPress={handleSelfTransfer}>
+            <EdgeTouchableOpacity style={styles.buttonContainer} onPress={handleSelfTransfer}>
               <AntDesign name="wallet" size={theme.rem(2)} color={theme.iconTappable} />
               <EdgeText style={styles.buttonText}>{lstrings.fragment_send_myself}</EdgeText>
-            </TouchableOpacity>
+            </EdgeTouchableOpacity>
           ) : null}
-          <TouchableOpacity style={styles.buttonContainer} onPress={handleScan}>
+          <EdgeTouchableOpacity style={styles.buttonContainer} onPress={handleScan}>
             <FontAwesome5 name="expand" size={theme.rem(2)} color={theme.iconTappable} />
             <EdgeText style={styles.buttonText}>{lstrings.scan_as_in_scan_barcode}</EdgeText>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.buttonContainer} onPress={handlePasteFromClipboard}>
+          </EdgeTouchableOpacity>
+          <EdgeTouchableOpacity style={styles.buttonContainer} onPress={handlePasteFromClipboard}>
             <FontAwesome5 name="clipboard" size={theme.rem(2)} color={theme.iconTappable} />
             <EdgeText style={styles.buttonText}>{lstrings.string_paste}</EdgeText>
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         </EdgeAnim>
       )}
       {recipientAddress == null || recipientAddress === '' ? null : (

--- a/src/components/ui4/BalanceCardUi4.tsx
+++ b/src/components/ui4/BalanceCardUi4.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 import IonIcon from 'react-native-vector-icons/Ionicons'
 
 import { toggleAccountBalanceVisibility } from '../../actions/LocalSettingsActions'
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
 import { getTotalFiatAmountFromExchangeRates } from '../../util/utils'
 import { AnimatedNumber } from '../common/AnimatedNumber'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { TransferModal } from '../modals/TransferModal'
 import { Airship } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
@@ -65,7 +66,7 @@ export const BalanceCardUi4 = (props: Props) => {
 
   return (
     <CardUi4>
-      <TouchableOpacity style={styles.balanceContainer} onPress={handleToggleAccountBalanceVisibility}>
+      <EdgeTouchableOpacity style={styles.balanceContainer} onPress={handleToggleAccountBalanceVisibility}>
         <View style={styles.titleContainer}>
           <EdgeText style={theme.cardTextShadow}>{lstrings.fragment_wallets_balance_text}</EdgeText>
           <IonIcon name={isBalanceVisible ? 'eye-off-outline' : 'eye-outline'} style={styles.eyeIcon} color={theme.iconTappable} size={theme.rem(1)} />
@@ -83,11 +84,11 @@ export const BalanceCardUi4 = (props: Props) => {
             <EdgeText style={styles.balanceTextNoAnim}>{balanceString}</EdgeText>
           </View>
         )}
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
       {onViewAssetsPress == null ? null : (
-        <TouchableOpacity style={styles.rightButtonContainer} onPress={onViewAssetsPress}>
+        <EdgeTouchableOpacity style={styles.rightButtonContainer} onPress={onViewAssetsPress}>
           <EdgeText style={styles.tappableText}>{lstrings.view_assets}</EdgeText>
-        </TouchableOpacity>
+        </EdgeTouchableOpacity>
       )}
 
       <ButtonsViewUi4

--- a/src/components/ui4/ButtonUi4.tsx
+++ b/src/components/ui4/ButtonUi4.tsx
@@ -3,12 +3,13 @@
  */
 
 import * as React from 'react'
-import { ActivityIndicator, TouchableOpacity, View, ViewStyle } from 'react-native'
+import { ActivityIndicator, View, ViewStyle } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import { cacheStyles } from 'react-native-patina'
 
 import { usePendingPress } from '../../hooks/usePendingPress'
 import { fixSides, mapSides, sidesToMargin, sidesToPadding } from '../../util/sides'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 
@@ -152,7 +153,7 @@ export function ButtonUi4(props: Props) {
   }, [disabled, hideContent, layout, mini, paddingRem, styles, theme, type])
 
   return (
-    <TouchableOpacity disabled={disabled || pending || spinner} style={touchContainerStyle} onPress={handlePress} testID={testID}>
+    <EdgeTouchableOpacity disabled={disabled || pending || spinner} style={touchContainerStyle} onPress={handlePress} testID={testID}>
       <LinearGradient {...gradientProps} style={visibleContainerStyle}>
         {hideContent ? (
           <View style={styles.invisibleContent}>
@@ -167,7 +168,7 @@ export function ButtonUi4(props: Props) {
         )}
       </LinearGradient>
       {!hideContent ? null : <ActivityIndicator color={spinnerColor} style={styles.spinner} />}
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   )
 }
 

--- a/src/components/ui4/CardUi4.tsx
+++ b/src/components/ui4/CardUi4.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { StyleSheet, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import LinearGradient, { LinearGradientProps } from 'react-native-linear-gradient'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
@@ -7,6 +7,7 @@ import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { useHandler } from '../../hooks/useHandler'
 import { triggerHaptic } from '../../util/haptic'
 import { fixSides, mapSides, sidesToMargin, sidesToPadding } from '../../util/sides'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { SectionView } from './SectionView'
@@ -114,9 +115,9 @@ export const CardUi4 = (props: Props) => {
 
   const maybeCloseButton =
     onClose == null ? null : (
-      <TouchableOpacity style={styles.cornerContainer} onPress={handleClose}>
+      <EdgeTouchableOpacity style={styles.cornerContainer} onPress={handleClose}>
         <AntDesignIcon color={theme.primaryText} name="close" size={theme.rem(1.25)} />
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     )
 
   const maybeOverlay = overlay == null ? null : <View style={styles.overlayContainer}>{overlay}</View>
@@ -142,9 +143,9 @@ export const CardUi4 = (props: Props) => {
     )
 
   return isPressable ? (
-    <TouchableOpacity accessible={false} onPress={handlePress} onLongPress={handleLongPress} style={viewStyle}>
+    <EdgeTouchableOpacity accessible={false} onPress={handlePress} onLongPress={handleLongPress} style={viewStyle}>
       {allContent}
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   ) : (
     <View style={viewStyle}>{allContent}</View>
   )

--- a/src/components/ui4/ModalUi4.tsx
+++ b/src/components/ui4/ModalUi4.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { BackHandler, Dimensions, TouchableOpacity, TouchableWithoutFeedback, View } from 'react-native'
+import { BackHandler, Dimensions, TouchableOpacity, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { Gesture, GestureDetector, ScrollView } from 'react-native-gesture-handler'
 import { cacheStyles } from 'react-native-patina'
@@ -8,6 +8,7 @@ import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
 import { useHandler } from '../../hooks/useHandler'
+import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { BlurBackground } from './BlurBackground'
@@ -124,9 +125,9 @@ export function ModalUi4<T>(props: ModalPropsUi4<T>): JSX.Element {
 
   return (
     <>
-      <TouchableWithoutFeedback onPress={handleCancel}>
+      <EdgeTouchableWithoutFeedback onPress={handleCancel}>
         <Animated.View style={[styles.underlay, underlayStyle]} />
-      </TouchableWithoutFeedback>
+      </EdgeTouchableWithoutFeedback>
       <GestureDetector gesture={gesture}>
         <Animated.View style={[styles.modal, modalStyle, modalLayout]}>
           <BlurBackground />

--- a/src/components/ui4/ModalUi4.tsx
+++ b/src/components/ui4/ModalUi4.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { BackHandler, Dimensions, TouchableOpacity, View } from 'react-native'
+import { BackHandler, Dimensions, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { Gesture, GestureDetector, ScrollView } from 'react-native-gesture-handler'
 import { cacheStyles } from 'react-native-patina'
@@ -8,6 +8,7 @@ import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
 import { useHandler } from '../../hooks/useHandler'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
@@ -146,9 +147,9 @@ export function ModalUi4<T>(props: ModalPropsUi4<T>): JSX.Element {
                 title ?? undefined
               )}
               {onCancel == null ? null : (
-                <TouchableOpacity style={isCustomTitle ? styles.closeIconContainerAbsolute : styles.closeIconContainer} onPress={onCancel}>
+                <EdgeTouchableOpacity style={isCustomTitle ? styles.closeIconContainerAbsolute : styles.closeIconContainer} onPress={onCancel}>
                   <AntDesignIcon name="close" color={theme.deactivatedText} size={theme.rem(1.25)} />
-                </TouchableOpacity>
+                </EdgeTouchableOpacity>
               )}
             </View>
           )}

--- a/src/components/ui4/RowUi4.tsx
+++ b/src/components/ui4/RowUi4.tsx
@@ -1,6 +1,6 @@
 import Clipboard from '@react-native-clipboard/clipboard'
 import * as React from 'react'
-import { ActivityIndicator, TouchableOpacity, View } from 'react-native'
+import { ActivityIndicator, View } from 'react-native'
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome'
 import FontAwesome5 from 'react-native-vector-icons/FontAwesome5'
 import SimpleLineIcons from 'react-native-vector-icons/SimpleLineIcons'
@@ -9,6 +9,7 @@ import { useHandler } from '../../hooks/useHandler'
 import { lstrings } from '../../locales/strings'
 import { triggerHaptic } from '../../util/haptic'
 import { fixSides, mapSides, sidesToMargin } from '../../util/sides'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { showError, showToast } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
@@ -99,13 +100,13 @@ export const RowUi4 = (props: Props) => {
       {
         // If right action icon button is visible, only the icon dims on row tap
         rightButtonVisible ? (
-          <TouchableOpacity style={styles.tappableIconContainer} accessible={false} onPress={handlePress} onLongPress={handleLongPress} disabled={loading}>
+          <EdgeTouchableOpacity style={styles.tappableIconContainer} accessible={false} onPress={handlePress} onLongPress={handleLongPress} disabled={loading}>
             {rightButtonType === 'touchable' ? <FontAwesome5 name="chevron-right" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
             {rightButtonType === 'editable' ? <FontAwesomeIcon name="edit" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
             {rightButtonType === 'copy' ? <FontAwesomeIcon name="copy" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
             {rightButtonType === 'delete' ? <FontAwesomeIcon name="times" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
             {rightButtonType === 'questionable' ? <SimpleLineIcons name="question" style={styles.tappableIcon} size={theme.rem(1)} /> : null}
-          </TouchableOpacity>
+          </EdgeTouchableOpacity>
         ) : null
       }
     </>
@@ -115,9 +116,9 @@ export const RowUi4 = (props: Props) => {
   // TODO: If a right button is specified, onPress/onLogPress is ignored! Refine
   // API and possibly restructure JSX.
   return isTappable && !rightButtonVisible ? (
-    <TouchableOpacity style={[styles.container, margin]} accessible={false} onPress={handlePress} onLongPress={handleLongPress} disabled={loading}>
+    <EdgeTouchableOpacity style={[styles.container, margin]} accessible={false} onPress={handlePress} onLongPress={handleLongPress} disabled={loading}>
       {content}
-    </TouchableOpacity>
+    </EdgeTouchableOpacity>
   ) : (
     <View style={[styles.container, margin]}>{content}</View>
   )

--- a/src/components/ui4/SectionHeaderUi4.tsx
+++ b/src/components/ui4/SectionHeaderUi4.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { TouchableOpacity } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { SplitRowsView } from './SplitRowsView'
@@ -34,9 +34,9 @@ export const SectionHeaderUi4 = (props: Props) => {
         left: <EdgeText>{leftTitle}</EdgeText>,
         right:
           typeof rightNode === 'string' && onRightPress != null ? (
-            <TouchableOpacity onPress={onRightPress} style={styles.rightTappableContainer}>
+            <EdgeTouchableOpacity onPress={onRightPress} style={styles.rightTappableContainer}>
               <EdgeText style={styles.tappableText}>{rightNode}</EdgeText>
-            </TouchableOpacity>
+            </EdgeTouchableOpacity>
           ) : (
             rightNode
           )

--- a/src/plugins/gui/scenes/AddressFormScene.tsx
+++ b/src/plugins/gui/scenes/AddressFormScene.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { asArray, asObject, asOptional, asString } from 'cleaners'
 import * as React from 'react'
-import { Platform, ScrollView, TouchableOpacity, View, ViewStyle } from 'react-native'
+import { Platform, ScrollView, View, ViewStyle } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import Animated, { Easing, interpolateColor, useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated'
 
+import { EdgeTouchableOpacity } from '../../../components/common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../../components/common/SceneWrapper'
 import { cacheStyles, Theme, useTheme } from '../../../components/services/ThemeContext'
 import { EdgeText } from '../../../components/themed/EdgeText'
@@ -283,13 +284,13 @@ export const AddressFormScene = React.memo((props: Props) => {
                   {searchResults.map(searchResult => {
                     const displaySearchResult = `${searchResult.address}\n${searchResult.city}, ${searchResult.state}, ${countryCode}`
                     return (
-                      <TouchableOpacity key={searchResults.indexOf(searchResult)} onPress={addressHintPress(searchResult)}>
+                      <EdgeTouchableOpacity key={searchResults.indexOf(searchResult)} onPress={addressHintPress(searchResult)}>
                         <View style={styles.rowContainer} onLayout={handleHintLayout}>
                           <EdgeText style={styles.addressHintText} numberOfLines={2}>
                             {displaySearchResult}
                           </EdgeText>
                         </View>
-                      </TouchableOpacity>
+                      </EdgeTouchableOpacity>
                     )
                   })}
                 </ScrollView>

--- a/src/plugins/gui/scenes/InfoDisplayScene.tsx
+++ b/src/plugins/gui/scenes/InfoDisplayScene.tsx
@@ -1,8 +1,9 @@
 import Clipboard from '@react-native-clipboard/clipboard'
 import * as React from 'react'
-import { TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
 
 import { Fontello } from '../../../assets/vector/index'
+import { EdgeTouchableOpacity } from '../../../components/common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../../components/common/SceneWrapper'
 import { cacheStyles, Theme, useTheme } from '../../../components/services/ThemeContext'
 import { EdgeText } from '../../../components/themed/EdgeText'
@@ -97,9 +98,9 @@ export const InfoDisplayScene = React.memo((props: Props) => {
 
   const renderCopyButton = (value: string) => {
     return (
-      <TouchableOpacity onPress={() => handleCopyPress(value)}>
+      <EdgeTouchableOpacity onPress={() => handleCopyPress(value)}>
         <Fontello name="Copy-icon" size={theme.rem(1)} color={theme.iconTappable} />
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     )
   }
 

--- a/src/plugins/gui/scenes/RewardsCardDashboardScene.tsx
+++ b/src/plugins/gui/scenes/RewardsCardDashboardScene.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import { Image, Text, TouchableOpacity, View } from 'react-native'
+import { Image, Text, View } from 'react-native'
 import Ionicon from 'react-native-vector-icons/Ionicons'
 
 import visaBrandImage from '../../../assets/images/guiPlugins/visaBrand.png'
+import { EdgeTouchableOpacity } from '../../../components/common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../../components/common/SceneWrapper'
 import { styled } from '../../../components/hoc/styled'
 import { Space } from '../../../components/layout/Space'
@@ -57,9 +58,9 @@ export const RewardsCardDashboardScene = (props: Props) => {
         <SceneHeader
           title={lstrings.rewards_card_dashboard_title}
           tertiary={
-            <TouchableOpacity onPress={handleHelpPress}>
+            <EdgeTouchableOpacity onPress={handleHelpPress}>
               <Ionicon name="help-circle-outline" size={theme.rem(1.5)} color={theme.iconTappable} />
-            </TouchableOpacity>
+            </EdgeTouchableOpacity>
           }
           underline
           withTopMargin
@@ -109,7 +110,7 @@ export const RewardsCard = (props: RewardsCardProps) => {
   return (
     <CardContainer>
       <CardBackground />
-      <TouchableOpacity
+      <EdgeTouchableOpacity
         onPress={onPress}
         onLongPress={onLongPress}
         // Disable opacity effect if no onPress handler
@@ -122,14 +123,14 @@ export const RewardsCard = (props: RewardsCardProps) => {
               {onPress == null ? null : <Ionicon name="chevron-forward-outline" size={theme.rem(1.5)} color={theme.iconTappable} />}
             </Space>
             {onRemovePress == null ? null : (
-              <TouchableOpacity onPress={onRemovePress}>
+              <EdgeTouchableOpacity onPress={onRemovePress}>
                 <Ionicon name="remove-circle-outline" size={theme.rem(1.5)} color={theme.dangerIcon} />
-              </TouchableOpacity>
+              </EdgeTouchableOpacity>
             )}
             {onQuestionPress == null ? null : (
-              <TouchableOpacity onPress={onQuestionPress}>
+              <EdgeTouchableOpacity onPress={onQuestionPress}>
                 <Ionicon name="help-circle-outline" size={theme.rem(1.5)} color={theme.iconTappable} />
-              </TouchableOpacity>
+              </EdgeTouchableOpacity>
             )}
           </CardHeader>
           <Space expand>
@@ -167,7 +168,7 @@ export const RewardsCard = (props: RewardsCardProps) => {
             </Space>
           </Space>
         </CardInner>
-      </TouchableOpacity>
+      </EdgeTouchableOpacity>
     </CardContainer>
   )
 }


### PR DESCRIPTION
New built-in await/debounce features were only implemented but not integrated. The design spec does not cleanly lend itself to be used for the most common `Button` components without further manual work due to the potential manual overrides callers of button components may be doing.

Besides simple search/replace of jsx and fixing imports, manual integration changes include:

1. Ensuring callers' defined `onPress` handlers return `void` or `Promise<void>`. Some callers were passing `onPress: ()-> null | undefined`. 
Unsure how it worked with the original `'react-native'` `Touchable*` but was unable to replicate support for this use case in the new components.

2. Changing all users of `Touchable*` from `'react-native-reanimated'` to the `'react-native'` counterpart used in all new Edge-wrapped Touchables.
On code and git history inspection, it was determined that users of the `'react-native-reanimated'` version of Touchable either:
- Didn't need to (files I personally authored and wasn't aware of the auto-import pitfall at the time)  
- Accidentally changed from the `'react-native'` counterpart somewhere in the commit history (everything else).

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205298523695455