### PR TITLE
Fix Android TransactionList Scroll Gestures

### DIFF
--- a/src/components/scenes/TransactionListScene.tsx
+++ b/src/components/scenes/TransactionListScene.tsx
@@ -1,7 +1,7 @@
 import { EdgeCurrencyWallet, EdgeTokenId, EdgeTokenMap, EdgeTransaction } from 'edge-core-js'
 import { AssetStatus } from 'edge-info-server'
 import * as React from 'react'
-import { ListRenderItemInfo, View } from 'react-native'
+import { ListRenderItemInfo, Platform, RefreshControl, View } from 'react-native'
 import { getVersion } from 'react-native-device-info'
 import Animated from 'react-native-reanimated'
 
@@ -187,6 +187,23 @@ function TransactionListComponent(props: Props) {
   // Renderers
   //
 
+  /**
+   * HACK: This `RefreshControl` doesn't actually do anything visually or
+   * functionally noticeable besides making Android scroll gestures actually
+   * work for the parent `Animated.FlatList`
+   */
+  const refreshControl = React.useMemo(() => {
+    return Platform.OS === 'ios' ? undefined : (
+      <RefreshControl
+        refreshing={false}
+        enabled={false}
+        style={{ opacity: 0 }}
+        // useHandler isn't needed, since we're already in useMemo:
+        onRefresh={() => {}}
+      />
+    )
+  }, [])
+
   const topArea = React.useMemo(() => {
     return (
       <>
@@ -316,6 +333,9 @@ function TransactionListComponent(props: Props) {
             onEndReached={handleScrollEnd}
             onScroll={handleScroll}
             scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
+            // Android scroll gestures break without refreshControl given the
+            // combination of props we use on this Animated.FlatList.
+            refreshControl={refreshControl}
           />
         </View>
       )}


### PR DESCRIPTION
Broken after removing the "drag down to search" feature.

Reinstate a gutted `refreshControl` to `Animated.FlatList` props

Several props are populated on this component, any of them could be causing some sort of Android-specific conflict.

Since we _do_ know that this broken when refreshControl was removed, just add it back with no functionality.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208100508540956