### PR TITLE
Handle light account backup while on `FiatPluginEnterAmountScene`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added: Close button (X) for `EdgeModals,` specifically if a desktop platform is detected.
 - changed: Auto-enable required tokens when navigating to `Stake*` scenes
 - fixed: Incorrect `SwapInput` amounts on `SwapCreateScene` after changing wallet.
+- fixed: Backing up a light account while on the `FiatPluginEnterAmountScene` retains light account-related quote errors
 - fixed: Various `EarnScene` display bugs
 - fixed: `EarnScene` missing wallet creation option in "Discover" view
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208615827323069