### PR TITLE
Jon/dropdown-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # edge-react-gui
 
+- added: `ExpandableList` component, replacing the address hint dropdown in `AddressFormScene`
+- fixed: Inconsistent content of address hint dropdown between iOS and Android in `AddressFormScene`
+- fixed: Inconsistent corners in `SideMenu`
+
 ## Unreleased
 
 - added: Add 'Free Talk Live' and 'Crypto Canal' options to survey modal

--- a/src/components/common/ExpandableList.tsx
+++ b/src/components/common/ExpandableList.tsx
@@ -1,43 +1,38 @@
-/**
- * IMPORTANT: Changes in this file MUST be synced between edge-react-gui and
- * edge-login-ui-rn!
- */
-
 import * as React from 'react'
-import { ScrollView, View } from 'react-native'
+import { Platform, ScrollView, View, ViewStyle } from 'react-native'
+import { AirshipBridge } from 'react-native-airship'
+import { ShadowedView } from 'react-native-fast-shadow'
 import { cacheStyles } from 'react-native-patina'
 import Animated, { Easing, useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated'
 
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
+import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { GradientFadeOut } from '../modals/GradientFadeout'
+import { Airship } from '../services/AirshipInstance'
 import { Theme, useTheme } from '../services/ThemeContext'
 
 interface Props {
   isExpanded: boolean
   items: React.ReactNode[]
-  itemHeight: number
-  /** Defaults to 4.75. */
+  /** Defaults to 4.75 */
   maxDisplayedItems?: number
-  /** Defaults to full scene width. If specified, is left-justified with
-   * built-in 0.5rem margins on the specified width. */
+  /** If not provided, defaults to full screen width. Whether set or not, 0.5rem
+   * margins are applied. */
   widthRem?: number
 }
 
-export const ExpandableList = ({ isExpanded, items, itemHeight, maxDisplayedItems = 4.75, widthRem }: Props) => {
+export const ExpandableList = (props: Props) => {
+  const { isExpanded, items, maxDisplayedItems = 4.75, widthRem } = props
+
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const [isAnimateItemsNumChange, setIsAnimateItemsNumChange] = React.useState(false)
+  const [localBridge, setLocalBridge] = React.useState<AirshipBridge<undefined>>()
+  const [itemHeight, setItemHeight] = React.useState(0)
+  const [dropdownLayoutStyle, setDropdownLayoutStyle] = React.useState<ViewStyle | null>()
 
-  const widthStyle = React.useMemo(
-    () =>
-      widthRem != null
-        ? {
-            width: theme.rem(widthRem)
-          }
-        : undefined,
-    [theme, widthRem]
-  )
+  /** To measure the positioning and width of the anchor view */
+  const anchorViewRef = React.useRef<View>(null)
 
   const sAnimationMult = useSharedValue(0)
 
@@ -45,48 +40,129 @@ export const ExpandableList = ({ isExpanded, items, itemHeight, maxDisplayedItem
     return itemHeight * Math.min(items.length, maxDisplayedItems)
   })
 
-  const aContainerStyle = useAnimatedStyle(() => ({
-    height: withTiming(dFinalHeight.value * sAnimationMult.value, {
-      duration: isAnimateItemsNumChange ? 250 : 0,
+  const aContainerHeightStyle = useAnimatedStyle(() => ({
+    height: withTiming(isExpanded ? dFinalHeight.value : 0, {
+      duration: 250,
       easing: Easing.inOut(Easing.circle)
     }),
     opacity: isExpanded && items.length > 0 ? sAnimationMult.value : withTiming(0, { duration: 500 })
   }))
 
-  React.useEffect(() => {
-    sAnimationMult.value = withTiming(isExpanded ? 1 : 0, {
-      duration: 500,
-      easing: Easing.inOut(Easing.circle)
-    })
-  }, [sAnimationMult, isExpanded])
+  const aFadeoutStyle = useAnimatedStyle(() => {
+    const isShowFade = items.length > maxDisplayedItems && isExpanded
+    return {
+      opacity: isShowFade ? withTiming(1, { duration: 500 }) : withTiming(0, { duration: 250 }),
+      height: isShowFade ? withTiming(48, { duration: 500 }) : withTiming(0, { duration: 250 })
+    }
+  })
 
+  useAsyncEffect(
+    async () => {
+      if (dropdownLayoutStyle == null || itemHeight === 0) return
+
+      sAnimationMult.value = withTiming(isExpanded ? 1 : 0, {
+        duration: 500,
+        easing: Easing.inOut(Easing.circle)
+      })
+
+      if (isExpanded && items.length > 0) {
+        if (localBridge != null) {
+          localBridge.resolve(undefined)
+        }
+
+        await Airship.show<undefined>(bridge => {
+          setLocalBridge(bridge)
+
+          return (
+            <Animated.View style={[styles.dropdownContainer, aContainerHeightStyle, dropdownLayoutStyle]}>
+              <ShadowedView style={[styles.shadowViewStyle, Platform.OS === 'android' && styles.shadowViewStyleAndroidAdjust]}>
+                <ScrollView keyboardShouldPersistTaps="always" style={styles.scrollContainer} scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}>
+                  {items}
+                </ScrollView>
+                {!isExpanded ? null : (
+                  <Animated.View style={[styles.fadeoutContainer, aFadeoutStyle]}>
+                    <GradientFadeOut />
+                  </Animated.View>
+                )}
+              </ShadowedView>
+            </Animated.View>
+          )
+        })
+      } else {
+        localBridge?.resolve(undefined)
+      }
+
+      // Cleanup
+      return () => {
+        localBridge?.resolve(undefined)
+      }
+    },
+    [sAnimationMult, isExpanded, items, dropdownLayoutStyle, itemHeight],
+    'ExpandableList'
+  )
+
+  // Measure the anchor view position and width
   React.useEffect(() => {
-    setIsAnimateItemsNumChange(isExpanded)
-  }, [items, isExpanded])
+    if (anchorViewRef.current != null) {
+      anchorViewRef.current.measureInWindow((x, y, width, height) => {
+        // iOS and Android return various garbage values initially.
+        // We expect positive nonzero values. We can always safely omit 0 values
+        // because we guarantee some amount of margin under correct UI design
+        if (x <= 0 || y <= 0 || width <= 0) return
+
+        setDropdownLayoutStyle({ left: x, top: Platform.OS === 'android' ? y + 25 : y, width: widthRem == null ? width : theme.rem(widthRem) })
+      })
+    }
+  }, [dropdownLayoutStyle, anchorViewRef, theme, isExpanded, widthRem])
+
+  const handleRowLayout = (event: { nativeEvent: { layout: { height: number } } }) => {
+    if (event != null && itemHeight === 0) {
+      const { height } = event.nativeEvent.layout
+      setItemHeight(height)
+    }
+  }
 
   return (
-    <View style={styles.relativeContainer}>
-      <Animated.View style={[styles.dropdownContainer, widthStyle, aContainerStyle]}>
-        <ScrollView keyboardShouldPersistTaps="always" nestedScrollEnabled scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}>
-          {items}
-        </ScrollView>
-        <GradientFadeOut />
-      </Animated.View>
+    <View ref={anchorViewRef} style={styles.anchorContainer} collapsable={false}>
+      {items.length === 0 ? null : (
+        <View style={styles.dummyMeasureContainer} onLayout={handleRowLayout}>
+          {items[0]}
+        </View>
+      )}
     </View>
   )
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
-  relativeContainer: {
-    position: 'relative',
-    zIndex: 1
+  anchorContainer: {
+    marginHorizontal: theme.rem(0.5)
   },
   dropdownContainer: {
     position: 'absolute',
-    top: '100%',
-    backgroundColor: theme.modal,
+    borderRadius: theme.rem(0.5)
+  },
+  dummyMeasureContainer: {
+    position: 'absolute',
+    opacity: 0
+  },
+  fadeoutContainer: {
+    position: 'absolute',
+    right: 0,
+    left: 0,
+    bottom: 0,
+    borderBottomLeftRadius: theme.rem(0.5),
+    borderBottomRightRadius: theme.rem(0.5),
+    overflow: 'hidden'
+  },
+  scrollContainer: {
+    flexGrow: 1
+  },
+  shadowViewStyle: {
     borderRadius: theme.rem(0.5),
-    left: theme.rem(0.5),
-    right: theme.rem(0.5)
+    backgroundColor: theme.modal,
+    ...theme.dropdownListShadow
+  },
+  shadowViewStyleAndroidAdjust: {
+    shadowOpacity: 0.1
   }
 }))

--- a/src/components/common/ExpandableList.tsx
+++ b/src/components/common/ExpandableList.tsx
@@ -1,0 +1,92 @@
+/**
+ * IMPORTANT: Changes in this file MUST be synced between edge-react-gui and
+ * edge-login-ui-rn!
+ */
+
+import * as React from 'react'
+import { ScrollView, View } from 'react-native'
+import { cacheStyles } from 'react-native-patina'
+import Animated, { Easing, useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated'
+
+import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
+import { GradientFadeOut } from '../modals/GradientFadeout'
+import { Theme, useTheme } from '../services/ThemeContext'
+
+interface Props {
+  isExpanded: boolean
+  items: React.ReactNode[]
+  itemHeight: number
+  /** Defaults to 4.75. */
+  maxDisplayedItems?: number
+  /** Defaults to full scene width. If specified, is left-justified with
+   * built-in 0.5rem margins on the specified width. */
+  widthRem?: number
+}
+
+export const ExpandableList = ({ isExpanded, items, itemHeight, maxDisplayedItems = 4.75, widthRem }: Props) => {
+  const theme = useTheme()
+  const styles = getStyles(theme)
+
+  const [isAnimateItemsNumChange, setIsAnimateItemsNumChange] = React.useState(false)
+
+  const widthStyle = React.useMemo(
+    () =>
+      widthRem != null
+        ? {
+            width: theme.rem(widthRem)
+          }
+        : undefined,
+    [theme, widthRem]
+  )
+
+  const sAnimationMult = useSharedValue(0)
+
+  const dFinalHeight = useDerivedValue(() => {
+    return itemHeight * Math.min(items.length, maxDisplayedItems)
+  })
+
+  const aContainerStyle = useAnimatedStyle(() => ({
+    height: withTiming(dFinalHeight.value * sAnimationMult.value, {
+      duration: isAnimateItemsNumChange ? 250 : 0,
+      easing: Easing.inOut(Easing.circle)
+    }),
+    opacity: isExpanded && items.length > 0 ? sAnimationMult.value : withTiming(0, { duration: 500 })
+  }))
+
+  React.useEffect(() => {
+    sAnimationMult.value = withTiming(isExpanded ? 1 : 0, {
+      duration: 500,
+      easing: Easing.inOut(Easing.circle)
+    })
+  }, [sAnimationMult, isExpanded])
+
+  React.useEffect(() => {
+    setIsAnimateItemsNumChange(isExpanded)
+  }, [items, isExpanded])
+
+  return (
+    <View style={styles.relativeContainer}>
+      <Animated.View style={[styles.dropdownContainer, widthStyle, aContainerStyle]}>
+        <ScrollView keyboardShouldPersistTaps="always" nestedScrollEnabled scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}>
+          {items}
+        </ScrollView>
+        <GradientFadeOut />
+      </Animated.View>
+    </View>
+  )
+}
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  relativeContainer: {
+    position: 'relative',
+    zIndex: 1
+  },
+  dropdownContainer: {
+    position: 'absolute',
+    top: '100%',
+    backgroundColor: theme.modal,
+    borderRadius: theme.rem(0.5),
+    left: theme.rem(0.5),
+    right: theme.rem(0.5)
+  }
+}))

