### PR TITLE
Fix 2FA/otp Reminder Notification

### DIFF
--- a/src/components/notification/NotificationView.tsx
+++ b/src/components/notification/NotificationView.tsx
@@ -16,7 +16,7 @@ import { config } from '../../theme/appConfig'
 import { useDispatch, useSelector } from '../../types/reactRedux'
 import { NavigationBase } from '../../types/routerTypes'
 import { getThemedIconUri } from '../../util/CdnUris'
-import { getOtpReminderModal } from '../../util/otpReminder'
+import { showOtpReminderModal } from '../../util/otpReminder'
 import { openBrowserUri } from '../../util/WebUtils'
 import { EdgeAnim, fadeIn, fadeOut } from '../common/EdgeAnim'
 import { styled } from '../hoc/styled'
@@ -83,8 +83,7 @@ const NotificationViewComponent = (props: Props) => {
   })
   const handleOtpReminderPress = useHandler(async () => {
     await handleOtpReminderClose()
-    const otpReminderModal = await getOtpReminderModal(account)
-    if (otpReminderModal != null) await otpReminderModal()
+    await showOtpReminderModal(account)
   })
 
   const handleLayout = useHandler((event: LayoutChangeEvent) => {

--- a/src/components/scenes/NotificationCenterScene.tsx
+++ b/src/components/scenes/NotificationCenterScene.tsx
@@ -11,7 +11,7 @@ import { config } from '../../theme/appConfig'
 import { useDispatch, useSelector } from '../../types/reactRedux'
 import { EdgeAppSceneProps, NavigationBase } from '../../types/routerTypes'
 import { getThemedIconUri } from '../../util/CdnUris.ts'
-import { getOtpReminderModal } from '../../util/otpReminder.tsx'
+import { showOtpReminderModal } from '../../util/otpReminder.tsx'
 import { openBrowserUri } from '../../util/WebUtils.ts'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { SectionHeader } from '../common/SectionHeader'
@@ -43,8 +43,7 @@ export const NotificationCenterScene = (props: Props) => {
   })
 
   const handleOtpReminderPress = useHandler(async () => {
-    const otpReminderModal = await getOtpReminderModal(account)
-    if (otpReminderModal != null) await otpReminderModal()
+    await showOtpReminderModal(account)
   })
 
   const handle2FaEnabledPress = useHandler(async () => {

--- a/src/util/otpReminder.tsx
+++ b/src/util/otpReminder.tsx
@@ -6,80 +6,62 @@ import { sprintf } from 'sprintf-js'
 import { ButtonsModal } from '../components/modals/ButtonsModal'
 import { Airship } from '../components/services/AirshipInstance'
 import { lstrings } from '../locales/strings'
-
-const OTP_REMINDER_MILLISECONDS = 7 * 24 * 60 * 60 * 1000
-const OTP_REMINDER_STORE_NAME = 'app.edge.login'
-const OTP_REMINDER_KEY_NAME_LAST_OTP_CHECKED = 'lastOtpCheck'
-const OTP_REMINDER_KEY_NAME_DONT_ASK = 'OtpDontAsk'
+import { OTP_REMINDER_MILLISECONDS, readOtpSettings, writeOtpSettings } from './otpUtils'
 
 /**
- * Check and return a potential 2fa reminder modal if needed to be shown onPress
- * of its corresponding notification card.
+ * Return an otp reminder modal, with or without a "don't ask again" button,
+ * depending on if they've seen this before.
  */
-export async function getOtpReminderModal(account: EdgeAccount): Promise<(() => Promise<void>) | undefined> {
-  const { otpKey, dataStore, username, created } = account
-  if (username == null || otpKey != null) return
-  const [dontAsk, lastOtpCheckString]: [string | null, string | null] = await Promise.all([
-    dataStore.getItem(OTP_REMINDER_STORE_NAME, OTP_REMINDER_KEY_NAME_DONT_ASK).catch(() => null),
-    dataStore.getItem(OTP_REMINDER_STORE_NAME, OTP_REMINDER_KEY_NAME_LAST_OTP_CHECKED).catch(() => null)
-  ])
-  if (dontAsk) return
+export async function showOtpReminderModal(account: EdgeAccount): Promise<void> {
+  const { created } = account
+  const { lastChecked } = await readOtpSettings(account)
+  Keyboard.dismiss()
 
   // Return a modal if we have never shown it before, and the account is old
   // enough:
-  const lastOtpCheck = lastOtpCheckString != null ? parseInt(lastOtpCheckString) : null
-  if (lastOtpCheck == null && (created == null || Date.now() > created.valueOf() + OTP_REMINDER_MILLISECONDS)) {
-    return async () => {
-      Keyboard.dismiss()
-      const result = await Airship.show<'yes' | 'no' | undefined>(bridge => (
-        <ButtonsModal
-          bridge={bridge}
-          title={lstrings.otp_reset_modal_header}
-          message={lstrings.otp_reset_modal_message}
-          buttons={{
-            yes: { label: lstrings.otp_enable },
-            no: { label: lstrings.skip, type: 'secondary' }
-          }}
-        />
-      ))
-      if (result === 'yes') {
-        await enableOtp(account)
-      } else {
-        await account.dataStore.setItem(OTP_REMINDER_STORE_NAME, OTP_REMINDER_KEY_NAME_LAST_OTP_CHECKED, Date.now().toString())
-      }
+  if (lastChecked == null && (created == null || Date.now() > created.valueOf() + OTP_REMINDER_MILLISECONDS)) {
+    const result = await Airship.show<'yes' | 'no' | undefined>(bridge => (
+      <ButtonsModal
+        bridge={bridge}
+        title={lstrings.otp_reset_modal_header}
+        message={lstrings.otp_reset_modal_message}
+        buttons={{
+          yes: { label: lstrings.otp_enable },
+          no: { label: lstrings.skip, type: 'secondary' }
+        }}
+      />
+    ))
+    if (result === 'yes') {
+      await enableOtp(account)
+    } else {
+      await writeOtpSettings(account, { lastChecked: new Date(Date.now()) })
+    }
+  } else {
+    // Return a modal with the "Don't ask again" button if we showed the first
+    // modal already:
+    const result = await Airship.show<'enable' | 'cancel' | 'dontAsk' | undefined>(bridge => (
+      <ButtonsModal
+        bridge={bridge}
+        title={lstrings.otp_reset_modal_header}
+        message={lstrings.otp_reset_modal_message}
+        buttons={{
+          enable: { label: lstrings.otp_enable, type: 'primary' },
+          cancel: { label: lstrings.skip, type: 'secondary' },
+          dontAsk: {
+            label: lstrings.otp_reset_modal_dont_ask,
+            type: 'secondary'
+          }
+        }}
+      />
+    ))
+    if (result === 'enable') {
+      await enableOtp(account)
+    } else if (result === 'dontAsk') {
+      await writeOtpSettings(account, { dontAsk: true })
+    } else {
+      await writeOtpSettings(account, { lastChecked: new Date(Date.now()) })
     }
   }
-
-  // Return a modal with the "Don't ask again" button if we have waited long
-  // enough since the last time we showed a 2fa reminder modal:
-  if (lastOtpCheck != null && Date.now() > lastOtpCheck + OTP_REMINDER_MILLISECONDS) {
-    return async () => {
-      Keyboard.dismiss()
-      const result = await Airship.show<'enable' | 'cancel' | 'dontAsk' | undefined>(bridge => (
-        <ButtonsModal
-          bridge={bridge}
-          title={lstrings.otp_reset_modal_header}
-          message={lstrings.otp_reset_modal_message}
-          buttons={{
-            enable: { label: lstrings.otp_enable, type: 'primary' },
-            cancel: { label: lstrings.skip, type: 'secondary' },
-            dontAsk: {
-              label: lstrings.otp_reset_modal_dont_ask,
-              type: 'secondary'
-            }
-          }}
-        />
-      ))
-      if (result === 'enable') {
-        await enableOtp(account)
-      } else if (result === 'dontAsk') {
-        await account.dataStore.setItem(OTP_REMINDER_STORE_NAME, OTP_REMINDER_KEY_NAME_DONT_ASK, 'true')
-      } else {
-        await account.dataStore.setItem(OTP_REMINDER_STORE_NAME, OTP_REMINDER_KEY_NAME_LAST_OTP_CHECKED, Date.now().toString())
-      }
-    }
-  }
-  return undefined
 }
 
 /**

--- a/src/util/otpUtils.ts
+++ b/src/util/otpUtils.ts
@@ -1,0 +1,75 @@
+import { asBoolean, asDate, asObject, asOptional } from 'cleaners'
+import { EdgeAccount } from 'edge-core-js'
+import React from 'react'
+import { makeEvent } from 'yavent'
+
+const OTP_REMINDER_STORE_NAME = 'app.edge.login'
+const OTP_REMINDER_KEY_NAME_LAST_OTP_CHECKED = 'lastOtpCheck'
+const OTP_REMINDER_KEY_NAME_DONT_ASK = 'OtpDontAsk'
+
+export const OTP_REMINDER_MILLISECONDS = 7 * 24 * 60 * 60 * 1000
+
+// Combined settings interface
+export interface OtpSettings {
+  lastChecked: Date | null
+  dontAsk: boolean
+}
+
+// Cleaner for the settings
+export const asOtpSettings = asObject({
+  lastChecked: asOptional(asDate, null),
+  dontAsk: asOptional(asBoolean, false)
+})
+
+// Local state management
+let localOtpSettings: OtpSettings = {
+  lastChecked: null,
+  dontAsk: false
+}
+
+// Event emitter for settings changes
+const [watchOtpSettings, emitOtpSettings] = makeEvent<OtpSettings>()
+
+export const getOtpSettings = (): OtpSettings => localOtpSettings
+
+// React hook for accessing OTP settings
+export function useOtpSettings(): OtpSettings {
+  const [, setOtpSettings] = React.useState(getOtpSettings())
+  React.useEffect(() => watchOtpSettings(setOtpSettings), [])
+  return localOtpSettings
+}
+
+// Read settings from disk
+export async function readOtpSettings(account: EdgeAccount): Promise<OtpSettings> {
+  const [lastCheckedStr, dontAskStr] = await Promise.all([
+    account.dataStore.getItem(OTP_REMINDER_STORE_NAME, OTP_REMINDER_KEY_NAME_LAST_OTP_CHECKED).catch(() => null),
+    account.dataStore.getItem(OTP_REMINDER_STORE_NAME, OTP_REMINDER_KEY_NAME_DONT_ASK).catch(() => null)
+  ])
+
+  const settings: OtpSettings = {
+    lastChecked: lastCheckedStr != null ? new Date(parseInt(lastCheckedStr)) : null,
+    dontAsk: dontAskStr === 'true'
+  }
+
+  localOtpSettings = settings
+  return settings
+}
+
+// Write settings to disk
+export async function writeOtpSettings(account: EdgeAccount, settings: Partial<OtpSettings>): Promise<void> {
+  const newSettings = { ...localOtpSettings, ...settings }
+
+  const promises: Array<Promise<void>> = []
+
+  if (settings.lastChecked !== undefined) {
+    promises.push(account.dataStore.setItem(OTP_REMINDER_STORE_NAME, OTP_REMINDER_KEY_NAME_LAST_OTP_CHECKED, settings.lastChecked?.toString() ?? '0'))
+  }
+
+  if (settings.dontAsk !== undefined) {
+    promises.push(account.dataStore.setItem(OTP_REMINDER_STORE_NAME, OTP_REMINDER_KEY_NAME_DONT_ASK, settings.dontAsk?.toString() ?? 'false'))
+  }
+
+  await Promise.all(promises)
+  localOtpSettings = newSettings
+  emitOtpSettings(newSettings)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,9 +2175,9 @@
     randombytes "^2.1.0"
     text-encoding "0.7.0"
 
-"@fioprotocol/fiosdk@git+https://github.com/jon-edge/fiosdk_typescript.git#92a0fb895b2ce57e5955cd30cb4b7fa2bcc66bf2":
+"@fioprotocol/fiosdk@https://github.com/jon-edge/fiosdk_typescript.git#92a0fb895b2ce57e5955cd30cb4b7fa2bcc66bf2":
   version "1.9.0"
-  resolved "git+https://github.com/jon-edge/fiosdk_typescript.git#92a0fb895b2ce57e5955cd30cb4b7fa2bcc66bf2"
+  resolved "https://github.com/jon-edge/fiosdk_typescript.git#92a0fb895b2ce57e5955cd30cb4b7fa2bcc66bf2"
   dependencies:
     "@fioprotocol/fiojs" "1.0.1"
     "@types/text-encoding" "0.0.35"
@@ -10566,9 +10566,9 @@ eyes@^0.1.8:
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
 
-"eztz.js@git+https://github.com/EdgeApp/eztz.git#edge-fixes":
+"eztz.js@https://github.com/EdgeApp/eztz.git#edge-fixes":
   version "0.0.1"
-  resolved "git+https://github.com/EdgeApp/eztz.git#eefa603586810c3d62f852e7f28cfe57c523b7db"
+  resolved "https://github.com/EdgeApp/eztz.git#eefa603586810c3d62f852e7f28cfe57c523b7db"
   dependencies:
     bignumber.js "^7.2.1"
     bip39 "^3.0.2"


### PR DESCRIPTION
- Isolate the modals to their own file
- Create a hook to ensure changes to otp disk settings are picked up by
  the `NotificationService`
- Pull all logic for otp reminder notification state into `NotificationService`

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209310723615615