### PR TITLE
Block Light Account Plugin Deeplinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - changed: Password reminder modal only shows after tapping new persistent notification
 - changed: Move wallet activation redux values to scenes
 - changed: Button width remains constant regardless of content visibility
+- changed: Certain deeplinks blocked for light accounts
+- chagned: 'Sweep Private Key' usage blocked for light accounts
 - fixed: FIO name transfer error when sending with no address
 
 ## 4.2.0

--- a/src/actions/BackupModalActions.tsx
+++ b/src/actions/BackupModalActions.tsx
@@ -1,3 +1,4 @@
+import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
 import { AirshipBridge } from 'react-native-airship'
 
@@ -37,7 +38,7 @@ export const showBackupModal = (props: { navigation: NavigationBase; forgetLogin
  * available for light accounts, prompting them to back up their account to
  * access those features.
  */
-export const showBackupForTransferModal = (onConfirm: () => void) => {
+const showBackupForTransferModal = (onConfirm: () => void) => {
   Airship.show((bridge: AirshipBridge<BackupForTransferModalResult | undefined>) => {
     return <BackupForTransferModal bridge={bridge} />
   })
@@ -47,4 +48,16 @@ export const showBackupForTransferModal = (onConfirm: () => void) => {
       }
     })
     .catch(error => showError(error))
+}
+
+/**
+ * Checks an account for light status and shows a backup modal if the account is
+ * a light account. Returns true if the modal was shown.
+ */
+export const checkAndShowLightBackupModal = (account: EdgeAccount, navigation: NavigationBase): boolean => {
+  if (account.username == null) {
+    showBackupForTransferModal(() => navigation.navigate('upgradeUsername', {}))
+    return true
+  }
+  return false
 }

--- a/src/actions/DeepLinkingActions.ts
+++ b/src/actions/DeepLinkingActions.ts
@@ -13,6 +13,7 @@ import { EdgeAsset } from '../types/types'
 import { logEvent } from '../util/tracking'
 import { base58ToUuid } from '../util/utils'
 import { activatePromotion } from './AccountReferralActions'
+import { checkAndShowLightBackupModal } from './BackupModalActions'
 import { DEEPLINK_MODAL_FNS } from './DeepLinkingModalActions'
 import { launchPaymentProto } from './PaymentProtoActions'
 import { doRequestAddress, handleWalletUris } from './ScanActions'
@@ -280,17 +281,19 @@ export async function handleLink(navigation: NavigationBase, dispatch: Dispatch,
       return true
     }
   }
-}
 
