### PR TITLE
Add "avoidKeyboard" in GuiPluginViewScene, WebViewScene, FiatPluginWebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed: Slight animation stutter when opening the CountryListModal
 - fixed: Account-level Default Fiat setting not being correctly used in Markets View Scenes
 - fixed: Changing Default Fiat setting does not properly refresh CoinRankingDetailsScene
+- fixed: Possible for keyboard to cover input fields in some Android WebViews
 - fixed: Call the correct method when rejecting a WalletConnect session
 
 ## 4.8.0

--- a/src/components/scenes/GuiPluginViewScene.tsx
+++ b/src/components/scenes/GuiPluginViewScene.tsx
@@ -27,7 +27,7 @@ export function GuiPluginViewScene(props: Props): JSX.Element {
   if (checkAndShowLightBackupModal(account, navigation)) navigation.pop()
 
   return (
-    <SceneWrapper hasTabs={route.name !== 'pluginView'}>
+    <SceneWrapper hasTabs={route.name !== 'pluginView'} avoidKeyboard>
       <EdgeProviderComponent plugin={plugin} deepPath={deepPath} deepQuery={deepQuery} navigation={navigation} />
     </SceneWrapper>
   )

--- a/src/components/scenes/WebViewScene.tsx
+++ b/src/components/scenes/WebViewScene.tsx
@@ -15,7 +15,7 @@ export const WebViewScene = (props: Props) => {
   const { uri } = props.route.params
 
   return (
-    <SceneWrapper>
+    <SceneWrapper avoidKeyboard>
       <WebView source={{ uri }} />
     </SceneWrapper>
   )

--- a/src/plugins/gui/scenes/FiatPluginWebView.tsx
+++ b/src/plugins/gui/scenes/FiatPluginWebView.tsx
@@ -41,7 +41,7 @@ export function FiatPluginWebViewComponent(props: Props): JSX.Element {
   })
 
   return (
-    <SceneWrapper hasTabs>
+    <SceneWrapper hasTabs avoidKeyboard>
       <WebView
         allowUniversalAccessFromFileURLs
         geolocationEnabled


### PR DESCRIPTION
BitRefill specifically was going through GuiPluginViewScene, though the fix was applied to various WebViews.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207393172981960