### PR TITLE
Properly size and flex the side menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added: Dynamic height for multiline text inputs
 - added: Sentry SDK for crash reporting
 - changed: Add EUID to Simplex quoting API calls
+- fixed: Excessive side menu width
 - removed: Bugsnag for crash reporting
 - removed: Firebase/Google Analytics
 - removed: Light Account Backup Modal A/B/C/D test experiment

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -348,7 +348,7 @@ const EdgeApp = () => {
       screenOptions={{
         drawerPosition: 'right',
         drawerType: 'front',
-        drawerStyle: { backgroundColor: 'transparent', bottom: 0 },
+        drawerStyle: { backgroundColor: 'transparent', bottom: 0, flexDirection: 'row', justifyContent: 'flex-end' },
         headerShown: false
       }}
     >

--- a/src/components/themed/SideMenu.tsx
+++ b/src/components/themed/SideMenu.tsx
@@ -30,6 +30,7 @@ import { NavigationBase } from '../../types/routerTypes'
 import { parseDeepLink } from '../../util/DeepLinkParser'
 import { IONIA_SUPPORTED_FIATS } from '../cards/VisaCardCard'
 import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
+import { styled } from '../hoc/styled'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { ScanModal } from '../modals/ScanModal'
 import { LoadingSplashScreen } from '../progress-indicators/LoadingSplashScreen'
@@ -280,7 +281,7 @@ export function SideMenuComponent(props: DrawerContentComponentProps) {
   const footerBottomColor = theme.modal
 
   return (
-    <View style={{ flex: 1, paddingTop: insets.top }}>
+    <OuterView insets={insets}>
       {/* ==== Top Panel Start ==== */}
       <View style={styles.topPanel}>
         <Image style={styles.logoImage} source={theme.primaryLogo} resizeMode="contain" />
@@ -348,7 +349,7 @@ export function SideMenuComponent(props: DrawerContentComponentProps) {
         {/* === Footer End === */}
       </View>
       {/* ==== Bottom Panel End ==== */}
-    </View>
+    </OuterView>
   )
 }
 
@@ -474,6 +475,13 @@ const getStyles = cacheStyles((theme: Theme) => ({
     borderBottomLeftRadius: theme.rem(2),
     zIndex: 1
   }
+}))
+
+// TODO: Refactor more of this component into styled components
+const OuterView = styled(View)<{ insets: { top: number; bottom: number } }>(() => props => ({
+  flexShrink: 1,
+  paddingTop: props.insets.top,
+  paddingBottom: props.insets.bottom
 }))
 
 export function SideMenu(props: DrawerContentComponentProps) {


### PR DESCRIPTION
Unclear what dependencies changed to make this issue surface, but we just got lucky before.
This change properly flexes the side menu

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
