### PR TITLE
Increase our minimum MacOS version to 13.0

### DIFF
--- a/ios/edge/Info.plist
+++ b/ios/edge/Info.plist
@@ -75,6 +75,8 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
 	<key>NFCReaderUsageDescription</key>
 	<string>$(PRODUCT_NAME) does not use NFC.</string>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
We received an App Store warning about this. Destop arm64 users need to have a correct version number. Without this info, the App store auto-guesses the supported version.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

The only way to test this is to upload a version to the store.

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207653199428272