### PR TITLE
Refactor Text Components, Modal cleanup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,7 @@
     "react-native/no-raw-text": [
       "error",
       {
-        "skip": ["B", "EdgeText"]
+        "skip": ["B", "EdgeText", "Paragraph", "SmallText", "WarningText"]
       }
     ],
     "react-native/sort-styles": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - added: More descriptive 504 transaction failure error message
+- added: New `Text`-based components
+- changed: Replace `ModalMessage` with `Paragraph`
 - changed: Allow light accounts to buy up to $50 worth of crypto at a time
 
 ## 4.4.0

--- a/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
@@ -14,9 +14,9 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
   onCancel={[Function]}
   title="Accelerate Transaction"
 >
-  <ModalMessage>
+  <Paragraph>
     This will resend your transaction with its fee doubled to help prioritize it for network confirmation. Please review new fee amount before confirming.
-  </ModalMessage>
+  </Paragraph>
   <View
     style={
       {

--- a/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
@@ -14,11 +14,11 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
   onCancel={[Function]}
   title="Verify your password"
 >
-  <ModalMessage>
+  <Paragraph>
     To ensure the security of your account.
 
 Please enter your password below. A successful verification will prevent this warning from appearing for a few logins.
-  </ModalMessage>
+  </Paragraph>
   <ForwardRef
     autoFocus={false}
     bottom={2}

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -310,22 +310,22 @@ exports[`CreateWalletAccountSelect renders 1`] = `
         </View>
       </View>
       <Text
+        adjustsFontSizeToFit={false}
+        numberOfLines={0}
         style={
           [
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
               "fontSize": 22,
-              "margin": 11,
-              "textAlign": "left",
+              "includeFontPadding": false,
             },
             {
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
+              "marginBottom": 11,
+              "marginLeft": 11,
+              "marginRight": 11,
+              "marginTop": 11,
             },
-            null,
             null,
           ]
         }
@@ -333,22 +333,22 @@ exports[`CreateWalletAccountSelect renders 1`] = `
         Create a unique account handle, this will also be the name of your BTC wallet:
       </Text>
       <Text
+        adjustsFontSizeToFit={false}
+        numberOfLines={0}
         style={
           [
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
               "fontSize": 22,
-              "margin": 11,
-              "textAlign": "left",
+              "includeFontPadding": false,
             },
             {
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
+              "marginBottom": 11,
+              "marginLeft": 11,
+              "marginRight": 11,
+              "marginTop": 11,
             },
-            null,
             null,
           ]
         }

--- a/src/actions/DeleteWalletModalActions.tsx
+++ b/src/actions/DeleteWalletModalActions.tsx
@@ -3,7 +3,7 @@ import { sprintf } from 'sprintf-js'
 
 import { ButtonsModal } from '../components/modals/ButtonsModal'
 import { Airship } from '../components/services/AirshipInstance'
-import { ModalMessage } from '../components/themed/ModalParts'
+import { Paragraph } from '../components/themed/EdgeText'
 import { lstrings } from '../locales/strings'
 import { B } from '../styles/common/textStyles'
 import { ThunkAction } from '../types/reduxTypes'
@@ -25,7 +25,7 @@ export function showDeleteWalletModal(walletId: string, tokenCode?: string, addi
         }}
       >
         <>
-          <ModalMessage>
+          <Paragraph>
             {tokenCode == null ? (
               <>
                 {lstrings.fragmet_wallets_delete_wallet_first_confirm_message_mobile}
@@ -34,8 +34,8 @@ export function showDeleteWalletModal(walletId: string, tokenCode?: string, addi
             ) : (
               <>{sprintf(lstrings.fragment_wallets_delete_token_prompt_2s, tokenCode, getWalletName(currencyWallets[walletId]))}</>
             )}
-          </ModalMessage>
-          {additionalMsg == null ? null : <ModalMessage>{additionalMsg}</ModalMessage>}
+          </Paragraph>
+          {additionalMsg == null ? null : <Paragraph>{additionalMsg}</Paragraph>}
         </>
       </ButtonsModal>
     ))

--- a/src/actions/LogActions.tsx
+++ b/src/actions/LogActions.tsx
@@ -91,7 +91,7 @@ export function showClearLogsModal(): ThunkAction<Promise<void>> {
           },
           no: {
             label: 'Cancel',
-            type: 'escape'
+            type: 'tertiary'
           }
         }}
       />

--- a/src/actions/ScamWarningActions.tsx
+++ b/src/actions/ScamWarningActions.tsx
@@ -4,7 +4,7 @@ import { sprintf } from 'sprintf-js'
 
 import { ConfirmContinueModal } from '../components/modals/ConfirmContinueModal'
 import { Airship } from '../components/services/AirshipInstance'
-import { ModalMessage } from '../components/themed/ModalParts'
+import { Paragraph, WarningText } from '../components/themed/EdgeText'
 import { SCAM_WARNING } from '../constants/constantSettings'
 import { lstrings } from '../locales/strings'
 import { config } from '../theme/appConfig'
@@ -23,7 +23,9 @@ export const triggerScamWarningModal = async (disklet: Disklet) => {
 
       return (
         <ConfirmContinueModal bridge={bridge} title={lstrings.warning_scam_title}>
-          <ModalMessage isWarning>{warningMessage}</ModalMessage>
+          <Paragraph>
+            <WarningText>{warningMessage}</WarningText>
+          </Paragraph>
         </ConfirmContinueModal>
       )
     })

