### PR TITLE
Standard FilledTextInput Modal Margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - changed: Consistent light account backup modal UI
 - changed: Currency icon now shown in wallet picker button in Swap and Transaction List scenes
 - changed: Transaction List Scene displays wallet name in title
+- changed: Consistent light account backup modal UI
+- changed: Consistent margins for modal text inputs
 - fixed: Various React Native debug warnings
 - fixed: Fio domain registration supported payment currencies
 - removed: Bitpay deeplink support

--- a/src/__tests__/modals/CountryListModal.test.tsx
+++ b/src/__tests__/modals/CountryListModal.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals'
+import * as React from 'react'
+import TestRenderer from 'react-test-renderer'
+
+import { CountryListModal } from '../../components/modals/CountryListModal'
+import { fakeAirshipBridge } from '../../util/fake/fakeAirshipBridge'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
+
+describe('CountryListModal', () => {
+  const fakeAccount: any = { disklet: { getText: async () => '' } }
+  const fakeState: FakeState = {
+    core: {
+      account: fakeAccount
+    }
+  }
+
+  it('should render with a country list', () => {
+    const renderer = TestRenderer.create(
+      <FakeProviders initialState={fakeState}>
+        <CountryListModal bridge={fakeAirshipBridge} countryCode="" />
+      </FakeProviders>
+    )
+
+    expect(renderer.toJSON()).toMatchSnapshot()
+    renderer.unmount()
+  })
+})

--- a/src/__tests__/modals/LogsModal.test.tsx
+++ b/src/__tests__/modals/LogsModal.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from '@jest/globals'
+import * as React from 'react'
+import TestRenderer from 'react-test-renderer'
+
+import { MultiLogOutput } from '../../actions/LogActions'
+import { LogsModal } from '../../components/modals/LogsModal'
+import { fakeAirshipBridge } from '../../util/fake/fakeAirshipBridge'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
+
+describe('LogsModal', () => {
+  const fakeAccount: any = { disklet: { getText: async () => '' } }
+  const fakeState: FakeState = {
+    core: {
+      account: fakeAccount
+    }
+  }
+
+  const fakeLogs: MultiLogOutput = {
+    activity: {
+      isoDate: 'isoDate',
+      uniqueId: 'uniqueId',
+      userMessage: 'userMessage',
+      deviceInfo: 'deviceInfo',
+      appVersion: 'appVersion',
+      OS: 'OS',
+      accounts: [
+        {
+          username: 'userName',
+          userId: 'userId'
+        }
+      ],
+      data: 'data'
+    },
+    info: {
+      isoDate: 'isoDate',
+      uniqueId: 'uniqueId',
+      userMessage: 'userMessage',
+      deviceInfo: 'deviceInfo',
+      appVersion: 'appVersion',
+      OS: 'OS',
+      accounts: [
+        {
+          username: 'userName',
+          userId: 'userId'
+        }
+      ],
+      data: 'data'
+    }
+  }
+
+  it('should render with a logs modal', () => {
+    const renderer = TestRenderer.create(
+      <FakeProviders initialState={fakeState}>
+        <LogsModal bridge={fakeAirshipBridge} logs={fakeLogs} />
+      </FakeProviders>
+    )
+
+    expect(renderer.toJSON()).toMatchSnapshot()
+    renderer.unmount()
+  })
+})

--- a/src/__tests__/modals/TextInputModal.test.tsx
+++ b/src/__tests__/modals/TextInputModal.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@jest/globals'
+import * as React from 'react'
+import TestRenderer from 'react-test-renderer'
+
+import { TextInputModal } from '../../components/modals/TextInputModal'
+import { fakeAirshipBridge } from '../../util/fake/fakeAirshipBridge'
+import { FakeProviders, FakeState } from '../../util/fake/FakeProviders'
+
+describe('TextInputModal', () => {
+  const fakeAccount: any = { disklet: { getText: async () => '' } }
+  const fakeState: FakeState = {
+    core: {
+      account: fakeAccount
+    }
+  }
+
+  it('should render with a blank input field', () => {
+    const renderer = TestRenderer.create(
+      <FakeProviders initialState={fakeState}>
+        <TextInputModal bridge={fakeAirshipBridge} title="title" message="message" />
+      </FakeProviders>
+    )
+
+    expect(renderer.toJSON()).toMatchSnapshot()
+    renderer.unmount()
+  })
+
+  it('should render with a populated input field', () => {
+    const renderer = TestRenderer.create(
+      <FakeProviders initialState={fakeState}>
+        <TextInputModal bridge={fakeAirshipBridge} title="title" message="message" initialValue="initialValue" />
+      </FakeProviders>
+    )
+
+    expect(renderer.toJSON()).toMatchSnapshot()
+    renderer.unmount()
+  })
+})

--- a/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
@@ -15,10 +15,8 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
   title="string"
 >
   <ForwardRef
-    around={0.5}
     autoCapitalize="none"
     autoCorrect={false}
-    bottom={1}
     onChangeText={[Function]}
     onSubmitEditing={[Function]}
     placeholder="Address"

