### PR TITLE
Remove selection after text change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - changed: Use number math when handling exchange rates
 - changed: Optimize `getCreateWalletList` function and usage
 - fixed: Correct the display name for ETH txs on non-Ethereum chains
+- fixed: Input text selection bug in Android caused by `autoSelect` prop.
 - fixed: Input text selection color adjusted for transparency on Android.
 
 ## 4.22.0 (2025-02-17)

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -206,7 +206,7 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
   function isFocused(): boolean {
     return inputRef.current != null ? inputRef.current.isFocused() : false
   }
-  function setNativeProps(nativeProps: Object): void {
+  function setNativeProps(nativeProps: object): void {
     if (inputRef.current != null) inputRef.current.setNativeProps(nativeProps)
   }
 
@@ -237,6 +237,11 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
     if (onBlur != null) onBlur()
   })
   const handleChangeText = useHandler((value: string) => {
+    if (autoSelect) {
+      setNativeProps({
+        selection: {}
+      })
+    }
     if (props.onChangeText != null) props.onChangeText(value)
   })
   const handleClearPress = useHandler(() => {


### PR DESCRIPTION
By setting a selection using setNativeProps, the input forces the
selection continuously. We need to unset the selection once the user
has change the text on the input.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209373617256156