--- a/src/components/scenes/DevTestScene.tsx
+++ b/src/components/scenes/DevTestScene.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native'
 import { addBreadcrumb, captureException } from '@sentry/react-native'
 import { eq } from 'biggystring'
 import { InsufficientFundsError } from 'edge-core-js'
@@ -11,9 +12,10 @@ import { Fontello } from '../../assets/vector'
 import { ENV } from '../../env'
 import { useSelectedWallet } from '../../hooks/useSelectedWallet'
 import { lstrings } from '../../locales/strings'
+import { HomeAddress } from '../../types/FormTypes'
 import { useState } from '../../types/reactHooks'
 import { useDispatch } from '../../types/reactRedux'
-import { EdgeSceneProps } from '../../types/routerTypes'
+import { EdgeSceneProps, NavigationBase } from '../../types/routerTypes'
 import { parseDeepLink } from '../../util/DeepLinkParser'
 import { consify } from '../../util/utils'
 import { ButtonsView } from '../buttons/ButtonsView'
@@ -112,6 +114,27 @@ export function DevTestScene(props: Props) {
     )).catch(error => console.log(error))
   }
 
+  const navigation2 = useNavigation<NavigationBase>()
+
+  const handleAddressFormPress = () => {
+    navigation2.navigate('buyTab', {
+      screen: 'guiPluginAddressForm',
+      params: {
+        // Add any necessary props here
+        countryCode: 'US',
+        headerTitle: 'Address Form',
+        onSubmit: async (homeAddress: HomeAddress) => {
+          console.log('Address submitted:', homeAddress)
+          // Handle the submitted address
+        },
+        onClose: () => {
+          console.log('Address form closed')
+          // Handle closing the form
+        }
+      }
+    })
+  }
+
   const coreWallet = selectedWallet?.wallet
   let balance = coreWallet?.balanceMap.get(tokenId) ?? ''
   if (eq(balance, '0')) balance = ''