--- a/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
@@ -1,0 +1,3574 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CountryListModal should render with a country list 1`] = `
+[
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "backgroundColor": "#000000",
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "opacity": 0,
+        },
+      ]
+    }
+  />,
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "alignSelf": "flex-end",
+          "backgroundColor": "rgba(255, 255, 255, .37)",
+          "borderTopLeftRadius": 22,
+          "borderTopRightRadius": 22,
+          "flexShrink": 1,
+          "overflow": "hidden",
+          "paddingLeft": 11,
+          "paddingRight": 11,
+          "width": 674,
+        },
+        {
+          "transform": [
+            {
+              "translateY": 1334,
+            },
+          ],
+        },
+        {
+          "borderColor": "rgba(255, 255, 255, 0)",
+          "borderWidth": 0,
+          "marginBottom": -86,
+          "paddingBottom": 97,
+          "paddingTop": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={10}
+      blurType="dark"
+      overlayColor="rgba(0, 0, 0, 0)"
+      style={
+        {
+          "backgroundColor": undefined,
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    />
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
+            "borderRadius": 3,
+            "height": 6,
+            "marginTop": 6,
+            "width": 67,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "marginBottom": 11,
+          "marginTop": 28,
+        }
+      }
+    >
+      <Text
+        adjustsFontSizeToFit={true}
+        minimumFontScale={0.65}
+        numberOfLines={2}
+        style={
+          [
+            {
+              "color": "#FFFFFF",
+              "fontFamily": "Quicksand-Regular",
+              "fontSize": 22,
+              "includeFontPadding": false,
+            },
+            {
+              "flexShrink": 1,
+              "fontFamily": "Quicksand-Medium",
+              "fontSize": 27,
+              "marginHorizontal": 11,
+            },
+            null,
+          ]
+        }
+      >
+        Select your region
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "alignItems": undefined,
+          "flex": undefined,
+          "flexDirection": "column",
+          "justifyContent": undefined,
+          "marginBottom": 22,
+          "marginLeft": 11,
+          "marginRight": 11,
+          "marginTop": 22,
+        }
+      }
+    >
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessible={false}
+        disableAnimation={
+          {
+            "value": 0,
+          }
+        }
+        focusAnimation={
+          {
+            "value": 0,
+          }
+        }
+        focusable={true}
+        multiline={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        scale={
+          {
+            "value": 1,
+          }
+        }
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 11,
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "flexGrow": undefined,
+              "paddingHorizontal": 17,
+            },
+            {
+              "backgroundColor": undefined,
+              "borderColor": undefined,
+              "marginHorizontal": undefined,
+              "opacity": undefined,
+              "paddingVertical": 22,
+            },
+          ]
+        }
+        testID="Select your region"
+      >
+        <View
+          scale={
+            {
+              "value": 0,
+            }
+          }
+          style={
+            [
+              {
+                "alignItems": "stretch",
+                "aspectRatio": 1,
+              },
+              {
+                "opacity": 0,
+                "width": 0,
+              },
+            ]
+          }
+        />
+        <View
+          focusValue={
+            {
+              "value": 0,
+            }
+          }
+          hasPlaceholder={true}
+          style={
+            [
+              {
+                "alignItems": "flex-start",
+                "alignSelf": "flex-start",
+                "flex": 1,
+                "flexDirection": "row",
+                "left": 0,
+              },
+              {
+                "marginBottom": NaN,
+                "marginTop": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            shift={
+              {
+                "value": 0,
+              }
+            }
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "justifyContent": "center",
+                  "left": 8.8,
+                  "margin": 0,
+                  "paddingHorizontal": 0,
+                  "paddingVertical": 0,
+                  "position": "absolute",
+                  "top": 0,
+                },
+                {
+                  "transform": [
+                    {
+                      "translateY": undefined,
+                    },
+                    {
+                      "translateX": undefined,
+                    },
+                  ],
+                },
+              ]
+            }
+          >
+            <Text
+              disableAnimation={
+                {
+                  "value": 0,
+                }
+              }
+              focusAnimation={
+                {
+                  "value": 0,
+                }
+              }
+              scale={
+                {
+                  "value": 1,
+                }
+              }
+              shift={
+                {
+                  "value": 0,
+                }
+              }
+              style={
+                [
+                  {
+                    "fontFamily": "Quicksand-Regular",
+                    "fontSize": 22,
+                    "includeFontPadding": false,
+                  },
+                  {
+                    "color": undefined,
+                    "fontSize": undefined,
+                  },
+                ]
+              }
+            >
+              Search region
+            </Text>
+          </View>
+          <TextInput
+            accessibilityState={
+              {
+                "disabled": false,
+              }
+            }
+            accessible={true}
+            animated={true}
+            autoCapitalize="words"
+            autoCorrect={false}
+            autoFocus={true}
+            disableAnimation={
+              {
+                "value": 0,
+              }
+            }
+            editable={true}
+            focusAnimation={
+              {
+                "value": 0,
+              }
+            }
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            returnKeyType="done"
+            scale={
+              {
+                "value": 1,
+              }
+            }
+            secureTextEntry={false}
+            selectionColor="#FFFFFF"
+            style={
+              [
+                {
+                  "color": "hsla(0, 0%, 100%, 0.20)",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontFamily": "Quicksand-Regular",
+                  "margin": 0,
+                  "paddingHorizontal": 0,
+                  "paddingVertical": 0,
+                  "transform": [
+                    {
+                      "translateY": -0,
+                    },
+                  ],
+                },
+                {
+                  "color": undefined,
+                  "fontSize": 22,
+                },
+              ]
+            }
+            testID="Select your region.textInput"
+            textAlignVertical="top"
+            value=""
+          />
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "marginHorizontal": -22,
+              "marginVertical": -28,
+              "opacity": 1,
+              "paddingHorizontal": 22,
+              "paddingVertical": 28,
+            }
+          }
+          testID="Select your region.clearIcon"
+        >
+          <View
+            scale={
+              {
+                "value": 0,
+              }
+            }
+            style={
+              [
+                {
+                  "alignItems": "stretch",
+                  "aspectRatio": 1,
+                },
+                {
+                  "opacity": 0,
+                  "width": 0,
+                },
+              ]
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "anticon",
+                  "fontSize": 0,
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                }
+              }
+            >
+              
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <RCTScrollView
+      collapsable={false}
+      contentContainerStyle={
+        {
+          "paddingBottom": 67,
+        }
+      }
+      data={
+        [
+          {
+            "alpha-2": "US",
+            "alpha-3": "USA",
+            "filename": "united-states-of-america",
+            "name": "United States of America",
+            "stateProvinces": [
+              {
+                "alpha-2": "AL",
+                "name": "Alabama",
+              },
+              {
+                "alpha-2": "AK",
+                "name": "Alaska",
+              },
+              {
+                "alpha-2": "AZ",
+                "name": "Arizona",
+              },
+              {
+                "alpha-2": "AR",
+                "name": "Arkansas",
+              },
+              {
+                "alpha-2": "CA",
+                "name": "California",
+              },
+              {
+                "alpha-2": "CO",
+                "name": "Colorado",
+              },
+              {
+                "alpha-2": "CT",
+                "name": "Connecticut",
+              },
+              {
+                "alpha-2": "DE",
+                "name": "Delaware",
+              },
+              {
+                "alpha-2": "FL",
+                "name": "Florida",
+              },
+              {
+                "alpha-2": "GA",
+                "name": "Georgia",
+              },
+              {
+                "alpha-2": "HI",
+                "name": "Hawaii",
+              },
+              {
+                "alpha-2": "ID",
+                "name": "Idaho",
+              },
+              {
+                "alpha-2": "IL",
+                "name": "Illinois",
+              },
+              {
+                "alpha-2": "IN",
+                "name": "Indiana",
+              },
+              {
+                "alpha-2": "IA",
+                "name": "Iowa",
+              },
+              {
+                "alpha-2": "KS",
+                "name": "Kansas",
+              },
+              {
+                "alpha-2": "KY",
+                "name": "Kentucky",
+              },
+              {
+                "alpha-2": "LA",
+                "name": "Louisiana",
+              },
+              {
+                "alpha-2": "ME",
+                "name": "Maine",
+              },
+              {
+                "alpha-2": "MD",
+                "name": "Maryland",
+              },
+              {
+                "alpha-2": "MA",
+                "name": "Massachusetts",
+              },
+              {
+                "alpha-2": "MI",
+                "name": "Michigan",
+              },
+              {
+                "alpha-2": "MN",
+                "name": "Minnesota",
+              },
+              {
+                "alpha-2": "MS",
+                "name": "Mississippi",
+              },
+              {
+                "alpha-2": "MO",
+                "name": "Missouri",
+              },
+              {
+                "alpha-2": "MT",
+                "name": "Montana",
+              },
+              {
+                "alpha-2": "NE",
+                "name": "Nebraska",
+              },
+              {
+                "alpha-2": "NV",
+                "name": "Nevada",
+              },
+              {
+                "alpha-2": "NH",
+                "name": "New Hampshire",
+              },
+              {
+                "alpha-2": "NJ",
+                "name": "New Jersey",
+              },
+              {
+                "alpha-2": "NM",
+                "name": "New Mexico",
+              },
+              {
+                "alpha-2": "NY",
+                "name": "New York",
+              },
+              {
+                "alpha-2": "NC",
+                "name": "North Carolina",
+              },
+              {
+                "alpha-2": "ND",
+                "name": "North Dakota",
+              },
+              {
+                "alpha-2": "OH",
+                "name": "Ohio",
+              },
+              {
+                "alpha-2": "OK",
+                "name": "Oklahoma",
+              },
+              {
+                "alpha-2": "OR",
+                "name": "Oregon",
+              },
+              {
+                "alpha-2": "PA",
+                "name": "Pennsylvania",
+              },
+              {
+                "alpha-2": "RI",
+                "name": "Rhode Island",
+              },
+              {
+                "alpha-2": "SC",
+                "name": "South Carolina",
+              },
+              {
+                "alpha-2": "SD",
+                "name": "South Dakota",
+              },
+              {
+                "alpha-2": "TN",
+                "name": "Tennessee",
+              },
+              {
+                "alpha-2": "TX",
+                "name": "Texas",
+              },
+              {
+                "alpha-2": "UT",
+                "name": "Utah",
+              },
+              {
+                "alpha-2": "VT",
+                "name": "Vermont",
+              },
+              {
+                "alpha-2": "VA",
+                "name": "Virginia",
+              },
+              {
+                "alpha-2": "WA",
+                "name": "Washington",
+              },
+              {
+                "alpha-2": "WV",
+                "name": "West Virginia",
+              },
+              {
+                "alpha-2": "WI",
+                "name": "Wisconsin",
+              },
+              {
+                "alpha-2": "WY",
+                "name": "Wyoming",
+              },
+            ],
+          },
+          {
+            "alpha-2": "AF",
+            "alpha-3": "AFG",
+            "name": "Afghanistan",
+          },
+          {
+            "alpha-2": "AX",
+            "alpha-3": "ALA",
+            "filename": "aland-islands",
+            "name": "Åland Islands",
+          },
+          {
+            "alpha-2": "AL",
+            "alpha-3": "ALB",
+            "name": "Albania",
+          },
+          {
+            "alpha-2": "DZ",
+            "alpha-3": "DZA",
+            "name": "Algeria",
+          },
+          {
+            "alpha-2": "AS",
+            "alpha-3": "ASM",
+            "name": "American Samoa",
+          },
+          {
+            "alpha-2": "AD",
+            "alpha-3": "AND",
+            "name": "Andorra",
+          },
+          {
+            "alpha-2": "AO",
+            "alpha-3": "AGO",
+            "name": "Angola",
+          },
+          {
+            "alpha-2": "AI",
+            "alpha-3": "AIA",
+            "name": "Anguilla",
+          },
+          {
+            "alpha-2": "AG",
+            "alpha-3": "ATG",
+            "filename": "antigua-and-barbuda",
+            "name": "Antigua and Barbuda",
+          },
+          {
+            "alpha-2": "AR",
+            "alpha-3": "ARG",
+            "name": "Argentina",
+          },
+          {
+            "alpha-2": "AM",
+            "alpha-3": "ARM",
+            "name": "Armenia",
+          },
+          {
+            "alpha-2": "AW",
+            "alpha-3": "ABW",
+            "name": "Aruba",
+          },
+          {
+            "alpha-2": "AU",
+            "alpha-3": "AUS",
+            "name": "Australia",
+          },
+          {
+            "alpha-2": "AT",
+            "alpha-3": "AUT",
+            "name": "Austria",
+          },
+          {
+            "alpha-2": "AZ",
+            "alpha-3": "AZE",
+            "name": "Azerbaijan",
+          },
+          {
+            "alpha-2": "BS",
+            "alpha-3": "BHS",
+            "name": "Bahamas",
+          },
+          {
+            "alpha-2": "BH",
+            "alpha-3": "BHR",
+            "name": "Bahrain",
+          },
+          {
+            "alpha-2": "BD",
+            "alpha-3": "BGD",
+            "name": "Bangladesh",
+          },
+          {
+            "alpha-2": "BB",
+            "alpha-3": "BRB",
+            "name": "Barbados",
+          },
+          {
+            "alpha-2": "BY",
+            "alpha-3": "BLR",
+            "name": "Belarus",
+          },
+          {
+            "alpha-2": "BE",
+            "alpha-3": "BEL",
+            "name": "Belgium",
+          },
+          {
+            "alpha-2": "BZ",
+            "alpha-3": "BLZ",
+            "name": "Belize",
+          },
+          {
+            "alpha-2": "BJ",
+            "alpha-3": "BEN",
+            "name": "Benin",
+          },
+          {
+            "alpha-2": "BM",
+            "alpha-3": "BMU",
+            "name": "Bermuda",
+          },
+          {
+            "alpha-2": "BT",
+            "alpha-3": "BTN",
+            "name": "Bhutan",
+          },
+          {
+            "alpha-2": "BO",
+            "alpha-3": "BOL",
+            "filename": "bolivia",
+            "name": "Bolivia (Plurinational State of)",
+          },
+          {
+            "alpha-2": "BQ",
+            "alpha-3": "BES",
+            "filename": "bonaire",
+            "name": "Bonaire, Sint Eustatius and Saba",
+          },
+          {
+            "alpha-2": "BA",
+            "alpha-3": "BIH",
+            "filename": "bosnia-and-herzegovina",
+            "name": "Bosnia and Herzegovina",
+          },
+          {
+            "alpha-2": "BW",
+            "alpha-3": "BWA",
+            "name": "Botswana",
+          },
+          {
+            "alpha-2": "BR",
+            "alpha-3": "BRA",
+            "name": "Brazil",
+          },
+          {
+            "alpha-2": "IO",
+            "alpha-3": "IOT",
+            "filename": "british-indian-ocean-territory",
+            "name": "British Indian Ocean Territory",
+          },
+          {
+            "alpha-2": "BN",
+            "alpha-3": "BRN",
+            "filename": "brunei",
+            "name": "Brunei Darussalam",
+          },
+          {
+            "alpha-2": "BG",
+            "alpha-3": "BGR",
+            "name": "Bulgaria",
+          },
+          {
+            "alpha-2": "BF",
+            "alpha-3": "BFA",
+            "name": "Burkina Faso",
+          },
+          {
+            "alpha-2": "BI",
+            "alpha-3": "BDI",
+            "name": "Burundi",
+          },
+          {
+            "alpha-2": "CV",
+            "alpha-3": "CPV",
+            "filename": "cape-verde",
+            "name": "Cabo Verde",
+          },
+          {
+            "alpha-2": "KH",
+            "alpha-3": "KHM",
+            "name": "Cambodia",
+          },
+          {
+            "alpha-2": "CM",
+            "alpha-3": "CMR",
+            "name": "Cameroon",
+          },
+          {
+            "alpha-2": "CA",
+            "alpha-3": "CAN",
+            "name": "Canada",
+          },
+          {
+            "alpha-2": "KY",
+            "alpha-3": "CYM",
+            "name": "Cayman Islands",
+          },
+          {
+            "alpha-2": "CF",
+            "alpha-3": "CAF",
+            "filename": "central-african-republic",
+            "name": "Central African Republic",
+          },
+          {
+            "alpha-2": "TD",
+            "alpha-3": "TCD",
+            "name": "Chad",
+          },
+          {
+            "alpha-2": "CL",
+            "alpha-3": "CHL",
+            "name": "Chile",
+          },
+          {
+            "alpha-2": "CN",
+            "alpha-3": "CHN",
+            "name": "China",
+          },
+          {
+            "alpha-2": "CX",
+            "alpha-3": "CXR",
+            "name": "Christmas Island",
+          },
+          {
+            "alpha-2": "CC",
+            "alpha-3": "CCK",
+            "filename": "cocos-island",
+            "name": "Cocos (Keeling) Islands",
+          },
+          {
+            "alpha-2": "CO",
+            "alpha-3": "COL",
+            "name": "Colombia",
+          },
+          {
+            "alpha-2": "KM",
+            "alpha-3": "COM",
+            "name": "Comoros",
+          },
+          {
+            "alpha-2": "CG",
+            "alpha-3": "COG",
+            "name": "Congo",
+          },
+          {
+            "alpha-2": "CD",
+            "alpha-3": "COD",
+            "filename": "democratic-republic-of-congo",
+            "name": "Congo, Democratic Republic of the",
+          },
+          {
+            "alpha-2": "CK",
+            "alpha-3": "COK",
+            "name": "Cook Islands",
+          },
+          {
+            "alpha-2": "CR",
+            "alpha-3": "CRI",
+            "name": "Costa Rica",
+          },
+          {
+            "alpha-2": "CI",
+            "alpha-3": "CIV",
+            "filename": "ivory-coast",
+            "name": "Côte d'Ivoire",
+          },
+          {
+            "alpha-2": "HR",
+            "alpha-3": "HRV",
+            "name": "Croatia",
+          },
+          {
+            "alpha-2": "CU",
+            "alpha-3": "CUB",
+            "name": "Cuba",
+          },
+          {
+            "alpha-2": "CW",
+            "alpha-3": "CUW",
+            "filename": "curacao",
+            "name": "Curaçao",
+          },
+          {
+            "alpha-2": "CY",
+            "alpha-3": "CYP",
+            "name": "Cyprus",
+          },
+          {
+            "alpha-2": "CZ",
+            "alpha-3": "CZE",
+            "filename": "czech-republic",
+            "name": "Czechia",
+          },
+          {
+            "alpha-2": "DK",
+            "alpha-3": "DNK",
+            "name": "Denmark",
+          },
+          {
+            "alpha-2": "DJ",
+            "alpha-3": "DJI",
+            "name": "Djibouti",
+          },
+          {
+            "alpha-2": "DM",
+            "alpha-3": "DMA",
+            "name": "Dominica",
+          },
+          {
+            "alpha-2": "DO",
+            "alpha-3": "DOM",
+            "name": "Dominican Republic",
+          },
+          {
+            "alpha-2": "EC",
+            "alpha-3": "ECU",
+            "name": "Ecuador",
+          },
+          {
+            "alpha-2": "EG",
+            "alpha-3": "EGY",
+            "name": "Egypt",
+          },
+          {
+            "alpha-2": "SV",
+            "alpha-3": "SLV",
+            "filename": "salvador",
+            "name": "El Salvador",
+          },
+          {
+            "alpha-2": "GQ",
+            "alpha-3": "GNQ",
+            "name": "Equatorial Guinea",
+          },
+          {
+            "alpha-2": "ER",
+            "alpha-3": "ERI",
+            "name": "Eritrea",
+          },
+          {
+            "alpha-2": "EE",
+            "alpha-3": "EST",
+            "name": "Estonia",
+          },
+          {
+            "alpha-2": "SZ",
+            "alpha-3": "SWZ",
+            "name": "Eswatini",
+          },
+          {
+            "alpha-2": "ET",
+            "alpha-3": "ETH",
+            "name": "Ethiopia",
+          },
+          {
+            "alpha-2": "FK",
+            "alpha-3": "FLK",
+            "filename": "falkland-islands",
+            "name": "Falkland Islands (Malvinas)",
+          },
+          {
+            "alpha-2": "FO",
+            "alpha-3": "FRO",
+            "name": "Faroe Islands",
+          },
+          {
+            "alpha-2": "FJ",
+            "alpha-3": "FJI",
+            "name": "Fiji",
+          },
+          {
+            "alpha-2": "FI",
+            "alpha-3": "FIN",
+            "name": "Finland",
+          },
+          {
+            "alpha-2": "FR",
+            "alpha-3": "FRA",
+            "name": "France",
+          },
+          {
+            "alpha-2": "GF",
+            "alpha-3": "GUF",
+            "filename": "guyana",
+            "name": "French Guiana",
+          },
+          {
+            "alpha-2": "PF",
+            "alpha-3": "PYF",
+            "name": "French Polynesia",
+          },
+          {
+            "alpha-2": "GA",
+            "alpha-3": "GAB",
+            "name": "Gabon",
+          },
+          {
+            "alpha-2": "GM",
+            "alpha-3": "GMB",
+            "name": "Gambia",
+          },
+          {
+            "alpha-2": "GE",
+            "alpha-3": "GEO",
+            "name": "Georgia",
+          },
+          {
+            "alpha-2": "DE",
+            "alpha-3": "DEU",
+            "name": "Germany",
+          },
+          {
+            "alpha-2": "GH",
+            "alpha-3": "GHA",
+            "name": "Ghana",
+          },
+          {
+            "alpha-2": "GI",
+            "alpha-3": "GIB",
+            "name": "Gibraltar",
+          },
+          {
+            "alpha-2": "GR",
+            "alpha-3": "GRC",
+            "name": "Greece",
+          },
+          {
+            "alpha-2": "GL",
+            "alpha-3": "GRL",
+            "name": "Greenland",
+          },
+          {
+            "alpha-2": "GD",
+            "alpha-3": "GRD",
+            "name": "Grenada",
+          },
+          {
+            "alpha-2": "GU",
+            "alpha-3": "GUM",
+            "name": "Guam",
+          },
+          {
+            "alpha-2": "GT",
+            "alpha-3": "GTM",
+            "name": "Guatemala",
+          },
+          {
+            "alpha-2": "GG",
+            "alpha-3": "GGY",
+            "name": "Guernsey",
+          },
+          {
+            "alpha-2": "GN",
+            "alpha-3": "GIN",
+            "name": "Guinea",
+          },
+          {
+            "alpha-2": "GW",
+            "alpha-3": "GNB",
+            "name": "Guinea-Bissau",
+          },
+          {
+            "alpha-2": "GY",
+            "alpha-3": "GUY",
+            "name": "Guyana",
+          },
+          {
+            "alpha-2": "HT",
+            "alpha-3": "HTI",
+            "name": "Haiti",
+          },
+          {
+            "alpha-2": "VA",
+            "alpha-3": "VAT",
+            "filename": "vatican-city",
+            "name": "Holy See",
+          },
+          {
+            "alpha-2": "HN",
+            "alpha-3": "HND",
+            "name": "Honduras",
+          },
+          {
+            "alpha-2": "HK",
+            "alpha-3": "HKG",
+            "name": "Hong Kong",
+          },
+          {
+            "alpha-2": "HU",
+            "alpha-3": "HUN",
+            "name": "Hungary",
+          },
+          {
+            "alpha-2": "IS",
+            "alpha-3": "ISL",
+            "name": "Iceland",
+          },
+          {
+            "alpha-2": "IN",
+            "alpha-3": "IND",
+            "name": "India",
+          },
+          {
+            "alpha-2": "ID",
+            "alpha-3": "IDN",
+            "name": "Indonesia",
+          },
+          {
+            "alpha-2": "IR",
+            "alpha-3": "IRN",
+            "filename": "iran",
+            "name": "Iran (Islamic Republic of)",
+          },
+          {
+            "alpha-2": "IQ",
+            "alpha-3": "IRQ",
+            "name": "Iraq",
+          },
+          {
+            "alpha-2": "IE",
+            "alpha-3": "IRL",
+            "name": "Ireland",
+          },
+          {
+            "alpha-2": "IM",
+            "alpha-3": "IMN",
+            "filename": "isle-of-man",
+            "name": "Isle of Man",
+          },
+          {
+            "alpha-2": "IL",
+            "alpha-3": "ISR",
+            "name": "Israel",
+          },
+          {
+            "alpha-2": "IT",
+            "alpha-3": "ITA",
+            "name": "Italy",
+          },
+          {
+            "alpha-2": "JM",
+            "alpha-3": "JAM",
+            "name": "Jamaica",
+          },
+          {
+            "alpha-2": "JP",
+            "alpha-3": "JPN",
+            "name": "Japan",
+          },
+          {
+            "alpha-2": "JE",
+            "alpha-3": "JEY",
+            "name": "Jersey",
+          },
+          {
+            "alpha-2": "JO",
+            "alpha-3": "JOR",
+            "name": "Jordan",
+          },
+          {
+            "alpha-2": "KZ",
+            "alpha-3": "KAZ",
+            "name": "Kazakhstan",
+          },
+          {
+            "alpha-2": "KE",
+            "alpha-3": "KEN",
+            "name": "Kenya",
+          },
+          {
+            "alpha-2": "KI",
+            "alpha-3": "KIR",
+            "name": "Kiribati",
+          },
+          {
+            "alpha-2": "KP",
+            "alpha-3": "PRK",
+            "filename": "north-korea",
+            "name": "Korea (Democratic People's Republic of)",
+          },
+          {
+            "alpha-2": "KR",
+            "alpha-3": "KOR",
+            "filename": "south-korea",
+            "name": "Korea, Republic of",
+          },
+          {
+            "alpha-2": "KW",
+            "alpha-3": "KWT",
+            "name": "Kuwait",
+          },
+          {
+            "alpha-2": "KG",
+            "alpha-3": "KGZ",
+            "name": "Kyrgyzstan",
+          },
+          {
+            "alpha-2": "LA",
+            "alpha-3": "LAO",
+            "filename": "laos",
+            "name": "Lao People's Democratic Republic",
+          },
+          {
+            "alpha-2": "LV",
+            "alpha-3": "LVA",
+            "name": "Latvia",
+          },
+          {
+            "alpha-2": "LB",
+            "alpha-3": "LBN",
+            "name": "Lebanon",
+          },
+          {
+            "alpha-2": "LS",
+            "alpha-3": "LSO",
+            "name": "Lesotho",
+          },
+          {
+            "alpha-2": "LR",
+            "alpha-3": "LBR",
+            "name": "Liberia",
+          },
+          {
+            "alpha-2": "LY",
+            "alpha-3": "LBY",
+            "name": "Libya",
+          },
+          {
+            "alpha-2": "LI",
+            "alpha-3": "LIE",
+            "name": "Liechtenstein",
+          },
+          {
+            "alpha-2": "LT",
+            "alpha-3": "LTU",
+            "name": "Lithuania",
+          },
+          {
+            "alpha-2": "LU",
+            "alpha-3": "LUX",
+            "name": "Luxembourg",
+          },
+          {
+            "alpha-2": "MO",
+            "alpha-3": "MAC",
+            "name": "Macao",
+          },
+          {
+            "alpha-2": "MG",
+            "alpha-3": "MDG",
+            "name": "Madagascar",
+          },
+          {
+            "alpha-2": "MW",
+            "alpha-3": "MWI",
+            "name": "Malawi",
+          },
+          {
+            "alpha-2": "MY",
+            "alpha-3": "MYS",
+            "name": "Malaysia",
+          },
+          {
+            "alpha-2": "MV",
+            "alpha-3": "MDV",
+            "name": "Maldives",
+          },
+          {
+            "alpha-2": "ML",
+            "alpha-3": "MLI",
+            "name": "Mali",
+          },
+          {
+            "alpha-2": "MT",
+            "alpha-3": "MLT",
+            "name": "Malta",
+          },
+          {
+            "alpha-2": "MH",
+            "alpha-3": "MHL",
+            "filename": "marshall-island",
+            "name": "Marshall Islands",
+          },
+          {
+            "alpha-2": "MQ",
+            "alpha-3": "MTQ",
+            "name": "Martinique",
+          },
+          {
+            "alpha-2": "MR",
+            "alpha-3": "MRT",
+            "name": "Mauritania",
+          },
+          {
+            "alpha-2": "MU",
+            "alpha-3": "MUS",
+            "name": "Mauritius",
+          },
+          {
+            "alpha-2": "MX",
+            "alpha-3": "MEX",
+            "name": "Mexico",
+          },
+          {
+            "alpha-2": "FM",
+            "alpha-3": "FSM",
+            "filename": "micronesia",
+            "name": "Micronesia (Federated States of)",
+          },
+          {
+            "alpha-2": "MD",
+            "alpha-3": "MDA",
+            "filename": "moldova",
+            "name": "Moldova, Republic of",
+          },
+          {
+            "alpha-2": "MC",
+            "alpha-3": "MCO",
+            "name": "Monaco",
+          },
+          {
+            "alpha-2": "MN",
+            "alpha-3": "MNG",
+            "name": "Mongolia",
+          },
+          {
+            "alpha-2": "ME",
+            "alpha-3": "MNE",
+            "name": "Montenegro",
+          },
+          {
+            "alpha-2": "MS",
+            "alpha-3": "MSR",
+            "name": "Montserrat",
+          },
+          {
+            "alpha-2": "MA",
+            "alpha-3": "MAR",
+            "name": "Morocco",
+          },
+          {
+            "alpha-2": "MZ",
+            "alpha-3": "MOZ",
+            "name": "Mozambique",
+          },
+          {
+            "alpha-2": "MM",
+            "alpha-3": "MMR",
+            "name": "Myanmar",
+          },
+          {
+            "alpha-2": "NA",
+            "alpha-3": "NAM",
+            "name": "Namibia",
+          },
+          {
+            "alpha-2": "NR",
+            "alpha-3": "NRU",
+            "name": "Nauru",
+          },
+          {
+            "alpha-2": "NP",
+            "alpha-3": "NPL",
+            "name": "Nepal",
+          },
+          {
+            "alpha-2": "NL",
+            "alpha-3": "NLD",
+            "name": "Netherlands",
+          },
+          {
+            "alpha-2": "NZ",
+            "alpha-3": "NZL",
+            "name": "New Zealand",
+          },
+          {
+            "alpha-2": "NI",
+            "alpha-3": "NIC",
+            "name": "Nicaragua",
+          },
+          {
+            "alpha-2": "NE",
+            "alpha-3": "NER",
+            "name": "Niger",
+          },
+          {
+            "alpha-2": "NG",
+            "alpha-3": "NGA",
+            "name": "Nigeria",
+          },
+          {
+            "alpha-2": "NU",
+            "alpha-3": "NIU",
+            "name": "Niue",
+          },
+          {
+            "alpha-2": "NF",
+            "alpha-3": "NFK",
+            "name": "Norfolk Island",
+          },
+          {
+            "alpha-2": "MK",
+            "alpha-3": "MKD",
+            "name": "North Macedonia",
+          },
+          {
+            "alpha-2": "MP",
+            "alpha-3": "MNP",
+            "filename": "northern-marianas-islands",
+            "name": "Northern Mariana Islands",
+          },
+          {
+            "alpha-2": "NO",
+            "alpha-3": "NOR",
+            "name": "Norway",
+          },
+          {
+            "alpha-2": "OM",
+            "alpha-3": "OMN",
+            "name": "Oman",
+          },
+          {
+            "alpha-2": "PK",
+            "alpha-3": "PAK",
+            "name": "Pakistan",
+          },
+          {
+            "alpha-2": "PW",
+            "alpha-3": "PLW",
+            "name": "Palau",
+          },
+          {
+            "alpha-2": "PS",
+            "alpha-3": "PSE",
+            "filename": "palestine",
+            "name": "Palestine, State of",
+          },
+          {
+            "alpha-2": "PA",
+            "alpha-3": "PAN",
+            "name": "Panama",
+          },
+          {
+            "alpha-2": "PG",
+            "alpha-3": "PNG",
+            "filename": "papua-new-guinea",
+            "name": "Papua New Guinea",
+          },
+          {
+            "alpha-2": "PY",
+            "alpha-3": "PRY",
+            "name": "Paraguay",
+          },
+          {
+            "alpha-2": "PE",
+            "alpha-3": "PER",
+            "name": "Peru",
+          },
+          {
+            "alpha-2": "PH",
+            "alpha-3": "PHL",
+            "name": "Philippines",
+          },
+          {
+            "alpha-2": "PN",
+            "alpha-3": "PCN",
+            "filename": "pitcairn-islands",
+            "name": "Pitcairn",
+          },
+          {
+            "alpha-2": "PL",
+            "alpha-3": "POL",
+            "filename": "republic-of-poland",
+            "name": "Poland",
+          },
+          {
+            "alpha-2": "PT",
+            "alpha-3": "PRT",
+            "name": "Portugal",
+          },
+          {
+            "alpha-2": "PR",
+            "alpha-3": "PRI",
+            "name": "Puerto Rico",
+          },
+          {
+            "alpha-2": "QA",
+            "alpha-3": "QAT",
+            "name": "Qatar",
+          },
+          {
+            "alpha-2": "RO",
+            "alpha-3": "ROU",
+            "name": "Romania",
+          },
+          {
+            "alpha-2": "RU",
+            "alpha-3": "RUS",
+            "filename": "russia",
+            "name": "Russian Federation",
+          },
+          {
+            "alpha-2": "RW",
+            "alpha-3": "RWA",
+            "name": "Rwanda",
+          },
+          {
+            "alpha-2": "KN",
+            "alpha-3": "KNA",
+            "filename": "saint-kitts-and-nevis",
+            "name": "Saint Kitts and Nevis",
+          },
+          {
+            "alpha-2": "LC",
+            "alpha-3": "LCA",
+            "filename": "st-lucia",
+            "name": "Saint Lucia",
+          },
+          {
+            "alpha-2": "VC",
+            "alpha-3": "VCT",
+            "filename": "st-vincent-and-the-grenadines",
+            "name": "Saint Vincent and the Grenadines",
+          },
+          {
+            "alpha-2": "WS",
+            "alpha-3": "WSM",
+            "name": "Samoa",
+          },
+          {
+            "alpha-2": "SM",
+            "alpha-3": "SMR",
+            "name": "San Marino",
+          },
+          {
+            "alpha-2": "ST",
+            "alpha-3": "STP",
+            "filename": "sao-tome-and-principe",
+            "name": "Sao Tome and Principe",
+          },
+          {
+            "alpha-2": "SA",
+            "alpha-3": "SAU",
+            "name": "Saudi Arabia",
+          },
+          {
+            "alpha-2": "SN",
+            "alpha-3": "SEN",
+            "name": "Senegal",
+          },
+          {
+            "alpha-2": "RS",
+            "alpha-3": "SRB",
+            "name": "Serbia",
+          },
+          {
+            "alpha-2": "SC",
+            "alpha-3": "SYC",
+            "name": "Seychelles",
+          },
+          {
+            "alpha-2": "SL",
+            "alpha-3": "SLE",
+            "name": "Sierra Leone",
+          },
+          {
+            "alpha-2": "SG",
+            "alpha-3": "SGP",
+            "name": "Singapore",
+          },
+          {
+            "alpha-2": "SK",
+            "alpha-3": "SVK",
+            "name": "Slovakia",
+          },
+          {
+            "alpha-2": "SI",
+            "alpha-3": "SVN",
+            "name": "Slovenia",
+          },
+          {
+            "alpha-2": "SB",
+            "alpha-3": "SLB",
+            "name": "Solomon Islands",
+          },
+          {
+            "alpha-2": "SO",
+            "alpha-3": "SOM",
+            "name": "Somalia",
+          },
+          {
+            "alpha-2": "ZA",
+            "alpha-3": "ZAF",
+            "name": "South Africa",
+          },
+          {
+            "alpha-2": "SS",
+            "alpha-3": "SSD",
+            "name": "South Sudan",
+          },
+          {
+            "alpha-2": "ES",
+            "alpha-3": "ESP",
+            "name": "Spain",
+          },
+          {
+            "alpha-2": "LK",
+            "alpha-3": "LKA",
+            "name": "Sri Lanka",
+          },
+          {
+            "alpha-2": "SD",
+            "alpha-3": "SDN",
+            "name": "Sudan",
+          },
+          {
+            "alpha-2": "SR",
+            "alpha-3": "SUR",
+            "name": "Suriname",
+          },
+          {
+            "alpha-2": "SE",
+            "alpha-3": "SWE",
+            "name": "Sweden",
+          },
+          {
+            "alpha-2": "CH",
+            "alpha-3": "CHE",
+            "name": "Switzerland",
+          },
+          {
+            "alpha-2": "SY",
+            "alpha-3": "SYR",
+            "filename": "syria",
+            "name": "Syrian Arab Republic",
+          },
+          {
+            "alpha-2": "TW",
+            "alpha-3": "TWN",
+            "filename": "taiwan",
+            "name": "Taiwan, Province of China",
+          },
+          {
+            "alpha-2": "TJ",
+            "alpha-3": "TJK",
+            "name": "Tajikistan",
+          },
+          {
+            "alpha-2": "TZ",
+            "alpha-3": "TZA",
+            "filename": "tanzania",
+            "name": "Tanzania, United Republic of",
+          },
+          {
+            "alpha-2": "TH",
+            "alpha-3": "THA",
+            "name": "Thailand",
+          },
+          {
+            "alpha-2": "TL",
+            "alpha-3": "TLS",
+            "filename": "east-timor",
+            "name": "Timor-Leste",
+          },
+          {
+            "alpha-2": "TG",
+            "alpha-3": "TGO",
+            "name": "Togo",
+          },
+          {
+            "alpha-2": "TK",
+            "alpha-3": "TKL",
+            "name": "Tokelau",
+          },
+          {
+            "alpha-2": "TO",
+            "alpha-3": "TON",
+            "name": "Tonga",
+          },
+          {
+            "alpha-2": "TT",
+            "alpha-3": "TTO",
+            "filename": "trinidad-and-tobago",
+            "name": "Trinidad and Tobago",
+          },
+          {
+            "alpha-2": "TN",
+            "alpha-3": "TUN",
+            "name": "Tunisia",
+          },
+          {
+            "alpha-2": "TR",
+            "alpha-3": "TUR",
+            "name": "Turkey",
+          },
+          {
+            "alpha-2": "TM",
+            "alpha-3": "TKM",
+            "name": "Turkmenistan",
+          },
+          {
+            "alpha-2": "TC",
+            "alpha-3": "TCA",
+            "filename": "turks-and-caicos",
+            "name": "Turks and Caicos Islands",
+          },
+          {
+            "alpha-2": "TV",
+            "alpha-3": "TUV",
+            "name": "Tuvalu",
+          },
+          {
+            "alpha-2": "UG",
+            "alpha-3": "UGA",
+            "name": "Uganda",
+          },
+          {
+            "alpha-2": "UA",
+            "alpha-3": "UKR",
+            "name": "Ukraine",
+          },
+          {
+            "alpha-2": "AE",
+            "alpha-3": "ARE",
+            "filename": "united-arab-emirates",
+            "name": "United Arab Emirates",
+          },
+          {
+            "alpha-2": "GB",
+            "alpha-3": "GBR",
+            "filename": "united-kingdom",
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+          },
+          {
+            "alpha-2": "UY",
+            "alpha-3": "URY",
+            "name": "Uruguay",
+          },
+          {
+            "alpha-2": "UZ",
+            "alpha-3": "UZB",
+            "filename": "uzbekistn",
+            "name": "Uzbekistan",
+          },
+          {
+            "alpha-2": "VU",
+            "alpha-3": "VUT",
+            "name": "Vanuatu",
+          },
+          {
+            "alpha-2": "VE",
+            "alpha-3": "VEN",
+            "filename": "venezuela",
+            "name": "Venezuela (Bolivarian Republic of)",
+          },
+          {
+            "alpha-2": "VN",
+            "alpha-3": "VNM",
+            "filename": "vietnam",
+            "name": "Viet Nam",
+          },
+          {
+            "alpha-2": "VG",
+            "alpha-3": "VGB",
+            "filename": "british-virgin-islands",
+            "name": "Virgin Islands (British)",
+          },
+          {
+            "alpha-2": "VI",
+            "alpha-3": "VIR",
+            "filename": "virgin-islands",
+            "name": "Virgin Islands (U.S.)",
+          },
+          {
+            "alpha-2": "EH",
+            "alpha-3": "ESH",
+            "name": "Western Sahara",
+          },
+          {
+            "alpha-2": "YE",
+            "alpha-3": "YEM",
+            "name": "Yemen",
+          },
+          {
+            "alpha-2": "ZM",
+            "alpha-3": "ZMB",
+            "name": "Zambia",
+          },
+          {
+            "alpha-2": "ZW",
+            "alpha-3": "ZWE",
+            "name": "Zimbabwe",
+          },
+        ]
+      }
+      getItem={[Function]}
+      getItemCount={[Function]}
+      handlerTag={2}
+      handlerType="NativeViewGestureHandler"
+      keyExtractor={[Function]}
+      keyboardDismissMode="on-drag"
+      keyboardShouldPersistTaps="handled"
+      onContentSizeChange={[Function]}
+      onGestureHandlerEvent={[Function]}
+      onGestureHandlerStateChange={[Function]}
+      onLayout={[Function]}
+      onMomentumScrollBegin={[Function]}
+      onMomentumScrollEnd={[Function]}
+      onScroll={[Function]}
+      onScrollBeginDrag={[Function]}
+      onScrollEndDrag={[Function]}
+      onViewableItemsChanged={[Function]}
+      removeClippedSubviews={false}
+      renderItem={[Function]}
+      renderScrollComponent={[Function]}
+      scrollEventThrottle={0.0001}
+      scrollIndicatorInsets={
+        {
+          "right": 1,
+        }
+      }
+      stickyHeaderIndices={[]}
+      viewabilityConfigCallbackPairs={
+        [
+          {
+            "onViewableItemsChanged": [Function],
+            "viewabilityConfig": undefined,
+          },
+        ]
+      }
+      waitFor={
+        [
+          {
+            "current": null,
+          },
+          {
+            "current": null,
+          },
+        ]
+      }
+    >
+      <View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  United States of America
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  US
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  Afghanistan
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  AF
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  Åland Islands
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  AX
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  Albania
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  AL
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  Algeria
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  DZ
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  American Samoa
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  AS
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  Andorra
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  AD
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  Angola
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  AO
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  Anguilla
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  AI
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignSelf": "stretch",
+                "borderRadius": 16,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+                "opacity": 1,
+                "paddingBottom": 11,
+                "paddingLeft": 11,
+                "paddingRight": 11,
+                "paddingTop": 11,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "rgba(255, 255, 255, .1)",
+                  "borderRadius": 16,
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "margin": 11,
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "height": 45,
+                        "width": 45,
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "column",
+                    "margin": 11,
+                  }
+                }
+              >
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      undefined,
+                      null,
+                    ]
+                  }
+                >
+                  Antigua and Barbuda
+                </Text>
+                <Text
+                  adjustsFontSizeToFit={true}
+                  minimumFontScale={0.65}
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#FFFFFF",
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": "#3dd9f4",
+                        "fontSize": 17,
+                        "marginTop": 6,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  AG
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "height": 0,
+            }
+          }
+        />
+      </View>
+    </RCTScrollView>
+  </View>,
+]
+`;

--- a/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
@@ -149,10 +149,10 @@ exports[`CountryListModal should render with a country list 1`] = `
           "flex": undefined,
           "flexDirection": "column",
           "justifyContent": undefined,
