### PR TITLE
Clear previous swap errors when entering new amounts or assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Clear previous swap errors when new amounts are entered or swap assets are changed in `SwapCreateScene`
+
 ## 4.14.0
 
 - added: `ExpandableList` component, replacing the address hint dropdown in `AddressFormScene`

--- a/src/components/scenes/SwapProcessingScene.tsx
+++ b/src/components/scenes/SwapProcessingScene.tsx
@@ -108,7 +108,8 @@ function processSwapQuoteError({
   if (insufficientFunds != null || errorMessage === 'InsufficientFundsError') {
     return {
       title: lstrings.exchange_insufficient_funds_title,
-      message: lstrings.exchange_insufficient_funds_message
+      message: lstrings.exchange_insufficient_funds_message,
+      error
     }
   }
 
@@ -122,7 +123,8 @@ function processSwapQuoteError({
 
     return {
       title: lstrings.exchange_generic_error_title,
-      message: sprintf(lstrings.amount_above_limit, displayMax, currentCurrencyDenomination.name)
+      message: sprintf(lstrings.amount_above_limit, displayMax, currentCurrencyDenomination.name),
+      error
     }
   }
 
@@ -136,7 +138,8 @@ function processSwapQuoteError({
 
     return {
       title: lstrings.exchange_generic_error_title,
-      message: sprintf(lstrings.amount_below_limit, displayMin, currentCurrencyDenomination.name)
+      message: sprintf(lstrings.amount_below_limit, displayMin, currentCurrencyDenomination.name),
+      error
     }
   }
 
@@ -147,7 +150,8 @@ function processSwapQuoteError({
 
     return {
       title: lstrings.exchange_generic_error_title,
-      message: sprintf(lstrings.ss_unable, fromCurrencyCode, toCurrencyCode)
+      message: sprintf(lstrings.ss_unable, fromCurrencyCode, toCurrencyCode),
+      error
     }
   }
 
@@ -155,13 +159,15 @@ function processSwapQuoteError({
   if (permissionError?.reason === 'geoRestriction') {
     return {
       title: lstrings.exchange_generic_error_title,
-      message: lstrings.ss_geolock
+      message: lstrings.ss_geolock,
+      error
     }
   }
 
   // Anything else:
   return {
     title: lstrings.exchange_generic_error_title,
-    message: errorMessage
+    message: errorMessage,
+    error
   }
 }


### PR DESCRIPTION
Minor changes: the original spec was not exhaustive. Amounts are also relevant to certain errors, not just the assets selected.

(Potentially) Amount-related errors:
```
'Entered amount plus fees exceeds wallet balance.' 
'Amount is above the max limit of %1$s %2$s. This max limit is subject to change based on market conditions'
Amount is below the min limit of %1$s %2$s. This min limit is subject to change based on market conditions
```

(Potentially) Asset-related errors:
```
No enabled exchanges support %1$s to %2$s.
Location restricted. Unable to complete exchange.
```

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208281641508390