### PR TITLE
Improve EdgeCrashEvent reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: New Kado OTC provider integration.
+- changed: Improved EdgeCrashEvent reporting with additional metadata, tags, and name/message information.
 - changed: Integrate `installSurvey` endpoint for post-install survey options
 
 ## 4.19.0

--- a/src/components/services/EdgeCoreManager.tsx
+++ b/src/components/services/EdgeCoreManager.tsx
@@ -70,16 +70,24 @@ const crashReporter: EdgeCrashReporter = {
   },
   logCrash(event) {
     // Index the crash error by the source and original error name:
-    const error = new Error(`${event.source}: ${String(event.error)}`)
+    const error = new Error(String(event.error))
     // All of these crash errors are grouped together using this error name:
-    error.name = 'EdgeCrashLog'
+    error.name = 'EdgeCrashEvent'
 
     captureException(error, scope => {
       scope.setLevel('fatal')
+      scope.setTags({ crashSource: event.source })
 
-      const context: Record<string, unknown> = {}
-      addMetadataToContext(context, event.metadata)
-      scope.setContext('Edge Crash Metadata', context)
+      const metadataContext: Record<string, unknown> = {}
+      addMetadataToContext(metadataContext, event.metadata)
+      scope.setContext('EdgeCrashEvent Metadata', metadataContext)
+
+      const detailsContext: Record<string, unknown> = {}
+      addMetadataToContext(detailsContext, {
+        source: event.source,
+        time: event.time
+      })
+      scope.setContext('EdgeCrashEvent Details', detailsContext)
 
       return scope
     })


### PR DESCRIPTION
Because Sentry's default fingerprint algorithm is based on stack-traces,
we need to add additional tagging for custom fingerprint rules for
issue grouping based on the tag and event message.

We'll filter using the error name (EdgeCrashEvent), and we'll group by
error message and the source tag.

We cannot group by context data, but
we'll add all the data from the event in a scope's context for easy
reference when reviewing issues.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208383880746610