-          "marginBottom": 22,
+          "marginBottom": 11,
           "marginLeft": 11,
           "marginRight": 11,
-          "marginTop": 22,
+          "marginTop": 11,
         }
       }
     >
@@ -464,6 +464,7 @@ exports[`CountryListModal should render with a country list 1`] = `
       collapsable={false}
       contentContainerStyle={
         {
+          "marginTop": 11,
           "paddingBottom": 67,
         }
       }

--- a/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
@@ -1,0 +1,789 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LogsModal should render with a logs modal 1`] = `
+[
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "backgroundColor": "#000000",
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "opacity": 0,
+        },
+      ]
+    }
+  />,
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "alignSelf": "flex-end",
+          "backgroundColor": "rgba(255, 255, 255, .37)",
+          "borderTopLeftRadius": 22,
+          "borderTopRightRadius": 22,
+          "flexShrink": 1,
+          "overflow": "hidden",
+          "paddingLeft": 11,
+          "paddingRight": 11,
+          "width": 674,
+        },
+        {
+          "transform": [
+            {
+              "translateY": 1334,
+            },
+          ],
+        },
+        {
+          "borderColor": "rgba(255, 255, 255, 0)",
+          "borderWidth": 0,
+          "marginBottom": -86,
+          "paddingBottom": 86,
+          "paddingTop": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={10}
+      blurType="dark"
+      overlayColor="rgba(0, 0, 0, 0)"
+      style={
+        {
+          "backgroundColor": undefined,
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    />
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
+            "borderRadius": 3,
+            "height": 6,
+            "marginTop": 6,
+            "width": 67,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "marginBottom": 11,
+          "marginTop": 28,
+        }
+      }
+    >
+      <Text
+        adjustsFontSizeToFit={true}
+        minimumFontScale={0.65}
+        numberOfLines={2}
+        style={
+          [
+            {
+              "color": "#FFFFFF",
+              "fontFamily": "Quicksand-Regular",
+              "fontSize": 22,
+              "includeFontPadding": false,
+            },
+            {
+              "flexShrink": 1,
+              "fontFamily": "Quicksand-Medium",
+              "fontSize": 27,
+              "marginHorizontal": 11,
+            },
+            null,
+          ]
+        }
+      >
+        Export Logs
+      </Text>
+    </View>
+    <RCTScrollView
+      collapsable={false}
+      handlerTag={2}
+      handlerType="NativeViewGestureHandler"
+      keyboardDismissMode="on-drag"
+      onGestureHandlerEvent={[Function]}
+      onGestureHandlerStateChange={[Function]}
+      scrollIndicatorInsets={
+        {
+          "right": 1,
+        }
+      }
+      style={
+        {
+          "flexGrow": 0,
+          "flexShrink": 1,
+        }
+      }
+      waitFor={
+        [
+          {
+            "current": null,
+          },
+        ]
+      }
+    >
+      <View>
+        <Text
+          adjustsFontSizeToFit={false}
+          numberOfLines={0}
+          style={
+            [
+              {
+                "color": "#FFFFFF",
+                "fontFamily": "Quicksand-Regular",
+                "fontSize": 22,
+                "includeFontPadding": false,
+              },
+              {
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+              },
+              false,
+              null,
+            ]
+          }
+        >
+          You may add any additional notes here, and select whether to share logs with Edge, or export logs to your device.
+        </Text>
+        <View
+          style={
+            {
+              "alignItems": undefined,
+              "flex": undefined,
+              "flexDirection": "column",
+              "justifyContent": undefined,
+              "marginBottom": 22,
+              "marginLeft": 22,
+              "marginRight": 22,
+              "marginTop": 22,
+            }
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessible={false}
+            disableAnimation={
+              {
+                "value": 0,
+              }
+            }
+            focusAnimation={
+              {
+                "value": 0,
+              }
+            }
+            focusable={true}
+            multiline={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            scale={
+              {
+                "value": 1,
+              }
+            }
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 11,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "flexGrow": undefined,
+                  "paddingHorizontal": 17,
+                },
+                {
+                  "backgroundColor": undefined,
+                  "borderColor": undefined,
+                  "marginHorizontal": undefined,
+                  "opacity": undefined,
+                  "paddingVertical": 22,
+                },
+              ]
+            }
+          >
+            <View
+              scale={
+                {
+                  "value": 0,
+                }
+              }
+              style={
+                [
+                  {
+                    "alignItems": "stretch",
+                    "aspectRatio": 1,
+                  },
+                  {
+                    "opacity": 0,
+                    "width": 0,
+                  },
+                ]
+              }
+            />
+            <View
+              focusValue={
+                {
+                  "value": 0,
+                }
+              }
+              hasPlaceholder={true}
+              style={
+                [
+                  {
+                    "alignItems": "flex-start",
+                    "alignSelf": "flex-start",
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "left": 0,
+                  },
+                  {
+                    "marginBottom": NaN,
+                    "marginTop": undefined,
+                  },
+                ]
+              }
+            >
+              <View
+                shift={
+                  {
+                    "value": 0,
+                  }
+                }
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                      "left": 8.8,
+                      "margin": 0,
+                      "paddingHorizontal": 0,
+                      "paddingVertical": 0,
+                      "position": "absolute",
+                      "top": 0,
+                    },
+                    {
+                      "transform": [
+                        {
+                          "translateY": undefined,
+                        },
+                        {
+                          "translateX": undefined,
+                        },
+                      ],
+                    },
+                  ]
+                }
+              >
+                <Text
+                  disableAnimation={
+                    {
+                      "value": 0,
+                    }
+                  }
+                  focusAnimation={
+                    {
+                      "value": 0,
+                    }
+                  }
+                  scale={
+                    {
+                      "value": 1,
+                    }
+                  }
+                  shift={
+                    {
+                      "value": 0,
+                    }
+                  }
+                  style={
+                    [
+                      {
+                        "fontFamily": "Quicksand-Regular",
+                        "fontSize": 22,
+                        "includeFontPadding": false,
+                      },
+                      {
+                        "color": undefined,
+                        "fontSize": undefined,
+                      },
+                    ]
+                  }
+                >
+                  Type Notes Here
+                </Text>
+              </View>
+              <TextInput
+                accessibilityState={
+                  {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                animated={true}
+                autoCorrect={true}
+                autoFocus={false}
+                disableAnimation={
+                  {
+                    "value": 0,
+                  }
+                }
+                editable={true}
+                focusAnimation={
+                  {
+                    "value": 0,
+                  }
+                }
+                maxLength={1000}
+                multiline={false}
+                onBlur={[Function]}
+                onChangeText={[Function]}
+                onFocus={[Function]}
+                onSubmitEditing={[Function]}
+                returnKeyType="done"
+                scale={
+                  {
+                    "value": 1,
+                  }
+                }
+                secureTextEntry={false}
+                selectionColor="#FFFFFF"
+                style={
+                  [
+                    {
+                      "color": "hsla(0, 0%, 100%, 0.20)",
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "fontFamily": "Quicksand-Regular",
+                      "margin": 0,
+                      "paddingHorizontal": 0,
+                      "paddingVertical": 0,
+                      "transform": [
+                        {
+                          "translateY": -0,
+                        },
+                      ],
+                    },
+                    {
+                      "color": undefined,
+                      "fontSize": 22,
+                    },
+                  ]
+                }
+                testID="undefined.textInput"
+                textAlignVertical="top"
+                value=""
+              />
+            </View>
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "marginHorizontal": -22,
+                  "marginVertical": -28,
+                  "opacity": 1,
+                  "paddingHorizontal": 22,
+                  "paddingVertical": 28,
+                }
+              }
+              testID="undefined.clearIcon"
+            >
+              <View
+                scale={
+                  {
+                    "value": 0,
+                  }
+                }
+                style={
+                  [
+                    {
+                      "alignItems": "stretch",
+                      "aspectRatio": 1,
+                    },
+                    {
+                      "opacity": 0,
+                      "width": 0,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "#FFFFFF",
+                      "fontFamily": "anticon",
+                      "fontSize": 0,
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    }
+                  }
+                >
+                  
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            noLayoutFlow={false}
+            style={
+              [
+                {
+                  "flexDirection": "row",
+                  "height": 22,
+                  "justifyContent": "space-between",
+                  "paddingHorizontal": 11,
+                },
+                {},
+              ]
+            }
+          >
+            <Text
+              danger={false}
+              style={
+                [
+                  {
+                    "color": "#3dd9f4",
+                    "fontFamily": "Quicksand-Regular",
+                    "fontSize": 17,
+                    "includeFontPadding": false,
+                  },
+                ]
+              }
+            />
+            <Text
+              style={
+                [
+                  {
+                    "color": "#3dd9f4",
+                    "fontFamily": "Quicksand-Regular",
+                    "fontSize": 17,
+                    "includeFontPadding": false,
+                  },
+                ]
+              }
+            >
+              1000
+            </Text>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "flexBasis": "auto",
+              "flexGrow": 0,
+              "flexShrink": 0,
+              "justifyContent": "center",
+              "opacity": 1,
+              "paddingBottom": 11,
+              "paddingLeft": 11,
+              "paddingRight": 11,
+              "paddingTop": 11,
+            }
+          }
+        >
+          <BVLinearGradient
+            colors={
+              [
+                4280299823,
+                4278214733,
+              ]
+            }
+            endPoint={
+              {
+                "x": 1,
+                "y": 0,
+              }
+            }
+            locations={null}
+            startPoint={
+              {
+                "x": 0,
+                "y": 0,
+              }
+            }
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 34,
+                  "flexDirection": "row",
+                  "flexGrow": 0,
+                  "flexShrink": 0,
+                  "justifyContent": "center",
+                },
+                {
+                  "alignSelf": "center",
+                },
+                {
+                  "height": 67,
+                  "paddingHorizontal": 34,
+                },
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+          >
+            <Text
+              adjustsFontSizeToFit={true}
+              minimumFontScale={0.65}
+              numberOfLines={1}
+              style={
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "Quicksand-Regular",
+                    "fontSize": 22,
+                    "includeFontPadding": false,
+                  },
+                  [
+                    {
+                      "color": "#FFFFFF",
+                      "fontFamily": "Quicksand-Medium",
+                      "fontSize": 22,
+                    },
+                    null,
+                  ],
+                  null,
+                ]
+              }
+            >
+              Send Logs to Edge
+            </Text>
+          </BVLinearGradient>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "flexBasis": "auto",
+              "flexGrow": 0,
+              "flexShrink": 0,
+              "justifyContent": "center",
+              "opacity": 1,
+              "paddingBottom": 22,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 11,
+            }
+          }
+        >
+          <BVLinearGradient
+            colors={
+              [
+                872415231,
+                872415231,
+              ]
+            }
+            endPoint={
+              {
+                "x": 1,
+                "y": 1,
+              }
+            }
+            locations={null}
+            startPoint={
+              {
+                "x": 0,
+                "y": 0,
+              }
+            }
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 34,
+                  "flexDirection": "row",
+                  "flexGrow": 0,
+                  "flexShrink": 0,
+                  "justifyContent": "center",
+                },
+                {
+                  "alignSelf": "center",
+                },
+                {
+                  "height": 67,
+                  "paddingHorizontal": 34,
+                },
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+          >
+            <Text
+              adjustsFontSizeToFit={true}
+              minimumFontScale={0.65}
+              numberOfLines={1}
+              style={
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "Quicksand-Regular",
+                    "fontSize": 22,
+                    "includeFontPadding": false,
+                  },
+                  [
+                    {
+                      "color": "#FFFFFF",
+                      "fontFamily": "Quicksand-Regular",
+                      "fontSize": 22,
+                    },
+                    null,
+                  ],
+                  null,
+                ]
+              }
+            >
+              Export Logs
+            </Text>
+          </BVLinearGradient>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>,
+]
+`;