-async function launchAzteco(navigation: NavigationBase, edgeWallet: EdgeCurrencyWallet, uri: string): Promise<void> {
-  const address = await edgeWallet.getReceiveAddress({ tokenId: null })
-  const response = await fetch(`${uri}${address.publicAddress}`)
-  if (response.ok) {
-    showToast(lstrings.azteco_success)
-  } else if (response.status === 400) {
-    showError(lstrings.azteco_invalid_code)
-  } else {
-    showError(lstrings.azteco_service_unavailable)
+  async function launchAzteco(navigation: NavigationBase, edgeWallet: EdgeCurrencyWallet, uri: string): Promise<void> {
+    if (checkAndShowLightBackupModal(account, navigation)) return
+
+    const address = await edgeWallet.getReceiveAddress({ tokenId: null })
+    const response = await fetch(`${uri}${address.publicAddress}`)
+    if (response.ok) {
+      showToast(lstrings.azteco_success)
+    } else if (response.status === 400) {
+      showError(lstrings.azteco_invalid_code)
+    } else {
+      showError(lstrings.azteco_service_unavailable)
+    }
+    navigation.navigate('homeTab', { screen: 'home' })
   }
-  navigation.navigate('homeTab', { screen: 'home' })
 }

--- a/src/actions/ScanActions.tsx
+++ b/src/actions/ScanActions.tsx
@@ -20,6 +20,7 @@ import { logActivity } from '../util/logger'
 import { makeCurrencyCodeTable, upgradeCurrencyCodes } from '../util/tokenIdTools'
 import { getPluginIdFromChainCode, toListString, zeroString } from '../util/utils'
 import { cleanQueryFlags, openBrowserUri } from '../util/WebUtils'
+import { checkAndShowLightBackupModal } from './BackupModalActions'
 
 /**
  * Handle Request for Address Links (WIP - pending refinement).
@@ -43,6 +44,9 @@ import { cleanQueryFlags, openBrowserUri } from '../util/WebUtils'
  *    infinite redirect loops).
  */
 export const doRequestAddress = async (navigation: NavigationBase, account: EdgeAccount, dispatch: Dispatch, link: RequestAddressLink) => {
+  // Block light accounts:
+  if (checkAndShowLightBackupModal(account, navigation)) return
+
   const { assets, post, redir, payer } = link
   try {
     // Check if all required fields are provided in the request

--- a/src/components/FioAddress/ConnectWallets.tsx
+++ b/src/components/FioAddress/ConnectWallets.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Switch, View } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 
-import { showBackupForTransferModal } from '../../actions/BackupModalActions'
+import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { showError } from '../../components/services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../../components/services/ThemeContext'
 import { EdgeText } from '../../components/themed/EdgeText'
@@ -35,7 +35,6 @@ export const ConnectWallets = (props: FioConnectWalletsProps) => {
   const styles = getStyles(theme)
 
   const account = useSelector(state => state.core.account)
-  const isLightAccount = account.username == null
   const edgeWallets = useWatch(account, 'currencyWallets')
   const ccWalletMap = useSelector(state => state.ui.fio.connectedWalletsByFioAddress[fioAddressName] ?? {})
   const walletItems = React.useMemo(() => makeConnectWallets(edgeWallets, ccWalletMap), [edgeWallets, ccWalletMap])
@@ -57,10 +56,8 @@ export const ConnectWallets = (props: FioConnectWalletsProps) => {
   }, [prevItemsConnected, walletItems])
 
   const handleContinuePress = useHandler(() => {
-    if (isLightAccount) {
-      showBackupForTransferModal(() => navigation.navigate('upgradeUsername', {}))
-      return
-    }
+    if (checkAndShowLightBackupModal(account, navigation)) return
+
     const walletsToDisconnect: FioConnectionWalletItem[] = []
     for (const walletKey of Object.keys(disconnectWalletsMap)) {
       if (

--- a/src/components/modals/PriceChangeBuySellSwapModal.tsx
+++ b/src/components/modals/PriceChangeBuySellSwapModal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { sprintf } from 'sprintf-js'
 
-import { showBackupForTransferModal } from '../../actions/BackupModalActions'
 import { PriceChangePayload } from '../../controllers/action-queue/types/pushPayloadTypes'
 import { lstrings } from '../../locales/strings'
 import { ThunkAction } from '../../types/reduxTypes'
@@ -13,7 +12,8 @@ export function launchPriceChangeBuySellSwapModal(navigation: NavigationBase, da
   return async (dispatch, getState) => {
     const state = getState()
     const { pluginId, body } = data
-    const currencyCode = state.core.account.currencyConfig[pluginId].currencyInfo.currencyCode
+    const { account } = state.core
+    const currencyCode = account.currencyConfig[pluginId].currencyInfo.currencyCode
 
     const threeButtonModal = await Airship.show<'buy' | 'sell' | 'exchange' | undefined>(bridge => (
       <ButtonsModal
@@ -29,11 +29,7 @@ export function launchPriceChangeBuySellSwapModal(navigation: NavigationBase, da
     ))
 
     if (threeButtonModal === 'buy') {
-      if (state.core.account.username == null) {
-        showBackupForTransferModal(() => navigation.navigate('upgradeUsername', {}))
-      } else {
-        navigation.navigate('buyTab', { screen: 'pluginListBuy' })
-      }
+      navigation.navigate('buyTab', { screen: 'pluginListBuy' })
     } else if (threeButtonModal === 'sell') {
       navigation.navigate('sellTab', { screen: 'pluginListSell' })
     } else if (threeButtonModal === 'exchange') {

--- a/src/components/modals/TransferModal.tsx
+++ b/src/components/modals/TransferModal.tsx
@@ -7,12 +7,12 @@ import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome'
 import { sprintf } from 'sprintf-js'
 
-import { showBackupForTransferModal } from '../../actions/BackupModalActions'
+import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { selectWalletToken } from '../../actions/WalletActions'
 import { useHandler } from '../../hooks/useHandler'
 import { lstrings } from '../../locales/strings'
 import { config } from '../../theme/appConfig'
-import { useDispatch, useSelector } from '../../types/reactRedux'
+import { useDispatch } from '../../types/reactRedux'
 import { Airship } from '../services/AirshipInstance'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { SelectableRow } from '../themed/SelectableRow'
@@ -41,20 +41,17 @@ export const TransferModal = ({ account, bridge, depositOrSend, navigation }: Pr
   const style = styles(theme)
   const dispatch = useDispatch()
 
-  const activeUsername = useSelector(state => state.core.account.username)
-  const isLightAccount = activeUsername == null
-
   const handleSell = useHandler(() => {
-    if (isLightAccount) {
-      showBackupForTransferModal(() => navigation.navigate('upgradeUsername', {}))
+    if (checkAndShowLightBackupModal(account, navigation)) {
+      return
     } else {
       navigation.navigate('sellTab', { screen: 'pluginListSell' })
     }
     Airship.clear()
   })
   const handleBuy = useHandler(() => {
-    if (isLightAccount) {
-      showBackupForTransferModal(() => navigation.navigate('upgradeUsername', {}))
+    if (checkAndShowLightBackupModal(account, navigation)) {
+      return
     } else {
       navigation.navigate('buyTab', { screen: 'pluginListBuy' })
     }

--- a/src/components/modals/TransferModal.tsx
+++ b/src/components/modals/TransferModal.tsx
@@ -7,7 +7,6 @@ import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome'
 import { sprintf } from 'sprintf-js'
 
-import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { selectWalletToken } from '../../actions/WalletActions'
 import { useHandler } from '../../hooks/useHandler'
 import { lstrings } from '../../locales/strings'
@@ -42,21 +41,15 @@ export const TransferModal = ({ account, bridge, depositOrSend, navigation }: Pr
   const dispatch = useDispatch()
 
   const handleSell = useHandler(() => {
-    if (checkAndShowLightBackupModal(account, navigation)) {
-      return
-    } else {
-      navigation.navigate('sellTab', { screen: 'pluginListSell' })
-    }
+    navigation.navigate('sellTab', { screen: 'pluginListSell' })
     Airship.clear()
   })
+
   const handleBuy = useHandler(() => {
-    if (checkAndShowLightBackupModal(account, navigation)) {
-      return
-    } else {
-      navigation.navigate('buyTab', { screen: 'pluginListBuy' })
-    }
+    navigation.navigate('buyTab', { screen: 'pluginListBuy' })
     Airship.clear()
   })
+
   const handleSend = useHandler(async () => {
     const result = await Airship.show<WalletListResult>(bridge => (
       <WalletListModal bridge={bridge} headerTitle={lstrings.select_wallet_to_send_from} navigation={navigation} />

--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -6,7 +6,7 @@ import FastImage from 'react-native-fast-image'
 import Animated from 'react-native-reanimated'
 import { sprintf } from 'sprintf-js'
 
-import { showBackupForTransferModal } from '../../actions/BackupModalActions'
+import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { getDeviceSettings, writeDeveloperPluginUri } from '../../actions/DeviceSettingsActions'
 import { NestedDisableMap } from '../../actions/ExchangeInfoActions'
 import { readSyncedSettings, SyncedAccountSettings, updateOneSetting, writeSyncedSettings } from '../../actions/SettingsActions'
@@ -230,10 +230,7 @@ class GuiPluginList extends React.PureComponent<Props, State> {
     const plugin = guiPlugins[pluginId]
 
     // Don't allow light accounts to enter plugins
-    if (account.username == null) {
-      showBackupForTransferModal(() => navigation.navigate('upgradeUsername', {}))
-      return
-    }
+    if (checkAndShowLightBackupModal(account, navigation)) return
 
     // Grab a custom URI if necessary:
     let { deepPath = undefined } = listRow

--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -229,8 +229,9 @@ class GuiPluginList extends React.PureComponent<Props, State> {
     const { pluginId, paymentType, deepQuery = {} } = listRow
     const plugin = guiPlugins[pluginId]
 
-    // Don't allow light accounts to enter plugins
-    if (checkAndShowLightBackupModal(account, navigation)) return
+    // Don't allow light accounts to enter sell plugins
+    const direction = this.getSceneDirection()
+    if (direction === 'buy' && checkAndShowLightBackupModal(account, navigation)) return
 
     // Grab a custom URI if necessary:
     let { deepPath = undefined } = listRow
@@ -257,8 +258,6 @@ class GuiPluginList extends React.PureComponent<Props, State> {
         writeDeveloperPluginUri(deepPath).catch(error => showError(error))
       }
     }
-
-    const direction = this.getSceneDirection()
     if (plugin.nativePlugin != null) {
       const disableProviders = disablePlugins[pluginId]
 

--- a/src/components/scenes/GuiPluginViewScene.tsx
+++ b/src/components/scenes/GuiPluginViewScene.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 
+import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { GuiPlugin } from '../../types/GuiPluginTypes'
+import { useSelector } from '../../types/reactRedux'
 import { EdgeSceneProps } from '../../types/routerTypes'
 import { UriQueryMap } from '../../types/WebTypes'
 import { SceneWrapper } from '../common/SceneWrapper'
@@ -20,6 +22,9 @@ interface Props extends EdgeSceneProps<'pluginView' | 'pluginViewBuy' | 'pluginV
 export function GuiPluginViewScene(props: Props): JSX.Element {
   const { route, navigation } = props
   const { deepPath, deepQuery, plugin } = route.params
+  const account = useSelector(state => state.core.account)
+
+  if (checkAndShowLightBackupModal(account, navigation)) navigation.pop()
 
   return (
     <SceneWrapper hasTabs={route.name !== 'pluginView'}>

--- a/src/components/scenes/WcConnectionsScene.tsx
+++ b/src/components/scenes/WcConnectionsScene.tsx
@@ -7,7 +7,7 @@ import FastImage from 'react-native-fast-image'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { sprintf } from 'sprintf-js'
 
-import { showBackupForTransferModal } from '../../actions/BackupModalActions'
+import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
 import { SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import { useAsyncEffect } from '../../hooks/useAsyncEffect'
@@ -40,9 +40,7 @@ export const WcConnectionsScene = (props: Props) => {
   const [connecting, setConnecting] = React.useState(false)
 
   const account = useSelector(state => state.core.account)
-  const activeUsername = useSelector(state => state.core.account.username)
   const walletConnect = useWalletConnect()
-  const isLightAccount = activeUsername == null
 
   useMount(() => {
     if (uri != null) onScanSuccess(uri).catch(err => showError(err))
@@ -75,8 +73,8 @@ export const WcConnectionsScene = (props: Props) => {
   }
 
   const handleNewConnectionPress = async () => {
-    if (isLightAccount) {
-      showBackupForTransferModal(() => navigation.navigate('upgradeUsername', {}))
+    if (checkAndShowLightBackupModal(account, navigation)) {
+      return await Promise.resolve()
     } else {
       const result = await Airship.show<string | undefined>(bridge => (
         <ScanModal

--- a/src/components/themed/BuyCrypto.tsx
+++ b/src/components/themed/BuyCrypto.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { View } from 'react-native'
 import { sprintf } from 'sprintf-js'
 
-import { showBackupForTransferModal } from '../../actions/BackupModalActions'
+import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { DONE_THRESHOLD, SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import { useHandler } from '../../hooks/useHandler'
 import { useWatch } from '../../hooks/useWatch'
@@ -32,16 +32,12 @@ export const BuyCrypto = (props: Props) => {
   const styles = getStyles(theme)
 
   const account = useSelector(state => state.core.account)
-  const isLightAccount = account.username == null
 
   const syncRatio = useWatch(wallet, 'syncRatio')
 
   const handlePress = useHandler(() => {
-    if (isLightAccount) {
-      showBackupForTransferModal(() => navigation.navigate('upgradeUsername', {}))
-    } else {
-      navigation.navigate('buyTab', { screen: 'pluginListBuy' })
-    }
+    if (checkAndShowLightBackupModal(account, navigation)) return
+    navigation.navigate('buyTab', { screen: 'pluginListBuy' })
   })
 
   const { displayName, pluginId } = wallet.currencyInfo

--- a/src/components/themed/BuyCrypto.tsx
+++ b/src/components/themed/BuyCrypto.tsx
@@ -3,13 +3,11 @@ import * as React from 'react'
 import { View } from 'react-native'
 import { sprintf } from 'sprintf-js'
 
-import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { DONE_THRESHOLD, SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import { useHandler } from '../../hooks/useHandler'
 import { useWatch } from '../../hooks/useWatch'
 import { toPercentString } from '../../locales/intl'
 import { lstrings } from '../../locales/strings'
-import { useSelector } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { CryptoIconUi4 } from '../ui4/CryptoIconUi4'
@@ -31,12 +29,9 @@ export const BuyCrypto = (props: Props) => {
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const account = useSelector(state => state.core.account)
-
   const syncRatio = useWatch(wallet, 'syncRatio')
 
   const handlePress = useHandler(() => {
-    if (checkAndShowLightBackupModal(account, navigation)) return
     navigation.navigate('buyTab', { screen: 'pluginListBuy' })
   })
 


### PR DESCRIPTION
Audit deeplinks:
- 'paymentProto' - Simply routes to send scene. User flow after that already blocks light accounts.

Block with backup modal:
- Request for Address Links
- azteco deeplink action (only entry point for azteco)
- fiatPlugin: openExternalWebView
- ScanActions sweepPrivateKeys()

Pop navigation on mount: 
-- 'plugin'->'pluginView'->EdgeProviderComponent
-- fiatPlugin: openWebView -> 'guiPluginWebView'/FiatPluginWebViewComponent 

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206549609896201