### PR TITLE
Fix the settings row crash

### DIFF
--- a/src/components/settings/SettingsRow.tsx
+++ b/src/components/settings/SettingsRow.tsx
@@ -59,6 +59,7 @@ const SettingsRowComponent = (props: Props) => {
 }
 
 const ActivityContainer = styled(Animated.View)<{ pending: boolean }>(_theme => props => {
+  const { pending } = props
   return [
     {
       position: 'absolute',
@@ -68,22 +69,26 @@ const ActivityContainer = styled(Animated.View)<{ pending: boolean }>(_theme => 
     },
     useAnimatedStyle(() => ({
       opacity: withDelay(
-        props.pending ? ACTIVITY_INDICATOR_FADE_IN_DELAY : 0,
-        withTiming(props.pending ? 1 : 0, { duration: ACTIVITY_INDICATOR_FADE_IN_DURATION })
+        pending ? ACTIVITY_INDICATOR_FADE_IN_DELAY : 0,
+        withTiming(pending ? 1 : 0, {
+          duration: ACTIVITY_INDICATOR_FADE_IN_DURATION
+        })
       )
     }))
   ]
 })
 
-const RightContainer = styled(Animated.View)<{ pending: boolean }>(
-  _theme => props =>
-    useAnimatedStyle(() => ({
-      opacity: withDelay(
-        props.pending ? ACTIVITY_INDICATOR_FADE_IN_DELAY : 0,
-        withTiming(props.pending ? 0 : 1, { duration: ACTIVITY_INDICATOR_FADE_IN_DURATION })
-      )
-    }))
-)
+const RightContainer = styled(Animated.View)<{ pending: boolean }>(_theme => props => {
+  const { pending } = props
+  return useAnimatedStyle(() => ({
+    opacity: withDelay(
+      pending ? ACTIVITY_INDICATOR_FADE_IN_DELAY : 0,
+      withTiming(pending ? 0 : 1, {
+        duration: ACTIVITY_INDICATOR_FADE_IN_DURATION
+      })
+    )
+  }))
+})
 
 const getStyles = cacheStyles((theme: Theme) => {
   const commonText: TextStyle = {


### PR DESCRIPTION
The `useAnimatedStyle` worklet was capturing `props`, which includes `props.children`. Since Reanimated calls `Object.freeze` on any captured values, the React runtime dies because it cannot modify things it expects to modify.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207319673522842