--- a/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
@@ -200,10 +200,10 @@ exports[`LogsModal should render with a logs modal 1`] = `
               "flex": undefined,
               "flexDirection": "column",
               "justifyContent": undefined,
-              "marginBottom": 22,
-              "marginLeft": 22,
-              "marginRight": 22,
-              "marginTop": 22,
+              "marginBottom": 11,
+              "marginLeft": 11,
+              "marginRight": 11,
+              "marginTop": 11,
             }
           }
         >

--- a/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
@@ -21,17 +21,13 @@ Please enter your password below. A successful verification will prevent this wa
   </Paragraph>
   <ForwardRef
     autoFocus={false}
-    bottom={2}
-    horizontal={0.5}
     onChangeText={[Function]}
     onSubmitEditing={[Function]}
     placeholder="Password"
     secureTextEntry={true}
-    top={0.5}
     value=""
   />
-  <Memo
-    layout="column"
+  <ModalButtons
     primary={
       {
         "disabled": true,

--- a/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
@@ -170,13 +170,13 @@ exports[`TextInputModal should render with a blank input field 1`] = `
       style={
         {
           "alignItems": undefined,
-          "flex": 1,
+          "flex": undefined,
           "flexDirection": "column",
           "justifyContent": undefined,
-          "marginBottom": 34,
+          "marginBottom": 11,
           "marginLeft": 11,
           "marginRight": 11,
-          "marginTop": 22,
+          "marginTop": 11,
         }
       }
     >
