### PR TITLE
Fix the stuck spinner on login

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -248,7 +248,8 @@ export const Main = () => {
     }
   }, [theme])
 
-  const localUsers = useSelector(state => state.core.context.localUsers)
+  const context = useSelector(state => state.core.context)
+  const { localUsers } = context
 
   useMount(() => {
     dispatch(logEvent('Start_App', { numAccounts: localUsers.length }))
@@ -274,6 +275,8 @@ export const Main = () => {
     'setLegacyLanding'
   )
 
+  const initialRouteName = ENV.USE_WELCOME_SCREENS && localUsers.length === 0 ? 'gettingStarted' : 'login'
+
   return (
     <>
       {experimentConfig == null ? (
@@ -288,7 +291,7 @@ export const Main = () => {
           theme={reactNavigationTheme}
         >
           <Stack.Navigator
-            initialRouteName={ENV.USE_WELCOME_SCREENS ? 'gettingStarted' : 'login'}
+            initialRouteName={initialRouteName}
             screenOptions={{
               headerShown: false
             }}


### PR DESCRIPTION
This happened because the getting-started scene would navigate back to the login scene. Instead of navigating inside an effect, just set up the initial route prop correctly.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207446566171049