### PR TITLE
Fix Markets SwipeChart

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,9 @@ import { App } from './src/components/App'
 if (typeof BigInt === 'undefined') global.BigInt = require('big-integer')
 
 // See https://github.com/software-mansion/react-native-reanimated/issues/1794#issuecomment-898393331
-Animated.addWhitelistedNativeProps({})
+// For ReText/SwipeChart support requirements, see:
+// https://github.com/software-mansion/react-native-reanimated/discussions/5621
+// https://github.com/software-mansion/react-native-reanimated/issues/5432
+Animated.addWhitelistedNativeProps({ text: true })
 
 AppRegistry.registerComponent(appName, () => App)

--- a/src/components/text/ReText.tsx
+++ b/src/components/text/ReText.tsx
@@ -6,8 +6,6 @@ import Animated, { useAnimatedProps } from 'react-native-reanimated'
 import { Theme } from '../../types/Theme'
 import { ThemeProps, withTheme } from '../services/ThemeContext'
 
-Animated.addWhitelistedNativeProps({ text: true })
-
 interface TextProps {
   text: Animated.SharedValue<string>
   style?: Animated.AnimateProps<RNTextProps>['style']


### PR DESCRIPTION
Only call Animated.addWhitelistedNativeProps once
No longer OK to call multiple times after expo and/or reanimated updates.

https://github.com/software-mansion/react-native-reanimated/discussions/5621
https://github.com/software-mansion/react-native-reanimated/issues/5432

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207195854678887