### PR TITLE
Remove superfluous dependency lists from reanimated

### DIFF
--- a/src/components/common/SceneWrapper.tsx
+++ b/src/components/common/SceneWrapper.tsx
@@ -225,7 +225,7 @@ function SceneWrapperComponent(props: SceneWrapperProps): JSX.Element {
     return {
       maxHeight: frameHeight + maybeKeyboardHeightDiff
     }
-  }, [avoidKeyboard, frameHeight])
+  })
 
   // If function children, the caller handles the insets and overscroll
   const memoizedChildren = useMemo(() => (typeof children === 'function' ? children(sceneWrapperInfo) : children), [children, sceneWrapperInfo])

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -219,15 +219,15 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
     if (onSubmitEditing != null) onSubmitEditing()
   })
 
-  const leftIconSize = useDerivedValue(() => (hasIcon ? (hasValue ? 0 : interpolate(focusAnimation.value, [0, 1], [themeRem, 0])) : 0), [hasIcon, hasValue])
-  const rightIconSize = useDerivedValue(() => (clearIcon ? (hasValue ? themeRem : focusAnimation.value * themeRem) : 0), [clearIcon, hasValue])
+  const leftIconSize = useDerivedValue(() => (hasIcon ? (hasValue ? 0 : interpolate(focusAnimation.value, [0, 1], [themeRem, 0])) : 0))
+  const rightIconSize = useDerivedValue(() => (clearIcon ? (hasValue ? themeRem : focusAnimation.value * themeRem) : 0))
 
   const scale = useDerivedValue(() => scaleProp?.value ?? 1)
 
   const interpolateIconColor = useAnimatedColorInterpolateFn(theme.textInputIconColor, theme.textInputIconColorFocused, theme.textInputIconColorDisabled)
   const iconColor = useDerivedValue(() => interpolateIconColor(focusAnimation, disableAnimation))
 
-  const focusValue = useDerivedValue(() => (hasValue ? 1 : focusAnimation.value), [hasValue])
+  const focusValue = useDerivedValue(() => (hasValue ? 1 : focusAnimation.value))
 
   // Character Limit:
   const charactersLeft = maxLength === undefined ? '' : `${maxLength - value.length}`

--- a/src/components/themed/FlipInput2.tsx
+++ b/src/components/themed/FlipInput2.tsx
@@ -117,7 +117,7 @@ export const FlipInput2 = React.forwardRef<FlipInputRef, Props>((props: Props, r
 
   const interpolateIconColor = useAnimatedColorInterpolateFn(theme.textInputIconColor, theme.textInputIconColorFocused, theme.textInputIconColorDisabled)
   const clearIconColor = useDerivedValue(() => interpolateIconColor(focusAnimation, disableAnimation))
-  const clearIconScale = useDerivedValue(() => (hasAmount ? 1 : focusAnimation.value), [hasAmount])
+  const clearIconScale = useDerivedValue(() => (hasAmount ? 1 : focusAnimation.value))
   // We have to use a SharedValue for the icon size event though it's not animated,
   // just because that is the expected type
   const clearIconSize = useSharedValue(themeRem)

--- a/src/components/themed/MenuTabs.tsx
+++ b/src/components/themed/MenuTabs.tsx
@@ -79,7 +79,7 @@ export const MenuTabs = (props: BottomTabBarProps) => {
   const renderFooter = useSceneFooterRenderState(state => state.renderFooter)
 
   const { height: keyboardHeight, progress: keyboardProgress } = useReanimatedKeyboardAnimation()
-  const menuTabHeightAndInsetBottomTermForShiftY = useDerivedValue(() => keyboardProgress.value * (insetBottom + MAX_TAB_BAR_HEIGHT), [insetBottom])
+  const menuTabHeightAndInsetBottomTermForShiftY = useDerivedValue(() => keyboardProgress.value * (insetBottom + MAX_TAB_BAR_HEIGHT))
   const shiftY = useDerivedValue(() => keyboardHeight.value + menuTabHeightAndInsetBottomTermForShiftY.value)
 
   return (

--- a/src/components/themed/SimpleTextInput.tsx
+++ b/src/components/themed/SimpleTextInput.tsx
@@ -171,8 +171,8 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
   })
 
   const backIconSize = useDerivedValue(() => interpolate(focusAnimation.value, [0, 1], [0, themeRem]))
-  const leftIconSize = useDerivedValue(() => (hasIcon ? (hasValue ? 0 : interpolate(focusAnimation.value, [0, 1], [themeRem, 0])) : 0), [hasIcon, hasValue])
-  const rightIconSize = useDerivedValue(() => (hasValue ? themeRem : focusAnimation.value * themeRem), [hasValue])
+  const leftIconSize = useDerivedValue(() => (hasIcon ? (hasValue ? 0 : interpolate(focusAnimation.value, [0, 1], [themeRem, 0])) : 0))
+  const rightIconSize = useDerivedValue(() => (hasValue ? themeRem : focusAnimation.value * themeRem))
 
   const scale = useDerivedValue(() => scaleProp?.value ?? 1)
 

--- a/src/hooks/useSharedEvent.ts
+++ b/src/hooks/useSharedEvent.ts
@@ -19,6 +19,5 @@ export const useSharedEvent = <T>(sharedEvent: SharedValue<T> | undefined, handl
         // runOnJS(handler)(currentValue)
         handler(currentValue)
       }
-    },
-    [sharedEvent, handler]
+    }
   )