@@ -412,119 +412,133 @@ exports[`TextInputModal should render with a blank input field 1`] = `
       </View>
     </View>
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      absolute={false}
+      layout="column"
+      parentType="modal"
       style={
         {
-          "alignItems": "center",
+          "alignItems": "stretch",
           "alignSelf": "center",
-          "flexBasis": "auto",
-          "flexGrow": 0,
-          "flexShrink": 0,
-          "justifyContent": "center",
-          "opacity": 1,
-          "paddingBottom": 22,
-          "paddingLeft": 22,
-          "paddingRight": 22,
-          "paddingTop": 22,
+          "flexDirection": "column",
+          "margin": 11,
+          "marginBottom": 22,
+          "marginTop": 45,
         }
       }
     >
-      <BVLinearGradient
-        colors={
-          [
-            4280299823,
-            4278214733,
-          ]
-        }
-        endPoint={
+      <View
+        accessibilityState={
           {
-            "x": 1,
-            "y": 0,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
         }
-        locations={null}
-        startPoint={
+        accessibilityValue={
           {
-            "x": 0,
-            "y": 0,
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
           }
         }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
-          [
-            {
-              "alignItems": "center",
-              "borderRadius": 34,
-              "flexDirection": "row",
-              "flexGrow": 0,
-              "flexShrink": 0,
-              "justifyContent": "center",
-            },
-            {
-              "alignSelf": "center",
-            },
-            {
-              "height": 67,
-              "paddingHorizontal": 34,
-            },
-            {
-              "opacity": 1,
-            },
-          ]
+          {
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "flexBasis": "auto",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "justifyContent": "center",
+            "margin": -11,
+            "opacity": 1,
+            "padding": 11,
+          }
         }
       >
-        <Text
-          adjustsFontSizeToFit={true}
-          minimumFontScale={0.65}
-          numberOfLines={1}
+        <BVLinearGradient
+          colors={
+            [
+              4280299823,
+              4278214733,
+            ]
+          }
+          endPoint={
+            {
+              "x": 1,
+              "y": 0,
+            }
+          }
+          locations={null}
+          startPoint={
+            {
+              "x": 0,
+              "y": 0,
+            }
+          }
           style={
             [
               {
-                "color": "#FFFFFF",
-                "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
-                "includeFontPadding": false,
+                "alignItems": "center",
+                "borderRadius": 34,
+                "flexDirection": "row",
+                "flexGrow": 0,
+                "flexShrink": 0,
+                "justifyContent": "center",
               },
-              [
-                {
-                  "color": "#FFFFFF",
-                  "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
-                },
-                null,
-              ],
-              null,
+              {
+                "alignSelf": "stretch",
+              },
+              {
+                "height": 67,
+                "paddingHorizontal": 34,
+              },
+              {
+                "opacity": 1,
+              },
             ]
           }
         >
-          Submit
-        </Text>
-      </BVLinearGradient>
+          <Text
+            adjustsFontSizeToFit={true}
+            minimumFontScale={0.65}
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "Quicksand-Regular",
+                  "fontSize": 22,
+                  "includeFontPadding": false,
+                },
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "Quicksand-Medium",
+                    "fontSize": 22,
+                  },
+                  null,
+                ],
+                null,
+              ]
+            }
+          >
+            Submit
+          </Text>
+        </BVLinearGradient>
+      </View>
     </View>
   </View>,
 ]
@@ -700,13 +714,13 @@ exports[`TextInputModal should render with a populated input field 1`] = `
       style={
         {
           "alignItems": undefined,
-          "flex": 1,
+          "flex": undefined,
           "flexDirection": "column",
           "justifyContent": undefined,
-          "marginBottom": 34,
+          "marginBottom": 11,
           "marginLeft": 11,
           "marginRight": 11,
-          "marginTop": 22,
+          "marginTop": 11,
         }
       }
     >
