### PR TITLE
Disallow (no-segwit) split option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: Support for splitting LTC to BTC wallets for recovering BTC erroneously sent to an LTC address
 - added: "Force Light Account Creation" developer mode setting
 - added: Allow promoCards to send promoCodes to fiat partners for special pricing
 - added: Allow promoCard URLs to specify a currency pluginId to have replaced with a public address

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -67,7 +67,7 @@ const CreateWalletSelectCryptoComponent = (props: Props) => {
   const [searchTerm, setSearchTerm] = React.useState('')
 
   const allowedAssets = splitPluginIds.length > 0 ? splitPluginIds.map(pluginId => ({ pluginId, tokenId: null })) : undefined
-  const createList = getCreateWalletList(account, { allowedAssets })
+  const createList = getCreateWalletList(account, { allowedAssets, disableLegacy: splitPluginIds.length > 0 })
 
   const createWalletList = React.useMemo(() => {
     const preselectedList: WalletCreateItem[] = []

--- a/src/selectors/getCreateWalletList.ts
+++ b/src/selectors/getCreateWalletList.ts
@@ -56,10 +56,12 @@ interface CreateWalletListOpts {
   filterActivation?: boolean
   allowedAssets?: EdgeAsset[]
   excludeAssets?: EdgeAsset[]
+  /** Don't return "(no Segwit)" create items */
+  disableLegacy?: boolean
 }
 
 export const getCreateWalletList = (account: EdgeAccount, opts: CreateWalletListOpts = {}): WalletCreateItem[] => {
-  const { filteredWalletList = [], filterActivation, allowedAssets, excludeAssets } = opts
+  const { filteredWalletList = [], filterActivation, allowedAssets, excludeAssets, disableLegacy = false } = opts
 
   // Add top-level wallet types:
   const newWallets: MainWalletCreateItem[] = []
@@ -73,7 +75,7 @@ export const getCreateWalletList = (account: EdgeAccount, opts: CreateWalletList
     // Prevent currencies that needs activation from being created from a modal
     if (filterActivation && requiresActivation(pluginId)) continue
 
-    if (['bitcoin', 'litecoin', 'digibyte'].includes(pluginId)) {
+    if (!disableLegacy && ['bitcoin', 'litecoin', 'digibyte'].includes(pluginId)) {
       newWallets.push({
         type: 'create',
         key: `create-${walletType}-bip49-${pluginId}`,


### PR DESCRIPTION
LTC split: 
<img width="425" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/aa0b9c40-491c-46b6-9dfc-06ceaf7efe72">

Normal create:
<img width="423" alt="image" src="https://github.com/EdgeApp/edge-react-gui/assets/90650827/332b7ed4-dc10-4a6b-a10c-e71e89218ada">

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-currency-plugins/pull/407

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207269774668906