### PR TITLE
Jon/fix/kado-deeplink

### DIFF
--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -229,7 +229,7 @@ class GuiPluginList extends React.PureComponent<Props, State> {
     const { pluginId, paymentType, deepQuery = {} } = listRow
     const plugin = guiPlugins[pluginId]
 
-    // Don't allow light accounts to enter sell plugins
+    // Don't allow light accounts to enter buy plugins
     const direction = this.getSceneDirection()
     if (direction === 'buy' && checkAndShowLightBackupModal(account, navigation)) return
 

--- a/src/plugins/gui/fiatPlugin.tsx
+++ b/src/plugins/gui/fiatPlugin.tsx
@@ -6,6 +6,7 @@ import { Platform } from 'react-native'
 import { CustomTabs } from 'react-native-custom-tabs'
 import SafariView from 'react-native-safari-view'
 
+import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { DisablePluginMap, NestedDisableMap } from '../../actions/ExchangeInfoActions'
 import { launchPaymentProto, LaunchPaymentProtoParams } from '../../actions/PaymentProtoActions'
 import { addressWarnings } from '../../actions/ScanActions'
@@ -67,9 +68,11 @@ export const executePlugin = async (params: {
     onLogEvent
   } = params
   const { defaultFiatAmount, forceFiatCurrencyCode, pluginId } = guiPlugin
+  const isBuy = direction === 'buy'
+  if (isBuy && checkAndShowLightBackupModal(account, navigation)) return
 
-  const tabSceneKey = direction === 'buy' ? 'buyTab' : 'sellTab'
-  const listSceneKey = direction === 'buy' ? 'pluginListBuy' : 'pluginListSell'
+  const tabSceneKey = isBuy ? 'buyTab' : 'sellTab'
+  const listSceneKey = isBuy ? 'pluginListBuy' : 'pluginListSell'
 
   function maybeNavigateToCorrectTabScene() {
     const navPath = getNavigationAbsolutePath(navigation)


### PR DESCRIPTION
Leaving the existing light account check in the GuiPluginListScene to avoid running any of the other logic prior to executePlugin

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206859452306514