@@ -942,119 +956,133 @@ exports[`TextInputModal should render with a populated input field 1`] = `
       </View>
     </View>
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      absolute={false}
+      layout="column"
+      parentType="modal"
       style={
         {
-          "alignItems": "center",
+          "alignItems": "stretch",
           "alignSelf": "center",
-          "flexBasis": "auto",
-          "flexGrow": 0,
-          "flexShrink": 0,
-          "justifyContent": "center",
-          "opacity": 1,
-          "paddingBottom": 22,
-          "paddingLeft": 22,
-          "paddingRight": 22,
-          "paddingTop": 22,
+          "flexDirection": "column",
+          "margin": 11,
+          "marginBottom": 22,
+          "marginTop": 45,
         }
       }
     >
-      <BVLinearGradient
-        colors={
-          [
-            4280299823,
-            4278214733,
-          ]
-        }
-        endPoint={
+      <View
+        accessibilityState={
           {
-            "x": 1,
-            "y": 0,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
         }
-        locations={null}
-        startPoint={
+        accessibilityValue={
           {
-            "x": 0,
-            "y": 0,
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
           }
         }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
-          [
-            {
-              "alignItems": "center",
-              "borderRadius": 34,
-              "flexDirection": "row",
-              "flexGrow": 0,
-              "flexShrink": 0,
-              "justifyContent": "center",
-            },
-            {
-              "alignSelf": "center",
-            },
-            {
-              "height": 67,
-              "paddingHorizontal": 34,
-            },
-            {
-              "opacity": 1,
-            },
-          ]
+          {
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "flexBasis": "auto",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "justifyContent": "center",
+            "margin": -11,
+            "opacity": 1,
+            "padding": 11,
+          }
         }
       >
-        <Text
-          adjustsFontSizeToFit={true}
-          minimumFontScale={0.65}
-          numberOfLines={1}
+        <BVLinearGradient
+          colors={
+            [
+              4280299823,
+              4278214733,
+            ]
+          }
+          endPoint={
+            {
+              "x": 1,
+              "y": 0,
+            }
+          }
+          locations={null}
+          startPoint={
+            {
+              "x": 0,
+              "y": 0,
+            }
+          }
           style={
             [
               {
-                "color": "#FFFFFF",
-                "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
-                "includeFontPadding": false,
+                "alignItems": "center",
+                "borderRadius": 34,
+                "flexDirection": "row",
+                "flexGrow": 0,
+                "flexShrink": 0,
+                "justifyContent": "center",
               },
-              [
-                {
-                  "color": "#FFFFFF",
-                  "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
-                },
-                null,
-              ],
-              null,
+              {
+                "alignSelf": "stretch",
+              },
+              {
+                "height": 67,
+                "paddingHorizontal": 34,
+              },
+              {
+                "opacity": 1,
+              },
             ]
           }
         >
-          Submit
-        </Text>
-      </BVLinearGradient>
+          <Text
+            adjustsFontSizeToFit={true}
+            minimumFontScale={0.65}
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "Quicksand-Regular",
+                  "fontSize": 22,
+                  "includeFontPadding": false,
+                },
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "Quicksand-Medium",
+                    "fontSize": 22,
+                  },
+                  null,
+                ],
+                null,
+              ]
+            }
+          >
+            Submit
+          </Text>
+        </BVLinearGradient>
+      </View>
     </View>
   </View>,
 ]

--- a/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
@@ -1,0 +1,1061 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextInputModal should render with a blank input field 1`] = `
+[
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "backgroundColor": "#000000",
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "opacity": 0,
+        },
+      ]
+    }
+  />,
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "alignSelf": "flex-end",
+          "backgroundColor": "rgba(255, 255, 255, .37)",
+          "borderTopLeftRadius": 22,
+          "borderTopRightRadius": 22,
+          "flexShrink": 1,
+          "overflow": "hidden",
+          "paddingLeft": 11,
+          "paddingRight": 11,
+          "width": 674,
+        },
+        {
+          "transform": [
+            {
+              "translateY": 1334,
+            },
+          ],
+        },
+        {
+          "borderColor": "rgba(255, 255, 255, 0)",
+          "borderWidth": 0,
+          "marginBottom": -86,
+          "paddingBottom": 97,
+          "paddingTop": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={10}
+      blurType="dark"
+      overlayColor="rgba(0, 0, 0, 0)"
+      style={
+        {
+          "backgroundColor": undefined,
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    />
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
+            "borderRadius": 3,
+            "height": 6,
+            "marginTop": 6,
+            "width": 67,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "marginBottom": 11,
+          "marginTop": 28,
+        }
+      }
+    >
+      <Text
+        adjustsFontSizeToFit={true}
+        minimumFontScale={0.65}
+        numberOfLines={2}
+        style={
+          [
+            {
+              "color": "#FFFFFF",
+              "fontFamily": "Quicksand-Regular",
+              "fontSize": 22,
+              "includeFontPadding": false,
+            },
+            {
+              "flexShrink": 1,
+              "fontFamily": "Quicksand-Medium",
+              "fontSize": 27,
+              "marginHorizontal": 11,
+            },
+            null,
+          ]
+        }
+      >
+        title
+      </Text>
+    </View>
+    <Text
+      adjustsFontSizeToFit={false}
+      numberOfLines={0}
+      style={
+        [
+          {
+            "color": "#FFFFFF",
+            "fontFamily": "Quicksand-Regular",
+            "fontSize": 22,
+            "includeFontPadding": false,
+          },
+          {
+            "marginBottom": 11,
+            "marginLeft": 11,
+            "marginRight": 11,
+            "marginTop": 11,
+          },
+          false,
+          null,
+        ]
+      }
+    >
+      message
+    </Text>
+    <View
+      style={
+        {
+          "alignItems": undefined,
+          "flex": 1,
+          "flexDirection": "column",
+          "justifyContent": undefined,
+          "marginBottom": 34,
+          "marginLeft": 11,
+          "marginRight": 11,
+          "marginTop": 22,
+        }
+      }
+    >
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessible={false}
+        disableAnimation={
+          {
+            "value": 0,
+          }
+        }
+        focusAnimation={
+          {
+            "value": 0,
+          }
+        }
+        focusable={true}
+        multiline={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        scale={
+          {
+            "value": 1,
+          }
+        }
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 11,
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "flexGrow": undefined,
+              "paddingHorizontal": 17,
+            },
+            {
+              "backgroundColor": undefined,
+              "borderColor": undefined,
+              "marginHorizontal": undefined,
+              "opacity": undefined,
+              "paddingVertical": 22,
+            },
+          ]
+        }
+      >
+        <View
+          scale={
+            {
+              "value": 0,
+            }
+          }
+          style={
+            [
+              {
+                "alignItems": "stretch",
+                "aspectRatio": 1,
+              },
+              {
+                "opacity": 0,
+                "width": 0,
+              },
+            ]
+          }
+        />
+        <View
+          focusValue={
+            {
+              "value": 0,
+            }
+          }
+          hasPlaceholder={false}
+          style={
+            [
+              {
+                "alignItems": "flex-start",
+                "alignSelf": "flex-start",
+                "flex": 1,
+                "flexDirection": "row",
+                "left": 0,
+              },
+              {
+                "marginBottom": undefined,
+                "marginTop": undefined,
+              },
+            ]
+          }
+        >
+          <TextInput
+            accessibilityState={
+              {
+                "disabled": false,
+              }
+            }
+            accessible={true}
+            animated={true}
+            autoFocus={true}
+            disableAnimation={
+              {
+                "value": 0,
+              }
+            }
+            editable={true}
+            focusAnimation={
+              {
+                "value": 0,
+              }
+            }
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            scale={
+              {
+                "value": 1,
+              }
+            }
+            secureTextEntry={false}
+            selectionColor="#FFFFFF"
+            style={
+              [
+                {
+                  "color": "hsla(0, 0%, 100%, 0.20)",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontFamily": "Quicksand-Regular",
+                  "margin": 0,
+                  "paddingHorizontal": 0,
+                  "paddingVertical": 0,
+                  "transform": [
+                    {
+                      "translateY": -0,
+                    },
+                  ],
+                },
+                {
+                  "color": undefined,
+                  "fontSize": 22,
+                },
+              ]
+            }
+            testID="undefined.textInput"
+            textAlignVertical="top"
+            value=""
+          />
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "marginHorizontal": -22,
+              "marginVertical": -28,
+              "opacity": 1,
+              "paddingHorizontal": 22,
+              "paddingVertical": 28,
+            }
+          }
+          testID="undefined.clearIcon"
+        >
+          <View
+            scale={
+              {
+                "value": 0,
+              }
+            }
+            style={
+              [
+                {
+                  "alignItems": "stretch",
+                  "aspectRatio": 1,
+                },
+                {
+                  "opacity": 0,
+                  "width": 0,
+                },
+              ]
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "anticon",
+                  "fontSize": 0,
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                }
+              }
+            >
+              
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "center",
+          "flexBasis": "auto",
+          "flexGrow": 0,
+          "flexShrink": 0,
+          "justifyContent": "center",
+          "opacity": 1,
+          "paddingBottom": 22,
+          "paddingLeft": 22,
+          "paddingRight": 22,
+          "paddingTop": 22,
+        }
+      }
+    >
+      <BVLinearGradient
+        colors={
+          [
+            4280299823,
+            4278214733,
+          ]
+        }
+        endPoint={
+          {
+            "x": 1,
+            "y": 0,
+          }
+        }
+        locations={null}
+        startPoint={
+          {
+            "x": 0,
+            "y": 0,
+          }
+        }
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 34,
+              "flexDirection": "row",
+              "flexGrow": 0,
+              "flexShrink": 0,
+              "justifyContent": "center",
+            },
+            {
+              "alignSelf": "center",
+            },
+            {
+              "height": 67,
+              "paddingHorizontal": 34,
+            },
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+      >
+        <Text
+          adjustsFontSizeToFit={true}
+          minimumFontScale={0.65}
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#FFFFFF",
+                "fontFamily": "Quicksand-Regular",
+                "fontSize": 22,
+                "includeFontPadding": false,
+              },
+              [
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "Quicksand-Medium",
+                  "fontSize": 22,
+                },
+                null,
+              ],
+              null,
+            ]
+          }
+        >
+          Submit
+        </Text>
+      </BVLinearGradient>
+    </View>
+  </View>,
+]
+`;
+
+exports[`TextInputModal should render with a populated input field 1`] = `
+[
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "backgroundColor": "#000000",
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "opacity": 0,
+        },
+      ]
+    }
+  />,
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "alignSelf": "flex-end",
+          "backgroundColor": "rgba(255, 255, 255, .37)",
+          "borderTopLeftRadius": 22,
+          "borderTopRightRadius": 22,
+          "flexShrink": 1,
+          "overflow": "hidden",
+          "paddingLeft": 11,
+          "paddingRight": 11,
+          "width": 674,
+        },
+        {
+          "transform": [
+            {
+              "translateY": 1334,
+            },
+          ],
+        },
+        {
+          "borderColor": "rgba(255, 255, 255, 0)",
+          "borderWidth": 0,
+          "marginBottom": -86,
+          "paddingBottom": 97,
+          "paddingTop": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={10}
+      blurType="dark"
+      overlayColor="rgba(0, 0, 0, 0)"
+      style={
+        {
+          "backgroundColor": undefined,
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    />
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
+            "borderRadius": 3,
+            "height": 6,
+            "marginTop": 6,
+            "width": 67,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "marginBottom": 11,
+          "marginTop": 28,
+        }
+      }
+    >
+      <Text
+        adjustsFontSizeToFit={true}
+        minimumFontScale={0.65}
+        numberOfLines={2}
+        style={
+          [
+            {
+              "color": "#FFFFFF",
+              "fontFamily": "Quicksand-Regular",
+              "fontSize": 22,
+              "includeFontPadding": false,
+            },
+            {
+              "flexShrink": 1,
+              "fontFamily": "Quicksand-Medium",
+              "fontSize": 27,
+              "marginHorizontal": 11,
+            },
+            null,
+          ]
+        }
+      >
+        title
+      </Text>
+    </View>
+    <Text
+      adjustsFontSizeToFit={false}
+      numberOfLines={0}
+      style={
+        [
+          {
+            "color": "#FFFFFF",
+            "fontFamily": "Quicksand-Regular",
+            "fontSize": 22,
+            "includeFontPadding": false,
+          },
+          {
+            "marginBottom": 11,
+            "marginLeft": 11,
+            "marginRight": 11,
+            "marginTop": 11,
+          },
+          false,
+          null,
+        ]
+      }
+    >
+      message
+    </Text>
+    <View
+      style={
+        {
+          "alignItems": undefined,
+          "flex": 1,
+          "flexDirection": "column",
+          "justifyContent": undefined,
+          "marginBottom": 34,
+          "marginLeft": 11,
+          "marginRight": 11,
+          "marginTop": 22,
+        }
+      }
+    >
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessible={false}
+        disableAnimation={
+          {
+            "value": 0,
+          }
+        }
+        focusAnimation={
+          {
+            "value": 0,
+          }
+        }
+        focusable={true}
+        multiline={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        scale={
+          {
+            "value": 1,
+          }
+        }
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 11,
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "flexGrow": undefined,
+              "paddingHorizontal": 17,
+            },
+            {
+              "backgroundColor": undefined,
+              "borderColor": undefined,
+              "marginHorizontal": undefined,
+              "opacity": undefined,
+              "paddingVertical": 22,
+            },
+          ]
+        }
+      >
+        <View
+          scale={
+            {
+              "value": 0,
+            }
+          }
+          style={
+            [
+              {
+                "alignItems": "stretch",
+                "aspectRatio": 1,
+              },
+              {
+                "opacity": 0,
+                "width": 0,
+              },
+            ]
+          }
+        />
+        <View
+          focusValue={
+            {
+              "value": 1,
+            }
+          }
+          hasPlaceholder={false}
+          style={
+            [
+              {
+                "alignItems": "flex-start",
+                "alignSelf": "flex-start",
+                "flex": 1,
+                "flexDirection": "row",
+                "left": 0,
+              },
+              {
+                "marginBottom": undefined,
+                "marginTop": undefined,
+              },
+            ]
+          }
+        >
+          <TextInput
+            accessibilityState={
+              {
+                "disabled": false,
+              }
+            }
+            accessible={true}
+            animated={true}
+            autoFocus={true}
+            disableAnimation={
+              {
+                "value": 0,
+              }
+            }
+            editable={true}
+            focusAnimation={
+              {
+                "value": 0,
+              }
+            }
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onFocus={[Function]}
+            onSubmitEditing={[Function]}
+            scale={
+              {
+                "value": 1,
+              }
+            }
+            secureTextEntry={false}
+            selectionColor="#FFFFFF"
+            style={
+              [
+                {
+                  "color": "hsla(0, 0%, 100%, 0.20)",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontFamily": "Quicksand-Regular",
+                  "margin": 0,
+                  "paddingHorizontal": 0,
+                  "paddingVertical": 0,
+                  "transform": [
+                    {
+                      "translateY": -0,
+                    },
+                  ],
+                },
+                {
+                  "color": undefined,
+                  "fontSize": 22,
+                },
+              ]
+            }
+            testID="undefined.textInput"
+            textAlignVertical="top"
+            value="initialValue"
+          />
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "marginHorizontal": -22,
+              "marginVertical": -28,
+              "opacity": 1,
+              "paddingHorizontal": 22,
+              "paddingVertical": 28,
+            }
+          }
+          testID="undefined.clearIcon"
+        >
+          <View
+            scale={
+              {
+                "value": 22,
+              }
+            }
+            style={
+              [
+                {
+                  "alignItems": "stretch",
+                  "aspectRatio": 1,
+                },
+                {
+                  "opacity": 22,
+                  "width": 22,
+                },
+              ]
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "anticon",
+                  "fontSize": 22,
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                }
+              }
+            >
+              
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "center",
+          "flexBasis": "auto",
+          "flexGrow": 0,
+          "flexShrink": 0,
+          "justifyContent": "center",
+          "opacity": 1,
+          "paddingBottom": 22,
+          "paddingLeft": 22,
+          "paddingRight": 22,
+          "paddingTop": 22,
+        }
+      }
+    >
+      <BVLinearGradient
+        colors={
+          [
+            4280299823,
+            4278214733,
+          ]
+        }
+        endPoint={
+          {
+            "x": 1,
+            "y": 0,
+          }
+        }
+        locations={null}
+        startPoint={
+          {
+            "x": 0,
+            "y": 0,
+          }
+        }
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 34,
+              "flexDirection": "row",
+              "flexGrow": 0,
+              "flexShrink": 0,
+              "justifyContent": "center",
+            },
+            {
+              "alignSelf": "center",
+            },
+            {
+              "height": 67,
+              "paddingHorizontal": 34,
+            },
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+      >
+        <Text
+          adjustsFontSizeToFit={true}
+          minimumFontScale={0.65}
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#FFFFFF",
+                "fontFamily": "Quicksand-Regular",
+                "fontSize": 22,
+                "includeFontPadding": false,
+              },
+              [
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "Quicksand-Medium",
+                  "fontSize": 22,
+                },
+                null,
+              ],
+              null,
+            ]
+          }
+        >
+          Submit
+        </Text>
+      </BVLinearGradient>
+    </View>
+  </View>,
+]
+`;

