### PR TITLE
Fix Swap Scene bugs

### DIFF
--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -350,6 +350,8 @@ const Pagination = styled(View)(theme => ({
 }))
 
 const PageIndicator = styled(Animated.View)<{ swipeOffset: SharedValue<number>; itemIndex: number }>(theme => props => {
+  const themeIcon = theme.icon
+  const themeIconTappable = theme.iconTappable
   const { itemIndex, swipeOffset } = props
   return [
     {
@@ -361,7 +363,7 @@ const PageIndicator = styled(Animated.View)<{ swipeOffset: SharedValue<number>; 
     useAnimatedStyle(() => {
       const delta = 1 - Math.max(0, Math.min(1, Math.abs(itemIndex - swipeOffset.value)))
       const opacity = interpolate(delta, [0, 1], [0.5, 1])
-      const backgroundColor = interpolateColor(delta, [0, 1], [theme.icon, theme.iconTappable])
+      const backgroundColor = interpolateColor(delta, [0, 1], [themeIcon, themeIconTappable])
       return {
         backgroundColor,
         opacity
@@ -377,6 +379,8 @@ const PageIndicator = styled(Animated.View)<{ swipeOffset: SharedValue<number>; 
 const SectionCoverAnimated = styled(Animated.View)<{ swipeOffset: SharedValue<number> }>(theme => props => {
   const { swipeOffset } = props
   const themeRem = theme.rem(1)
+  const themeModal = theme.modal
+  const themeModalLikeBackground = theme.modalLikeBackground
   const insets = useSafeAreaInsets()
 
   return [
@@ -388,7 +392,7 @@ const SectionCoverAnimated = styled(Animated.View)<{ swipeOffset: SharedValue<nu
       marginBottom: -insets.bottom
     },
     useAnimatedStyle(() => {
-      const backgroundColor = interpolateColor(swipeOffset.value, [0, 1], [`${theme.modal}00`, theme.modalLikeBackground])
+      const backgroundColor = interpolateColor(swipeOffset.value, [0, 1], [`${themeModal}00`, themeModalLikeBackground])
       const paddingVertical = interpolate(swipeOffset.value, [0, 1], [0, themeRem], Extrapolation.CLAMP)
       const flexGrow = interpolate(swipeOffset.value, [0, 1], [0, 1.2], Extrapolation.CLAMP)
       return {

--- a/src/components/scenes/SwapProcessingScene.tsx
+++ b/src/components/scenes/SwapProcessingScene.tsx
@@ -81,15 +81,12 @@ export function SwapProcessingScene(props: Props) {
           toDenomination
         })
 
-        navigation.navigate('swapTab', {
-          screen: 'swapCreate',
-          params: {
-            fromWalletId: swapRequest.fromWallet.id,
-            fromTokenId: swapRequest.fromTokenId,
-            toWalletId: swapRequest.toWallet.id,
-            toTokenId: swapRequest.toTokenId,
-            errorDisplayInfo
-          }
+        navigation.popTo('swapCreate', {
+          fromWalletId: swapRequest.fromWallet.id,
+          fromTokenId: swapRequest.fromTokenId,
+          toWalletId: swapRequest.toWallet.id,
+          toTokenId: swapRequest.toTokenId,
+          errorDisplayInfo
         })
 
         const insufficientFunds = asMaybeInsufficientFundsError(error)

--- a/src/components/themed/SafeSlider.tsx
+++ b/src/components/themed/SafeSlider.tsx
@@ -29,6 +29,7 @@ export const SafeSlider = (props: Props) => {
 
   const theme = useTheme()
   const styles = getStyles(theme)
+  const { confirmationSliderThumbWidth } = theme
   const [completed, setCompleted] = React.useState(false)
 
   const { width = theme.confirmationSliderWidth } = props
@@ -85,7 +86,7 @@ export const SafeSlider = (props: Props) => {
 
   const progressStyle = useAnimatedStyle(() => {
     return {
-      width: translateX.value + theme.confirmationSliderThumbWidth
+      width: translateX.value + confirmationSliderThumbWidth
     }
   })
 

--- a/src/components/themed/Slider.tsx
+++ b/src/components/themed/Slider.tsx
@@ -43,6 +43,7 @@ export const SliderComponent = (props: Props) => {
     width = props.theme.confirmationSliderWidth
   } = props
   const styles = getStyles(theme)
+  const { confirmationSliderThumbWidth } = theme
   const [completed, setCompleted] = React.useState(false)
 
   const upperBound = width - theme.confirmationSliderThumbWidth
@@ -98,7 +99,7 @@ export const SliderComponent = (props: Props) => {
 
   const progressStyle = useAnimatedStyle(() => {
     return {
-      width: translateX.value + theme.confirmationSliderThumbWidth
+      width: translateX.value + confirmationSliderThumbWidth
     }
   })
 


### PR DESCRIPTION
The use of `navigation.navigate` to pop back to a scene in the stack has
been deprecate behavior in react-navigation v7.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205615584416006