### PR TITLE
Fix crash on EarnScene

### DIFF
--- a/src/components/scenes/Staking/EarnScene.tsx
+++ b/src/components/scenes/Staking/EarnScene.tsx
@@ -239,6 +239,8 @@ export const EarnScene = (props: Props) => {
       // User backed out of the WalletListModal
       if (walletId == null) return
 
+      dispatch({ type: 'STAKING/ADD_POLICY', walletId, stakePolicy })
+
       navigation.push('stakeOverview', {
         walletId,
         stakePlugin,


### PR DESCRIPTION
We were missing loading the staking position for the impending scene
transition.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208993351823602