### PR TITLE
Do not allow RBF for Thorchain Savers txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - fixed: Fix duplicate transactions bug and re-enable transaction support in Filecoin FEVM
 - fixed: 'tokenId' related crash on Send scene under certain conditions
 - fixed: Properly show the Thorchain Savers unstake amount including earned amt
+- fixed: Disable RBF for Thorchain Savers transactions
+- fixed: Xcode 15 builds. Remove Flipper as it is deprecated anyway
 
 ## 4.3.0 (2024-03-25)
 

--- a/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.ts
+++ b/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.ts
@@ -556,7 +556,7 @@ const stakeRequest = async (opts: EdgeGuiPluginOptions, request: ChangeQuoteRequ
     // 1. Sort the outputs by how they are sent to makeSpend making the target output the 1st, change 2nd
     // 2. Only use UTXOs from the primary address (index 0)
     // 3. Force change to go to the primary address
-    otherParams: { outputSort: 'targets', utxoSourceAddress, forceChangeAddress },
+    otherParams: { enableRbf: false, outputSort: 'targets', utxoSourceAddress, forceChangeAddress },
     assetAction: { assetActionType: 'stake' },
     savedAction: {
       actionType: 'stake',
@@ -622,7 +622,7 @@ const stakeRequest = async (opts: EdgeGuiPluginOptions, request: ChangeQuoteRequ
           }
         ]
       },
-      otherParams: { forceChangeAddress }
+      otherParams: { forceChangeAddress, enableRbf: false }
     }
 
     const estimateTx = await wallet.makeSpend(fundingSpendInfo)
@@ -879,7 +879,7 @@ const unstakeRequestInner = async (opts: EdgeGuiPluginOptions, request: ChangeQu
   const spendInfo: EdgeSpendInfo = {
     tokenId,
     spendTargets: [{ publicAddress: poolAddress, nativeAmount: sendNativeAmount }],
-    otherParams: { outputSort: 'targets', utxoSourceAddress, forceChangeAddress },
+    otherParams: { enableRbf: false, outputSort: 'targets', utxoSourceAddress, forceChangeAddress },
     assetAction: { assetActionType: 'unstakeOrder' },
     savedAction: {
       actionType: 'stake',
@@ -1007,7 +1007,7 @@ const unstakeRequestInner = async (opts: EdgeGuiPluginOptions, request: ChangeQu
               }
             ]
           },
-          otherParams: { forceChangeAddress }
+          otherParams: { enableRbf: false, forceChangeAddress }
         })
         const signedTx = await wallet.signTx(tx)
         const broadcastedTx = await wallet.broadcastTx(signedTx)


### PR DESCRIPTION
Savers txs require specific input/output ordering and an RBF tx will likely mess up the ordering.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206924062004099