--- a/src/components/modals/AddressModal.tsx
+++ b/src/components/modals/AddressModal.tsx
@@ -16,7 +16,7 @@ import { checkPubAddress, FioAddresses, getFioAddressCache } from '../../util/Fi
 import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { showError } from '../services/AirshipInstance'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../services/ThemeContext'
-import { FilledTextInput } from '../themed/FilledTextInput'
+import { ModalFilledTextInput } from '../themed/FilledTextInput'
 import { ButtonUi4 } from '../ui4/ButtonUi4'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
@@ -303,9 +303,7 @@ export class AddressModalComponent extends React.Component<Props, State> {
 
     return (
       <ModalUi4 bridge={this.props.bridge} onCancel={this.handleClose} title={title ?? lstrings.address_modal_default_header}>
-        <FilledTextInput
-          around={0.5}
-          bottom={1}
+        <ModalFilledTextInput
           autoCorrect={false}
           returnKeyType="search"
           autoCapitalize="none"
@@ -365,7 +363,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
   },
   listContainer: {
     flexGrow: 0,
-    flexShrink: 1
+    flexShrink: 1,
+    marginTop: theme.rem(0.5)
   }
 }))
 

--- a/src/components/modals/CategoryModal.tsx
+++ b/src/components/modals/CategoryModal.tsx
@@ -15,7 +15,7 @@ import { EdgeTouchableHighlight } from '../common/EdgeTouchableHighlight'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { DividerLine } from '../themed/DividerLine'
 import { EdgeText } from '../themed/EdgeText'
-import { FilledTextInput } from '../themed/FilledTextInput'
+import { ModalFilledTextInput } from '../themed/FilledTextInput'
 import { ModalFooter } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
@@ -141,8 +141,7 @@ export function CategoryModal(props: Props) {
           <MinimalButton key={item} highlighted={category === item} label={displayCategories[item]} onPress={() => setCategory(item)} />
         ))}
       </View>
-      <FilledTextInput
-        around={0.5}
+      <ModalFilledTextInput
         autoFocus
         returnKeyType="done"
         autoCapitalize="words"
@@ -161,7 +160,6 @@ export function CategoryModal(props: Props) {
           renderItem={renderRow}
           scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
         />
-        {/* <ModalFooterFade /> */}
       </View>
     </ModalUi4>
   )

--- a/src/components/modals/ListModal.tsx
+++ b/src/components/modals/ListModal.tsx
@@ -7,7 +7,7 @@ import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
 import { useFilter } from '../../hooks/useFilter'
 import { useTheme } from '../services/ThemeContext'
 import { Paragraph } from '../themed/EdgeText'
-import { FilledTextInput } from '../themed/FilledTextInput'
+import { ModalFilledTextInput } from '../themed/FilledTextInput'
 import { ModalFooter } from '../themed/ModalParts'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
