### PR TITLE
Use the header dimensions from `useHeaderHeight`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,5 @@ module.exports = {
   },
   preset: 'react-native',
   setupFiles: ['./jestSetup.js'],
-  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@react-native|react-native|react-navigation))']
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@react-native|react-native))']
 }

--- a/jestSetup.js
+++ b/jestSetup.js
@@ -72,7 +72,7 @@ jest.mock('react-native/Libraries/Utilities/Platform', () => ({
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 
 jest.mock('@react-navigation/elements', () => ({
-  getDefaultHeaderHeight: () => 44
+  useHeaderHeight: () => 64
 }))
 
 jest.mock('rn-qr-generator', () => ({

--- a/src/components/common/SceneWrapper.tsx
+++ b/src/components/common/SceneWrapper.tsx
@@ -1,4 +1,4 @@
-import { getDefaultHeaderHeight } from '@react-navigation/elements'
+import { useHeaderHeight } from '@react-navigation/elements'
 import { useFocusEffect, useIsFocused, useNavigation } from '@react-navigation/native'
 import * as React from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -157,27 +157,28 @@ function SceneWrapperComponent(props: SceneWrapperProps): JSX.Element {
     [frameHeight, frameWidth]
   )
 
-  const headerBarHeight = getDefaultHeaderHeight({ height: frameHeight, width: frameWidth }, false, 0)
+  // This includes the top safe area inset:
+  const headerBarHeight = useHeaderHeight()
 
   // Calculate app insets considering the app's header, tab-bar,
   // notification area, etc:
   const maybeNotificationHeight = hasNotifications ? notificationHeight : 0
 
-  const maybeHeaderHeight = hasHeader ? headerBarHeight : 0
   // Ignore tab bar height when keyboard is open because it is rendered behind it
   const maybeTabBarHeight = hasTabs && !isKeyboardOpen ? MAX_TAB_BAR_HEIGHT : 0
   // Ignore inset bottom when keyboard is open because it is rendered behind it
   const maybeInsetBottom = !isKeyboardOpen ? safeAreaInsets.bottom : 0
   const insets: EdgeInsets = useMemo(
     () => ({
-      top: safeAreaInsets.top + maybeHeaderHeight,
+      top: hasHeader ? headerBarHeight : safeAreaInsets.top,
       right: safeAreaInsets.right,
       bottom: maybeInsetBottom + maybeNotificationHeight + maybeTabBarHeight + footerHeight,
       left: safeAreaInsets.left
     }),
     [
       footerHeight,
-      maybeHeaderHeight,
+      hasHeader,
+      headerBarHeight,
       maybeInsetBottom,
       maybeNotificationHeight,
       maybeTabBarHeight,


### PR DESCRIPTION
Our header-height calculation was getting different results than react-navigation, leading to a gap. Switching to the `useHeaderHeight` hook causes us to use the same number that react-navigation itself is using, making the calculation moot. One difference is that this hook includes the top safe area inset in the height, so we need to stop adding that in separately.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [x] Tested on small-screen device (iPod Touch)
- [x] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207515890919849