### PR TITLE
Properly set default fiat value for non-USD amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - changed: "Split" wallet menu options consolidated into one
 - fixed: Possible to see receive address for a wallet requiring activation when creating the wallet from search
 - fixed: Glitch on transaction list scene when starting search
+- fixed: Properly set default buy/sell fiat amount for non-USD wallets
 - removed: 'X' button on modals
 
 ## 4.5.0


### PR DESCRIPTION
Convert $500 to fiat denom of wallet and round to highest decimal precision. This prevents getting a default quote for excessively small or large amounts

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207000283682116