### PR TITLE
Show correct unstake amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed: FIO handle/domain registration error with MATIC payment
 - fixed: Fix duplicate transactions bug and re-enable transaction support in Filecoin FEVM
 - fixed: 'tokenId' related crash on Send scene under certain conditions
+- fixed: Properly show the Thorchain Savers unstake amount including earned amt
 
 ## 4.3.0 (2024-03-25)
 

--- a/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.ts
+++ b/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.ts
@@ -888,7 +888,7 @@ const unstakeRequestInner = async (opts: EdgeGuiPluginOptions, request: ChangeQu
         {
           pluginId,
           tokenId,
-          nativeAmount
+          nativeAmount: totalUnstakeNativeAmount
         }
       ]
     },
@@ -949,7 +949,7 @@ const unstakeRequestInner = async (opts: EdgeGuiPluginOptions, request: ChangeQu
           {
             pluginId,
             tokenId,
-            nativeAmount
+            nativeAmount: totalUnstakeNativeAmount
           }
         ]
       }
@@ -969,7 +969,7 @@ const unstakeRequestInner = async (opts: EdgeGuiPluginOptions, request: ChangeQu
         allocationType: 'unstake',
         pluginId,
         currencyCode,
-        nativeAmount
+        nativeAmount: totalUnstakeNativeAmount
       },
       {
         allocationType: 'networkFee',


### PR DESCRIPTION
While we were actually unstaking the correct amount including the earned amount, we didn't properly show that to the user or log it in the savedAction

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206958843387214