### PR TITLE
Restore missing receive drop-down

### DIFF
--- a/src/actions/ReceiveDropdown.tsx
+++ b/src/actions/ReceiveDropdown.tsx
@@ -7,7 +7,6 @@ import { FlashNotification } from '../components/navigation/FlashNotification'
 import { Airship, showError } from '../components/services/AirshipInstance'
 import { lstrings } from '../locales/strings'
 import { getExchangeDenom, selectDisplayDenom } from '../selectors/DenominationSelectors'
-import { useSelector } from '../types/reactRedux'
 import { ThunkAction } from '../types/reduxTypes'
 import { NavigationBase } from '../types/routerTypes'
 import { calculateSpamThreshold, convertNativeToDisplay, zeroString } from '../util/utils'
@@ -29,7 +28,7 @@ export function showReceiveDropdown(navigation: NavigationBase, transaction: Edg
     const wallet = account.currencyWallets[walletId]
     if (wallet == null) return
 
-    const isoFiatCurrencyCode = useSelector(state => state.ui.settings.defaultIsoFiat)
+    const isoFiatCurrencyCode = state.ui.settings.defaultIsoFiat
 
     // Never stack dropdowns:
     if (receiveDropdownShowing) return


### PR DESCRIPTION
We can't use `useSelector` in a redux action.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207760128838465