### PR TITLE
Jon/fix/notif-slider-conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@
 - changed: Move wallet activation redux values to scenes
 - changed: Button width remains constant regardless of content visibility
 - changed: Certain deeplinks blocked for light accounts
-- chagned: 'Sweep Private Key' usage blocked for light accounts
+- changed: 'Sweep Private Key' usage blocked for light accounts
 - fixed: FIO name transfer error when sending with no address
+- fixed: Bottom notification cards sometimes covering parts of the scene
 
 ## 4.2.0 (2024-03-12)
 

--- a/src/__tests__/reducers/__snapshots__/RootReducer.test.ts.snap
+++ b/src/__tests__/reducers/__snapshots__/RootReducer.test.ts.snap
@@ -86,6 +86,7 @@ exports[`initialState 1`] = `
       "fioAddressesLoading": false,
       "fioDomains": [],
     },
+    "notificationHeight": 0,
     "passwordReminder": {
       "lastLoginDate": -Infinity,
       "lastPasswordUseDate": -Infinity,

--- a/src/__tests__/scenes/__snapshots__/CryptoExchangeQuoteScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CryptoExchangeQuoteScene.test.tsx.snap
@@ -1792,13 +1792,14 @@ exports[`CryptoExchangeQuoteScreenComponent should render with loading props 1`]
     }
     hasTabs={true}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {

--- a/src/__tests__/scenes/__snapshots__/CryptoExchangeScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CryptoExchangeScene.test.tsx.snap
@@ -648,13 +648,14 @@ exports[`CryptoExchangeComponent should render with loading props 1`] = `
     }
     hasTabs={true}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -212,7 +212,6 @@ exports[`SendScene2 1 spendTarget 1`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -1163,7 +1162,8 @@ exports[`SendScene2 1 spendTarget 1`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -1324,13 +1324,14 @@ exports[`SendScene2 1 spendTarget 1`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -1558,7 +1559,6 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -2697,7 +2697,8 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -2858,13 +2859,14 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -3092,7 +3094,6 @@ exports[`SendScene2 2 spendTargets 1`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -4208,7 +4209,8 @@ exports[`SendScene2 2 spendTargets 1`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -4369,13 +4371,14 @@ exports[`SendScene2 2 spendTargets 1`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -4603,7 +4606,6 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -5420,7 +5422,8 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -5581,13 +5584,14 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -5815,7 +5819,6 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -6608,7 +6611,8 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -6769,13 +6773,14 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -7003,7 +7008,6 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -7635,7 +7639,8 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -7796,13 +7801,14 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -8030,7 +8036,6 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -8967,7 +8972,8 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -9128,13 +9134,14 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -9362,7 +9369,6 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -10234,7 +10240,8 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -10395,13 +10402,14 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -10629,7 +10637,6 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -11460,7 +11467,8 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -11621,13 +11629,14 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -11855,7 +11864,6 @@ exports[`SendScene2 Render SendScene 1`] = `
       keyboardDismissMode="interactive"
       keyboardOpeningTime={250}
       keyboardSpace={0}
-      notificationHeight={0}
       onScroll={[Function]}
       resetKeyboardSpace={[Function]}
       scrollEventThrottle={1}
@@ -12810,7 +12818,8 @@ exports[`SendScene2 Render SendScene 1`] = `
       </View>
     </RCTScrollView>
     <View
-      notificationHeight={0}
+      hasNotifications={false}
+      insetBottom={0}
       style={
         {
           "alignItems": "center",
@@ -12831,13 +12840,14 @@ exports[`SendScene2 Render SendScene 1`] = `
     }
     hasTabs={false}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {

--- a/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
@@ -2137,13 +2137,14 @@ exports[`TransactionDetailsScene should render 1`] = `
     }
     hasTabs={true}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {
@@ -4296,13 +4297,14 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
     }
     hasTabs={true}
     insetBottom={0}
+    onLayout={[Function]}
     style={
       [
         {
           "alignSelf": "center",
           "bottom": 0,
           "justifyContent": "flex-end",
-          "padding": 11,
+          "paddingHorizontal": 11,
           "position": "absolute",
         },
         {

--- a/src/components/common/SceneWrapper.tsx
+++ b/src/components/common/SceneWrapper.tsx
@@ -15,7 +15,6 @@ import { NavigationBase } from '../../types/routerTypes'
 import { OverrideDots } from '../../types/Theme'
 import { styled } from '../hoc/styled'
 import { NotificationView } from '../notification/NotificationView'
-import { useTheme } from '../services/ThemeContext'
 import { MAX_TAB_BAR_HEIGHT } from '../themed/MenuTabs'
 import { AccentColors, DotsBackground } from '../ui4/DotsBackground'
 
@@ -124,12 +123,9 @@ function SceneWrapperComponent(props: SceneWrapperProps): JSX.Element {
     scroll = false
   } = props
 
-  const accountId = useSelector(state => state.core.account.id)
-  const activeUsername = useSelector(state => state.core.account.username)
-  const isLightAccount = accountId != null && activeUsername == null
+  const notificationHeight = useSelector(state => state.ui.notificationHeight)
 
   const navigation = useNavigation<NavigationBase>()
-  const theme = useTheme()
 
   // We need to track this state in the JS thread because insets are not shared values
   const [isKeyboardOpen, setIsKeyboardOpen] = useState(false)
@@ -161,13 +157,11 @@ function SceneWrapperComponent(props: SceneWrapperProps): JSX.Element {
     [frameHeight, frameWidth]
   )
 
-  const notificationHeight = theme.rem(4)
   const headerBarHeight = getDefaultHeaderHeight({ height: frameHeight, width: frameWidth }, false, 0)
 
   // Calculate app insets considering the app's header, tab-bar,
   // notification area, etc:
   const maybeHeaderHeight = hasHeader ? headerBarHeight : 0
-  const maybeNotificationHeight = isLightAccount ? notificationHeight : 0
   // Ignore tab bar height when keyboard is open because it is rendered behind it
   const maybeTabBarHeight = hasTabs && !isKeyboardOpen ? MAX_TAB_BAR_HEIGHT : 0
   // Ignore inset bottom when keyboard is open because it is rendered behind it
@@ -176,19 +170,10 @@ function SceneWrapperComponent(props: SceneWrapperProps): JSX.Element {
     () => ({
       top: safeAreaInsets.top + maybeHeaderHeight,
       right: safeAreaInsets.right,
-      bottom: maybeInsetBottom + maybeNotificationHeight + maybeTabBarHeight + footerHeight,
+      bottom: maybeInsetBottom + notificationHeight + maybeTabBarHeight + footerHeight,
       left: safeAreaInsets.left
     }),
-    [
-      footerHeight,
-      maybeHeaderHeight,
-      maybeInsetBottom,
-      maybeNotificationHeight,
-      maybeTabBarHeight,
-      safeAreaInsets.left,
-      safeAreaInsets.right,
-      safeAreaInsets.top
-    ]
+    [footerHeight, maybeHeaderHeight, maybeInsetBottom, notificationHeight, maybeTabBarHeight, safeAreaInsets.left, safeAreaInsets.right, safeAreaInsets.top]
   )
 
   // This is a convenient styles object which may be applied as

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -109,7 +109,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     flexDirection: 'row',
     justifyContent: 'center',
     padding: theme.rem(0.5),
-    margin: theme.rem(0.5)
+    margin: theme.rem(0.5),
+    marginTop: 0
   }
 }))
 

--- a/src/components/notification/NotificationView.tsx
+++ b/src/components/notification/NotificationView.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { LayoutChangeEvent } from 'react-native'
 import Animated, { interpolate, SharedValue, useAnimatedStyle } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { sprintf } from 'sprintf-js'
@@ -64,6 +65,11 @@ const NotificationViewComponent = (props: Props) => {
     await Airship.show(bridge => <PasswordReminderModal bridge={bridge} navigation={navigation} />)
   })
 
+  const handleLayout = useHandler((event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout
+    dispatch({ type: 'UI/SET_NOTIFICATION_HEIGHT', data: { height } })
+  })
+
   // Show a tokens detected notification per walletId found in newTokens
   React.useEffect(() => {
     const newNotifs: React.JSX.Element[] = []
@@ -124,7 +130,13 @@ const NotificationViewComponent = (props: Props) => {
   )
 
   return (
-    <NotificationCardsContainer hasTabs={hasTabs} insetBottom={insetBottom} footerHeight={footerHeight} footerOpenRatio={footerOpenRatio}>
+    <NotificationCardsContainer
+      hasTabs={hasTabs}
+      insetBottom={insetBottom}
+      footerHeight={footerHeight}
+      footerOpenRatio={footerOpenRatio}
+      onLayout={handleLayout}
+    >
       <EdgeAnim visible={isBackupWarningShown} enter={fadeIn} exit={fadeOut}>
         <NotificationCard type="warning" title={lstrings.backup_title} message={lstrings.backup_web3_handle_warning_message} onPress={handleBackupPress} />
       </EdgeAnim>
@@ -152,7 +164,7 @@ const NotificationCardsContainer = styled(Animated.View)<{ hasTabs: boolean; ins
       return [
         {
           position: 'absolute',
-          padding: theme.rem(0.5),
+          paddingHorizontal: theme.rem(0.5),
           alignSelf: 'center',
           justifyContent: 'flex-end',
           bottom: 0

--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -176,6 +176,8 @@ const SendComponent = (props: Props) => {
   const pinSpendingLimitsEnabled = useSelector<boolean>(state => state.ui.settings.spendingLimits.transaction.isEnabled)
   const pinSpendingLimitsAmount = useSelector<number>(state => state.ui.settings.spendingLimits.transaction.amount ?? 0)
   const defaultIsoFiat = useSelector<string>(state => state.ui.settings.defaultIsoFiat)
+  const hasNotifications = useSelector(state => state.ui.notificationHeight > 0)
+
   const currencyWallets = useWatch(account, 'currencyWallets')
   const [tokenId, setTokenId] = useState<EdgeTokenId>(spendInfo.tokenId ?? tokenIdProp)
   const coreWallet = currencyWallets[walletId]
@@ -1030,8 +1032,7 @@ const SendComponent = (props: Props) => {
       {({ insetStyle }) => (
         <>
           <StyledKeyboardAwareScrollView
-            notificationHeight={insetStyle.paddingBottom}
-            contentContainerStyle={{ ...insetStyle, paddingTop: 0, paddingBottom: theme.rem(5) + insetStyle.paddingBottom }}
+            contentContainerStyle={{ ...insetStyle, paddingTop: 0, paddingBottom: theme.rem(5) }}
             extraScrollHeight={theme.rem(2.75)}
             enableOnAndroid
             scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
@@ -1059,7 +1060,7 @@ const SendComponent = (props: Props) => {
             </EdgeAnim>
             <EdgeAnim enter={{ type: 'fadeInDown', distance: 80 }}>{renderScamWarning()}</EdgeAnim>
           </StyledKeyboardAwareScrollView>
-          <StyledSliderView notificationHeight={insetStyle.paddingBottom}>
+          <StyledSliderView hasNotifications={hasNotifications} insetBottom={insetStyle.paddingBottom}>
             {showSlider && (
               <EdgeAnim enter={{ type: 'fadeInDown', distance: 120 }}>
                 <SafeSlider disabledText={disabledText} onSlidingComplete={handleSliderComplete} disabled={disableSlider} />
@@ -1072,18 +1073,27 @@ const SendComponent = (props: Props) => {
   )
 }
 
-const StyledKeyboardAwareScrollView = styled(KeyboardAwareScrollView)<{ notificationHeight: number }>(theme => props => ({
-  marginBottom: props.notificationHeight,
-  margin: theme.rem(0.5)
+const StyledKeyboardAwareScrollView = styled(KeyboardAwareScrollView)(theme => ({
+  margin: theme.rem(0.5),
+  marginBottom: 0
 }))
 
-const StyledSliderView = styled(View)<{ notificationHeight: number }>(theme => props => {
+const StyledSliderView = styled(View)<{ insetBottom: number; hasNotifications: boolean }>(theme => props => {
+  const { insetBottom, hasNotifications } = props
+
+  // We only need a bit more room under the slider when it's against the bottom
+  // edge of the screen to improve usability - things close to the edges of the
+  // screen are hard to access.
+  // We don't need this extra space when notifications push the slider up away
+  // from the bottom edge, so reduce the bottom margins in this case.
+  const bottom = insetBottom + (hasNotifications ? theme.rem(1) : theme.rem(2))
+
   return {
     width: '100%',
     justifyContent: 'center',
     alignItems: 'center',
     position: 'absolute',
-    bottom: theme.rem(2) + props.notificationHeight
+    bottom
   }
 })
 

--- a/src/reducers/uiReducer.ts
+++ b/src/reducers/uiReducer.ts
@@ -15,6 +15,7 @@ export interface UiState {
   readonly fioAddress: FioAddressSceneState
   readonly passwordReminder: PasswordReminderState
   readonly settings: SettingsState
+  readonly notificationHeight: number
   readonly subcategories: string[]
   readonly wallets: WalletsState
 }
@@ -25,6 +26,12 @@ const uiInner = combineReducers<UiState, Action>({
   fioAddress,
   passwordReminder,
   settings,
+  notificationHeight(state = 0, action) {
+    if (action.type === 'UI/SET_NOTIFICATION_HEIGHT') {
+      return action.data.height
+    }
+    return state
+  },
 
   subcategories(state = [], action) {
     switch (action.type) {

--- a/src/types/reduxActions.ts
+++ b/src/types/reduxActions.ts
@@ -92,6 +92,10 @@ export type Action =
       type: 'UI/WALLETS/SELECT_WALLET'
       data: { currencyCode: string; walletId: string }
     }
+  | {
+      type: 'UI/SET_NOTIFICATION_HEIGHT'
+      data: { height: number }
+    }
   | { type: 'UI/WALLETS/UPSERT_WALLETS'; data: { wallets: EdgeCurrencyWallet[] } }
   | { type: 'UPDATE_EXCHANGE_INFO'; data: ExchangeInfo }
   | { type: 'UPDATE_SORTED_WALLET_LIST'; data: WalletListItem[] }


### PR DESCRIPTION
- Simplify all the weird spacing assignments. The scene simply needs insets for the main scroll view - the notification height is already provided through those insets and was actually previously doubling up on those insets. There's no observed need to add any extra bottom padding as nothing gets covered and the inset works as expected.
- Small dynamic adjustment added to the slider placement depending on the existence of notifications

![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/56cffc48-8391-453e-89c7-66d1fa62f89a)
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/6bd4f968-9bbe-4bff-ae0b-d2e18464ec9d)

Proof hard-coded extra 5 rem was not required and nothing gets covered:
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/fbf37ced-fd9b-4e1b-8d1f-6d10ec7d9247)


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206832602251889