--- a/src/plugins/gui/scenes/AddressFormScene.tsx
+++ b/src/plugins/gui/scenes/AddressFormScene.tsx
@@ -85,23 +85,20 @@ export const AddressFormScene = React.memo((props: Props) => {
 
   const dFinalHeight = useDerivedValue(() => {
     return hintHeight * Math.min(searchResults.length, MAX_DISPLAYED_HINTS)
-  }, [searchResults, hintHeight])
+  })
 
   // Further calculations to determine the height. Also add another
   // conditional animation based on the number of hints changing as
   // the search query changes from user input
-  const aDropContainerStyle = useAnimatedStyle(
-    () => ({
-      height: withTiming(dFinalHeight.value * sAnimationMult.value, {
-        duration: isAnimateHintsNumChange ? 250 : 0,
-        easing: Easing.inOut(Easing.circle)
-      }),
-      opacity: isHintsDropped && searchResults.length > 0 ? sAnimationMult.value : withTiming(0, { duration: 500 }),
-
-      borderColor: interpolateColor(sAnimationMult.value, [0, 1], dropdownBorderColor)
+  const aDropContainerStyle = useAnimatedStyle(() => ({
+    height: withTiming(dFinalHeight.value * sAnimationMult.value, {
+      duration: isAnimateHintsNumChange ? 250 : 0,
+      easing: Easing.inOut(Easing.circle)
     }),
-    [isHintsDropped, searchResults.length]
-  )
+    opacity: isHintsDropped && searchResults.length > 0 ? sAnimationMult.value : withTiming(0, { duration: 500 }),
+
+    borderColor: interpolateColor(sAnimationMult.value, [0, 1], dropdownBorderColor)
+  }))
 
   const handleHintLayout = useHandler(event => {
     if (event != null && hintHeight === 0) {

--- a/src/state/SceneFooterState.tsx
+++ b/src/state/SceneFooterState.tsx
@@ -211,8 +211,7 @@ export const FooterAccordionEventService = () => {
       if (footerOpenRatio.value !== currentValue) {
         footerOpenRatio.value = withTiming(currentValue, { duration: 200 })
       }
-    },
-    [keepOpen, scrollDeltaToRatioDeltaFactor]
+    }
   )
 
   useAnimatedReaction(
@@ -227,8 +226,7 @@ export const FooterAccordionEventService = () => {
       if (currentValue == null) return
 
       footerOpenRatio.value = withTiming(currentValue, { duration: 300 })
-    },
-    [keepOpen]
+    }
   )
 
   return null


### PR DESCRIPTION
The Babel plugin auto-detects worklet dependencies, so according to the documentation, passing these lists is superflous. They are only needed on the web, when the Babel plugin is missing.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207319749532395