### PR TITLE
Properly size and flex the side menu

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -348,7 +348,7 @@ const EdgeApp = () => {
       screenOptions={{
         drawerPosition: 'right',
         drawerType: 'front',
-        drawerStyle: { backgroundColor: 'transparent', bottom: 0 },
+        drawerStyle: { backgroundColor: 'transparent', bottom: 0, width: '66%' },
         headerShown: false
       }}
     >

--- a/src/components/themed/SideMenu.tsx
+++ b/src/components/themed/SideMenu.tsx
@@ -30,6 +30,7 @@ import { NavigationBase } from '../../types/routerTypes'
 import { parseDeepLink } from '../../util/DeepLinkParser'
 import { IONIA_SUPPORTED_FIATS } from '../cards/VisaCardCard'
 import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
+import { styled } from '../hoc/styled'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { ScanModal } from '../modals/ScanModal'
 import { LoadingSplashScreen } from '../progress-indicators/LoadingSplashScreen'
@@ -280,7 +281,7 @@ export function SideMenuComponent(props: DrawerContentComponentProps) {
   const footerBottomColor = theme.modal
 
   return (
-    <View style={{ flex: 1, paddingTop: insets.top }}>
+    <OuterView insets={insets}>
       {/* ==== Top Panel Start ==== */}
       <View style={styles.topPanel}>
         <Image style={styles.logoImage} source={theme.primaryLogo} resizeMode="contain" />
@@ -348,7 +349,7 @@ export function SideMenuComponent(props: DrawerContentComponentProps) {
         {/* === Footer End === */}
       </View>
       {/* ==== Bottom Panel End ==== */}
-    </View>
+    </OuterView>
   )
 }
 
@@ -474,6 +475,13 @@ const getStyles = cacheStyles((theme: Theme) => ({
     borderBottomLeftRadius: theme.rem(2),
     zIndex: 1
   }
+}))
+
+// TODO: Refactor more of SideMenu into styled components
+const OuterView = styled(View)<{ insets: { top: number; bottom: number } }>(() => props => ({
+  flexGrow: 1,
+  paddingTop: props.insets.top,
+  paddingBottom: props.insets.bottom
 }))
 
 export function SideMenu(props: DrawerContentComponentProps) {


### PR DESCRIPTION
![image](https://github.com/EdgeApp/edge-react-gui/assets/90650827/24f6ccae-039e-4dc9-a749-984a6f3d278a)

Unclear what dependencies changed to make this issue surface, but we just got lucky before.
This change properly flexes the side menu

### Update:
Updates to RN/RN Navigation are likely the culprit. Likely some defaults were changed, and in combination with our 
Since the `Drawer` itself is absolutely positioned and does translations to `right` under the hood, we cannot rely on flex and must set a specific width. 

Without setting an explicit width, though the side menu appears properly sized, the drawer itself takes up extra invisible horizontal space to the left of the menu. This extra horizontal space is not tappable and prevents the side menu from closing when tapping outside of the menu.
<img width="395" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/4f23df15-d14d-461a-9573-655da49b44a4">

Below are after the updates:
<img width="394" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/d401350c-e92c-47ce-94f5-23ba0c670b15">
<img width="265" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/8d7eae4a-c8dd-4f59-922a-2a6fd820630e">



### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207409357193836