### PR TITLE
2nd pass of unecessary showErrors on scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- changed: Some unecessary `showError` dropdowns demoted to hidden `showDevError`
 - removed: 'fasterpayments' payment type
 
 ## 4.12.0

--- a/src/components/scenes/Fio/FioAddressRegisterSelectWalletScene.tsx
+++ b/src/components/scenes/Fio/FioAddressRegisterSelectWalletScene.tsx
@@ -23,7 +23,7 @@ import { withWallet } from '../../hoc/withWallet'
 import { ButtonsModal } from '../../modals/ButtonsModal'
 import { WalletListModal, WalletListResult } from '../../modals/WalletListModal'
 import { EdgeRow } from '../../rows/EdgeRow'
-import { Airship, showError } from '../../services/AirshipInstance'
+import { Airship, showDevError, showError } from '../../services/AirshipInstance'
 import { cacheStyles, Theme, ThemeProps, withTheme } from '../../services/ThemeContext'
 import { EdgeText } from '../../themed/EdgeText'
 
@@ -97,8 +97,8 @@ export class FioAddressRegisterSelectWallet extends React.Component<Props, Local
         )
         this.setState({ activationCost, bitpayUrl, feeValue, supportedAssets: [...supportedAssets, { pluginId: 'fio', tokenId: null }], paymentInfo })
       } catch (e: any) {
-        showError(e)
-        this.setState({ errorMessage: e.message })
+        showDevError(String(e))
+        this.setState({ errorMessage: String(e) })
       }
     }
 

--- a/src/components/scenes/Fio/FioRequestConfirmationScene.tsx
+++ b/src/components/scenes/Fio/FioRequestConfirmationScene.tsx
@@ -27,7 +27,7 @@ import { AddressModal } from '../../modals/AddressModal'
 import { ButtonsModal } from '../../modals/ButtonsModal'
 import { TextInputModal } from '../../modals/TextInputModal'
 import { EdgeRow } from '../../rows/EdgeRow'
-import { Airship, showError, showToast } from '../../services/AirshipInstance'
+import { Airship, showDevError, showError, showToast } from '../../services/AirshipInstance'
 import { cacheStyles, Theme, ThemeProps, useTheme } from '../../services/ThemeContext'
 import { ExchangedFlipInputAmounts } from '../../themed/ExchangedFlipInput2'
 import { SceneHeader } from '../../themed/SceneHeader'
@@ -87,7 +87,7 @@ export class FioRequestConfirmationConnected extends React.Component<Props, Stat
   }
 
   componentDidMount() {
-    this.setAddressesState().catch(err => showError(err))
+    this.setAddressesState().catch(err => showDevError(err))
   }
 
   setAddressesState = async () => {
@@ -211,9 +211,7 @@ export class FioRequestConfirmationConnected extends React.Component<Props, Stat
       } catch (error: any) {
         this.setState({ loading: false })
         this.resetSlider()
-        showError(
-          `${lstrings.fio_request_error_header}. ${error.json && error.json.fields && error.json.fields[0] ? JSON.stringify(error.json.fields[0].error) : ''}`
-        )
+        showError(`${lstrings.fio_request_error_header}: "${error.json?.fields?.[0]?.error ?? ''}"`)
       }
     } else {
       showError(lstrings.fio_wallet_missing_for_fio_address)

--- a/src/components/scenes/LoginScene.tsx
+++ b/src/components/scenes/LoginScene.tsx
@@ -20,7 +20,7 @@ import { EdgeSceneProps } from '../../types/routerTypes'
 import { logEvent } from '../../util/tracking'
 import { DotsBackground } from '../common/DotsBackground'
 import { showHelpModal } from '../modals/HelpModal'
-import { showError } from '../services/AirshipInstance'
+import { showDevError, showError } from '../services/AirshipInstance'
 import { LoadingScene } from './LoadingScene'
 
 export interface LoginParams {
@@ -98,7 +98,7 @@ export function LoginScene(props: Props) {
     () => ({
       callback() {
         Keyboard.dismiss()
-        showHelpModal(navigation).catch(err => showError(err))
+        showHelpModal(navigation).catch(err => showDevError(err))
       },
       text: lstrings.string_help
     }),

--- a/src/components/scenes/SettingsScene.tsx
+++ b/src/components/scenes/SettingsScene.tsx
@@ -39,7 +39,7 @@ import { SectionView } from '../layout/SectionView'
 import { AutoLogoutModal } from '../modals/AutoLogoutModal'
 import { ConfirmContinueModal } from '../modals/ConfirmContinueModal'
 import { TextInputModal } from '../modals/TextInputModal'
-import { Airship, showError } from '../services/AirshipInstance'
+import { Airship, showDevError, showError } from '../services/AirshipInstance'
 import { changeTheme, useTheme } from '../services/ThemeContext'
 import { SettingsHeaderRow } from '../settings/SettingsHeaderRow'
 import { SettingsLabelRow } from '../settings/SettingsLabelRow'
@@ -204,7 +204,7 @@ export const SettingsScene = (props: Props) => {
           await account.deleteRemoteAccount()
           await dispatch(logoutRequest(navigation))
           await context.forgetAccount(rootLoginId)
-          Airship.show(bridge => <TextDropdown bridge={bridge} message={sprintf(lstrings.delete_account_feedback, username)} />).catch(err => showError(err))
+          Airship.show(bridge => <TextDropdown bridge={bridge} message={sprintf(lstrings.delete_account_feedback, username)} />).catch(err => showDevError(err))
           return true
         }}
       />

--- a/src/components/scenes/Staking/StakeModifyScene.tsx
+++ b/src/components/scenes/Staking/StakeModifyScene.tsx
@@ -33,7 +33,7 @@ import { FlipInputModal2, FlipInputModalResult } from '../../modals/FlipInputMod
 import { FlashNotification } from '../../navigation/FlashNotification'
 import { FillLoader } from '../../progress-indicators/FillLoader'
 import { EdgeRow } from '../../rows/EdgeRow'
-import { Airship, showError } from '../../services/AirshipInstance'
+import { Airship, showDevError, showError } from '../../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../../services/ThemeContext'
 import { Alert } from '../../themed/Alert'
 import { EdgeText } from '../../themed/EdgeText'
@@ -150,7 +150,7 @@ const StakeModifySceneComponent = (props: Props) => {
                   setErrorMessage(errMessage)
                 })
                 .catch(err => {
-                  showError(err)
+                  showDevError(err)
                   setErrorMessage(errMessage)
                 })
             } else {


### PR DESCRIPTION
Often we are already showing some sort of error on the scene itself, or the error is attached to a simple info-only situation

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207474082380292