### PR TITLE
React Navigation v7 Hack fixes

### DIFF
--- a/src/components/scenes/GuiPluginListScene.tsx
+++ b/src/components/scenes/GuiPluginListScene.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native'
 import { Disklet } from 'disklet'
 import { EdgeAccount } from 'edge-core-js/types'
 import * as React from 'react'
@@ -521,6 +522,7 @@ export const GuiPluginListScene = React.memo((props: OwnProps) => {
   const developerModeOn = useSelector(state => state.ui.settings.developerModeOn)
   const direction = props.route.name === 'pluginListSell' ? 'sell' : 'buy'
   const disablePlugins = useSelector(state => state.ui.exchangeInfo[direction].disablePlugins)
+  const isFocused = useIsFocused()
 
   const [forcedWalletResultLocal, setForcedWalletResultLocal] = React.useState<WalletListResult | undefined>(params.forcedWalletResult)
 
@@ -551,6 +553,9 @@ export const GuiPluginListScene = React.memo((props: OwnProps) => {
   })
 
   React.useEffect(() => {
+    // HACK: Latest React Navigation causes multiple mounts
+    if (isFocused) return
+
     dispatch(checkAndSetRegion({ account, countryCode, stateProvinceCode }))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/components/services/Services.tsx
+++ b/src/components/services/Services.tsx
@@ -48,6 +48,8 @@ const asFioCreateHandleRecord = asJSON(
   })
 )
 
+let isFioModalShown = false
+
 /**
  * Provides various services to the application. These are non-visual components
  * which provide some background tasks and exterior functionality for the app.
@@ -59,6 +61,10 @@ export function Services(props: Props) {
 
   // Show FIO handle modal for new accounts or existing accounts without a FIO wallet:
   const maybeShowFioHandleModal = useHandler(async (account: EdgeAccount) => {
+    // HACK: Latest React Navigation causes multiple mounts
+    if (isFioModalShown) return
+    isFioModalShown = true
+
     const { freeRegApiToken = undefined, freeRegRefCode = undefined } = typeof ENV.FIO_INIT === 'object' ? ENV.FIO_INIT : {}
     const hasFioWallets = account.allKeys.some(keyInfo => keyInfo.type === 'wallet:fio')
 


### PR DESCRIPTION
React Navigation v7 caused the regression. Services and tabs mount twice immediately on login now.

Apply hack fixes to known problem areas as an interim fix

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207497117195103