### PR TITLE
Refactor Conversion Tracking

### DIFF
--- a/src/actions/CreateWalletActions.tsx
+++ b/src/actions/CreateWalletActions.tsx
@@ -128,7 +128,7 @@ export function createAccountTransaction(
           // Hack. Keyboard pops up for some reason. Close it
           dispatch(
             logEvent('Activate_Wallet_Cancel', {
-              currencyCode: createdWalletCurrencyCode
+              createdWalletCurrencyCode
             })
           )
         },
@@ -141,7 +141,7 @@ export function createAccountTransaction(
           } else if (edgeTransaction) {
             dispatch(
               logEvent('Activate_Wallet_Done', {
-                currencyCode: createdWalletCurrencyCode
+                createdWalletCurrencyCode
               })
             )
             const edgeMetadata: EdgeMetadata = {

--- a/src/actions/CryptoExchangeActions.tsx
+++ b/src/actions/CryptoExchangeActions.tsx
@@ -24,6 +24,7 @@ import { convertCurrency } from '../selectors/WalletSelectors'
 import { RootState, ThunkAction } from '../types/reduxTypes'
 import { NavigationBase } from '../types/routerTypes'
 import { GuiCurrencyInfo, GuiSwapInfo } from '../types/types'
+import { CryptoAmount } from '../util/CryptoAmount'
 import { getCurrencyCode, getWalletTokenId } from '../util/CurrencyInfoHelpers'
 import { logActivity } from '../util/logger'
 import { bestOfPlugins } from '../util/ReferralHelpers'
@@ -338,13 +339,18 @@ export function shiftCryptoCurrency(navigation: NavigationBase, quote: EdgeSwapQ
 
       await updateSwapCount(state)
 
-      const exchangeAmount = await toWallet.nativeToDenomination(toNativeAmount, toCurrencyCode)
       dispatch(
         logEvent('Exchange_Shift_Success', {
-          pluginId,
-          currencyCode: toCurrencyCode,
-          exchangeAmount,
-          orderId: result.orderId
+          conversionValues: {
+            conversionType: 'crypto',
+            cryptoAmount: new CryptoAmount({
+              nativeAmount: toNativeAmount,
+              currencyCode: toCurrencyCode,
+              currencyConfig: toWallet.currencyConfig
+            }),
+            orderId: result.orderId,
+            swapProviderId: pluginId
+          }
         })
       )
     } catch (error: any) {

--- a/src/components/scenes/Fio/FioAddressSettingsScene.tsx
+++ b/src/components/scenes/Fio/FioAddressSettingsScene.tsx
@@ -6,6 +6,7 @@ import { refreshAllFioAddresses } from '../../../actions/FioAddressActions'
 import { lstrings } from '../../../locales/strings'
 import { connect } from '../../../types/reactRedux'
 import { EdgeSceneProps } from '../../../types/routerTypes'
+import { CryptoAmount } from '../../../util/CryptoAmount'
 import { addBundledTxs, getAddBundledTxsFee, getTransferFee } from '../../../util/FioAddressUtils'
 import { logEvent, TrackingEventName, TrackingValues } from '../../../util/tracking'
 import { SceneWrapper } from '../../common/SceneWrapper'
@@ -104,8 +105,12 @@ export class FioAddressSettingsComponent extends React.Component<Props, LocalSta
     }
     await addBundledTxs(fioWallet, fioAddressName, fee)
 
-    const { currencyCode, pluginId } = fioWallet.currencyInfo
-    onLogEvent('Fio_Handle_Bundled_Tx', { nativeAmount: String(fee), pluginId, currencyCode })
+    onLogEvent('Fio_Handle_Bundled_Tx', {
+      conversionValues: {
+        conversionType: 'crypto',
+        cryptoAmount: new CryptoAmount({ nativeAmount: String(fee), currencyConfig: fioWallet.currencyConfig })
+      }
+    })
   }
 
   goToTransfer = (params: { fee: number }) => {

--- a/src/components/scenes/Fio/FioAddressSettingsScene.tsx
+++ b/src/components/scenes/Fio/FioAddressSettingsScene.tsx
@@ -108,7 +108,7 @@ export class FioAddressSettingsComponent extends React.Component<Props, LocalSta
     onLogEvent('Fio_Handle_Bundled_Tx', {
       conversionValues: {
         conversionType: 'crypto',
-        cryptoAmount: new CryptoAmount({ nativeAmount: String(fee), currencyConfig: fioWallet.currencyConfig })
+        cryptoAmount: new CryptoAmount({ nativeAmount: String(fee), currencyConfig: fioWallet.currencyConfig, tokenId: null })
       }
     })
   }

--- a/src/components/scenes/Fio/FioCreateHandleScene.tsx
+++ b/src/components/scenes/Fio/FioCreateHandleScene.tsx
@@ -130,7 +130,14 @@ export const FioCreateHandleScene = (props: Props) => {
         await dispatch(refreshAllFioAddresses())
         showToast(lstrings.fio_free_handle_complete)
 
-        await dispatch(logEvent('Fio_Handle_Register', { dollarValue: 3 }))
+        await dispatch(
+          logEvent('Fio_Handle_Register', {
+            conversionValues: {
+              conversionType: 'dollar',
+              dollarConversionValue: 3
+            }
+          })
+        )
 
         navigation.pop()
       } catch (e: any) {

--- a/src/components/scenes/Fio/FioDomainSettingsScene.tsx
+++ b/src/components/scenes/Fio/FioDomainSettingsScene.tsx
@@ -8,6 +8,7 @@ import { formatDate } from '../../../locales/intl'
 import { lstrings } from '../../../locales/strings'
 import { connect } from '../../../types/reactRedux'
 import { EdgeSceneProps } from '../../../types/routerTypes'
+import { CryptoAmount } from '../../../util/CryptoAmount'
 import { getDomainSetVisibilityFee, getRenewalFee, getTransferFee, renewFioDomain, setDomainVisibility } from '../../../util/FioAddressUtils'
 import { logEvent, TrackingEventName, TrackingValues } from '../../../util/tracking'
 import { SceneWrapper } from '../../common/SceneWrapper'
@@ -118,11 +119,11 @@ export class FioDomainSettingsComponent extends React.Component<Props, State> {
 
     await renewFioDomain(fioWallet, fioDomainName, renewalFee)
 
-    const { currencyCode, pluginId } = fioWallet.currencyInfo
     onLogEvent('Fio_Domain_Renew', {
-      nativeAmount: String(renewalFee),
-      currencyCode,
-      pluginId
+      conversionValues: {
+        conversionType: 'crypto',
+        cryptoAmount: new CryptoAmount({ nativeAmount: String(renewalFee), currencyConfig: fioWallet.currencyConfig })
+      }
     })
   }
 

--- a/src/components/scenes/Fio/FioDomainSettingsScene.tsx
+++ b/src/components/scenes/Fio/FioDomainSettingsScene.tsx
@@ -122,7 +122,7 @@ export class FioDomainSettingsComponent extends React.Component<Props, State> {
     onLogEvent('Fio_Domain_Renew', {
       conversionValues: {
         conversionType: 'crypto',
-        cryptoAmount: new CryptoAmount({ nativeAmount: String(renewalFee), currencyConfig: fioWallet.currencyConfig })
+        cryptoAmount: new CryptoAmount({ nativeAmount: String(renewalFee), currencyConfig: fioWallet.currencyConfig, tokenId: null })
       }
     })
   }

--- a/src/components/scenes/Fio/FioNameConfirmScene.tsx
+++ b/src/components/scenes/Fio/FioNameConfirmScene.tsx
@@ -6,6 +6,7 @@ import { FIO_ADDRESS_DELIMITER } from '../../../constants/WalletAndCurrencyConst
 import { lstrings } from '../../../locales/strings'
 import { connect } from '../../../types/reactRedux'
 import { EdgeSceneProps } from '../../../types/routerTypes'
+import { CryptoAmount } from '../../../util/CryptoAmount'
 import { fioMakeSpend, fioSignAndBroadcast } from '../../../util/FioAddressUtils'
 import { logEvent, TrackingEventName, TrackingValues } from '../../../util/tracking'
 import { SceneWrapper } from '../../common/SceneWrapper'
@@ -111,16 +112,19 @@ class FioNameConfirm extends React.PureComponent<Props> {
       }
     } else {
       try {
-        const { currencyCode, pluginId } = paymentWallet.currencyInfo
         if (this.isFioAddress()) {
           let edgeTx = await fioMakeSpend(paymentWallet, 'registerFioAddress', { fioAddress: fioName })
           edgeTx = await fioSignAndBroadcast(paymentWallet, edgeTx)
           await paymentWallet.saveTx(edgeTx)
 
           onLogEvent('Fio_Handle_Register', {
-            nativeAmount: edgeTx.nativeAmount,
-            currencyCode,
-            pluginId
+            conversionValues: {
+              conversionType: 'crypto',
+              cryptoAmount: new CryptoAmount({
+                nativeAmount: edgeTx.nativeAmount,
+                currencyConfig: paymentWallet.currencyConfig
+              })
+            }
           })
 
           // @ts-expect-error
@@ -136,9 +140,13 @@ class FioNameConfirm extends React.PureComponent<Props> {
           const expiration = edgeTx.otherParams?.broadcastResult?.expiration
 
           onLogEvent('Fio_Domain_Register', {
-            nativeAmount: edgeTx.nativeAmount,
-            currencyCode,
-            pluginId
+            conversionValues: {
+              conversionType: 'crypto',
+              cryptoAmount: new CryptoAmount({
+                nativeAmount: edgeTx.nativeAmount,
+                currencyConfig: paymentWallet.currencyConfig
+              })
+            }
           })
 
           // @ts-expect-error

--- a/src/components/scenes/Fio/FioNameConfirmScene.tsx
+++ b/src/components/scenes/Fio/FioNameConfirmScene.tsx
@@ -121,8 +121,9 @@ class FioNameConfirm extends React.PureComponent<Props> {
             conversionValues: {
               conversionType: 'crypto',
               cryptoAmount: new CryptoAmount({
+                currencyConfig: paymentWallet.currencyConfig,
                 nativeAmount: edgeTx.nativeAmount,
-                currencyConfig: paymentWallet.currencyConfig
+                tokenId: null
               })
             }
           })
@@ -143,8 +144,9 @@ class FioNameConfirm extends React.PureComponent<Props> {
             conversionValues: {
               conversionType: 'crypto',
               cryptoAmount: new CryptoAmount({
+                currencyConfig: paymentWallet.currencyConfig,
                 nativeAmount: edgeTx.nativeAmount,
-                currencyConfig: paymentWallet.currencyConfig
+                tokenId: null
               })
             }
           })

--- a/src/controllers/edgeProvider/EdgeProviderServer.tsx
+++ b/src/controllers/edgeProvider/EdgeProviderServer.tsx
@@ -28,6 +28,7 @@ import { Dispatch } from '../../types/reduxTypes'
 import { NavigationBase } from '../../types/routerTypes'
 import { EdgeAsset, MapObject } from '../../types/types'
 import { getCurrencyIconUris } from '../../util/CdnUris'
+import { CryptoAmount } from '../../util/CryptoAmount'
 import { getTokenIdForced } from '../../util/CurrencyInfoHelpers'
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import { makeCurrencyCodeTable } from '../../util/tokenIdTools'
@@ -410,10 +411,16 @@ export class EdgeProviderServer implements EdgeProviderMethods {
             .then(exchangeAmount => {
               this._dispatch(
                 logEvent('EdgeProvider_Conversion_Success', {
-                  pluginId: this._plugin.storeId,
-                  orderId,
-                  currencyCode: transaction.currencyCode,
-                  exchangeAmount: abs(exchangeAmount)
+                  conversionValues: {
+                    conversionType: 'crypto',
+                    cryptoAmount: new CryptoAmount({
+                      currencyConfig: wallet.currencyConfig,
+                      currencyCode: transaction.currencyCode,
+                      exchangeAmount: abs(exchangeAmount)
+                    }),
+                    swapProviderId: this._plugin.storeId,
+                    orderId
+                  }
                 })
               )
             })

--- a/src/plugins/gui/fiatPlugin.tsx
+++ b/src/plugins/gui/fiatPlugin.tsx
@@ -19,7 +19,7 @@ import { HomeAddress, SepaInfo } from '../../types/FormTypes'
 import { GuiPlugin } from '../../types/GuiPluginTypes'
 import { AppParamList, NavigationBase } from '../../types/routerTypes'
 import { getNavigationAbsolutePath } from '../../util/routerUtils'
-import { OnLogEvent, TrackingEventName } from '../../util/tracking'
+import { OnLogEvent, SellConversionValues, TrackingEventName } from '../../util/tracking'
 import {
   FiatPaymentType,
   FiatPluginAddressFormParams,
@@ -222,19 +222,7 @@ export const executePlugin = async (params: {
     showToast: async (message: string, autoHideMs?: number) => {
       showToast(message, autoHideMs)
     },
-    trackConversion: async (
-      event: TrackingEventName,
-      opts: {
-        destCurrencyCode: string
-        destExchangeAmount: string
-        destPluginId?: string
-        sourceCurrencyCode: string
-        sourceExchangeAmount: string
-        sourcePluginId?: string
-        pluginId: string
-        orderId?: string
-      }
-    ) => {
+    trackConversion: async (event: TrackingEventName, opts: { conversionValues: SellConversionValues }) => {
       onLogEvent(event, opts)
     },
     exitScene: async () => {

--- a/src/plugins/gui/fiatPluginTypes.ts
+++ b/src/plugins/gui/fiatPluginTypes.ts
@@ -11,7 +11,7 @@ import { HomeAddress, SepaInfo } from '../../types/FormTypes'
 import { GuiPlugin } from '../../types/GuiPluginTypes'
 import { AppParamList } from '../../types/routerTypes'
 import { EdgeAsset } from '../../types/types'
-import { TrackingEventName } from '../../util/tracking'
+import { SellConversionValues, TrackingEventName } from '../../util/tracking'
 import { FiatPluginOpenWebViewParams } from './scenes/FiatPluginWebView'
 import { RewardsCardDashboardParams } from './scenes/RewardsCardDashboardScene'
 import { RewardsCardWelcomeParams } from './scenes/RewardsCardWelcomeScene'
@@ -146,14 +146,7 @@ export interface FiatPluginUi {
   trackConversion: (
     event: TrackingEventName,
     opts: {
-      destCurrencyCode: string
-      destExchangeAmount: string
-      destPluginId?: string
-      sourceCurrencyCode: string
-      sourceExchangeAmount: string
-      sourcePluginId?: string
-      pluginId: string
-      orderId?: string
+      conversionValues: SellConversionValues
     }
   ) => Promise<void>
 

--- a/src/plugins/gui/providers/banxaProvider.ts
+++ b/src/plugins/gui/providers/banxaProvider.ts
@@ -7,6 +7,7 @@ import URL from 'url-parse'
 import { SendScene2Params } from '../../../components/scenes/SendScene2'
 import { lstrings } from '../../../locales/strings'
 import { StringMap } from '../../../types/types'
+import { CryptoAmount } from '../../../util/CryptoAmount'
 import { fetchInfo } from '../../../util/network'
 import { consify, makeUuid } from '../../../util/utils'
 import { SendErrorBackPressed, SendErrorNoTransaction } from '../fiatPlugin'
@@ -645,13 +646,19 @@ export const banxaProvider: FiatProviderFactory = {
                             interval = undefined
 
                             await showUi.trackConversion('Sell_Success', {
-                              destCurrencyCode: fiatCurrencyCode,
-                              destExchangeAmount: priceQuote.fiat_amount,
-                              sourceCurrencyCode: displayCurrencyCode,
-                              sourceExchangeAmount: coinAmount.toString(),
-                              sourcePluginId: coreWallet.currencyInfo.pluginId,
-                              pluginId: providerId,
-                              orderId: id
+                              conversionValues: {
+                                conversionType: 'sell',
+                                destFiatCurrencyCode: fiatCurrencyCode,
+                                destFiatAmount: priceQuote.fiat_amount,
+                                sourceAmount: CryptoAmount({
+                                  pluginId: coreWallet.currencyInfo.pluginId,
+                                  currencyConfig: coreWallet.currencyConfig,
+                                  currencyCode: displayCurrencyCode,
+                                  exchangeAmount: coinAmount
+                                }),
+                                fiatProviderId: providerId,
+                                orderId: id
+                              }
                             })
 
                             // Below is an optional step

--- a/src/plugins/gui/providers/banxaProvider.ts
+++ b/src/plugins/gui/providers/banxaProvider.ts
@@ -650,8 +650,7 @@ export const banxaProvider: FiatProviderFactory = {
                                 conversionType: 'sell',
                                 destFiatCurrencyCode: fiatCurrencyCode,
                                 destFiatAmount: priceQuote.fiat_amount,
-                                sourceAmount: CryptoAmount({
-                                  pluginId: coreWallet.currencyInfo.pluginId,
+                                sourceAmount: new CryptoAmount({
                                   currencyConfig: coreWallet.currencyConfig,
                                   currencyCode: displayCurrencyCode,
                                   exchangeAmount: coinAmount

--- a/src/plugins/gui/providers/kadoProvider.ts
+++ b/src/plugins/gui/providers/kadoProvider.ts
@@ -768,8 +768,7 @@ export const kadoProvider: FiatProviderFactory = {
                           conversionType: 'sell',
                           destFiatCurrencyCode: 'USD',
                           destFiatAmount: fiatAmount,
-                          sourceAmount: CryptoAmount({
-                            pluginId: coreWallet.currencyInfo.pluginId,
+                          sourceAmount: new CryptoAmount({
                             currencyConfig: coreWallet.currencyConfig,
                             currencyCode: displayCurrencyCode,
                             exchangeAmount: paymentExchangeAmount

--- a/src/plugins/gui/providers/kadoProvider.ts
+++ b/src/plugins/gui/providers/kadoProvider.ts
@@ -6,6 +6,7 @@ import URL from 'url-parse'
 import { SendScene2Params } from '../../../components/scenes/SendScene2'
 import { ENV } from '../../../env'
 import { lstrings } from '../../../locales/strings'
+import { CryptoAmount } from '../../../util/CryptoAmount'
 import { isHex } from '../../../util/utils'
 import { SendErrorBackPressed, SendErrorNoTransaction } from '../fiatPlugin'
 import { FiatDirection, FiatPaymentType, SaveTxActionParams } from '../fiatPluginTypes'
@@ -763,13 +764,19 @@ export const kadoProvider: FiatProviderFactory = {
                       }
                       const tx = await showUi.send(sendParams)
                       await showUi.trackConversion('Sell_Success', {
-                        destCurrencyCode: 'USD',
-                        destExchangeAmount: fiatAmount,
-                        sourceCurrencyCode: displayCurrencyCode,
-                        sourceExchangeAmount: paymentExchangeAmount,
-                        sourcePluginId: coreWallet.currencyInfo.pluginId,
-                        pluginId: providerId,
-                        orderId
+                        conversionValues: {
+                          conversionType: 'sell',
+                          destFiatCurrencyCode: 'USD',
+                          destFiatAmount: fiatAmount,
+                          sourceAmount: CryptoAmount({
+                            pluginId: coreWallet.currencyInfo.pluginId,
+                            currencyConfig: coreWallet.currencyConfig,
+                            currencyCode: displayCurrencyCode,
+                            exchangeAmount: paymentExchangeAmount
+                          }),
+                          fiatProviderId: providerId,
+                          orderId
+                        }
                       })
 
                       // Save separate metadata/action for token transaction fee

--- a/src/plugins/gui/providers/paybisProvider.ts
+++ b/src/plugins/gui/providers/paybisProvider.ts
@@ -7,6 +7,7 @@ import { SendScene2Params } from '../../../components/scenes/SendScene2'
 import { locale } from '../../../locales/intl'
 import { lstrings } from '../../../locales/strings'
 import { EdgeAsset, StringMap } from '../../../types/types'
+import { CryptoAmount } from '../../../util/CryptoAmount'
 import { makeUuid } from '../../../util/utils'
 import { SendErrorNoTransaction } from '../fiatPlugin'
 import { FiatDirection, FiatPaymentType, SaveTxActionParams } from '../fiatPluginTypes'
@@ -609,13 +610,19 @@ export const paybisProvider: FiatProviderFactory = {
                       }
                       const tx = await showUi.send(sendParams)
                       await showUi.trackConversion('Sell_Success', {
-                        destCurrencyCode: fiatCurrencyCode,
-                        destExchangeAmount: fiatAmount,
-                        sourceCurrencyCode: displayCurrencyCode,
-                        sourceExchangeAmount: amount,
-                        sourcePluginId: coreWallet.currencyInfo.pluginId,
-                        pluginId: providerId,
-                        orderId: invoice
+                        conversionValues: {
+                          conversionType: 'sell',
+                          destFiatCurrencyCode: fiatCurrencyCode,
+                          destFiatAmount: fiatAmount,
+                          sourceAmount: CryptoAmount({
+                            pluginId: coreWallet.currencyInfo.pluginId,
+                            currencyConfig: coreWallet.currencyConfig,
+                            currencyCode: displayCurrencyCode,
+                            exchangeAmount: amount
+                          }),
+                          fiatProviderId: providerId,
+                          orderId: invoice
+                        }
                       })
 
                       // Save separate metadata/action for token transaction fee

--- a/src/plugins/gui/providers/paybisProvider.ts
+++ b/src/plugins/gui/providers/paybisProvider.ts
@@ -614,8 +614,7 @@ export const paybisProvider: FiatProviderFactory = {
                           conversionType: 'sell',
                           destFiatCurrencyCode: fiatCurrencyCode,
                           destFiatAmount: fiatAmount,
-                          sourceAmount: CryptoAmount({
-                            pluginId: coreWallet.currencyInfo.pluginId,
+                          sourceAmount: new CryptoAmount({
                             currencyConfig: coreWallet.currencyConfig,
                             currencyCode: displayCurrencyCode,
                             exchangeAmount: amount

--- a/src/util/CryptoAmount.ts
+++ b/src/util/CryptoAmount.ts
@@ -1,0 +1,148 @@
+import { div, mul } from 'biggystring'
+import { EdgeCurrencyConfig, EdgeDenomination } from 'edge-core-js'
+
+import { RootState } from '../reducers/RootReducer'
+import { emptyEdgeDenomination } from '../selectors/DenominationSelectors'
+import { convertCurrency } from '../selectors/WalletSelectors'
+import { asBiggystring } from './cleaners'
+import { DECIMAL_PRECISION, mulToPrecision } from './utils'
+
+// Defines base properties for asset configuration.
+interface AssetBaseArgs {
+  currencyConfig: EdgeCurrencyConfig
+}
+
+// Specifies that one of tokenId or currencyCode must be provided, or neither.
+type TokenOrCurrencyCodeArgs =
+  | {
+      tokenId: string
+      currencyCode?: never
+    }
+  | {
+      tokenId?: never
+      currencyCode: string
+    }
+  | {
+      tokenId?: never
+      currencyCode?: never
+    }
+
+// Specifies that one of exchangeAmount or nativeAmount must be provided.
+type ExchangeOrNativeAmountArgs =
+  | {
+      exchangeAmount: number | string
+      nativeAmount?: never
+    }
+  | {
+      exchangeAmount?: never
+      nativeAmount: string
+    }
+
+// Combines both requirements.
+type CryptoAmountConstructorArgs = AssetBaseArgs & TokenOrCurrencyCodeArgs & ExchangeOrNativeAmountArgs
+
+/**
+ * One-stop shop for any information pertaining to a crypto asset.
+ * Pass whatever you happen to have, get what you need.
+ *
+ * Usage:
+ * const cryptoAmountWithExchange = CryptoAmount.createWithExchangeAmount({
+ *   currencyConfig,
+ *   exchangeAmount: '100',
+ * })
+ *
+ * const cryptoAmountWithNative = CryptoAmount.createWithNativeAmount({
+ *   currencyCode: 'USDC',
+ *   nativeAmount: '12345678',
+ * })
+ */
+export class CryptoAmount {
+  public readonly currencyConfig: EdgeCurrencyConfig
+  public readonly nativeAmount: string
+  public readonly tokenId: string | null
+
+  public constructor(args: CryptoAmountConstructorArgs) {
+    const { currencyCode, currencyConfig, exchangeAmount, nativeAmount, tokenId } = args
+    this.currencyConfig = currencyConfig
+
+    // Populate tokenId
+    if (currencyCode != null) {
+      // Ensure currencyCode is recognized, if given as a constructor argument.
+      const foundTokenId = Object.keys(currencyConfig.allTokens).find(edgeToken => currencyConfig.allTokens[edgeToken].currencyCode === currencyCode)
+      if (foundTokenId == null) {
+        throw new Error(`CryptoAmount: Could not find tokenId for currencyCode: ${currencyCode}, pluginId: ${currencyConfig.currencyInfo.pluginId}.`)
+      } else {
+        this.tokenId = foundTokenId
+      }
+    } else {
+      this.tokenId = tokenId ?? null
+    }
+
+    // Populate nativeAmount
+    if (exchangeAmount != null) {
+      try {
+        asBiggystring(exchangeAmount.toString())
+      } catch (e) {
+        throw new Error(`CryptoAmount: Error instantiating with exchangeAmount: ${String(e)}\n${JSON.stringify(args)}`)
+      }
+
+      this.nativeAmount = mul(this.getExchangeDenom().multiplier, exchangeAmount.toString())
+      if (this.nativeAmount.includes('.')) {
+        this.nativeAmount = this.nativeAmount.split('.')[0]
+      }
+    } else {
+      this.nativeAmount = nativeAmount
+    }
+  }
+
+  //
+  // Getters:
+  //
+
+  get chainCode(): string {
+    return this.currencyConfig.currencyInfo.currencyCode
+  }
+
+  get currencyCode(): string {
+    const { currencyCode } = this.tokenId == null ? this.currencyConfig.currencyInfo : this.currencyConfig.allTokens[this.tokenId]
+    return currencyCode
+  }
+
+  get exchangeAmount(): string {
+    const { multiplier } = this.getExchangeDenom()
+    return div(this.nativeAmount, multiplier, DECIMAL_PRECISION)
+  }
+
+  get pluginId(): string {
+    return this.currencyConfig.currencyInfo.pluginId
+  }
+
+  //
+  // Utilities:
+  //
+
+  displayDollarValue(state: RootState, precision?: number): string {
+    return parseFloat(convertCurrency(state, this.currencyCode, 'iso:USD', this.exchangeAmount)).toFixed(precision ?? 2)
+  }
+
+  displayFiatValue(state: RootState, isoFiatCode: string, precision?: number) {
+    return parseFloat(convertCurrency(state, this.currencyCode, isoFiatCode, this.exchangeAmount)).toFixed(precision ?? 2)
+  }
+
+  getExchangeAmount(precision?: number): string {
+    const { multiplier } = this.getExchangeDenom()
+    return div(this.nativeAmount, multiplier, precision ?? mulToPrecision(multiplier))
+  }
+
+  getExchangeDenom(): EdgeDenomination {
+    const { allTokens, currencyInfo } = this.currencyConfig
+
+    if (this.tokenId == null) return currencyInfo.denominations[0]
+    for (const tokenId of Object.keys(allTokens)) {
+      const token = allTokens[tokenId]
+      if (token.currencyCode === this.currencyCode) return token.denominations[0]
+    }
+
+    return emptyEdgeDenomination
+  }
+}

--- a/src/util/CryptoAmount.ts
+++ b/src/util/CryptoAmount.ts
@@ -2,29 +2,30 @@ import { div, mul } from 'biggystring'
 import { EdgeCurrencyConfig, EdgeDenomination } from 'edge-core-js'
 
 import { RootState } from '../reducers/RootReducer'
-import { emptyEdgeDenomination } from '../selectors/DenominationSelectors'
 import { convertCurrency } from '../selectors/WalletSelectors'
 import { asBiggystring } from './cleaners'
 import { DECIMAL_PRECISION, mulToPrecision } from './utils'
 
-// Defines base properties for asset configuration.
+/**
+ * Defines base properties for the CryptoAmount asset configuration.
+ */
 interface AssetBaseArgs {
   currencyConfig: EdgeCurrencyConfig
 }
 
-// Specifies that one of tokenId or currencyCode must be provided, or neither.
+/**
+ * Specifies that one of tokenId or currencyCode must be provided. To describe a
+ * mainnet/parent/chain currency, an explicit null must be provided to tokenId
+ * or currencyCode.
+ */
 type TokenOrCurrencyCodeArgs =
   | {
-      tokenId: string
+      tokenId: string | null
       currencyCode?: never
     }
   | {
       tokenId?: never
       currencyCode: string
-    }
-  | {
-      tokenId?: never
-      currencyCode?: never
     }
 
 // Specifies that one of exchangeAmount or nativeAmount must be provided.
@@ -46,26 +47,33 @@ type CryptoAmountConstructorArgs = AssetBaseArgs & TokenOrCurrencyCodeArgs & Exc
  * Pass whatever you happen to have, get what you need.
  *
  * Usage:
- * const cryptoAmountWithExchange = CryptoAmount.createWithExchangeAmount({
- *   currencyConfig,
+ * const ethAmountWithExchange = new CryptoAmount({
+ *   currencyConfig, // 'ethereum'
+ *   tokenId: null,
  *   exchangeAmount: '100',
  * })
  *
- * const cryptoAmountWithNative = CryptoAmount.createWithNativeAmount({
+ * const cryptoAmountWithNative = new CryptoAmount({
+ *   currencyConfig,
  *   currencyCode: 'USDC',
  *   nativeAmount: '12345678',
  * })
+ *
+ * cryptoAmount.getDollarValue()
  */
 export class CryptoAmount {
   public readonly currencyConfig: EdgeCurrencyConfig
   public readonly nativeAmount: string
   public readonly tokenId: string | null
 
+  /**
+   * Must construct CryptoAmount with currencyConfig and one of either: tokenId or currencyCode
+   */
   public constructor(args: CryptoAmountConstructorArgs) {
     const { currencyCode, currencyConfig, exchangeAmount, nativeAmount, tokenId } = args
     this.currencyConfig = currencyConfig
 
-    // Populate tokenId
+    // Populate tokenId, derived from currencyCode
     if (currencyCode != null) {
       // Ensure currencyCode is recognized, if given as a constructor argument.
       const foundTokenId = Object.keys(currencyConfig.allTokens).find(edgeToken => currencyConfig.allTokens[edgeToken].currencyCode === currencyCode)
@@ -75,7 +83,7 @@ export class CryptoAmount {
         this.tokenId = foundTokenId
       }
     } else {
-      this.tokenId = tokenId ?? null
+      this.tokenId = tokenId
     }
 
     // Populate nativeAmount
@@ -99,20 +107,37 @@ export class CryptoAmount {
   // Getters:
   //
 
+  /**
+   * Mainnet, parent, network or chain currency code.
+   */
   get chainCode(): string {
     return this.currencyConfig.currencyInfo.currencyCode
   }
 
+  /**
+   * If this CryptoAmount is about a token, the currency code for that token.
+   * Else, the mainnet, parent, network or chain code.
+   */
   get currencyCode(): string {
     const { currencyCode } = this.tokenId == null ? this.currencyConfig.currencyInfo : this.currencyConfig.allTokens[this.tokenId]
     return currencyCode
   }
 
+  /**
+   * The decimal amount you would see on exchanges and pretty much anywhere
+   * else. Given in maximum decimal precision.
+   *
+   * If typical app precision or a specific precision is required, use
+   * getExchangeAmount() instead.
+   */
   get exchangeAmount(): string {
     const { multiplier } = this.getExchangeDenom()
     return div(this.nativeAmount, multiplier, DECIMAL_PRECISION)
   }
 
+  /**
+   * Core pluginId associated with this currency
+   */
   get pluginId(): string {
     return this.currencyConfig.currencyInfo.pluginId
   }
@@ -121,14 +146,25 @@ export class CryptoAmount {
   // Utilities:
   //
 
+  /**
+   * Automatically uses 2 decimal/cent places if unspecified.
+   */
   displayDollarValue(state: RootState, precision?: number): string {
-    return parseFloat(convertCurrency(state, this.currencyCode, 'iso:USD', this.exchangeAmount)).toFixed(precision ?? 2)
+    return this.displayFiatValue(state, 'iso:USD', precision)
   }
 
+  /**
+   * Automatically uses 2 decimal/cent places if unspecified.
+   */
   displayFiatValue(state: RootState, isoFiatCode: string, precision?: number) {
     return parseFloat(convertCurrency(state, this.currencyCode, isoFiatCode, this.exchangeAmount)).toFixed(precision ?? 2)
   }
 
+  /**
+   * The amount you would see on exchanges and pretty much anywhere else. If
+   * precision is unset, precision is dynamically set according to the asset's
+   * multiplier.
+   */
   getExchangeAmount(precision?: number): string {
     const { multiplier } = this.getExchangeDenom()
     return div(this.nativeAmount, multiplier, precision ?? mulToPrecision(multiplier))
@@ -136,13 +172,6 @@ export class CryptoAmount {
 
   getExchangeDenom(): EdgeDenomination {
     const { allTokens, currencyInfo } = this.currencyConfig
-
-    if (this.tokenId == null) return currencyInfo.denominations[0]
-    for (const tokenId of Object.keys(allTokens)) {
-      const token = allTokens[tokenId]
-      if (token.currencyCode === this.currencyCode) return token.denominations[0]
-    }
-
-    return emptyEdgeDenomination
+    return this.tokenId == null ? currencyInfo.denominations[0] : allTokens[this.tokenId].denominations[0]
   }
 }

--- a/src/util/tracking.ts
+++ b/src/util/tracking.ts
@@ -56,13 +56,18 @@ export type TrackingEventName =
 
 export type OnLogEvent = (event: TrackingEventName, values?: TrackingValues) => void
 
-// Known dollar amount revenue
+/**
+ * Analytics: Known dollar amount revenue
+ */
 export interface DollarConversionValues {
   conversionType: 'dollar'
   dollarConversionValue: number
 }
 
-// Some unknown revenue based on a send (e.g. FIO handle/domain fees) or swap
+/**
+ * Analytics: Some unknown revenue based on a send (e.g. FIO handle/domain fees)
+ * or swap
+ */
 export interface CryptoConversionValues {
   conversionType: 'crypto'
   cryptoAmount: CryptoAmount
@@ -71,7 +76,9 @@ export interface CryptoConversionValues {
   orderId?: string
 }
 
-// Sell to fiat
+/**
+ * Analytics: Sell to fiat
+ */
 export interface SellConversionValues {
   conversionType: 'sell'
 
@@ -85,6 +92,10 @@ export interface SellConversionValues {
   orderId?: string // Unique order identifier provided by fiat provider
 }
 
+/**
+ * Culmination of defined tracking value types, including those defined in
+ * LoginUi.
+ */
 export interface TrackingValues extends LoginTrackingValues {
   error?: unknown | string // Any error
 

--- a/src/util/tracking.ts
+++ b/src/util/tracking.ts
@@ -1,6 +1,5 @@
 import Bugsnag from '@bugsnag/react-native'
 import analytics from '@react-native-firebase/analytics'
-import { div } from 'biggystring'
 import { TrackingEventName as LoginTrackingEventName, TrackingValues as LoginTrackingValues } from 'edge-login-ui-rn/lib/components/publicApi/publicTypes'
 import PostHog from 'posthog-react-native'
 import { getBuildNumber, getUniqueId, getVersion } from 'react-native-device-info'
@@ -9,13 +8,11 @@ import { checkNotifications } from 'react-native-permissions'
 import { getFirstOpenInfo } from '../actions/FirstOpenActions'
 import { ENV } from '../env'
 import { ExperimentConfig, getExperimentConfig } from '../experimentConfig'
-import { getExchangeDenomByCurrencyCode } from '../selectors/DenominationSelectors'
-import { convertCurrency } from '../selectors/WalletSelectors'
 import { ThunkAction } from '../types/reduxTypes'
-import { asBiggystring } from './cleaners'
+import { CryptoAmount } from './CryptoAmount'
 import { fetchReferral } from './network'
 import { makeErrorLog } from './translateError'
-import { consify, mulToPrecision } from './utils'
+import { consify } from './utils'
 export type TrackingEventName =
   | 'Activate_Wallet_Cancel'
   | 'Activate_Wallet_Done'
@@ -59,22 +56,44 @@ export type TrackingEventName =
 
 export type OnLogEvent = (event: TrackingEventName, values?: TrackingValues) => void
 
+// Known dollar amount revenue
+export interface DollarConversionValues {
+  conversionType: 'dollar'
+  dollarConversionValue: number
+}
+
+// Some unknown revenue based on a send (e.g. FIO handle/domain fees) or swap
+export interface CryptoConversionValues {
+  conversionType: 'crypto'
+  cryptoAmount: CryptoAmount
+
+  swapProviderId?: string
+  orderId?: string
+}
+
+// Sell to fiat
+export interface SellConversionValues {
+  conversionType: 'sell'
+
+  // The quoted fiat amounts resulting from this sale
+  destFiatAmount: string
+  destFiatCurrencyCode: string
+
+  sourceAmount: CryptoAmount
+
+  fiatProviderId: string // Fiat provider that provided the conversion
+  orderId?: string // Unique order identifier provided by fiat provider
+}
+
 export interface TrackingValues extends LoginTrackingValues {
-  currencyCode?: string // Wallet currency code
-  dollarValue?: number // Conversion amount, in USD
   error?: unknown | string // Any error
-  orderId?: string // Unique order identifier provided by plugin
-  pluginId?: string // Plugin that provided the conversion
+
+  createdWalletCurrencyCode?: string
   numSelectedWallets?: number // Number of wallets to be created
-  destCurrencyCode?: string
-  destExchangeAmount?: string
-  destPluginId?: string // currency pluginId of source asset
-  sourceCurrencyCode?: string
-  sourceExchangeAmount?: string
-  sourcePluginId?: string // currency pluginId of dest asset
   numAccounts?: number // Number of full accounts saved on the device
-  exchangeAmount?: string
-  nativeAmount?: string
+
+  // Conversion values
+  conversionValues?: DollarConversionValues | CryptoConversionValues | SellConversionValues
 }
 
 // Set up the global Firebase analytics instance at boot:
@@ -141,7 +160,7 @@ export function trackError(
  */
 export function logEvent(event: TrackingEventName, values: TrackingValues = {}): ThunkAction<void> {
   return async (dispatch, getState) => {
-    const { currencyCode, dollarValue, pluginId, error, exchangeAmount, nativeAmount, sourceExchangeAmount, destExchangeAmount } = values
+    const { error, conversionValues, createdWalletCurrencyCode } = values
     getExperimentConfig()
       .then(async (experimentConfig: ExperimentConfig) => {
         // Persistent & Unchanged params:
@@ -151,7 +170,6 @@ export function logEvent(event: TrackingEventName, values: TrackingValues = {}):
 
         // Populate referral params:
         const state = getState()
-        const { account } = state.core
         const { accountReferral } = state.account
         params.refDeviceInstallerId = state.deviceReferral.installerId
         params.refDeviceCurrencyCodes = state.deviceReferral.currencyCodes
@@ -162,52 +180,39 @@ export function logEvent(event: TrackingEventName, values: TrackingValues = {}):
         params.refAccountCurrencyCodes = accountReferral.currencyCodes
 
         // Adjust params:
-        if (currencyCode != null) params.currency = currencyCode
-        if (dollarValue != null) {
-          // If an explicit dollarValue was given, prioritize it
-          params.currency = 'USD'
-          params.value = Number(dollarValue.toFixed(2))
-          params.items = [String(event)]
-        } else if (currencyCode != null) {
-          // Else, calculate the dollar value from crypto amounts, if required props given
-          if (nativeAmount != null && pluginId != null) {
-            try {
-              asBiggystring(nativeAmount)
-            } catch (e) {
-              trackError('Error in tracking nativeAmount: ' + JSON.stringify({ event, values }))
-            }
-            const { multiplier } = getExchangeDenomByCurrencyCode(account.currencyConfig[pluginId], currencyCode)
-            params.value = div(nativeAmount, multiplier, mulToPrecision(multiplier))
-          } else if (exchangeAmount != null) {
-            params.value = parseFloat(
-              convertCurrency(state, currencyCode, 'iso:USD', typeof destExchangeAmount === 'string' ? destExchangeAmount : String(destExchangeAmount))
-            )
-          } else if (sourceExchangeAmount != null) {
-            try {
-              asBiggystring(sourceExchangeAmount)
-            } catch (e) {
-              trackError('Error in tracking sourceExchangeAmount: ' + JSON.stringify({ event, values }))
-            }
-            params.sourceExchangeAmount = sourceExchangeAmount
-          } else if (destExchangeAmount != null) {
-            try {
-              asBiggystring(destExchangeAmount)
-            } catch (e) {
-              trackError('Error in tracking destExchangeAmount: ' + JSON.stringify({ event, values }))
-            }
-            params.destExchangeAmount = destExchangeAmount
-            try {
-              asBiggystring(exchangeAmount)
-            } catch (e) {
-              trackError('Error in tracking exchangeAmount: ' + JSON.stringify({ event, values }))
-            }
-            params.value = convertCurrency(state, currencyCode, 'iso:USD', exchangeAmount)
-          } else {
-            console.warn('Unable to calculate dollar value for event:', event, values)
+        if (createdWalletCurrencyCode != null) params.currency = createdWalletCurrencyCode
+        if (error != null) params.error = makeErrorLog(error)
+
+        // Conversion values:
+        if (conversionValues != null) {
+          const { conversionType } = conversionValues
+          if (conversionType === 'dollar') {
+            params.currency = 'USD'
+            params.dollarConverisonValue = Number(conversionValues.dollarConversionValue.toFixed(2))
+          } else if (conversionType === 'sell') {
+            const { sourceAmount, destFiatAmount, destFiatCurrencyCode, orderId, fiatProviderId } = conversionValues
+
+            params.sourceDollarValue = Number(sourceAmount.displayDollarValue(state))
+            params.sourceCryptoAmount = Number(sourceAmount.exchangeAmount)
+            params.sourceCurrencyCode = sourceAmount.currencyCode
+
+            params.destFiatValue = Number(destFiatAmount).toFixed(2)
+            params.destFiatCurrencyCode = destFiatCurrencyCode
+
+            if (orderId != null) params.orderId = orderId
+            if (fiatProviderId != null) params.fiatProviderId = fiatProviderId
+          } else if (conversionType === 'crypto') {
+            const { cryptoAmount, swapProviderId, orderId } = conversionValues
+
+            params.cryptoAmount = Number(cryptoAmount.exchangeAmount)
+            params.currency = cryptoAmount.currencyCode
+
+            params.dollarValue = Number(cryptoAmount.displayDollarValue(state))
+
+            if (orderId != null) params.orderId = orderId
+            if (swapProviderId != null) params.swapProviderId = swapProviderId
           }
         }
-        if (pluginId != null) params.plugin = pluginId
-        if (error != null) params.error = makeErrorLog(error)
 
         // Add all 'sticky' remote config variant values:
         for (const key of Object.keys(experimentConfig)) params[`svar_${key}`] = experimentConfig[key as keyof ExperimentConfig]


### PR DESCRIPTION
Conversion tracking was broken in some cases. Wrong values, including our very ambiguous `pluginId`, were being used to calculate dollar conversion values. As a result, `logEvent` either silently failed without sending out the tracking event, or reported the incorrect amount values.

Refactor tracking in general, introduce an MVP of `CryptoAmount`, and make props more explicit. All of those combined ought to reduce the likelihood of similar future mistakes.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206683289208449