@@ -132,6 +155,10 @@ export function DevTestScene(props: Props) {
       <SceneHeaderUi4 title="Scene Header" />
       <SceneHeader title="Scene Header (Legacy)" underline />
       <SectionView>
+        <>
+          <SectionHeader leftTitle="Scenes" />
+          <EdgeButton label="AddressFormScene" onPress={handleAddressFormPress} marginRem={0.5} />
+        </>
         <>
           <SectionHeader leftTitle="Modals" rightNode={<EdgeText>Galore</EdgeText>} />
           <EdgeButton

--- a/src/components/themed/SideMenu.tsx
+++ b/src/components/themed/SideMenu.tsx
@@ -176,7 +176,6 @@ export function SideMenu(props: DrawerContentComponentProps) {
   // Track the destination height of the dropdown
   const userListDesiredHeight = styles.rowContainer.height * sortedUsers.length + theme.rem(1)
   const userListHeight = Math.min(userListDesiredHeight, bottomPanelHeight)
-  const isUserListHeightOverflowing = userListDesiredHeight >= bottomPanelHeight
 
   // Height value above can change if users are added/removed
   const sMaxHeight = useSharedValue(userListHeight)
@@ -196,11 +195,6 @@ export function SideMenu(props: DrawerContentComponentProps) {
 
   /// ---- Dynamic CSS ----
 
-  const themeRem2 = theme.rem(2) // We cannot call theme.rem from within worklet
-  const aBorderBottomRightRadius = useAnimatedStyle(() => ({
-    // Use a easeInCirc easing function for the border transition
-    borderBottomRightRadius: isUserListHeightOverflowing ? themeRem2 - themeRem2 * (1 - Math.sqrt(1 - sAnimationMult.value ** 4)) : themeRem2
-  }))
   const aDropdown = useAnimatedStyle(() => ({
     height: sMaxHeight.value * sAnimationMult.value
   }))
@@ -320,7 +314,7 @@ export function SideMenu(props: DrawerContentComponentProps) {
 
   const usernameDropdown = (
     <>
-      <Animated.View style={[styles.dropContainer, aBorderBottomRightRadius, aDropdown]}>
+      <Animated.View style={[styles.dropContainer, aDropdown]}>
         <ScrollView scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}>
           {sortedUsers.map(userInfo => (
             <View key={userInfo.loginId} style={styles.rowContainer}>
@@ -472,7 +466,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   // Animation
   dropContainer: {
     backgroundColor: theme.modal,
-    borderBottomLeftRadius: theme.rem(2),
+    borderBottomLeftRadius: theme.rem(1),
     zIndex: 2,
     position: 'absolute',
     width: '100%'
@@ -498,7 +492,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
     position: 'absolute',
     height: '100%',
     width: '100%',
-    borderBottomLeftRadius: theme.rem(2),
+    borderBottomLeftRadius: theme.rem(1),
     zIndex: 1
   }
 }))

--- a/src/plugins/gui/scenes/AddressFormScene.tsx
+++ b/src/plugins/gui/scenes/AddressFormScene.tsx
@@ -80,6 +80,7 @@ export const AddressFormScene = React.memo((props: Props) => {
   const mounted = React.useRef<boolean>(true)
 
   const addressHintPress = (selectedAddressHint: HomeAddress) => () => {
+    handleHideAddressHints()
     setFormData({ ...selectedAddressHint })
     if (rAddressInput.current != null) {
       rAddressInput.current.blur()
@@ -243,7 +244,7 @@ export const AddressFormScene = React.memo((props: Props) => {
         onFocus={handleShowAddressHints}
         onBlur={handleHideAddressHints}
       />
-      <ExpandableList isExpanded={isHintsDropped} items={addressHints} maxDisplayedItems={MAX_DISPLAYED_HINTS} itemHeight={hintHeight} />
+      <ExpandableList isExpanded={isHintsDropped} items={addressHints} maxDisplayedItems={MAX_DISPLAYED_HINTS} />
       <GuiFormField
         fieldType="address2"
         label={lstrings.form_field_title_address_line_2}

--- a/src/plugins/gui/scenes/AddressFormScene.tsx
+++ b/src/plugins/gui/scenes/AddressFormScene.tsx
@@ -95,18 +95,19 @@ export const AddressFormScene = React.memo((props: Props) => {
 
   const addressHints = React.useMemo(() => {
     return searchResults.map(searchResult => {
-      const displaySearchResult = `${searchResult.address}\n${searchResult.city}, ${searchResult.state}, ${countryCode}`
+      const displaySearchResult1 = searchResult.address
+      const displaySearchResult2 = `${searchResult.city}, ${searchResult.state}, ${countryCode}`
+
       return (
         <EdgeTouchableOpacity key={searchResults.indexOf(searchResult)} onPress={addressHintPress(searchResult)}>
           <View style={styles.rowContainer} onLayout={handleHintLayout}>
-            <EdgeText style={styles.addressHintText} numberOfLines={2}>
-              {displaySearchResult}
-            </EdgeText>
+            <EdgeText>{displaySearchResult1}</EdgeText>
+            <EdgeText>{displaySearchResult2}</EdgeText>
           </View>
         </EdgeTouchableOpacity>
       )
     })
-  }, [searchResults, countryCode, addressHintPress, handleHintLayout, styles.rowContainer, styles.addressHintText])
+  }, [searchResults, countryCode, addressHintPress, handleHintLayout, styles.rowContainer])
 
   const handleShowAddressHints = useHandler(() => {
     setIsHintsDropped(true)
@@ -305,10 +306,6 @@ export const AddressFormScene = React.memo((props: Props) => {
 
 const getStyles = cacheStyles((theme: Theme) => {
   return {
-    addressHintText: {
-      marginHorizontal: theme.rem(0.5),
-      marginVertical: theme.rem(0.25)
-    },
     container: {
       paddingTop: 0,
       paddingHorizontal: theme.rem(0.5),
@@ -321,11 +318,12 @@ const getStyles = cacheStyles((theme: Theme) => {
       fontFamily: theme.fontFaceBold
     },
     rowContainer: {
-      display: 'flex',
-      height: theme.rem(2.75),
-      flexDirection: 'row',
-      justifyContent: 'flex-start',
-      alignItems: 'center'
+      flexGrow: 1,
+      flexShrink: 1,
+      justifyContent: 'center',
+      alignItems: 'flex-start',
+      marginHorizontal: theme.rem(0.5),
+      marginVertical: theme.rem(0.25)
     }
   }
 })

--- a/src/plugins/gui/scenes/AddressFormScene.tsx
+++ b/src/plugins/gui/scenes/AddressFormScene.tsx
@@ -3,7 +3,7 @@ import { asArray, asObject, asOptional, asString } from 'cleaners'
 import * as React from 'react'
 import { Platform, ScrollView, View, ViewStyle } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
-import Animated, { Easing, interpolateColor, useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated'
+import Animated, { Easing, useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated'
 
 import { SceneButtons } from '../../../components/buttons/SceneButtons'
 import { EdgeTouchableOpacity } from '../../../components/common/EdgeTouchableOpacity'
@@ -60,7 +60,6 @@ export const AddressFormScene = React.memo((props: Props) => {
   const { route, navigation } = props
   const { countryCode, headerTitle, /* headerIconUri, */ onSubmit, onClose } = route.params
   const disklet = useSelector(state => state.core.disklet)
-  const dropdownBorderColor = React.useMemo(() => [theme.iconDeactivated, theme.iconTappable], [theme])
 
   const [formData, setFormData] = React.useState<HomeAddress>({
     address: '',
@@ -95,9 +94,7 @@ export const AddressFormScene = React.memo((props: Props) => {
       duration: isAnimateHintsNumChange ? 250 : 0,
       easing: Easing.inOut(Easing.circle)
     }),
-    opacity: isHintsDropped && searchResults.length > 0 ? sAnimationMult.value : withTiming(0, { duration: 500 }),
-
-    borderColor: interpolateColor(sAnimationMult.value, [0, 1], dropdownBorderColor)
+    opacity: isHintsDropped && searchResults.length > 0 ? sAnimationMult.value : withTiming(0, { duration: 500 })
   }))
 
   const handleHintLayout = useHandler(event => {
@@ -353,8 +350,6 @@ const getStyles = cacheStyles((theme: Theme) => {
     backgroundColor: theme.modal,
     borderRadius: theme.rem(0.5),
     zIndex: 1,
-    borderColor: theme.iconTappable,
-    borderWidth: theme.thinLineWidth,
     overflow: 'hidden',
     position: 'absolute',
     left: theme.rem(0.5),

--- a/src/theme/variables/edgeDark.ts
+++ b/src/theme/variables/edgeDark.ts
@@ -472,6 +472,19 @@ export const edgeDark: Theme = {
     },
     shadowOpacity: 0.6,
     shadowRadius: 4,
+    // Disable Android shadow
+    elevation: 0
+  },
+
+  dropdownListShadow: {
+    shadowColor: 'white',
+    shadowOffset: {
+      width: 10,
+      height: 10
+    },
+    shadowOpacity: 0.3,
+    shadowRadius: 64,
+    // Disable Android shadow
     elevation: 0
   },
 

--- a/src/theme/variables/edgeLight.ts
+++ b/src/theme/variables/edgeLight.ts
@@ -431,6 +431,18 @@ export const edgeLight: Theme = {
     elevation: 0
   },
 
+  dropdownListShadow: {
+    shadowColor: 'white',
+    shadowOffset: {
+      width: 10,
+      height: 10
+    },
+    shadowOpacity: 0.3,
+    shadowRadius: 64,
+    // Disable Android shadow
+    elevation: 0
+  },
+
   // Basic Card Styles
   cardBaseColor: palette.whiteOp10,
   cardGradientWarning: {

--- a/src/theme/variables/testDark.ts
+++ b/src/theme/variables/testDark.ts
@@ -472,6 +472,18 @@ export const testDark: Theme = {
     elevation: 0
   },
 
+  dropdownListShadow: {
+    shadowColor: 'white',
+    shadowOffset: {
+      width: 10,
+      height: 10
+    },
+    shadowOpacity: 0.3,
+    shadowRadius: 64,
+    // Disable Android shadow
+    elevation: 0
+  },
+
   // Basic Card Styles
   cardBaseColor: palette.whiteOp10,
   cardGradientWarning: {

--- a/src/theme/variables/testLight.ts
+++ b/src/theme/variables/testLight.ts
@@ -431,6 +431,18 @@ export const testLight: Theme = {
     elevation: 0
   },
 
+  dropdownListShadow: {
+    shadowColor: 'white',
+    shadowOffset: {
+      width: 10,
+      height: 10
+    },
+    shadowOpacity: 0.3,
+    shadowRadius: 64,
+    // Disable Android shadow
+    elevation: 0
+  },
+
   // Basic Card Styles
   cardBaseColor: palette.whiteOp10,
   cardGradientWarning: {

--- a/src/types/Theme.ts
+++ b/src/types/Theme.ts
@@ -442,6 +442,7 @@ export interface Theme {
 
   // Shadows
   iconShadow: ThemeShadowParams
+  dropdownListShadow: ThemeShadowParams
 
   // Basic Card Styles
   cardBaseColor: string


### PR DESCRIPTION
<img width="881" alt="image" src="https://github.com/user-attachments/assets/12e3a9e6-f733-499a-a2bc-e398a7caa773">
<img width="434" alt="image" src="https://github.com/user-attachments/assets/8fb06c2d-ebbc-44a3-bab1-ccd063b7c8ab">

Unable to clip an upper border's shadow for the `SideMenu.` We already fade out the background when the username list is dropped, anyway, so skipping shadows on this component for now. 

Given the original spec didn't really consider full-width dropdowns, we may need to reduce the shadow radius, anyway, in which case a simple diagonal shadow offset is passable for a side menu username dropdown.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206926834012048