### PR TITLE
Immediately reload rates as soon as the wallet list changes

### DIFF
--- a/src/components/services/AccountCallbackManager.tsx
+++ b/src/components/services/AccountCallbackManager.tsx
@@ -40,6 +40,7 @@ export function AccountCallbackManager(props: Props) {
   const { account, navigation } = props
   const dispatch = useDispatch()
   const [dirty, setDirty] = React.useState<DirtyList>(notDirty)
+  const numWallets = React.useRef(0)
 
   // Helper for marking wallets dirty:
   function setRatesDirty() {
@@ -52,12 +53,19 @@ export function AccountCallbackManager(props: Props) {
   // Subscribe to the account:
   React.useEffect(() => {
     const cleanups = [
-      account.watch('currencyWallets', () =>
+      account.watch('currencyWallets', () => {
+        let ratesDirty: true | undefined
+        const numW = Object.keys(account.currencyWallets).length
+        if (numWallets.current !== numW) {
+          numWallets.current = numW
+          ratesDirty = true
+        }
         setDirty(dirty => ({
           ...dirty,
-          walletList: true
+          walletList: true,
+          rates: ratesDirty ?? dirty.rates
         }))
-      ),
+      }),
 
       account.watch('loggedIn', () => {
         if (!account.loggedIn) {


### PR DESCRIPTION
This ensures we get rates as soon as the wallets are loaded and we don't wait until the next 30s rates query.

On the iOS simulator, this PR changes the amount of time for the Total Balance card to show a balance from 25s to 4s

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207749579877501