### PR TITLE
Add events to Cosmos WalletConnect supported namespaces

### DIFF
--- a/src/hooks/useWalletConnect.tsx
+++ b/src/hooks/useWalletConnect.tsx
@@ -206,7 +206,6 @@ const getSupportedNamespaces = (chainId: WalletConnectChainId, addr: string) => 
   const { namespace, reference } = chainId
 
   let methods: string[]
-  let events = ['chainChanged', 'accountsChanged']
   switch (namespace) {
     case 'eip155':
       methods = [
@@ -225,14 +224,13 @@ const getSupportedNamespaces = (chainId: WalletConnectChainId, addr: string) => 
       break
     case 'cosmos':
       methods = ['cosmos_getAccounts', 'cosmos_signDirect', 'cosmos_signAmino']
-      events = []
   }
 
   return {
     [namespace]: {
       chains: [`${namespace}:${reference}`],
       methods,
-      events,
+      events: ['chainChanged', 'accountsChanged'],
       accounts: [`${namespace}:${reference}:${addr}`]
     }
   }


### PR DESCRIPTION
You don't actually need to support that events you just need to pretend to. We already do this with the other WalletConnect chains so we can do it for Cosmos, too.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207489271357886