--- a/src/actions/WalletListMenuActions.tsx
+++ b/src/actions/WalletListMenuActions.tsx
@@ -9,7 +9,7 @@ import { RawTextModal } from '../components/modals/RawTextModal'
 import { TextInputModal } from '../components/modals/TextInputModal'
 import { Airship, showError, showToast } from '../components/services/AirshipInstance'
 import { Alert } from '../components/themed/Alert'
-import { ModalMessage } from '../components/themed/ModalParts'
+import { Paragraph } from '../components/themed/EdgeText'
 import { deleteLoanAccount } from '../controllers/loan-manager/redux/actions'
 import { lstrings } from '../locales/strings'
 import { ThunkAction } from '../types/reduxTypes'
@@ -70,8 +70,8 @@ export function walletListMenuAction(
         if (Object.values(currencyWallets).length === 1) {
           await Airship.show(bridge => (
             <ButtonsModal bridge={bridge} buttons={{}} closeArrow title={lstrings.cannot_delete_last_wallet_modal_title}>
-              <ModalMessage>{lstrings.cannot_delete_last_wallet_modal_message_part_1}</ModalMessage>
-              <ModalMessage>{lstrings.cannot_delete_last_wallet_modal_message_part_2}</ModalMessage>
+              <Paragraph>{lstrings.cannot_delete_last_wallet_modal_message_part_1}</Paragraph>
+              <Paragraph>{lstrings.cannot_delete_last_wallet_modal_message_part_2}</Paragraph>
             </ButtonsModal>
           ))
           return

--- a/src/components/modals/AccelerateTxModal.tsx
+++ b/src/components/modals/AccelerateTxModal.tsx
@@ -11,7 +11,7 @@ import { GuiExchangeRates } from '../../types/types'
 import { convertTransactionFeeToDisplayFee } from '../../util/utils'
 import { WarningCard } from '../cards/WarningCard'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
-import { ModalMessage } from '../themed/ModalParts'
+import { Paragraph } from '../themed/EdgeText'
 import { Slider } from '../themed/Slider'
 import { ModalUi4 } from '../ui4/ModalUi4'
 import { RowUi4 } from '../ui4/RowUi4'
@@ -108,7 +108,7 @@ export class AccelerateTxModalComponent extends PureComponent<Props, State> {
 
     return (
       <ModalUi4 bridge={bridge} onCancel={this.handleCancel} title={lstrings.transaction_details_accelerate_transaction_header}>
-        <ModalMessage>{lstrings.transaction_details_accelerate_transaction_instructional}</ModalMessage>
+        <Paragraph>{lstrings.transaction_details_accelerate_transaction_instructional}</Paragraph>
         <View style={styles.container}>
           <RowUi4 title={lstrings.transaction_details_accelerate_transaction_old_fee_title} body={oldFee} />
           {newFee == null ? null : <RowUi4 title={lstrings.transaction_details_accelerate_transaction_new_fee_title} body={newFee} />}

--- a/src/components/modals/BackupForTransferModal.tsx
+++ b/src/components/modals/BackupForTransferModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { AirshipBridge } from 'react-native-airship'
 
 import { lstrings } from '../../locales/strings'
-import { ModalMessage } from '../themed/ModalParts'
+import { Paragraph } from '../themed/EdgeText'
 import { ButtonsModal } from './ButtonsModal'
 
 export type BackupForTransferModalResult = 'upgrade'
@@ -23,7 +23,7 @@ export function BackupForTransferModal(props: Props) {
       title={lstrings.backup_title}
       closeArrow
     >
-      <ModalMessage paddingRem={[0, 0, 1.5, 0]}>{lstrings.backup_for_transfer_message}</ModalMessage>
+      <Paragraph marginRem={[0, 0, 1.5, 0]}>{lstrings.backup_for_transfer_message}</Paragraph>
     </ButtonsModal>
   )
 }

--- a/src/components/modals/ButtonsModal.tsx
+++ b/src/components/modals/ButtonsModal.tsx
@@ -4,9 +4,9 @@ import { AirshipBridge } from 'react-native-airship'
 
 import { useHandler } from '../../hooks/useHandler'
 import { showError } from '../services/AirshipInstance'
-import { useTheme } from '../services/ThemeContext'
+import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
+import { Paragraph } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 export interface ButtonInfo {
@@ -23,14 +23,19 @@ export interface ButtonInfo {
 
 export interface ButtonModalProps<Buttons> {
   bridge: AirshipBridge<keyof Buttons | undefined>
-  title?: string
-  message?: string
-  children?: React.ReactNode
   buttons: Buttons
+  /** Ideally mutually exclusive with message/subtext since children are
+   * rendered in the body of the modal along with message/subtext */
+  children?: React.ReactNode
+  /** No corner close button */
   disableCancel?: boolean
+  /** Full height (flex: 1) */
   fullScreen?: boolean
-
-  // Adds a border:
+  /** Main body message */
+  message?: string
+  /** Modal title */
+  title?: string
+  /** Adds a border around the modal */
   warning?: boolean
 
   /** @deprecated. Does nothing. */
@@ -52,41 +57,22 @@ export interface ButtonModalProps<Buttons> {
 export function ButtonsModal<Buttons extends { [key: string]: ButtonInfo }>(props: ButtonModalProps<Buttons>) {
   const { bridge, title, message, children, buttons, disableCancel = false, fullScreen = false, warning } = props
   const theme = useTheme()
+  const styles = getStyles(theme)
 
   const handleCancel = useHandler(() => bridge.resolve(undefined))
 
   const containerStyle: ViewStyle = {
     flex: fullScreen ? 1 : 0
   }
-  const textStyle: ViewStyle = {
-    justifyContent: 'flex-start'
-  }
-  const buttonsStyle: ViewStyle = {
-    justifyContent: 'flex-end',
-    marginTop: theme.rem(0.5)
-  }
-
-  // TODO:
-  // Since we don't have clear definitions yet for primary/secondary/tertiary
-  // button assignments, we can't use ButtonsViewUi4. For now, just style
-  // the buttons with a shared width
-  const innerButtonStyle: ViewStyle = {
-    justifyContent: 'space-between',
-    alignSelf: 'center', // Shrink view around buttons
-    alignItems: 'stretch', // Stretch our children out
-    flexDirection: 'column'
-  }
 
   return (
     <ModalUi4 warning={warning} bridge={bridge} title={title} onCancel={disableCancel ? undefined : handleCancel}>
-      <View style={containerStyle}>
-        <View style={textStyle}>
-          {message != null ? <ModalMessage>{message}</ModalMessage> : null}
-          {children}
-        </View>
+      <View style={[styles.textStyle, containerStyle]}>
+        {message != null ? <Paragraph>{message}</Paragraph> : null}
+        {children}
       </View>
-      <View style={buttonsStyle}>
-        <View style={innerButtonStyle}>
+      <View style={styles.buttonsStyle}>
+        <View style={styles.innerButtonStyle}>
           {Object.keys(buttons).map((key, i, arr) => {
             let defaultType: 'primary' | 'secondary'
             if (theme.preferPrimaryButton) {
@@ -116,3 +102,23 @@ export function ButtonsModal<Buttons extends { [key: string]: ButtonInfo }>(prop
     </ModalUi4>
   )
 }
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  buttonsStyle: {
+    justifyContent: 'flex-end',
+    marginTop: theme.rem(0.5)
+  },
+  // TODO:
+  // Since we don't have clear definitions yet for primary/secondary/tertiary
+  // button assignments, we can't use ButtonsViewUi4. For now, just style
+  // the buttons with a shared width
+  innerButtonStyle: {
+    justifyContent: 'space-between',
+    alignSelf: 'center', // Shrink view around buttons
+    alignItems: 'stretch', // Stretch our children out
+    flexDirection: 'column'
+  },
+  textStyle: {
+    justifyContent: 'flex-start'
+  }
+}))

--- a/src/components/modals/ButtonsModal.tsx
+++ b/src/components/modals/ButtonsModal.tsx
@@ -6,12 +6,12 @@ import { useHandler } from '../../hooks/useHandler'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { Paragraph } from '../themed/EdgeText'
-import { MainButton } from '../themed/MainButton'
+import { ButtonTypeUi4, ButtonUi4 } from '../ui4/ButtonUi4'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 export interface ButtonInfo {
   label: string
-  type?: 'primary' | 'secondary' | 'escape'
+  type?: ButtonTypeUi4
 
   // The modal will show a spinner as long as this promise is pending.
   // Returning true will dismiss the modal,
@@ -24,8 +24,8 @@ export interface ButtonInfo {
 export interface ButtonModalProps<Buttons> {
   bridge: AirshipBridge<keyof Buttons | undefined>
   buttons: Buttons
-  /** Ideally mutually exclusive with message/subtext since children are
-   * rendered in the body of the modal along with message/subtext */
+  /** Used to pass non-text children, to be rendered after the title and message
+   * but before the buttons themselves. */
   children?: React.ReactNode
   /** No corner close button */
   disableCancel?: boolean
@@ -95,7 +95,7 @@ export function ButtonsModal<Buttons extends { [key: string]: ButtonInfo }>(prop
               )
             }
 
-            return <MainButton key={key} label={label} marginRem={0.5} type={type} onPress={handlePress} layout="column" />
+            return <ButtonUi4 key={key} label={label} marginRem={0.5} type={type} onPress={handlePress} layout="column" />
           })}
         </View>
       </View>

--- a/src/components/modals/ConfirmContinueModal.tsx
+++ b/src/components/modals/ConfirmContinueModal.tsx
@@ -7,10 +7,10 @@ import Ionicons from 'react-native-vector-icons/Ionicons'
 import { lstrings } from '../../locales/strings'
 import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
-import { EdgeText } from '../themed/EdgeText'
+import { EdgeText, Paragraph } from '../themed/EdgeText'
 import { Fade } from '../themed/Fade'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalTitle } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 interface Props {
@@ -62,8 +62,8 @@ export function ConfirmContinueModal(props: Props) {
       onCancel={isSkippable ? handleClose : undefined}
     >
       {children}
-      {body != null ? <ModalMessage>{body}</ModalMessage> : null}
-      <ModalMessage>{lstrings.confirm_continue_modal_body}</ModalMessage>
+      {body != null ? <Paragraph>{body}</Paragraph> : null}
+      <Paragraph>{lstrings.confirm_continue_modal_body}</Paragraph>
       <EdgeTouchableWithoutFeedback onPress={handleTogggle}>
         <View style={styles.checkBoxContainer}>
           <EdgeText style={styles.checkboxText}>{lstrings.confirm_continue_modal_button_text}</EdgeText>

--- a/src/components/modals/FioExpiredModal.tsx
+++ b/src/components/modals/FioExpiredModal.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 import { AirshipBridge } from 'react-native-airship'
 
 import { lstrings } from '../../locales/strings'
+import { Paragraph } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 export function FioExpiredModal(props: { bridge: AirshipBridge<boolean>; fioName: string }) {
@@ -12,8 +12,8 @@ export function FioExpiredModal(props: { bridge: AirshipBridge<boolean>; fioName
 
   return (
     <ModalUi4 bridge={bridge} title={title} onCancel={() => bridge.resolve(false)}>
-      <ModalMessage>{lstrings.fio_domain_details_expired_soon}</ModalMessage>
-      <ModalMessage>{fioName}</ModalMessage>
+      <Paragraph>{lstrings.fio_domain_details_expired_soon}</Paragraph>
+      <Paragraph>{fioName}</Paragraph>
       <MainButton label={lstrings.title_fio_renew} marginRem={1} type="secondary" onPress={() => bridge.resolve(true)} />
     </ModalUi4>
   )

--- a/src/components/modals/InsufficientFeesModal.tsx
+++ b/src/components/modals/InsufficientFeesModal.tsx
@@ -9,7 +9,7 @@ import { lstrings } from '../../locales/strings'
 import { NavigationBase } from '../../types/routerTypes'
 import { getCurrencyCode } from '../../util/CurrencyInfoHelpers'
 import { roundedFee } from '../../util/utils'
-import { ModalMessage } from '../themed/ModalParts'
+import { Paragraph } from '../themed/EdgeText'
 import { ButtonsViewUi4 } from '../ui4/ButtonsViewUi4'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
@@ -50,7 +50,7 @@ export function InsufficientFeesModal(props: Props) {
 
   return (
     <ModalUi4 bridge={bridge} title={lstrings.buy_crypto_modal_title} onCancel={handleCancel}>
-      <ModalMessage>{sprintf(lstrings.buy_parent_crypto_modal_message_2s, amountString, name)}</ModalMessage>
+      <Paragraph>{sprintf(lstrings.buy_parent_crypto_modal_message_2s, amountString, name)}</Paragraph>
       <ButtonsViewUi4
         primary={{ label: sprintf(lstrings.buy_crypto_modal_buy_action, currencyCode), onPress: handleBuy }}
         secondary={{ label: lstrings.buy_crypto_modal_exchange, onPress: handleSwap }}

--- a/src/components/modals/ListModal.tsx
+++ b/src/components/modals/ListModal.tsx
@@ -6,8 +6,9 @@ import { FlatList } from 'react-native-gesture-handler'
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
 import { useFilter } from '../../hooks/useFilter'
 import { useTheme } from '../services/ThemeContext'
+import { Paragraph } from '../themed/EdgeText'
 import { FilledTextInput } from '../themed/FilledTextInput'
-import { ModalFooter, ModalMessage } from '../themed/ModalParts'
+import { ModalFooter } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 interface Props<T> {
@@ -71,7 +72,7 @@ export function ListModal<T>({
 
   return (
     <ModalUi4 title={title} bridge={bridge} onCancel={handleCancel}>
-      {message == null ? null : <ModalMessage>{message}</ModalMessage>}
+      {message == null ? null : <Paragraph>{message}</Paragraph>}
       {!textInput ? null : (
         <FilledTextInput
           vertical={1}

--- a/src/components/modals/LogsModal.tsx
+++ b/src/components/modals/LogsModal.tsx
@@ -8,9 +8,9 @@ import { MultiLogOutput, sendLogs } from '../../actions/LogActions'
 import { lstrings } from '../../locales/strings'
 import { WarningCard } from '../cards/WarningCard'
 import { showToast } from '../services/AirshipInstance'
+import { Paragraph } from '../themed/EdgeText'
 import { FilledTextInput } from '../themed/FilledTextInput'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 interface Props {
   bridge: AirshipBridge<void>
@@ -73,7 +73,7 @@ export const LogsModal = (props: Props) => {
   return (
     <ModalUi4 bridge={bridge} onCancel={handleCancel} title={lstrings.settings_button_export_logs} scroll>
       {!isDangerous ? null : <WarningCard key="warning" title={lstrings.string_warning} footer={lstrings.settings_modal_send_unsafe} marginRem={0.5} />}
-      {isDangerous ? null : <ModalMessage>{lstrings.settings_modal_export_logs_message}</ModalMessage>}
+      {isDangerous ? null : <Paragraph>{lstrings.settings_modal_export_logs_message}</Paragraph>}
       <FilledTextInput
         around={1}
         autoCorrect

--- a/src/components/modals/PasswordReminderModal.tsx
+++ b/src/components/modals/PasswordReminderModal.tsx
@@ -7,8 +7,8 @@ import { connect } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
 import { showError, showToast } from '../services/AirshipInstance'
 import { ThemeProps, withTheme } from '../services/ThemeContext'
+import { Paragraph } from '../themed/EdgeText'
 import { FilledTextInput } from '../themed/FilledTextInput'
-import { ModalMessage } from '../themed/ModalParts'
 import { ButtonsViewUi4 } from '../ui4/ButtonsViewUi4'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
@@ -79,7 +79,7 @@ export class PasswordReminderModalComponent extends React.PureComponent<Props, S
 
     return (
       <ModalUi4 bridge={bridge} title={lstrings.password_reminder_modal_title} onCancel={this.handleCancel}>
-        <ModalMessage>{lstrings.password_reminder_modal_body}</ModalMessage>
+        <Paragraph>{lstrings.password_reminder_modal_body}</Paragraph>
         <FilledTextInput
           top={0.5}
           bottom={2}

--- a/src/components/modals/PermissionsSettingModal.tsx
+++ b/src/components/modals/PermissionsSettingModal.tsx
@@ -9,8 +9,8 @@ import { lstrings } from '../../locales/strings'
 import { Permission, permissionNames } from '../../reducers/PermissionsReducer'
 import { showError } from '../services/AirshipInstance'
 import { checkIfDenied } from '../services/PermissionsManager'
+import { Paragraph } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 export function PermissionsSettingModal(props: {
@@ -46,7 +46,7 @@ export function PermissionsSettingModal(props: {
 
   return (
     <ModalUi4 bridge={bridge} onCancel={handleClose}>
-      <ModalMessage>{message}</ModalMessage>
+      <Paragraph>{message}</Paragraph>
       <MainButton label={lstrings.string_ok_cap} marginRem={1} type="primary" onPress={handlePress} />
     </ModalUi4>
   )

--- a/src/components/modals/RawTextModal.tsx
+++ b/src/components/modals/RawTextModal.tsx
@@ -6,8 +6,8 @@ import { AirshipBridge } from 'react-native-airship'
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
 import { lstrings } from '../../locales/strings'
 import { showToast } from '../services/AirshipInstance'
+import { Paragraph } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 interface Props {
@@ -30,7 +30,7 @@ export function RawTextModal(props: Props) {
   return (
     <ModalUi4 bridge={bridge} title={title} onCancel={handleCancel}>
       <ScrollView scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}>
-        <ModalMessage>{body}</ModalMessage>
+        <Paragraph>{body}</Paragraph>
       </ScrollView>
       {disableCopy ? null : <MainButton label={lstrings.fragment_request_copy_title} marginRem={1} onPress={handleCopy} type="secondary" />}
     </ModalUi4>

--- a/src/components/modals/ScanModal.tsx
+++ b/src/components/modals/ScanModal.tsx
@@ -19,9 +19,9 @@ import { TextInputModal } from '../modals/TextInputModal'
 import { Airship, showError, showWarning } from '../services/AirshipInstance'
 import { checkAndRequestPermission } from '../services/PermissionsManager'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
-import { EdgeText } from '../themed/EdgeText'
+import { EdgeText, Paragraph } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalFooter, ModalMessage } from '../themed/ModalParts'
+import { ModalFooter } from '../themed/ModalParts'
 import { SceneHeader } from '../themed/SceneHeader'
 
 interface Props {
@@ -212,7 +212,7 @@ export const ScanModal = (props: Props) => {
 
     return (
       <View style={styles.cameraPermissionContainer}>
-        <ModalMessage>{lstrings.scan_camera_permission_denied}</ModalMessage>
+        <Paragraph>{lstrings.scan_camera_permission_denied}</Paragraph>
         <MainButton onPress={handleSettings} label={lstrings.open_settings} marginRem={1} />
       </View>
     )

--- a/src/components/modals/SwapVerifyTermsModal.tsx
+++ b/src/components/modals/SwapVerifyTermsModal.tsx
@@ -8,8 +8,9 @@ import { lstrings } from '../../locales/strings'
 import { getSwapPluginIconUri } from '../../util/CdnUris'
 import { Airship } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
+import { Paragraph } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalTitle } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 interface TermsUri {
@@ -69,7 +70,7 @@ function SwapVerifyTermsModal(props: Props) {
       }
       onCancel={() => bridge.resolve(false)}
     >
-      <ModalMessage>{lstrings.swap_terms_statement}</ModalMessage>
+      <Paragraph>{lstrings.swap_terms_statement}</Paragraph>
       <MainButton label={lstrings.swap_terms_accept_button} marginRem={1} onPress={() => bridge.resolve(true)} />
       <MainButton label={lstrings.swap_terms_reject_button} marginRem={1} type="secondary" onPress={() => bridge.resolve(false)} />
       <View style={styles.linkContainer}>

--- a/src/components/modals/TextInputModal.tsx
+++ b/src/components/modals/TextInputModal.tsx
@@ -5,9 +5,9 @@ import { AirshipBridge } from 'react-native-airship'
 import { lstrings } from '../../locales/strings'
 import { showError } from '../services/AirshipInstance'
 import { Alert } from '../themed/Alert'
+import { Paragraph } from '../themed/EdgeText'
 import { FilledTextInput } from '../themed/FilledTextInput'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 interface Props {
@@ -98,7 +98,7 @@ export function TextInputModal(props: Props) {
 
   return (
     <ModalUi4 warning={warning} bridge={bridge} title={title} onCancel={() => bridge.resolve(undefined)}>
-      {typeof message === 'string' ? <ModalMessage>{message}</ModalMessage> : <>{message}</>}
+      {typeof message === 'string' ? <Paragraph>{message}</Paragraph> : <>{message}</>}
       {warningMessage != null ? <Alert type="warning" title={lstrings.string_warning} marginRem={0.5} message={warningMessage} numberOfLines={0} /> : null}
       <FilledTextInput
         top={1}

--- a/src/components/modals/UpdateModal.tsx
+++ b/src/components/modals/UpdateModal.tsx
@@ -7,8 +7,9 @@ import { sprintf } from 'sprintf-js'
 import { lstrings } from '../../locales/strings'
 import { config } from '../../theme/appConfig'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
+import { Paragraph } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage, ModalTitle } from '../themed/ModalParts'
+import { ModalTitle } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 interface Props {
@@ -41,7 +42,7 @@ export function UpdateModal(props: Props) {
       }
       onCancel={handleClose}
     >
-      <ModalMessage>{message}</ModalMessage>
+      <Paragraph>{message}</Paragraph>
       <MainButton label={lstrings.update_now} marginRem={0.5} type="primary" onPress={handleUpdate} />
       <MainButton label={lstrings.update_later} marginRem={[0.5, 0, 1]} type="secondary" onPress={onSkip} />
     </ModalUi4>

--- a/src/components/scenes/CreateWalletAccountSetupScene.tsx
+++ b/src/components/scenes/CreateWalletAccountSetupScene.tsx
@@ -11,9 +11,9 @@ import { EdgeSceneProps } from '../../types/routerTypes'
 import { logEvent } from '../../util/tracking'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { withWallet } from '../hoc/withWallet'
+import { Paragraph } from '../themed/EdgeText'
 import { FilledTextInput } from '../themed/FilledTextInput'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage } from '../themed/ModalParts'
 import { CryptoIconUi4 } from '../ui4/CryptoIconUi4'
 
 export interface CreateWalletAccountSetupParams {
@@ -86,8 +86,8 @@ export const CreateWalletAccountSetupScene = withWallet((props: Props) => {
       {/* This is an abuse of ModalMessage,
       but EdgeText breaks this text by setting numberOfLines.
       Switch to MessageText if we ever define that: */}
-      <ModalMessage>{sprintf(lstrings.create_wallet_account_review_instructions, existingCurrencyCode)}</ModalMessage>
-      <ModalMessage>{lstrings.create_wallet_account_requirements_eos}</ModalMessage>
+      <Paragraph>{sprintf(lstrings.create_wallet_account_review_instructions, existingCurrencyCode)}</Paragraph>
+      <Paragraph>{lstrings.create_wallet_account_requirements_eos}</Paragraph>
       <FilledTextInput
         around={1}
         bottom={2}

--- a/src/components/scenes/CreateWalletImportOptionsScene.tsx
+++ b/src/components/scenes/CreateWalletImportOptionsScene.tsx
@@ -16,9 +16,8 @@ import { SceneWrapper } from '../common/SceneWrapper'
 import { TextInputModal } from '../modals/TextInputModal'
 import { Airship, showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
-import { EdgeText } from '../themed/EdgeText'
+import { EdgeText, Paragraph } from '../themed/EdgeText'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage } from '../themed/ModalParts'
 import { SceneHeader } from '../themed/SceneHeader'
 import { CryptoIconUi4 } from '../ui4/CryptoIconUi4'
 import { RowUi4 } from '../ui4/RowUi4'
@@ -111,12 +110,12 @@ const CreateWalletImportOptionsComponent = (props: Props) => {
           Linking.openURL(knowledgeBaseUri).catch(err => showError(err))
         }
         description = (
-          <ModalMessage>
+          <Paragraph>
             {message}
             <EdgeTouchableOpacity onPress={onPress}>
               <Ionicon name="help-circle-outline" size={theme.rem(1)} color={theme.iconTappable} />
             </EdgeTouchableOpacity>
-          </ModalMessage>
+          </Paragraph>
         )
       } else {
         description = message

--- a/src/components/scenes/Fio/FioStakingChangeScene.tsx
+++ b/src/components/scenes/Fio/FioStakingChangeScene.tsx
@@ -23,9 +23,9 @@ import { withWallet } from '../../hoc/withWallet'
 import { FlipInputModal2, FlipInputModalResult } from '../../modals/FlipInputModal2'
 import { Airship, showToast } from '../../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../../services/ThemeContext'
-import { EdgeText } from '../../themed/EdgeText'
+import { EdgeText, Paragraph } from '../../themed/EdgeText'
 import { ExchangedFlipInputAmounts } from '../../themed/ExchangedFlipInput2'
-import { ModalMessage, ModalTitle } from '../../themed/ModalParts'
+import { ModalTitle } from '../../themed/ModalParts'
 import { SceneHeader } from '../../themed/SceneHeader'
 import { Slider } from '../../themed/Slider'
 import { AlertCardUi4 } from '../../ui4/AlertCardUi4'
@@ -197,8 +197,8 @@ export const FioStakingChangeScene = withWallet((props: Props) => {
             </ModalTitle>
           }
         >
-          <ModalMessage>{lstrings.staking_change_unlock_explainer1}</ModalMessage>
-          <ModalMessage>{lstrings.staking_change_unlock_explainer2}</ModalMessage>
+          <Paragraph>{lstrings.staking_change_unlock_explainer1}</Paragraph>
+          <Paragraph>{lstrings.staking_change_unlock_explainer2}</Paragraph>
         </ModalUi4>
       )
     })
@@ -294,8 +294,8 @@ export const FioStakingChangeScene = withWallet((props: Props) => {
           <Image style={styles.currencyLogo} source={fioLogo} />
         </SceneHeader>
         <View style={styles.explainer}>
-          <ModalMessage>{lstrings.staking_change_explaner1}</ModalMessage>
-          <ModalMessage>{lstrings.staking_change_explaner2}</ModalMessage>
+          <Paragraph>{lstrings.staking_change_explaner1}</Paragraph>
+          <Paragraph>{lstrings.staking_change_explaner2}</Paragraph>
         </View>
         <CardUi4 marginRem={1}>
           <RowUi4 rightButtonType="editable" title={lstrings.staking_change_add_amount_title} onPress={handleAmount}>

--- a/src/components/themed/EdgeText.tsx
+++ b/src/components/themed/EdgeText.tsx
@@ -1,18 +1,27 @@
 import * as React from 'react'
 import { Platform, StyleProp, Text, TextProps, TextStyle } from 'react-native'
 
+import { fixSides, mapSides, sidesToMargin } from '../../util/sides'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 
-interface Props extends TextProps {
+export const androidAdjustTextStyle = (theme: Theme) => {
+  const styles = getStyles(theme)
+  return Platform.OS === 'android' ? styles.androidAdjust : null
+}
+
+interface LabelProps extends TextProps {
   children: React.ReactNode
   ellipsizeMode?: 'head' | 'middle' | 'tail' | 'clip'
   numberOfLines?: number
-  style?: StyleProp<TextStyle>
   disableFontScaling?: boolean
   minimumFontScale?: number
+
+  /** @deprecated Use or create an appropriate `___Text` component instead */
+  style?: StyleProp<TextStyle>
 }
 
-export const EdgeText = (props: Props) => {
+// TODO: Rename to LabelText
+export const EdgeText = (props: LabelProps) => {
   const { children, style, disableFontScaling = false, ...rest } = props
   const theme = useTheme()
   const styles = getStyles(theme)
@@ -24,7 +33,7 @@ export const EdgeText = (props: Props) => {
 
   return (
     <Text
-      style={[styles.text, style, Platform.OS === 'android' ? styles.androidAdjust : null]}
+      style={[styles.common, style, androidAdjustTextStyle(theme)]}
       numberOfLines={numberOfLines}
       adjustsFontSizeToFit={!disableFontScaling}
       minimumFontScale={0.65}
@@ -35,14 +44,65 @@ export const EdgeText = (props: Props) => {
   )
 }
 
+/** A properly spaced block of text with default font color and size. Children
+ * that are wrapped in other `___Text` component types will override those defaults.
+ *
+ * A `Paragraph` *can* have `marginRem`, but *only* to avoid an extra `View` for
+ * spacing out `Paragraph(s)` in relation to their parent, *NOT* to give special
+ * spacing *between* `Paragraphs` */
+export const Paragraph = (props: {
+  children: React.ReactNode
+
+  /** @deprecated A `Paragraph` *can* have `marginRem`, but *only* to avoid an extra `View` for spacing out `Paragraph(s)` in relation to their parent, *NOT* to give special spacing *between* `Paragraphs`. It's still preferable to have the parents deal with spacing outside of `Paragraphs`. */
+  marginRem?: number[] | number
+}) => {
+  const { children, marginRem } = props
+  const theme = useTheme()
+  const styles = getStyles(theme)
+  const margin = sidesToMargin(mapSides(fixSides(marginRem, 0.5), theme.rem))
+
+  return (
+    <Text style={[styles.common, margin, androidAdjustTextStyle(theme)]} numberOfLines={0} adjustsFontSizeToFit={false}>
+      {children}
+    </Text>
+  )
+}
+
+/** Makes the contents of an `EdgeText` or `Paragraph` smaller (0.75rem).
+ * Unless used within a `Paragraph` block, provides no outer spacing. */
+export const SmallText = (props: { children: React.ReactNode }) => {
+  const { children } = props
+  const theme = useTheme()
+  const styles = getStyles(theme)
+
+  return <Text style={[styles.sizeSmall, androidAdjustTextStyle(theme)]}>{children}</Text>
+}
+
+/** Makes the contents of an `EdgeText` or `Paragraph` orange, for warnings.
+ * Unless used within a `Paragraph` block, provides no outer spacing. */
+export const WarningText = (props: { children: React.ReactNode }) => {
+  const { children } = props
+  const theme = useTheme()
+  const styles = getStyles(theme)
+
+  return <Text style={[styles.colorWarning, androidAdjustTextStyle(theme)]}>{children}</Text>
+}
+
 const getStyles = cacheStyles((theme: Theme) => ({
-  text: {
+  androidAdjust: {
+    top: -1
+  },
+  common: {
     color: theme.primaryText,
     fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(1),
     includeFontPadding: false
   },
-  androidAdjust: {
-    top: -1
+
+  colorWarning: {
+    color: theme.warningText
+  },
+  sizeSmall: {
+    fontSize: theme.rem(0.75)
   }
 }))

--- a/src/components/themed/ModalParts.tsx
+++ b/src/components/themed/ModalParts.tsx
@@ -37,17 +37,6 @@ export function ModalTitle(props: ModalTitleProps) {
   )
 }
 
-export function ModalMessage(props: { children: React.ReactNode; paddingRem?: number[] | number; isWarning?: boolean }) {
-  const { children, isWarning, paddingRem } = props
-  const theme = useTheme()
-  const styles = getStyles(theme)
-  const padding = sidesToPadding(mapSides(fixSides(paddingRem, 0), theme.rem))
-  const warningStyle = isWarning ? styles.warningText : null
-  const androidAdjust = Platform.OS === 'android' ? styles.androidAdjust : null
-
-  return <Text style={[styles.messageText, padding, warningStyle, androidAdjust]}>{children}</Text>
-}
-
 /**
  * Renders a close button
  */
@@ -129,16 +118,6 @@ const getStyles = cacheStyles((theme: Theme) => ({
   titleCenter: {
     textAlign: 'center',
     flexGrow: 1
-  },
-  warningText: {
-    color: theme.warningText
-  },
-  messageText: {
-    color: theme.primaryText,
-    fontFamily: theme.fontFaceDefault,
-    fontSize: theme.rem(1),
-    margin: theme.rem(0.5),
-    textAlign: 'left'
   },
   footerFadeContainer: {
     position: 'absolute',

--- a/src/plugins/gui/RewardsCardPlugin.tsx
+++ b/src/plugins/gui/RewardsCardPlugin.tsx
@@ -114,7 +114,7 @@ export const makeRewardsCardPlugin: FiatPluginFactory = async params => {
     const answer = await showUi.buttonModal({
       buttons: {
         delete: { label: lstrings.string_delete, type: 'secondary' },
-        keep: { label: lstrings.string_keep, type: 'escape' }
+        keep: { label: lstrings.string_keep, type: 'tertiary' }
       },
       title: lstrings.delete_card_confirmation_title,
       message: lstrings.rewards_card_delete_modal_message,
@@ -260,7 +260,7 @@ export const makeRewardsCardPlugin: FiatPluginFactory = async params => {
                 },
                 no: {
                   label: lstrings.string_decline,
-                  type: 'escape'
+                  type: 'tertiary'
                 }
               }
             })

--- a/src/theme/variables/edgeDark.ts
+++ b/src/theme/variables/edgeDark.ts
@@ -35,9 +35,16 @@ const palette = {
 
   darkMint: '#089e73',
   edgeMint: '#00f1a2',
+
   gray: '#888888',
-  darkGrey: '#494949',
-  lightGray: '#D9E3ED',
+  darkGray: '#494949',
+  darkGrayOp30: 'hsla(0, 0%, 53%, 0.3)',
+  lightGray: '#e2e2e2',
+
+  blueGray: '#D9E3ED',
+  blueGrayOp75: 'rgba(217, 227, 237, .75)',
+  blueGrayOp80: 'rgba(135, 147, 158, .8)',
+
   accentGreen: '#77C513',
   accentRed: '#E85466',
   accentBlue: '#0073D9',
@@ -49,17 +56,13 @@ const palette = {
   blackOp50: 'rgba(0, 0, 0, .5)',
   blackOp70: 'rgba(0, 0, 0, .7)',
 
-  darkGreyOp30: 'hsla(0, 0%, 53%, 0.3)',
-
   whiteOp05: 'rgba(255, 255, 255, .05)',
   whiteOp10: 'rgba(255, 255, 255, .1)',
   whiteOp37: 'rgba(255, 255, 255, .37)',
   whiteOp50: 'rgba(255, 255, 255, .5)',
   whiteOp75: 'rgba(255, 255, 255, .75)',
 
-  grayOp80: 'rgba(135, 147, 158, .8)',
   accentOrangeOp30: 'rgba(241, 170, 25, .3)',
-  lightGrayOp75: 'rgba(217, 227, 237, .75)',
   transparent: 'rgba(255, 255, 255, 0)',
 
   // Fonts
@@ -74,7 +77,7 @@ const palette = {
   skyBlue: '#3dd9f4',
   blackOp65: 'rgba(0, 0, 0, .65)',
   redOp60: 'rgba(232, 84, 102, .6)',
-  grayOp70: 'rgba(135, 147, 158, .7)',
+  blueGrayOp70: 'rgba(135, 147, 158, .7)',
   greenOp60: 'rgba(119, 197, 19, .6)',
   lightGreen: '#75C649',
   lightRed: '#E84D65',
@@ -180,7 +183,7 @@ export const edgeDark: Theme = {
   modalBorderRadiusRem: 1,
   modalBackground: palette.whiteOp37,
   modalSceneOverlayColor: palette.black,
-  modalDragbarColor: palette.darkGreyOp30,
+  modalDragbarColor: palette.darkGrayOp30,
 
   modalLikeBackground: '#333232',
 
@@ -204,7 +207,7 @@ export const edgeDark: Theme = {
   secondaryText: palette.skyBlue,
   warningText: palette.accentOrange,
   positiveText: palette.accentGreen,
-  negativeText: palette.lightGray,
+  negativeText: palette.blueGray,
   negativeDeltaText: palette.accentRed,
   dangerText: palette.accentRed,
   textLink: palette.edgeMint,
@@ -330,7 +333,7 @@ export const edgeDark: Theme = {
   toggleButtonOff: palette.gray,
 
   // Confirmation slider
-  confirmationSlider: palette.darkGrey,
+  confirmationSlider: palette.darkGray,
   confirmationSliderCompleted: palette.darkGreen,
   confirmationSliderText: palette.white,
   confirmationSliderArrow: palette.backgroundBlack,
@@ -511,8 +514,8 @@ export const edgeDark: Theme = {
 
   txDirBgReceive: palette.greenOp60,
   txDirBgSend: palette.redOp60,
-  txDirBgSwap: palette.grayOp70,
+  txDirBgSwap: palette.blueGrayOp70,
   txDirFgReceive: palette.lightGreen,
   txDirFgSend: palette.lightRed,
-  txDirFgSwap: palette.lightGray
+  txDirFgSwap: palette.blueGray
 }


### PR DESCRIPTION
This pull request refactors the Text Components by changing `ModalMessage` to `Paragraph` and moving it to the `EdgeText` file. Also introduces new EdgeText component types: `WarningText` and `SmallText`

Finally, small cleanups made for `ButtonsModal`

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207012234574059