### PR TITLE
Fix EdgeCarousel's first render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - fixed: Buying non-BTC assets with Bity
 - fixed: Misc styling fixes on SepaFormScene and AddressFormScene
 - fixed: Pressing back during native fiat buy/sell flows results in stuck button spinners
+- fixed: Promo cards not visible until scroll for new accounts
 
 ## 4.9.2 (2024-07-22)
 

--- a/src/components/common/EdgeCarousel.tsx
+++ b/src/components/common/EdgeCarousel.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
-import { ListRenderItem, View } from 'react-native'
+import { InteractionManager, ListRenderItem, View } from 'react-native'
 import Carousel, { Pagination } from 'react-native-snap-carousel'
 
+import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { useHandler } from '../../hooks/useHandler'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 
@@ -24,13 +25,28 @@ export function EdgeCarousel<T>(props: Props<T>): JSX.Element {
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const carouselRef = React.useRef(null)
+  const carouselRef = React.useRef<Carousel<any>>(null)
 
   const [activeIndex, setActiveIndex] = useState(0)
 
   const renderItem = useHandler<ListRenderItem<T>>(info => (
     <View style={[styles.childContainer, { width: width * 0.9, height }]}>{props.renderItem(info)}</View>
   ))
+
+  /**
+   * Carousel's FlatList bug workaround
+   */
+  useAsyncEffect(
+    async () => {
+      if (carouselRef.current != null) {
+        await InteractionManager.runAfterInteractions(() => {
+          carouselRef.current?.triggerRenderingHack()
+        })
+      }
+    },
+    [],
+    'triggerRenderingHack'
+  )
 
   return (
     <View style={styles.carouselContainer}>


### PR DESCRIPTION
A known issue with a built-in workaround for `react-native-snap-carousel.`

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207973610789783