@@ -67,16 +67,14 @@ export function ListModal<T>({
   const handleSubmitEditing = () => (onSubmitEditing != null ? onSubmitEditing(text) : bridge.resolve(text))
 
   const scrollPadding = React.useMemo<ViewStyle>(() => {
-    return { paddingBottom: theme.rem(ModalFooter.bottomRem) }
+    return { paddingBottom: theme.rem(ModalFooter.bottomRem), marginTop: theme.rem(0.5) }
   }, [theme])
 
   return (
     <ModalUi4 title={title} bridge={bridge} onCancel={handleCancel}>
       {message == null ? null : <Paragraph>{message}</Paragraph>}
       {!textInput ? null : (
-        <FilledTextInput
-          vertical={1}
-          horizontal={0.5}
+        <ModalFilledTextInput
           // Our props:
           searchIcon
           blurOnClear={false}

--- a/src/components/modals/LogsModal.tsx
+++ b/src/components/modals/LogsModal.tsx
@@ -9,7 +9,7 @@ import { lstrings } from '../../locales/strings'
 import { WarningCard } from '../cards/WarningCard'
 import { showToast } from '../services/AirshipInstance'
 import { Paragraph } from '../themed/EdgeText'
-import { FilledTextInput } from '../themed/FilledTextInput'
+import { ModalFilledTextInput } from '../themed/FilledTextInput'
 import { MainButton } from '../themed/MainButton'
 import { ModalUi4 } from '../ui4/ModalUi4'
 interface Props {
@@ -74,8 +74,7 @@ export const LogsModal = (props: Props) => {
     <ModalUi4 bridge={bridge} onCancel={handleCancel} title={lstrings.settings_button_export_logs} scroll>
       {!isDangerous ? null : <WarningCard key="warning" title={lstrings.string_warning} footer={lstrings.settings_modal_send_unsafe} marginRem={0.5} />}
       {isDangerous ? null : <Paragraph>{lstrings.settings_modal_export_logs_message}</Paragraph>}
-      <FilledTextInput
-        around={1}
+      <ModalFilledTextInput
         autoCorrect
         autoFocus={false}
         placeholder={lstrings.settings_modal_send_logs_label}

--- a/src/components/modals/PasswordReminderModal.tsx
+++ b/src/components/modals/PasswordReminderModal.tsx
@@ -5,11 +5,11 @@ import { AirshipBridge } from 'react-native-airship'
 import { lstrings } from '../../locales/strings'
 import { connect } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
+import { ModalButtons } from '../common/ModalButtons'
 import { showError, showToast } from '../services/AirshipInstance'
 import { ThemeProps, withTheme } from '../services/ThemeContext'
 import { Paragraph } from '../themed/EdgeText'
-import { FilledTextInput } from '../themed/FilledTextInput'
-import { ButtonsViewUi4 } from '../ui4/ButtonsViewUi4'
+import { ModalFilledTextInput } from '../themed/FilledTextInput'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 interface OwnProps {
@@ -80,10 +80,7 @@ export class PasswordReminderModalComponent extends React.PureComponent<Props, S
     return (
       <ModalUi4 bridge={bridge} title={lstrings.password_reminder_modal_title} onCancel={this.handleCancel}>
         <Paragraph>{lstrings.password_reminder_modal_body}</Paragraph>
-        <FilledTextInput
-          top={0.5}
-          bottom={2}
-          horizontal={0.5}
+        <ModalFilledTextInput
           autoFocus={false}
           error={errorMessage}
           placeholder={lstrings.password}
@@ -92,10 +89,9 @@ export class PasswordReminderModalComponent extends React.PureComponent<Props, S
           secureTextEntry
           value={password}
         />
-        <ButtonsViewUi4
+        <ModalButtons
           primary={{ label: lstrings.password_reminder_check_password, onPress: this.handleSubmit, disabled: password.length === 0 }}
           secondary={{ label: lstrings.password_reminder_forgot_password, onPress: this.handleRequestChangePassword, disabled: checkingPassword }}
-          layout="column"
         />
       </ModalUi4>
     )

--- a/src/components/modals/TextInputModal.tsx
+++ b/src/components/modals/TextInputModal.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react'
-import { Platform } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 
 import { lstrings } from '../../locales/strings'
+import { ModalButtons } from '../common/ModalButtons'
 import { showError } from '../services/AirshipInstance'
 import { Alert } from '../themed/Alert'
 import { Paragraph } from '../themed/EdgeText'
-import { FilledTextInput } from '../themed/FilledTextInput'
-import { MainButton } from '../themed/MainButton'
+import { ModalFilledTextInput } from '../themed/FilledTextInput'
 import { ModalUi4 } from '../ui4/ModalUi4'
 
 interface Props {
@@ -65,7 +64,6 @@ export function TextInputModal(props: Props) {
   } = props
 
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>()
-  const [spinning, setSpinning] = React.useState(false)
   const [text, setText] = React.useState(initialValue)
 
   const handleChangeText = (text: string) => {
@@ -75,10 +73,8 @@ export function TextInputModal(props: Props) {
 
   const handleSubmit = () => {
     if (onSubmit == null) return bridge.resolve(text)
-    setSpinning(true)
     onSubmit(text).then(
       result => {
-        setSpinning(false)
         if (typeof result === 'string') {
           setErrorMessage(result)
         } else if (result) {
@@ -86,25 +82,16 @@ export function TextInputModal(props: Props) {
         }
       },
       error => {
-        setSpinning(false)
         showError(error)
       }
     )
   }
 
-  const isAndroid = Platform.OS === 'android'
-  // TODO: Address this in ButtonsViewUi4
-  const androidButtonMargin = isAndroid ? [1, 1, 2, 1] : 1
-
   return (
     <ModalUi4 warning={warning} bridge={bridge} title={title} onCancel={() => bridge.resolve(undefined)}>
       {typeof message === 'string' ? <Paragraph>{message}</Paragraph> : <>{message}</>}
       {warningMessage != null ? <Alert type="warning" title={lstrings.string_warning} marginRem={0.5} message={warningMessage} numberOfLines={0} /> : null}
-      <FilledTextInput
-        top={1}
-        horizontal={0.5}
-        bottom={1.5}
-        expand
+      <ModalFilledTextInput
         // Text input props:
         autoCapitalize={autoCapitalize}
         autoFocus={autoFocus}
@@ -122,12 +109,7 @@ export function TextInputModal(props: Props) {
         value={text}
         maxLength={maxLength}
       />
-      {/* TODO: Style ButtonsViewUi4 for Modals */}
-      {spinning ? (
-        <MainButton disabled marginRem={androidButtonMargin} type="primary" spinner />
-      ) : (
-        <MainButton label={submitLabel} marginRem={androidButtonMargin} onPress={handleSubmit} type="primary" />
-      )}
+      <ModalButtons primary={{ label: submitLabel, onPress: handleSubmit }} />
     </ModalUi4>
   )
 }

--- a/src/components/scenes/DevTestScene.tsx
+++ b/src/components/scenes/DevTestScene.tsx
@@ -30,7 +30,7 @@ import { Airship, showError } from '../services/AirshipInstance'
 import { useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { ExchangedFlipInput2, ExchangedFlipInputAmounts, ExchangedFlipInputRef } from '../themed/ExchangedFlipInput2'
-import { FilledTextInput } from '../themed/FilledTextInput'
+import { ModalFilledTextInput } from '../themed/FilledTextInput'
 import { SimpleTextInput } from '../themed/SimpleTextInput'
 import { AlertCardUi4 } from '../ui4/AlertCardUi4'
 import { ButtonsViewUi4 } from '../ui4/ButtonsViewUi4'
@@ -113,9 +113,8 @@ export function DevTestScene(props: Props) {
     <SceneWrapper scroll hasTabs hasHeader={false}>
       <SectionView marginRem={1}>
         <AlertCardUi4 title={lstrings.warning_alphanumeric} type="error" />
-        <FilledTextInput
+        <ModalFilledTextInput
           iconComponent={SearchIconAnimated}
-          vertical={1}
           value={filledTextInputValue6}
           onChangeText={setFilledTextInputValue6}
           autoFocus={false}
@@ -123,9 +122,8 @@ export function DevTestScene(props: Props) {
           textsizeRem={1.5}
           maxLength={100}
         />
-        <FilledTextInput
+        <ModalFilledTextInput
           numeric
-          vertical={1}
           value={filledTextInputValue7}
           onChangeText={setFilledTextInputValue7}
           autoFocus={false}
@@ -133,16 +131,14 @@ export function DevTestScene(props: Props) {
           textsizeRem={1.5}
           maxLength={100}
         />
-        <FilledTextInput
-          vertical={1}
+        <ModalFilledTextInput
           value={filledTextInputValue}
           onChangeText={setFilledTextInputValue}
           autoFocus={false}
           placeholder="Test FilledTextInput"
           maxLength={100}
         />
-        <FilledTextInput
-          vertical={1}
+        <ModalFilledTextInput
           prefix="PRE"
           value={filledTextInputValue2}
           onChangeText={setFilledTextInputValue2}
@@ -150,17 +146,15 @@ export function DevTestScene(props: Props) {
           placeholder="Test FilledTextInput"
           maxLength={100}
         />
-        <FilledTextInput
+        <ModalFilledTextInput
           numeric
-          vertical={1}
           value={filledTextInputValue3}
           onChangeText={setFilledTextInputValue3}
           autoFocus={false}
           placeholder="Test FilledTextInput num"
         />
-        <FilledTextInput
+        <ModalFilledTextInput
           numeric
-          vertical={1}
           prefix="$"
           suffix="BTC"
           value={filledTextInputValue4}
@@ -170,8 +164,7 @@ export function DevTestScene(props: Props) {
           error="Error"
           maxLength={100}
         />
-        <FilledTextInput
-          vertical={1}
+        <ModalFilledTextInput
           prefix="USD"
           suffix="BTC"
           value={filledTextInputValue5}
@@ -182,8 +175,7 @@ export function DevTestScene(props: Props) {
           maxLength={100}
         />
         <>
-          <FilledTextInput
-            vertical={1}
+          <ModalFilledTextInput
             value={filledTextInputValue8}
             onChangeText={setFilledTextInputValue8}
             autoFocus={false}
@@ -211,9 +203,9 @@ export function DevTestScene(props: Props) {
         )}
 
         <>
-          <SimpleTextInput vertical={1} value={value0} onChangeText={onChangeText0} autoFocus={false} placeholder="Crypto Amount" />
+          <SimpleTextInput value={value0} onChangeText={onChangeText0} autoFocus={false} placeholder="Crypto Amount" />
           <ButtonUi4 label="Set Crypto Amt" onPress={onPress0} />
-          <SimpleTextInput vertical={1} value={value1} onChangeText={onChangeText1} autoFocus={false} placeholder="Fiat Amount" />
+          <SimpleTextInput value={value1} onChangeText={onChangeText1} autoFocus={false} placeholder="Fiat Amount" />
           <ButtonUi4 label="Set Fiat Amt" onPress={onPress1} />
         </>
 
@@ -397,8 +389,7 @@ export function DevTestScene(props: Props) {
         </>
         <>
           <SectionHeaderUi4 leftTitle="DeepLinking" />
-          <FilledTextInput
-            vertical={0.5}
+          <ModalFilledTextInput
             value={deepLinkInputValue}
             onChangeText={setDeepLinkInputValue}
             autoFocus={false}

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -31,7 +31,7 @@ const isAndroid = Platform.OS === 'android'
 
 export type FilledTextInputReturnKeyType = 'done' | 'go' | 'next' | 'search' | 'send' // Defaults to 'done'
 
-export interface FilledTextInputProps extends SpaceProps {
+export interface FilledTextInputBaseProps extends SpaceProps {
   // Contents:
   value: string
   error?: string
@@ -80,6 +80,15 @@ export interface FilledTextInputProps extends SpaceProps {
   disabled?: boolean // Defaults to 'false'
 }
 
+export type ModalFilledTextInputProps = Omit<FilledTextInputBaseProps, keyof SpaceProps>
+
+/**
+ * FilledTextInput with standard `around=0.5` UI4 margins, for use in modals
+ */
+export const ModalFilledTextInput = React.forwardRef<FilledTextInputRef, ModalFilledTextInputProps>((props: ModalFilledTextInputProps) => (
+  <FilledTextInput {...props} around={0.5} />
+))
+
 /**
  * Type definitions for our static methods.
  * Create a ref object using `useRef<FilledTextInputRef>(null)` or
@@ -93,7 +102,12 @@ export interface FilledTextInputRef {
   setNativeProps: (nativeProps: Object) => void
 }
 
-export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextInputProps>((props: FilledTextInputProps, ref) => {
+/**
+ * Raw FilledTextInput that includes no built-in margins. Not meant to be used
+ * by top-level parents, but rather as a raw building block to build a child
+ * component with some fixed margins according to the child use case.
+ */
+export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextInputBaseProps>((props: FilledTextInputBaseProps, ref) => {
   const {
     // Contents:
     error,

--- a/src/types/FormTypes.ts
+++ b/src/types/FormTypes.ts
@@ -1,6 +1,6 @@
 import { asMaybe, asObject, asString } from 'cleaners'
 
-import { FilledTextInputProps } from '../components/themed/FilledTextInput'
+import { FilledTextInputBaseProps } from '../components/themed/FilledTextInput'
 
 // Define all form field types here.
 export type FormFieldType = 'address' | 'address2' | 'text' | 'postalcode' | 'state' | 'city' | 'name' | 'iban' | 'swift'
@@ -8,7 +8,7 @@ export type FormFieldType = 'address' | 'address2' | 'text' | 'postalcode' | 'st
 // For each form field type, define the relevant display properties that will be
 // used to pass along to the FilledTextInput.
 export const FORM_FIELD_DISPLAY_PROPS: {
-  readonly [fieldType in FormFieldType]: { widthRem?: number; textInputProps?: Partial<FilledTextInputProps> }
+  readonly [fieldType in FormFieldType]: { widthRem?: number; textInputProps?: Partial<FilledTextInputBaseProps> }
 } = {
   address: {
     widthRem: undefined,


### PR DESCRIPTION
- Retained total margins for the most part. Prioritizing consistency over 100% retaining original margins.
- `PasswordReminderModal`, `TextInputModal`: Changes might look like they're losing vertical margins between `FilledTextInput` and buttons, but using the new standard `ModalButtons` takes care of that by providing extra top button margins.
- Added unit tests for changed modals that had no coverage

![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/b3ef4890-4aeb-443d-b968-97ffd03bd761)
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/56b67097-c7e9-4c4c-aa1c-97b53bbe9cd3)
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/bce0e7c5-4554-46c4-8ca2-587f32b97528)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-react-gui/pull/5009

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206366276415248