### PR TITLE
Use account default fiat for transaction fee display in `SweepPrivateKeyCalculateFeeScene`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - changed: Navigate to wallet list after restoring wallets
+- fixed: Use account default fiat for transaction fee display in `SweepPrivateKeyCalculateFeeScene`
 
 ## 4.15.0
 

--- a/src/components/scenes/SweepPrivateKeyCalculateFeeScene.tsx
+++ b/src/components/scenes/SweepPrivateKeyCalculateFeeScene.tsx
@@ -44,6 +44,7 @@ const SweepPrivateKeyCalculateFeeComponent = (props: Props) => {
   const theme = useTheme()
   const styles = getStyles(theme)
 
+  const defaultFiat = useSelector(state => state.ui.settings.defaultIsoFiat)
   const exchangeRates = useSelector(state => state.exchangeRates)
   const displayDenominations = useSelector(state => {
     const { denominationSettings = {} } = state.ui.settings
@@ -97,7 +98,7 @@ const SweepPrivateKeyCalculateFeeComponent = (props: Props) => {
       const exchangeDenom = denominations.find(denom => denom.name === currencyCode) as EdgeDenomination
       const displayDenom = displayDenominations[pluginId]?.[currencyCode] ?? exchangeDenom
 
-      const transactionFee = convertTransactionFeeToDisplayFee(currencyCode, receivingWallet.fiatCurrencyCode, exchangeRates, tx, displayDenom, exchangeDenom)
+      const transactionFee = convertTransactionFeeToDisplayFee(currencyCode, defaultFiat, exchangeRates, tx, displayDenom, exchangeDenom)
       const fiatAmount = transactionFee.fiatAmount === '0' ? '0' : ` ${transactionFee.fiatAmount}`
       const feeSyntax = `${transactionFee.cryptoSymbol ?? ''} ${truncateDecimals(transactionFee.cryptoAmount)} (${
         transactionFee.fiatSymbol ?? ''


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208056566426971