### PR TITLE
Fix login routing 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - fixed: Broken link in "Help Closing App"
 - fixed: Incorrect best quote picking for sell plugins
 
+## 4.9.1
+
+- fixed: Possible to get stuck on account creation flow with specific navigation steps
+
 ## 4.9.0
 
 - added: Support for Universal and App Links

--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -97,7 +97,7 @@ export const GettingStartedScene = (props: Props) => {
 
   // Route helpers
   const visitPasswordScene = (): void =>
-    navigation.navigate('login', {
+    navigation.replace('login', {
       loginUiInitialRoute: lightAccounts ? 'login-password-light' : 'login-password',
       experimentConfig
     })
@@ -142,7 +142,7 @@ export const GettingStartedScene = (props: Props) => {
   })
 
   const handlePressSkip = useHandler(() => {
-    navigation.navigate('login', { experimentConfig })
+    navigation.replace('login', { experimentConfig })
   })
 
   // Redirect to login or new account screen if the user swipes past the last

--- a/src/components/scenes/LoginScene.tsx
+++ b/src/components/scenes/LoginScene.tsx
@@ -126,7 +126,7 @@ export function LoginSceneComponent(props: Props) {
 
   const maybeHandleComplete = ENV.USE_WELCOME_SCREENS
     ? () => {
-        navigation.navigate('gettingStarted', { experimentConfig })
+        navigation.replace('gettingStarted', { experimentConfig })
       }
     : undefined
 


### PR DESCRIPTION
Ensure we always only have either login or gui stacks mounted

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207848254943124