### PR TITLE
Re-enable screenshots on Android

### DIFF
--- a/android/app/src/main/java/co/edgesecure/app/MainActivity.kt
+++ b/android/app/src/main/java/co/edgesecure/app/MainActivity.kt
@@ -39,12 +39,6 @@ class MainActivity : ReactActivity() {
         // Hide app contents in the background:
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             setRecentsScreenshotEnabled(false);
-        } else {
-            getWindow()
-                .setFlags(
-                    WindowManager.LayoutParams.FLAG_SECURE,
-                    WindowManager.LayoutParams.FLAG_SECURE
-                ) ;
         }
 
         // Lock the app to portrait mode:


### PR DESCRIPTION
On older Android versions, we either lose the ability to take screenshots, or we leave the app visible in the task switcher. There is no middle ground until recently, where they added an API to hide the app in the switcher while allowing screenshots.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207169437567098