### PR TITLE
WalletConnect: Select wallet before navigating to connect scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - changed: Prefer DEX estimate quotes over CEX fixed rate quotes if the DEX quote has a better rate
 - changed: Light account backup notification card now persists no matter what while logged in to a light account
 - changed: Replaced 'react-native-camera' with 'react-native-vision-camera'
+- changed: WalletConnect: Move initial wallet selection to connections list scene
 - fixed: Stabilize the account sync bar progress motion.
 - fixed: Update Algorand's WalletConnectv2 reference
 - fixed: Slight animation stutter when opening the CountryListModal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed: Slight animation stutter when opening the CountryListModal
 - fixed: Account-level Default Fiat setting not being correctly used in Markets View Scenes
 - fixed: Changing Default Fiat setting does not properly refresh CoinRankingDetailsScene
+- fixed: Call the correct method when rejecting a WalletConnect session
 
 ## 4.8.0
 

--- a/src/components/scenes/WcConnectScene.tsx
+++ b/src/components/scenes/WcConnectScene.tsx
@@ -102,8 +102,8 @@ export const WcConnectScene = (props: Props) => {
     handleWalletListModal().catch(err => showError(err))
   })
 
-  useUnmount(() => {
-    if (!connected.current) wallet.otherMethods.rejectSession(proposal)
+  useUnmount(async () => {
+    if (!connected.current) await walletConnect.rejectSession(proposal)
   })
 
   const renderWalletSelect = () => {

--- a/src/components/scenes/WcConnectScene.tsx
+++ b/src/components/scenes/WcConnectScene.tsx
@@ -4,21 +4,18 @@ import { ScrollView, View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import { sprintf } from 'sprintf-js'
 
-import { selectWalletToken } from '../../actions/WalletActions'
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
 import { MAX_ADDRESS_CHARACTERS } from '../../constants/WalletAndCurrencyConstants'
 import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { useHandler } from '../../hooks/useHandler'
-import { useMount } from '../../hooks/useMount'
 import { useUnmount } from '../../hooks/useUnmount'
 import { useWalletConnect } from '../../hooks/useWalletConnect'
 import { useWalletName } from '../../hooks/useWalletName'
 import { useWatch } from '../../hooks/useWatch'
 import { lstrings } from '../../locales/strings'
-import { useDispatch, useSelector } from '../../types/reactRedux'
+import { useSelector } from '../../types/reactRedux'
 import { EdgeSceneProps } from '../../types/routerTypes'
 import { EdgeAsset } from '../../types/types'
-import { getTokenIdForced } from '../../util/CurrencyInfoHelpers'
 import { truncateString } from '../../util/utils'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { WalletListModal, WalletListResult } from '../modals/WalletListModal'
@@ -36,19 +33,19 @@ interface Props extends EdgeSceneProps<'wcConnect'> {}
 export interface WcConnectParams {
   proposal: Web3WalletTypes.SessionProposal
   edgeTokenIds: EdgeAsset[]
+  walletId: string
 }
 
 export const WcConnectScene = (props: Props) => {
   const { navigation } = props
-  const [selectedWallet, setSelectedWallet] = React.useState({ walletId: '', currencyCode: '' })
   const connected = React.useRef(false)
   const theme = useTheme()
   const styles = getStyles(theme)
-  const { proposal, edgeTokenIds } = props.route.params
+  const { proposal, edgeTokenIds, walletId } = props.route.params
   const [walletAddress, setWalletAddress] = React.useState('')
+  const [selectedWalletId, setSelectedWallet] = React.useState(walletId)
 
   const account = useSelector(state => state.core.account)
-  const selectedWalletId = useSelector(state => state.ui.wallets.selectedWalletId)
   const currencyWallets = useWatch(account, 'currencyWallets')
   const wallet = currencyWallets[selectedWalletId]
   const walletName = useWalletName(wallet)
@@ -71,8 +68,6 @@ export const WcConnectScene = (props: Props) => {
     'WcConnectScene'
   )
 
-  const dispatch = useDispatch()
-
   const handleConnect = async () => {
     try {
       await walletConnect.approveSession(proposal, wallet.id)
@@ -90,16 +85,8 @@ export const WcConnectScene = (props: Props) => {
       <WalletListModal bridge={bridge} headerTitle={lstrings.select_wallet} allowedAssets={edgeTokenIds} showCreateWallet navigation={navigation} />
     ))
     if (result?.type === 'wallet') {
-      const { walletId, currencyCode } = result
-      const wallet = account.currencyWallets[walletId]
-      const tokenId = getTokenIdForced(account, wallet.currencyInfo.pluginId, currencyCode)
-      await dispatch(selectWalletToken({ navigation, walletId, tokenId }))
-      setSelectedWallet({ walletId, currencyCode })
+      setSelectedWallet(result.walletId)
     }
-  })
-
-  useMount(() => {
-    handleWalletListModal().catch(err => showError(err))
   })
 
   useUnmount(async () => {
@@ -107,16 +94,10 @@ export const WcConnectScene = (props: Props) => {
   })
 
   const renderWalletSelect = () => {
-    if (selectedWallet.walletId === '' && selectedWallet.currencyCode === '') {
-      return <SelectableRow title={lstrings.wc_confirm_select_wallet} onPress={handleWalletListModal} />
-    } else {
-      const walletNameStr = truncateString(walletName || '', MAX_ADDRESS_CHARACTERS)
-      const walletImage = (
-        <CryptoIconUi4 pluginId={wallet.currencyInfo.pluginId} tokenId={getTokenIdForced(account, wallet.currencyInfo.pluginId, selectedWallet.currencyCode)} />
-      )
-      const walletAddressStr = truncateString(walletAddress, MAX_ADDRESS_CHARACTERS, true)
-      return <SelectableRow icon={walletImage} subTitle={walletAddressStr} title={walletNameStr} onPress={handleWalletListModal} />
-    }
+    const walletNameStr = truncateString(walletName, MAX_ADDRESS_CHARACTERS)
+    const walletImage = <CryptoIconUi4 pluginId={wallet.currencyInfo.pluginId} tokenId={null} />
+    const walletAddressStr = truncateString(walletAddress, MAX_ADDRESS_CHARACTERS, true)
+    return <SelectableRow icon={walletImage} subTitle={walletAddressStr} title={walletNameStr} onPress={handleWalletListModal} />
   }
 
   return (


### PR DESCRIPTION
Passing a wallet into the scene means we don't need to use redux selected wallet ID

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207574551270982