### PR TITLE
Update unique ID for share referral links

### DIFF
--- a/src/components/themed/SideMenu.tsx
+++ b/src/components/themed/SideMenu.tsx
@@ -2,6 +2,7 @@
 import { DrawerContentComponentProps, useDrawerStatus } from '@react-navigation/drawer'
 import { DrawerActions } from '@react-navigation/native'
 import { EdgeAccount, EdgeUserInfo } from 'edge-core-js'
+import hashjs from 'hash.js'
 import * as React from 'react'
 import { Image, Platform, Pressable, ScrollView, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
@@ -28,7 +29,6 @@ import { config } from '../../theme/appConfig'
 import { useDispatch, useSelector } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
 import { parseDeepLink } from '../../util/DeepLinkParser'
-import { base58ToUuid } from '../../util/utils'
 import { IONIA_SUPPORTED_FIATS } from '../cards/VisaCardCard'
 import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { ButtonsModal } from '../modals/ButtonsModal'
@@ -144,7 +144,12 @@ export function SideMenuComponent(props: DrawerContentComponentProps) {
 
   const handleShareApp = () => {
     const message = `${sprintf(lstrings.share_subject, config.appName)}\n\n${lstrings.share_message}\n\n`
-    const website = `${config.website}?af=appreferred-${base58ToUuid(context.clientId)}`
+
+    // Generate anonymized referral ID
+    const data = Uint8Array.from(Buffer.from(account.rootLoginId, 'hex'))
+    const refId = hashjs.sha256().update(data).digest('hex').replace('0x', '').substring(0, 10)
+
+    const website = `${config.website}?af=appreferred_${refId}`
 
     const shareOptions = {
       message: Platform.OS === 'ios' ? message : message + website,


### PR DESCRIPTION
This pull request updates the unique ID used for generating share referral links. It replaces the previous method of using base58ToUuid with a new method that generates an anonymized referral ID using hash.js. This ensures that the referral links are more secure and unique.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206488798092857