### PR TITLE
Jon/fix/swap-navigation

### DIFF
--- a/src/components/progress-indicators/CircleTimer.tsx
+++ b/src/components/progress-indicators/CircleTimer.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native'
 import React, { useEffect, useRef } from 'react'
 import { View } from 'react-native'
 
@@ -11,9 +12,10 @@ export const TEN_MINUTES = 600
 export const CircleTimer: React.FC<Props> = ({ expiration, timeExpired }) => {
   const componentMounted = useRef(true)
   const timeoutId = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isFocused = useIsFocused()
 
   const timerTick = () => {
-    if (!componentMounted.current) {
+    if (!componentMounted.current || !isFocused) {
       if (timeoutId.current != null) {
         clearTimeout(timeoutId.current)
       }

--- a/src/components/scenes/SwapConfirmationScene.tsx
+++ b/src/components/scenes/SwapConfirmationScene.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native'
 import { add, div, gte, toFixed } from 'biggystring'
 import { EdgeSwapQuote, EdgeSwapResult } from 'edge-core-js'
 import React, { useState } from 'react'
@@ -69,6 +70,8 @@ export const SwapConfirmationScene = (props: Props) => {
 
   const swapRequestOptions = useSwapRequestOptions()
 
+  const isFocused = useIsFocused()
+
   const [selectedQuote, setSelectedQuote] = useState(pickBestQuote(quotes))
   const [calledApprove, setCalledApprove] = useState(false)
 
@@ -108,6 +111,8 @@ export const SwapConfirmationScene = (props: Props) => {
   const showFeeWarning = gte(feePercent, '0.05')
 
   const handleExchangeTimerExpired = useHandler(() => {
+    if (!isFocused) return
+
     navigation.replace('swapProcessing', {
       swapRequest: selectedQuote.request,
       swapRequestOptions,
@@ -200,6 +205,7 @@ export const SwapConfirmationScene = (props: Props) => {
       }, 1)
     }
     setPending(false)
+    await selectedQuote.close()
   }
 
   const renderTimer = () => {


### PR DESCRIPTION
Hack-fix React Navigation bug for swap scenes
- CircleTimer never gets unmounted as expected. Stale timers from prior swaps will keep firing indefinitely.
- SwapConfirmationScene also remains mounted when unfocused, and auto-refreshes with stale data from swaps that never approved can happen from unmounted instances. This can occur when the scene is focused with an unapproved quote, and the Exchange tab is tapped. That *should* fully reset the flow/state to the beginning but no longer does post-nav upgrade.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207613997841638