### PR TITLE
Fix FilledTextInput using `autoCapitalize` for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - fixed: Buying non-BTC assets with Bity
 - fixed: Misc styling fixes on SepaFormScene and AddressFormScene
 - fixed: Pressing back during native fiat buy/sell flows results in stuck button spinners
+- fixed: Broken Android paste into `TextInputModal` in "ScanQR" -> "Enter" 
 - fixed: Promo cards not visible until scroll for new accounts
 
 ## 4.9.2 (2024-07-22)

--- a/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
@@ -133,7 +133,6 @@ exports[`FilledTextInput should render with some props 1`] = `
               "value": 1,
             }
           }
-          secureTextEntry={false}
           selectionColor="#FFFFFF"
           testID="string.textInput"
           textAlignVertical="top"

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -621,7 +621,6 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 "value": 1,
               }
             }
-            secureTextEntry={false}
             selectionColor="#FFFFFF"
             style={
               [
@@ -2009,7 +2008,6 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                 "value": 1,
               }
             }
-            secureTextEntry={false}
             selectionColor="#FFFFFF"
             style={
               [

--- a/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
@@ -364,7 +364,6 @@ exports[`CountryListModal should render with a country list 1`] = `
                 "value": 1,
               }
             }
-            secureTextEntry={false}
             selectionColor="#FFFFFF"
             style={
               [

--- a/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
@@ -414,7 +414,6 @@ exports[`LogsModal should render with a logs modal 1`] = `
                     "value": 1,
                   }
                 }
-                secureTextEntry={false}
                 selectionColor="#FFFFFF"
                 style={
                   [

--- a/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
@@ -324,7 +324,6 @@ exports[`TextInputModal should render with a blank input field 1`] = `
                   "value": 1,
                 }
               }
-              secureTextEntry={false}
               selectionColor="#FFFFFF"
               style={
                 [
@@ -886,7 +885,6 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                   "value": 1,
                 }
               }
-              secureTextEntry={false}
               selectionColor="#FFFFFF"
               style={
                 [

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -581,7 +581,6 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                   "value": 1,
                 }
               }
-              secureTextEntry={false}
               selectionColor="#FFFFFF"
               style={
                 [

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -558,7 +558,6 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                 "value": 1,
               }
             }
-            secureTextEntry={false}
             selectionColor="#FFFFFF"
             style={
               [

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -67,7 +67,8 @@ export interface FilledTextInputBaseProps extends MarginRemProps {
   maxLength?: number
   onSubmitEditing?: () => void
   returnKeyType?: FilledTextInputReturnKeyType // Defaults to 'done'
-  secureTextEntry?: boolean // Defaults to 'false'
+
+  secureTextEntry?: boolean
   testID?: string
 
   // Unless 'autoFocus' is passed explicitly in the props, Search Bars 'autoFocus' and 'regular' text inputs don't.
@@ -292,7 +293,7 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
               autoComplete={autoComplete}
               blurOnSubmit={multiline ? false : blurOnSubmit}
               inputAccessoryViewID={inputAccessoryViewID}
-              secureTextEntry={hidePassword}
+              secureTextEntry={secureTextEntry === true ? hidePassword : undefined}
               numberOfLines={multiline ? 20 : undefined}
             />
             {suffix == null ? null : <SuffixText>{suffix}</SuffixText>}


### PR DESCRIPTION
In Android, TextInput context menus break specifically when setting both `autoCapitalize="none"` and `secureTextEntry=false`

Ensure we always keep `secureTextEntry` on the React Native component `undefined` unless explicitly true.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
