### PR TITLE
Fix light account buy/sell limitation logic

### DIFF
--- a/src/plugins/gui/amountQuotePlugin.ts
+++ b/src/plugins/gui/amountQuotePlugin.ts
@@ -484,7 +484,7 @@ export const amountQuoteFiatPlugin: FiatPluginFactory = async (params: FiatPlugi
           }
 
           // Restrict light accounts from buying more than $50 at a time
-          if (isLightAccount) {
+          if (isLightAccount && isBuy) {
             const quoteFiatCurrencyCode = bestQuote.fiatCurrencyCode
             const quoteFiatRate =
               quoteFiatCurrencyCode === 'iso:USD' ? '1' : (await getHistoricalRate(`${quoteFiatCurrencyCode}_iso:USD`, new Date().toISOString())).toString()

--- a/src/plugins/gui/fiatPlugin.tsx
+++ b/src/plugins/gui/fiatPlugin.tsx
@@ -6,7 +6,6 @@ import { Platform } from 'react-native'
 import { CustomTabs } from 'react-native-custom-tabs'
 import SafariView from 'react-native-safari-view'
 
-import { checkAndShowLightBackupModal } from '../../actions/BackupModalActions'
 import { DisablePluginMap, NestedDisableMap } from '../../actions/ExchangeInfoActions'
 import { launchPaymentProto, LaunchPaymentProtoParams } from '../../actions/PaymentProtoActions'
 import { addressWarnings } from '../../actions/ScanActions'
@@ -73,7 +72,6 @@ export const executePlugin = async (params: {
   } = params
   const { defaultFiatAmount, forceFiatCurrencyCode, pluginId } = guiPlugin
   const isBuy = direction === 'buy'
-  if (isBuy && checkAndShowLightBackupModal(account, navigation)) return
 
   const tabSceneKey = isBuy ? 'buyTab' : 'sellTab'
   const listSceneKey = isBuy ? 'pluginListBuy' : 'pluginListSell'


### PR DESCRIPTION
For light accounts:
- Change executePlugin to allow buys with native plugins
- Add check for buy/sell direction in the max $50 check when accepting the quote

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207049347208575