### PR TITLE
Jon/fix/earn-display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - added: Add TON
 - added: Log swap errors to Sentry.
 - added: Tracking for unexpected fiat provider errors.
+- changed: Redesign `StakingReturnsCard,` specifically for `StakeOverviewScene`
+- changed: `EarnScene` shows all possible stake options, instead of only those for enabled wallets
+- changed: `EarnScene` shows one card per stake option if multiple wallets have stake positions on that stake option
+- changed: `EarnScene` only intializes stake options once, regardless of re-navigation to the scene
 - changed: `FiatProviderError` messages now include `FiatProviderQuoteError` info.
 - changed: Add explicit gas limit for Kiln staking.
 - changed: Various strings updated to UK compliance spec

--- a/src/components/cards/EarnOptionCard.tsx
+++ b/src/components/cards/EarnOptionCard.tsx
@@ -1,4 +1,4 @@
-import { EdgeCurrencyWallet } from 'edge-core-js'
+import { EdgeCurrencyInfo } from 'edge-core-js'
 import * as React from 'react'
 import { View } from 'react-native'
 import { sprintf } from 'sprintf-js'
@@ -15,8 +15,8 @@ import { EdgeText } from '../themed/EdgeText'
 import { EdgeCard } from './EdgeCard'
 
 interface Props {
+  currencyInfo: EdgeCurrencyInfo
   stakePolicy: StakePolicy
-  wallet: EdgeCurrencyWallet
 
   countryCode?: string
   /** If false, show "Stake"/"Earn"
@@ -29,7 +29,7 @@ export function EarnOptionCard(props: Props) {
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const { stakePolicy, wallet, isOpenPosition, countryCode, onPress } = props
+  const { stakePolicy, currencyInfo, isOpenPosition, countryCode, onPress } = props
   const { apy, yieldType, stakeProviderInfo } = stakePolicy
 
   const { stakeAssets, rewardAssets } = stakePolicy
@@ -41,7 +41,7 @@ export function EarnOptionCard(props: Props) {
     ? sprintf(lstrings.stake_earning_1s, rewardCurrencyCodes)
     : getUkCompliantString(countryCode, 'stake_earn_1s', rewardCurrencyCodes)
 
-  const policyIcons = getPolicyIconUris(wallet.currencyInfo, stakePolicy)
+  const policyIcons = getPolicyIconUris(currencyInfo, stakePolicy)
 
   const variablePrefix = yieldType === 'stable' ? '' : '~ '
   const apyText = apy == null || apy <= 0 ? lstrings.stake_variable_apy : variablePrefix + sprintf(lstrings.stake_apy_1s, toPercentString(apy / 100))

--- a/src/components/cards/EarnOptionCard.tsx
+++ b/src/components/cards/EarnOptionCard.tsx
@@ -1,0 +1,95 @@
+import { EdgeCurrencyWallet } from 'edge-core-js'
+import * as React from 'react'
+import { View } from 'react-native'
+import { sprintf } from 'sprintf-js'
+
+import { toPercentString } from '../../locales/intl'
+import { lstrings } from '../../locales/strings'
+import { StakePolicy } from '../../plugins/stake-plugins/types'
+import { getPolicyIconUris } from '../../util/stakeUtils'
+import { getUkCompliantString } from '../../util/ukComplianceUtils'
+import { PairIcons } from '../icons/PairIcons'
+import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
+import { TitleText } from '../text/TitleText'
+import { EdgeText } from '../themed/EdgeText'
+import { EdgeCard } from './EdgeCard'
+
+interface Props {
+  stakePolicy: StakePolicy
+  wallet: EdgeCurrencyWallet
+
+  countryCode?: string
+  /** If false, show "Stake"/"Earn"
+   * If true, show "Staked"/"Earned" */
+  isOpenPosition?: boolean
+  onPress?: () => void
+}
+
+export function EarnOptionCard(props: Props) {
+  const theme = useTheme()
+  const styles = getStyles(theme)
+
+  const { stakePolicy, wallet, isOpenPosition, countryCode, onPress } = props
+  const { apy, yieldType, stakeProviderInfo } = stakePolicy
+
+  const { stakeAssets, rewardAssets } = stakePolicy
+  const stakeCurrencyCodes = stakeAssets.map(asset => asset.currencyCode).join(' + ')
+  const rewardCurrencyCodes = rewardAssets.map(asset => asset.currencyCode).join(', ')
+
+  const stakeText = sprintf(isOpenPosition ? lstrings.stake_staked_1s : lstrings.stake_stake_1s, stakeCurrencyCodes)
+  const rewardText = isOpenPosition
+    ? sprintf(lstrings.stake_earning_1s, rewardCurrencyCodes)
+    : getUkCompliantString(countryCode, 'stake_earn_1s', rewardCurrencyCodes)
+
+  const policyIcons = getPolicyIconUris(wallet.currencyInfo, stakePolicy)
+
+  const variablePrefix = yieldType === 'stable' ? '' : '~ '
+  const apyText = apy == null || apy <= 0 ? lstrings.stake_variable_apy : variablePrefix + sprintf(lstrings.stake_apy_1s, toPercentString(apy / 100))
+
+  return (
+    <EdgeCard onPress={onPress}>
+      <View style={styles.contentContainer}>
+        <View style={styles.textContainer}>
+          <TitleText>{stakeText}</TitleText>
+          <EdgeText style={styles.rewardText}>{rewardText}</EdgeText>
+          <EdgeText style={styles.apyText}>{apyText}</EdgeText>
+          <EdgeText style={styles.providerText} numberOfLines={1}>{`${lstrings.plugin_powered_by_space}${stakeProviderInfo.displayName}`}</EdgeText>
+        </View>
+
+        <PairIcons icons={policyIcons.stakeAssetUris} />
+      </View>
+    </EdgeCard>
+  )
+}
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  contentContainer: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  textContainer: {
+    flexGrow: 1,
+    flexShrink: 1,
+    justifyContent: 'center',
+    padding: theme.rem(0.5)
+  },
+  rewardText: {
+    fontSize: theme.rem(0.8),
+    marginTop: theme.rem(1),
+    marginBottom: theme.rem(0.15)
+  },
+  apyText: {
+    fontSize: theme.rem(0.8),
+    color: theme.positiveText,
+    marginVertical: theme.rem(0.15)
+  },
+  providerIcon: {
+    width: theme.rem(1),
+    height: theme.rem(1),
+    marginRight: theme.rem(0.25)
+  },
+  providerText: {
+    fontSize: theme.rem(0.75),
+    color: theme.secondaryText
+  }
+}))

