### PR TITLE
Remove the `getCurrencyInfos` helper function

### DIFF
--- a/src/components/scenes/Loans/LoanDashboardScene.tsx
+++ b/src/components/scenes/Loans/LoanDashboardScene.tsx
@@ -1,4 +1,3 @@
-import { EdgeCurrencyInfo } from 'edge-core-js'
 import * as React from 'react'
 import { ListRenderItemInfo, View } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
@@ -21,7 +20,6 @@ import { useDispatch, useSelector } from '../../../types/reactRedux'
 import { EdgeSceneProps } from '../../../types/routerTypes'
 import { Theme } from '../../../types/Theme'
 import { getBorrowPluginIconUri } from '../../../util/CdnUris'
-import { getCurrencyInfos } from '../../../util/CurrencyInfoHelpers'
 import { LoanSummaryCard } from '../../cards/LoanSummaryCard'
 import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../../common/SceneWrapper'
@@ -128,14 +126,13 @@ export const LoanDashboardScene = (props: Props) => {
       newLoanWallet = currencyWallets[hardPluginWalletIds[0]]
     } else {
       // If the user owns no polygon wallets, auto-create one
-      const filteredCurrencyInfo = SUPPORTED_WALLET_PLUGIN_IDS.reduce((info: EdgeCurrencyInfo | undefined, pluginId) => {
-        if (info != null) return info // Already found
-        return getCurrencyInfos(account).find(currencyInfo => pluginId === currencyInfo.pluginId)
-      }, undefined)
-      if (filteredCurrencyInfo == null) throw new Error(`Could not auto-create wallet of the supported types: ${SUPPORTED_WALLET_PLUGIN_IDS.join(', ')}`)
+      const [createPluginId] = SUPPORTED_WALLET_PLUGIN_IDS.filter(pluginId => account.currencyConfig[pluginId] != null)
+      if (createPluginId == null) {
+        throw new Error(`Could not auto-create wallet of the supported types: ${SUPPORTED_WALLET_PLUGIN_IDS.join(', ')}`)
+      }
       newLoanWallet = await createWallet(account, {
         name: `AAVE Loan Account`,
-        walletType: filteredCurrencyInfo.walletType
+        walletType: account.currencyConfig[createPluginId].currencyInfo.walletType
       })
     }
 

--- a/src/util/CurrencyInfoHelpers.ts
+++ b/src/util/CurrencyInfoHelpers.ts
@@ -1,4 +1,4 @@
-import { EdgeAccount, EdgeCurrencyConfig, EdgeCurrencyInfo, EdgeCurrencyWallet, EdgeToken, EdgeTokenId } from 'edge-core-js'
+import { EdgeAccount, EdgeCurrencyConfig, EdgeCurrencyWallet, EdgeToken, EdgeTokenId } from 'edge-core-js'
 
 import { showError } from '../components/services/AirshipInstance'
 import { SPECIAL_CURRENCY_INFO } from '../constants/WalletAndCurrencyConstants'
@@ -12,14 +12,6 @@ import { EdgeAsset } from '../types/types'
 export function isKeysOnlyPlugin(pluginId: string): boolean {
   const { keysOnlyMode = false } = SPECIAL_CURRENCY_INFO[pluginId] ?? {}
   return keysOnlyMode || ENV.KEYS_ONLY_PLUGINS[pluginId]
-}
-
-/**
- * Grab all the EdgeCurrencyInfo objects in an account.
- */
-export function getCurrencyInfos(account: EdgeAccount): EdgeCurrencyInfo[] {
-  const { currencyConfig = {} } = account
-  return Object.keys(currencyConfig).map(pluginId => currencyConfig[pluginId].currencyInfo)
 }
 
 export const getTokenId = (currencyConfig: EdgeCurrencyConfig, currencyCode: string): EdgeTokenId | undefined => {


### PR DESCRIPTION
Getting rid of this helper function actually leads to simpler code. We were doing a doing a super-inefficient O(n^2) loop when a simple key-value lookup would have been enough.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

It's hard to test this without AAVE being present.

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207670071437624