--- a/src/components/cards/StakingReturnsCard.tsx
+++ b/src/components/cards/StakingReturnsCard.tsx
@@ -10,6 +10,7 @@ import { getStakeProviderIcon } from '../../util/CdnUris'
 import { PairIcons } from '../icons/PairIcons'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
+import { EdgeCard } from './EdgeCard'
 
 interface StakingReturnsCardParams {
   fromCurrencyLogos: string[]
@@ -51,35 +52,21 @@ export function StakingReturnsCard({ fromCurrencyLogos, toCurrencyLogos, apy, st
   }
 
   return (
-    <View style={styles.container}>
-      <View style={styles.leftCap} />
-      <View>
-        <View style={styles.iconsContainer}>
-          <View style={styles.middleLine} />
-          <View style={styles.icon}>
-            <PairIcons icons={fromCurrencyLogos} />
-            {renderArrow()}
-            <PairIcons icons={toCurrencyLogos} />
-          </View>
-          <View style={styles.middleLine} />
-        </View>
-        <View style={styles.textContainer}>
-          {renderEstimatedReturn()}
-          {renderStakeProvider()}
-        </View>
+    <EdgeCard>
+      <View style={styles.iconsContainer}>
+        <PairIcons icons={fromCurrencyLogos} />
+        {renderArrow()}
+        <PairIcons icons={toCurrencyLogos} />
       </View>
-      <View style={styles.rightCap} />
-    </View>
+      <View style={styles.textContainer}>
+        {renderEstimatedReturn()}
+        {renderStakeProvider()}
+      </View>
+    </EdgeCard>
   )
 }
 
 const getStyles = cacheStyles((theme: Theme) => {
-  const commonCap: ViewStyle = {
-    borderColor: theme.lineDivider,
-    borderBottomWidth: theme.thinLineWidth,
-    borderTopWidth: theme.thinLineWidth,
-    width: theme.rem(1)
-  }
   const commonArrow: ViewStyle = {
     position: 'absolute',
     width: theme.thinLineWidth * 2,
@@ -96,40 +83,15 @@ const getStyles = cacheStyles((theme: Theme) => {
     },
     iconsContainer: {
       flexDirection: 'row',
-      position: 'absolute'
+      marginVertical: theme.rem(0.5),
+      alignItems: 'center',
+      justifyContent: 'center'
     },
     textContainer: {
       alignItems: 'center',
-      paddingHorizontal: theme.rem(1),
-      paddingTop: theme.rem(2),
-      paddingBottom: theme.rem(1),
-      borderBottomWidth: theme.thinLineWidth,
+      margin: theme.rem(0.5),
       borderColor: theme.lineDivider,
       minWidth: theme.rem(15)
-    },
-    icon: {
-      top: theme.rem(-1.5),
-      flexDirection: 'row',
-      alignItems: 'center'
-    },
-    middleLine: {
-      flex: 1,
-      borderTopWidth: theme.thinLineWidth,
-      borderColor: theme.lineDivider
-    },
-    leftCap: {
-      ...commonCap,
-      borderLeftWidth: theme.thinLineWidth,
-      borderRightWidth: 0,
-      borderBottomLeftRadius: theme.rem(0.5),
-      borderTopLeftRadius: theme.rem(0.5)
-    },
-    rightCap: {
-      ...commonCap,
-      borderLeftWidth: 0,
-      borderRightWidth: theme.thinLineWidth,
-      borderBottomRightRadius: theme.rem(0.5),
-      borderTopRightRadius: theme.rem(0.5)
     },
     swapProvider: {
       marginTop: theme.rem(0.25),

--- a/src/components/cards/StakingReturnsCard.tsx
+++ b/src/components/cards/StakingReturnsCard.tsx
@@ -1,95 +1,168 @@
-import { EdgeCurrencyWallet } from 'edge-core-js'
+import { toFixed } from 'biggystring'
 import * as React from 'react'
-import { View } from 'react-native'
+import { View, ViewStyle } from 'react-native'
+import FastImage from 'react-native-fast-image'
 import { sprintf } from 'sprintf-js'
 
-import { toPercentString } from '../../locales/intl'
 import { lstrings } from '../../locales/strings'
-import { StakePolicy } from '../../plugins/stake-plugins/types'
-import { getPolicyIconUris } from '../../util/stakeUtils'
-import { getUkCompliantString } from '../../util/ukComplianceUtils'
+import { StakeProviderInfo } from '../../plugins/stake-plugins/types'
+import { getStakeProviderIcon } from '../../util/CdnUris'
 import { PairIcons } from '../icons/PairIcons'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
-import { TitleText } from '../text/TitleText'
 import { EdgeText } from '../themed/EdgeText'
-import { EdgeCard } from './EdgeCard'
 
-interface Props {
-  stakePolicy: StakePolicy
-  wallet: EdgeCurrencyWallet
-
-  countryCode?: string
-  /** If false, show "Stake"/"Earn"
-   * If true, show "Staked"/"Earned" */
-  isOpenPosition?: boolean
-  onPress?: () => void
+interface StakingReturnsCardParams {
+  fromCurrencyLogos: string[]
+  toCurrencyLogos: string[]
+  apy?: number
+  stakeProviderInfo?: StakeProviderInfo
 }
 
-export function StakingReturnsCard(props: Props) {
+export function StakingReturnsCard({ fromCurrencyLogos, toCurrencyLogos, apy, stakeProviderInfo }: StakingReturnsCardParams) {
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const { stakePolicy, wallet, isOpenPosition, countryCode, onPress } = props
-  const { apy, yieldType, stakeProviderInfo } = stakePolicy
+  const renderArrow = () => {
+    return (
+      <View style={styles.arrowContainer}>
+        <View style={styles.arrowTopLine} />
+        <View style={styles.arrowBase} />
+        <View style={styles.arrowBottomLine} />
+      </View>
+    )
+  }
 
-  const { stakeAssets, rewardAssets } = stakePolicy
-  const stakeCurrencyCodes = stakeAssets.map(asset => asset.currencyCode).join(' + ')
-  const rewardCurrencyCodes = rewardAssets.map(asset => asset.currencyCode).join(', ')
+  const renderEstimatedReturn = () => {
+    if (apy == null || apy <= 0) return null
+    const estimatedReturnMsg = toFixed(apy.toString(), 1, 1) + '% APR'
+    return <EdgeText>{sprintf(lstrings.stake_estimated_return, estimatedReturnMsg)}</EdgeText>
+  }
 
-  const stakeText = sprintf(isOpenPosition ? lstrings.stake_staked_1s : lstrings.stake_stake_1s, stakeCurrencyCodes)
-  const rewardText = isOpenPosition
-    ? sprintf(lstrings.stake_earning_1s, rewardCurrencyCodes)
-    : getUkCompliantString(countryCode, 'stake_earn_1s', rewardCurrencyCodes)
-
-  const policyIcons = getPolicyIconUris(wallet.currencyInfo, stakePolicy)
-
-  const variablePrefix = yieldType === 'stable' ? '' : '~ '
-  const apyText = apy == null || apy <= 0 ? lstrings.stake_variable_apy : variablePrefix + sprintf(lstrings.stake_apy_1s, toPercentString(apy / 100))
+  const renderStakeProvider = () => {
+    if (stakeProviderInfo == null) return null
+    const { displayName, pluginId, stakeProviderId } = stakeProviderInfo
+    const swapProviderIcon = getStakeProviderIcon(pluginId, stakeProviderId, theme)
+    return (
+      <View style={styles.swapProvider}>
+        {swapProviderIcon ? <FastImage style={styles.swapProviderIcon} resizeMode={FastImage.resizeMode.contain} source={{ uri: swapProviderIcon }} /> : null}
+        <EdgeText style={styles.swapProviderText}>{displayName}</EdgeText>
+      </View>
+    )
+  }
 
   return (
-    <EdgeCard onPress={onPress}>
-      <View style={styles.contentContainer}>
-        <View style={styles.textContainer}>
-          <TitleText>{stakeText}</TitleText>
-          <EdgeText style={styles.rewardText}>{rewardText}</EdgeText>
-          <EdgeText style={styles.apyText}>{apyText}</EdgeText>
-          <EdgeText style={styles.providerText} numberOfLines={1}>{`${lstrings.plugin_powered_by_space}${stakeProviderInfo.displayName}`}</EdgeText>
+    <View style={styles.container}>
+      <View style={styles.leftCap} />
+      <View>
+        <View style={styles.iconsContainer}>
+          <View style={styles.middleLine} />
+          <View style={styles.icon}>
+            <PairIcons icons={fromCurrencyLogos} />
+            {renderArrow()}
+            <PairIcons icons={toCurrencyLogos} />
+          </View>
+          <View style={styles.middleLine} />
         </View>
-
-        <PairIcons icons={policyIcons.stakeAssetUris} />
+        <View style={styles.textContainer}>
+          {renderEstimatedReturn()}
+          {renderStakeProvider()}
+        </View>
       </View>
-    </EdgeCard>
+      <View style={styles.rightCap} />
+    </View>
   )
 }
 
-const getStyles = cacheStyles((theme: Theme) => ({
-  contentContainer: {
-    flexDirection: 'row',
-    alignItems: 'center'
-  },
-  textContainer: {
-    flexGrow: 1,
-    flexShrink: 1,
-    justifyContent: 'center',
-    padding: theme.rem(0.5)
-  },
-  rewardText: {
-    fontSize: theme.rem(0.8),
-    marginTop: theme.rem(1),
-    marginBottom: theme.rem(0.15)
-  },
-  apyText: {
-    fontSize: theme.rem(0.8),
-    color: theme.positiveText,
-    marginVertical: theme.rem(0.15)
-  },
-  providerIcon: {
-    width: theme.rem(1),
-    height: theme.rem(1),
-    marginRight: theme.rem(0.25)
-  },
-  providerText: {
-    fontSize: theme.rem(0.75),
-    color: theme.secondaryText
+const getStyles = cacheStyles((theme: Theme) => {
+  const commonCap: ViewStyle = {
+    borderColor: theme.lineDivider,
+    borderBottomWidth: theme.thinLineWidth,
+    borderTopWidth: theme.thinLineWidth,
+    width: theme.rem(1)
   }
-}))
+  const commonArrow: ViewStyle = {
+    position: 'absolute',
+    width: theme.thinLineWidth * 2,
+    height: theme.rem(0.625),
+    right: 0 + theme.thinLineWidth * 1.5,
+    borderRadius: theme.thinLineWidth,
+    backgroundColor: theme.icon
+  }
+  return {
+    container: {
+      flexDirection: 'row',
+      minWidth: theme.rem(10),
+      marginTop: theme.rem(1.5)
+    },
+    iconsContainer: {
+      flexDirection: 'row',
+      position: 'absolute'
+    },
+    textContainer: {
+      alignItems: 'center',
+      paddingHorizontal: theme.rem(1),
+      paddingTop: theme.rem(2),
+      paddingBottom: theme.rem(1),
+      borderBottomWidth: theme.thinLineWidth,
+      borderColor: theme.lineDivider,
+      minWidth: theme.rem(15)
+    },
+    icon: {
+      top: theme.rem(-1.5),
+      flexDirection: 'row',
+      alignItems: 'center'
+    },
+    middleLine: {
+      flex: 1,
+      borderTopWidth: theme.thinLineWidth,
+      borderColor: theme.lineDivider
+    },
+    leftCap: {
+      ...commonCap,
+      borderLeftWidth: theme.thinLineWidth,
+      borderRightWidth: 0,
+      borderBottomLeftRadius: theme.rem(0.5),
+      borderTopLeftRadius: theme.rem(0.5)
+    },
+    rightCap: {
+      ...commonCap,
+      borderLeftWidth: 0,
+      borderRightWidth: theme.thinLineWidth,
+      borderBottomRightRadius: theme.rem(0.5),
+      borderTopRightRadius: theme.rem(0.5)
+    },
+    swapProvider: {
+      marginTop: theme.rem(0.25),
+      flexDirection: 'row',
+      alignItems: 'center'
+    },
+    swapProviderIcon: {
+      width: theme.rem(0.625),
+      height: theme.rem(0.625),
+      marginRight: theme.rem(0.5)
+    },
+    swapProviderText: {
+      fontSize: theme.rem(0.75),
+      color: theme.secondaryText
+    },
+    arrowContainer: {
+      flexDirection: 'row'
+    },
+    arrowBase: {
+      width: theme.rem(3),
+      height: theme.thinLineWidth * 2,
+      borderRadius: theme.thinLineWidth,
+      backgroundColor: theme.icon
+    },
+    arrowTopLine: {
+      ...commonArrow,
+      bottom: 0 - theme.thinLineWidth * 1.325,
+      transform: [{ rotateZ: '-45deg' }]
+    },
+    arrowBottomLine: {
+      ...commonArrow,
+      top: 0 - theme.thinLineWidth * 1.325,
+      transform: [{ rotateZ: '45deg' }]
+    }
+  }
+})

--- a/src/components/scenes/Staking/EarnScene.tsx
+++ b/src/components/scenes/Staking/EarnScene.tsx
@@ -15,7 +15,7 @@ import { EdgeAppSceneProps } from '../../../types/routerTypes'
 import { getPluginFromPolicy, getPositionAllocations } from '../../../util/stakeUtils'
 import { zeroString } from '../../../util/utils'
 import { EdgeSwitch } from '../../buttons/EdgeSwitch'
-import { StakingReturnsCard } from '../../cards/StakingReturnsCard'
+import { EarnOptionCard } from '../../cards/EarnOptionCard'
 import { EdgeAnim, fadeInUp20 } from '../../common/EdgeAnim'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { SectionHeader } from '../../common/SectionHeader'
@@ -119,7 +119,7 @@ export const EarnScene = (props: Props) => {
 
           return (
             <EdgeAnim key={`${wallet.id}-${index}`} enter={fadeInUp20}>
-              <StakingReturnsCard wallet={wallet} stakePolicy={stakePolicy} isOpenPosition={isPortfolioSelected} onPress={handlePress} />
+              <EarnOptionCard wallet={wallet} stakePolicy={stakePolicy} isOpenPosition={isPortfolioSelected} onPress={handlePress} />
             </EdgeAnim>
           )
         })}

--- a/src/components/scenes/Staking/EarnScene.tsx
+++ b/src/components/scenes/Staking/EarnScene.tsx
@@ -1,4 +1,4 @@
-import { EdgeCurrencyWallet } from 'edge-core-js'
+import { EdgeCurrencyInfo, EdgeCurrencyWallet } from 'edge-core-js'
 import * as React from 'react'
 import { ActivityIndicator } from 'react-native'
 
@@ -11,28 +11,36 @@ import { lstrings } from '../../../locales/strings'
 import { getStakePlugins } from '../../../plugins/stake-plugins/stakePlugins'
 import { StakePlugin, StakePolicy, StakePosition } from '../../../plugins/stake-plugins/types'
 import { useSelector } from '../../../types/reactRedux'
-import { EdgeAppSceneProps } from '../../../types/routerTypes'
-import { getPluginFromPolicy, getPositionAllocations } from '../../../util/stakeUtils'
+import { EdgeAppSceneProps, NavigationBase } from '../../../types/routerTypes'
+import { getPositionAllocations } from '../../../util/stakeUtils'
 import { zeroString } from '../../../util/utils'
 import { EdgeSwitch } from '../../buttons/EdgeSwitch'
 import { EarnOptionCard } from '../../cards/EarnOptionCard'
 import { EdgeAnim, fadeInUp20 } from '../../common/EdgeAnim'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { SectionHeader } from '../../common/SectionHeader'
-import { showDevError } from '../../services/AirshipInstance'
+import { WalletListModal, WalletListResult } from '../../modals/WalletListModal'
+import { Airship, showDevError } from '../../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../../services/ThemeContext'
 
 interface Props extends EdgeAppSceneProps<'earnScene'> {}
 
 export interface EarnSceneParams {}
 
-interface StakePolicyPosition {
-  stakePolicy: StakePolicy
+interface WalletStakeInfo {
+  wallet: EdgeCurrencyWallet
+  isPositionOpen: boolean
   stakePosition: StakePosition
 }
 
+interface DisplayStakeInfo {
+  stakePlugin: StakePlugin
+  stakePolicy: StakePolicy
+  walletStakeInfos: WalletStakeInfo[]
+}
+
 interface StakePolicyMap {
-  [walletId: string]: { stakePolicyPositions: StakePolicyPosition[]; stakePlugins: StakePlugin[] }
+  [pluginId: string]: DisplayStakeInfo[]
 }
 
 export const EarnScene = (props: Props) => {
@@ -41,101 +49,139 @@ export const EarnScene = (props: Props) => {
   const styles = getStyles(theme)
 
   const account = useSelector(state => state.core.account)
+
+  const currencyConfigMap = useSelector(state => state.core.account.currencyConfig)
+
   const currencyWallets = useWatch(account, 'currencyWallets')
   const wallets = Object.values(currencyWallets)
 
-  const [stakePolicyMap, setStakePolicyMap] = React.useState<StakePolicyMap>()
-  const [positionWallets, setPositionWallets] = React.useState<EdgeCurrencyWallet[]>([])
   const [isPortfolioSelected, setIsPortfolioSelected] = React.useState(false)
   const [isLoading, setIsLoading] = React.useState(true)
 
-  // Filter wallets based on isPortfolioSelected
-  const displayWallets = !stakePolicyMap ? [] : isPortfolioSelected ? positionWallets : wallets
+  // Store `stakePolicyMap` in a ref and manage re-renders manually to avoid
+  // re-initializing it every time we enter the scene.
+  const [updateCounter, setUpdateCounter] = React.useState(0)
+  const stakePolicyMapRef = React.useRef<StakePolicyMap>({})
+  const stakePolicyMap = stakePolicyMapRef.current
 
   const handleSelectEarn = useHandler(() => setIsPortfolioSelected(false))
   const handleSelectPortfolio = useHandler(() => setIsPortfolioSelected(true))
 
   useAsyncEffect(
     async () => {
-      if (stakePolicyMap != null) return
+      for (const pluginId of Object.keys(currencyConfigMap)) {
+        const isStakingSupported = SPECIAL_CURRENCY_INFO[pluginId]?.isStakingSupported === true && ENV.ENABLE_STAKING
+        if (stakePolicyMap[pluginId] != null || !isStakingSupported) continue
 
-      const positionWallets = []
-      const policyMap: StakePolicyMap = {}
+        // Initialize stake policy
+        try {
+          const stakePlugins = await getStakePlugins(pluginId)
+          stakePolicyMap[pluginId] = []
 
-      for (const wallet of wallets) {
-        // Get all available stake policies
-        const { pluginId } = wallet.currencyInfo
-        if (SPECIAL_CURRENCY_INFO[pluginId]?.isStakingSupported === true && ENV.ENABLE_STAKING) {
-          // For each wallet
-          const stakePolicyPositions: StakePolicyPosition[] = []
+          for (const stakePlugin of stakePlugins) {
+            const stakePolicies = stakePlugin.getPolicies({ currencyCode: currencyConfigMap[pluginId].currencyInfo.currencyCode })
+            const matchingWallets = wallets.filter((wallet: EdgeCurrencyWallet) => wallet.currencyInfo.pluginId === pluginId)
 
-          try {
-            const stakePlugins = await getStakePlugins(pluginId)
-            for (const stakePlugin of stakePlugins) {
-              const stakePolicies = stakePlugin.getPolicies({ wallet, currencyCode: wallet.currencyInfo.currencyCode })
-
-              // Check if there's open positions
-              for (const stakePolicy of stakePolicies) {
+            for (const stakePolicy of stakePolicies) {
+              const walletStakePositions = []
+              for (const wallet of matchingWallets) {
+                // Determine if a wallet matching this policy has an open position
                 const stakePosition = await stakePlugin.fetchStakePosition({ stakePolicyId: stakePolicy.stakePolicyId, wallet, account })
-                stakePolicyPositions.push({ stakePolicy, stakePosition })
-
                 const allocations = getPositionAllocations(stakePosition)
                 const { staked, earned, unstaked } = allocations
-                if ([...staked, ...earned, ...unstaked].some(positionAllocation => !zeroString(positionAllocation.nativeAmount))) {
-                  positionWallets.push(wallet)
-                }
-              }
-            }
+                const isPositionOpen = [...staked, ...earned, ...unstaked].some(positionAllocation => !zeroString(positionAllocation.nativeAmount))
 
-            policyMap[wallet.id] = { stakePolicyPositions, stakePlugins }
-            setStakePolicyMap({ ...policyMap })
-            setPositionWallets(positionWallets)
-          } catch (e) {
-            showDevError(e)
+                walletStakePositions.push({ wallet, isPositionOpen, stakePosition })
+              }
+
+              stakePolicyMap[pluginId].push({
+                stakePlugin,
+                stakePolicy,
+                walletStakeInfos: walletStakePositions
+              })
+              // Trigger re-render
+              setUpdateCounter(prevCounter => prevCounter + 1)
+            }
           }
+        } catch (e) {
+          showDevError(e)
         }
       }
       setIsLoading(false)
     },
-    [],
+    [updateCounter],
     'EarnScene'
   )
 
-  const renderStakeItems = (wallet: EdgeCurrencyWallet) => {
-    if (stakePolicyMap == null) return null
+  const renderStakeItems = (displayStakeInfo: DisplayStakeInfo, currencyInfo: EdgeCurrencyInfo) => {
+    const { stakePlugin, stakePolicy, walletStakeInfos } = displayStakeInfo
 
-    const { stakePolicyPositions, stakePlugins } = stakePolicyMap[wallet.id] ?? { stakePolicyPositions: [], stakePlugins: [] }
+    const handlePress = async () => {
+      let walletId: string | undefined
+      let stakePosition
+
+      const openStakePositions = walletStakeInfos.filter(walletStakeInfo => walletStakeInfo.isPositionOpen)
+
+      if (walletStakeInfos.length === 1 || (isPortfolioSelected && openStakePositions.length === 1)) {
+        // Only one compatible wallet if on "Discover", or only one open
+        // position on "Portfolio." Auto-select the wallet.
+        const { wallet, stakePosition: existingStakePosition } = walletStakeInfos[0]
+
+        walletId = wallet.id
+        stakePosition = existingStakePosition
+      } else {
+        // Select an existing wallet that matches this policy or create a new one
+        const allowedAssets = stakePolicy.stakeAssets.map(stakeAsset => ({ pluginId: stakeAsset.pluginId, tokenId: null }))
+
+        // Filter for wallets that have an open position if "Portfolio" is
+        // selected
+        const allowedWalletIds = isPortfolioSelected
+          ? walletStakeInfos.filter(walletStakeInfo => walletStakeInfo.isPositionOpen).map(walletStakePosition => walletStakePosition.wallet.id)
+          : undefined
+
+        const result = await Airship.show<WalletListResult>(bridge => (
+          <WalletListModal
+            bridge={bridge}
+            allowedAssets={allowedAssets}
+            allowedWalletIds={allowedWalletIds}
+            headerTitle={lstrings.select_wallet}
+            // Only allow wallet creation on the Discover tab
+            showCreateWallet={isPortfolioSelected}
+            navigation={navigation as NavigationBase}
+          />
+        ))
+
+        if (result?.type === 'wallet') {
+          walletId = result.walletId
+          stakePosition = walletStakeInfos.find(walletStakeInfo => walletStakeInfo.wallet.id === result.walletId)?.stakePosition
+        }
+      }
+
+      // User backed out of the WalletListModal
+      if (walletId == null) return
+
+      navigation.push('stakeOverview', {
+        walletId,
+        stakePlugin,
+        stakePolicy,
+        stakePosition
+      })
+    }
 
     return (
-      <>
-        {stakePolicyPositions.map((stakePolicyPosition: { stakePolicy: StakePolicy; stakePosition: StakePosition }, index: number) => {
-          const { stakePolicy, stakePosition } = stakePolicyPosition
-
-          if (stakePolicy == null) return null
-          const stakePlugin = getPluginFromPolicy(stakePlugins, stakePolicy)
-
-          const handlePress =
-            stakePlugin == null ? undefined : () => navigation.push('stakeOverview', { stakePlugin, walletId: wallet.id, stakePolicy, stakePosition })
-
-          return (
-            <EdgeAnim key={`${wallet.id}-${index}`} enter={fadeInUp20}>
-              <EarnOptionCard currencyInfo={wallet.currencyInfo} stakePolicy={stakePolicy} isOpenPosition={isPortfolioSelected} onPress={handlePress} />
-            </EdgeAnim>
-          )
-        })}
-      </>
+      <EdgeAnim key={stakePolicy.stakePolicyId} enter={fadeInUp20}>
+        <EarnOptionCard currencyInfo={currencyInfo} stakePolicy={stakePolicy} isOpenPosition={isPortfolioSelected} onPress={handlePress} />
+      </EdgeAnim>
     )
   }
 
   return (
-    // TODO: Address "VirtualizedLists should never be nested inside plain
-    // ScrollViews with the same orientation because it can break windowing and
-    // other functionality - use another VirtualizedList-backed container
-    // instead." somehow, while retaining the bottom loader positioning...
     <SceneWrapper scroll padding={theme.rem(0.5)}>
       <EdgeSwitch labelA={lstrings.staking_discover} labelB={lstrings.staking_portfolio} onSelectA={handleSelectEarn} onSelectB={handleSelectPortfolio} />
       <SectionHeader leftTitle={lstrings.staking_earning_pools} />
-      {displayWallets.map(wallet => renderStakeItems(wallet))}
+      {Object.keys(stakePolicyMap).map(pluginId =>
+        stakePolicyMap[pluginId].map(displayStakeInfo => renderStakeItems(displayStakeInfo, currencyConfigMap[pluginId].currencyInfo))
+      )}
       {isLoading && <ActivityIndicator style={styles.loader} size="large" color={theme.primaryText} />}
     </SceneWrapper>
   )

--- a/src/components/scenes/Staking/EarnScene.tsx
+++ b/src/components/scenes/Staking/EarnScene.tsx
@@ -119,7 +119,7 @@ export const EarnScene = (props: Props) => {
 
           return (
             <EdgeAnim key={`${wallet.id}-${index}`} enter={fadeInUp20}>
-              <EarnOptionCard wallet={wallet} stakePolicy={stakePolicy} isOpenPosition={isPortfolioSelected} onPress={handlePress} />
+              <EarnOptionCard currencyInfo={wallet.currencyInfo} stakePolicy={stakePolicy} isOpenPosition={isPortfolioSelected} onPress={handlePress} />
             </EdgeAnim>
           )
         })}

--- a/src/components/scenes/Staking/StakeOverviewScene.tsx
+++ b/src/components/scenes/Staking/StakeOverviewScene.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import { sprintf } from 'sprintf-js'
 
+import { getFirstOpenInfo } from '../../../actions/FirstOpenActions'
 import { SCROLL_INDICATOR_INSET_FIX } from '../../../constants/constantSettings'
 import { useAsyncEffect } from '../../../hooks/useAsyncEffect'
 import { lstrings } from '../../../locales/strings'
@@ -13,7 +14,7 @@ import { useDispatch, useSelector } from '../../../types/reactRedux'
 import { EdgeSceneProps } from '../../../types/routerTypes'
 import { getTokenIdForced } from '../../../util/CurrencyInfoHelpers'
 import { getAllocationLocktimeMessage, getPolicyIconUris, getPolicyTitleName, getPositionAllocations } from '../../../util/stakeUtils'
-import { StyledButtonContainer } from '../../buttons/ButtonsView'
+import { SceneButtons } from '../../buttons/SceneButtons'
 import { StakingReturnsCard } from '../../cards/StakingReturnsCard'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { withWallet } from '../../hoc/withWallet'
@@ -21,8 +22,7 @@ import { FillLoader } from '../../progress-indicators/FillLoader'
 import { Shimmer } from '../../progress-indicators/Shimmer'
 import { showError } from '../../services/AirshipInstance'
 import { cacheStyles, Theme, useTheme } from '../../services/ThemeContext'
-import { MainButton } from '../../themed/MainButton'
-import { SceneHeader } from '../../themed/SceneHeader'
+import { SceneHeaderUi4 } from '../../themed/SceneHeaderUi4'
 import { CryptoFiatAmountTile } from '../../tiles/CryptoFiatAmountTile'
 
 interface Props extends EdgeSceneProps<'stakeOverview'> {
@@ -57,6 +57,8 @@ const StakeOverviewSceneComponent = (props: Props) => {
   const policyIcons = getPolicyIconUris(wallet.currencyInfo, stakePolicy)
 
   // Hooks
+
+  const [countryCode, setCountryCode] = React.useState<string | undefined>()
   const [stakeAllocations, setStakeAllocations] = React.useState<PositionAllocation[]>([])
   const [rewardAllocations, setRewardAllocations] = React.useState<PositionAllocation[]>([])
   const [unstakedAllocations, setUnstakedAllocations] = React.useState<PositionAllocation[]>([])
@@ -74,6 +76,8 @@ const StakeOverviewSceneComponent = (props: Props) => {
 
   useAsyncEffect(
     async () => {
+      setCountryCode((await getFirstOpenInfo()).countryCode)
+
       let sp: StakePosition
       try {
         if (stakePosition == null) {
@@ -98,7 +102,7 @@ const StakeOverviewSceneComponent = (props: Props) => {
   // Handlers
   const handleModifyPress = (modification: ChangeQuoteRequest['action'] | 'unstakeAndClaim') => () => {
     const sceneTitleMap = {
-      stake: getPolicyTitleName(stakePolicy),
+      stake: getPolicyTitleName(stakePolicy, countryCode),
       claim: lstrings.stake_claim_rewards,
       unstake: lstrings.stake_unstake,
       unstakeAndClaim: lstrings.stake_unstake_claim,
@@ -146,15 +150,13 @@ const StakeOverviewSceneComponent = (props: Props) => {
 
   return (
     <SceneWrapper padding={theme.rem(0.5)} scroll>
-      <SceneHeader title={title} withTopMargin />
-      <View style={styles.card}>
-        <StakingReturnsCard
-          fromCurrencyLogos={policyIcons.stakeAssetUris}
-          toCurrencyLogos={policyIcons.rewardAssetUris}
-          apy={stakePolicy.apy}
-          stakeProviderInfo={stakePolicy.stakeProviderInfo}
-        />
-      </View>
+      <SceneHeaderUi4 title={title} />
+      <StakingReturnsCard
+        fromCurrencyLogos={policyIcons.stakeAssetUris}
+        toCurrencyLogos={policyIcons.rewardAssetUris}
+        apy={stakePolicy.apy}
+        stakeProviderInfo={stakePolicy.stakeProviderInfo}
+      />
       {stakePosition == null ? (
         <>
           <View style={styles.shimmer}>
@@ -173,34 +175,42 @@ const StakeOverviewSceneComponent = (props: Props) => {
         }
         scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
       />
-      <StyledButtonContainer layout="column">
-        <MainButton label={lstrings.stake_stake_more_funds} disabled={!canStake} type="primary" onPress={handleModifyPress('stake')} marginRem={0.5} />
-        {stakePolicy.hideClaimAction ? null : (
-          <MainButton label={lstrings.stake_claim_rewards} disabled={!canClaim} type="secondary" onPress={handleModifyPress('claim')} marginRem={0.5} />
-        )}
-        {stakePolicy.hideUnstakeAndClaimAction ? null : (
-          <MainButton
-            label={lstrings.stake_unstake_claim}
-            disabled={!canUnstakeAndClaim}
-            type="escape"
-            onPress={handleModifyPress('unstakeAndClaim')}
-            marginRem={0.5}
-          />
-        )}
-        {stakePolicy.hideUnstakeAction ? null : (
-          <MainButton label={lstrings.stake_unstake} disabled={!canUnstake} type="escape" onPress={handleModifyPress('unstake')} marginRem={0.5} />
-        )}
-      </StyledButtonContainer>
+      <SceneButtons
+        primary={{
+          label: lstrings.stake_stake_more_funds,
+          disabled: !canStake,
+          onPress: handleModifyPress('stake')
+        }}
+        secondary={
+          stakePolicy.hideClaimAction
+            ? undefined
+            : {
+                label: lstrings.stake_claim_rewards,
+                disabled: !canClaim,
+                onPress: handleModifyPress('claim')
+              }
+        }
+        tertiary={
+          stakePolicy.hideUnstakeAndClaimAction
+            ? stakePolicy.hideUnstakeAction
+              ? undefined
+              : {
+                  label: lstrings.stake_unstake,
+                  disabled: !canUnstake,
+                  onPress: handleModifyPress('unstake')
+                }
+            : {
+                label: lstrings.stake_unstake_claim,
+                disabled: !canUnstakeAndClaim,
+                onPress: handleModifyPress('unstakeAndClaim')
+              }
+        }
+      />
     </SceneWrapper>
   )
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
-  card: {
-    alignItems: 'center',
-    justifyContent: 'flex-start',
-    padding: theme.rem(0.5)
-  },
   shimmer: {
     height: theme.rem(3),
     marginLeft: theme.rem(1),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9bcac1d3-387c-499d-b8e6-6d25d3a49519)

- `StakingReturnsCard` split into a redesigned old-style `StakingReturnsCard` and an `EarnScene` specific `EarnOptionCard`
- Initialization of `stakePolicyMap` to be based on all supported instead of only enabled wallet `pluginIds.` This also limits the display to one card per policy instead of one card per wallet.
- Add wallet picker logic based on "Discover/Portfolio" state and number of open positions
- Only initialize `stakePolicyMap` once, regardless of if we re-navigate to the scene

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208561731583351