### PR TITLE
Make text input components semi-controlled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fixed: Correct the display name for ETH txs on non-Ethereum chains
 - fixed: Input text selection bug in Android caused by `autoSelect` prop.
 - fixed: Input text selection color adjusted for transparency on Android.
+- fixed: Unstable text input cursor on Android for some instances.
 
 ## 4.22.0 (2025-02-17)
 

--- a/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
@@ -107,6 +107,7 @@ exports[`FilledTextInput should render with some props 1`] = `
           autoCorrect={true}
           autoFocus={true}
           blurOnSubmit={false}
+          defaultValue="string"
           disableAnimation={
             {
               "value": 0,
@@ -136,7 +137,6 @@ exports[`FilledTextInput should render with some props 1`] = `
           selectionColor="rgba(255, 255, 255, .25)"
           testID="string.textInput"
           textAlignVertical="top"
-          value="string"
         />
       </StyledComponent(View)>
       <StyledComponent(TouchableOpacity)

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -604,6 +604,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             animated={true}
             autoCapitalize="words"
             autoFocus={true}
+            defaultValue="Paycheck"
             disableAnimation={
               {
                 "value": 0,
@@ -651,7 +652,6 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             }
             testID="undefined.textInput"
             textAlignVertical="top"
-            value="Paycheck"
           />
         </View>
         <View
@@ -1996,6 +1996,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             animated={true}
             autoCapitalize="words"
             autoFocus={true}
+            defaultValue=""
             disableAnimation={
               {
                 "value": 0,
@@ -2043,7 +2044,6 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             }
             testID="undefined.textInput"
             textAlignVertical="top"
-            value=""
           />
         </View>
         <View

--- a/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
@@ -347,6 +347,7 @@ exports[`CountryListModal should render with a country list 1`] = `
             autoCapitalize="words"
             autoCorrect={false}
             autoFocus={true}
+            defaultValue=""
             disableAnimation={
               {
                 "value": 0,
@@ -394,7 +395,6 @@ exports[`CountryListModal should render with a country list 1`] = `
             }
             testID="Select your region.textInput"
             textAlignVertical="top"
-            value=""
           />
         </View>
         <View

--- a/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
@@ -530,6 +530,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                 animated={true}
                 autoCorrect={true}
                 autoFocus={false}
+                defaultValue=""
                 disableAnimation={
                   {
                     "value": 0,
@@ -578,7 +579,6 @@ exports[`LogsModal should render with a logs modal 1`] = `
                 }
                 testID="undefined.textInput"
                 textAlignVertical="top"
-                value=""
               />
             </View>
             <View

--- a/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
@@ -308,6 +308,7 @@ exports[`TextInputModal should render with a blank input field 1`] = `
               accessible={true}
               animated={true}
               autoFocus={true}
+              defaultValue=""
               disableAnimation={
                 {
                   "value": 0,
@@ -354,7 +355,6 @@ exports[`TextInputModal should render with a blank input field 1`] = `
               }
               testID="undefined.textInput"
               textAlignVertical="top"
-              value=""
             />
           </View>
           <View
@@ -874,6 +874,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
               accessible={true}
               animated={true}
               autoFocus={true}
+              defaultValue="initialValue"
               disableAnimation={
                 {
                   "value": 0,
@@ -920,7 +921,6 @@ exports[`TextInputModal should render with a populated input field 1`] = `
               }
               testID="undefined.textInput"
               textAlignVertical="top"
-              value="initialValue"
             />
           </View>
           <View

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -360,6 +360,7 @@ exports[`WalletListModal should render with loading props 1`] = `
                 }
                 accessible={true}
                 autoFocus={false}
+                defaultValue=""
                 disableAnimation={
                   {
                     "value": 0,
@@ -396,7 +397,6 @@ exports[`WalletListModal should render with loading props 1`] = `
                 }
                 testID="undefined.textInput"
                 textAlignVertical="top"
-                value=""
               />
             </View>
             <View

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -558,6 +558,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
               autoCapitalize="none"
               autoCorrect={false}
               autoFocus={true}
+              defaultValue=""
               disableAnimation={
                 {
                   "value": 0,
@@ -606,7 +607,6 @@ exports[`CreateWalletAccountSelect renders 1`] = `
               }
               testID="undefined.textInput"
               textAlignVertical="top"
-              value=""
             />
           </View>
           <View

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -552,6 +552,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
             autoCorrect={false}
             autoFocus={false}
             blurOnSubmit={false}
+            defaultValue=""
             disableAnimation={
               {
                 "value": 0,
@@ -601,7 +602,6 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
             }
             testID="undefined.textInput"
             textAlignVertical="top"
-            value=""
           />
         </View>
         <View

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -495,6 +495,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             autoCapitalize="words"
             autoCorrect={false}
             autoFocus={false}
+            defaultValue=""
             disableAnimation={
               {
                 "value": 0,
@@ -530,7 +531,6 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             }
             testID="undefined.textInput"
             textAlignVertical="top"
-            value=""
           />
         </View>
         <View

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -181,7 +181,8 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
 
   const LeftIcon = iconComponent
   const hasIcon = LeftIcon != null
-  const hasValue = value !== ''
+
+  const valueRef = React.useRef(value)
 
   const marginRemStyle = useMarginRemStyle(marginRemProps)
 
@@ -195,9 +196,9 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
     if (inputRef.current != null) inputRef.current.blur()
   }
   function clear(): void {
+    if (blurOnClear || valueRef.current === '') blur()
     if (inputRef.current != null) inputRef.current.clear()
-    if (onChangeText != null) onChangeText('')
-    if (blurOnClear || !hasValue) blur()
+    handleChangeText('')
     if (onClear != null) onClear()
   }
   function focus(): void {
@@ -209,6 +210,18 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
   function setNativeProps(nativeProps: object): void {
     if (inputRef.current != null) inputRef.current.setNativeProps(nativeProps)
   }
+
+  // This fixes RN bugs with controlled TextInput components.
+  // By avoiding the `value` prop for the TextInput, we can avoid the bugs.
+  // So an alternative to using the `value` prop, is to imperatively set the,
+  // TextInput's text value using `setNativeProps({ text: value })`.
+  // We do this only if the `value` prop from this component has changed.
+  React.useEffect(() => {
+    if (inputRef.current != null && value !== valueRef.current) {
+      valueRef.current = value
+      inputRef.current.setNativeProps({ text: value })
+    }
+  }, [inputRef, value])
 
   React.useImperativeHandle(ref, () => ({
     blur,
@@ -237,6 +250,7 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
     if (onBlur != null) onBlur()
   })
   const handleChangeText = useHandler((value: string) => {
+    valueRef.current = value
     if (autoSelect) {
       setNativeProps({
         selection: {}
@@ -251,7 +265,7 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
     focusAnimation.value = withTiming(1, { duration: baseDuration })
     if (autoSelect) {
       setNativeProps({
-        selection: { start: 0, end: value.length },
+        selection: { start: 0, end: valueRef.current.length },
         selectTextOnFocus: true
       })
     }
@@ -261,15 +275,24 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
     if (onSubmitEditing != null) onSubmitEditing()
   })
 
-  const leftIconSize = useDerivedValue(() => (hasIcon ? (hasValue ? 0 : interpolate(focusAnimation.value, [0, 1], [themeRem, 0])) : 0))
-  const rightIconSize = useDerivedValue(() => (clearIcon ? (hasValue ? themeRem : focusAnimation.value * themeRem) : 0))
+  const leftIconSize = useDerivedValue(() => {
+    const hasValue = valueRef.current !== ''
+    return hasIcon ? (hasValue ? 0 : interpolate(focusAnimation.value, [0, 1], [themeRem, 0])) : 0
+  })
+  const rightIconSize = useDerivedValue(() => {
+    const hasValue = valueRef.current !== ''
+    return clearIcon ? (hasValue ? themeRem : focusAnimation.value * themeRem) : 0
+  })
 
   const scale = useDerivedValue(() => scaleProp?.value ?? 1)
 
   const interpolateIconColor = useAnimatedColorInterpolateFn(theme.textInputIconColor, theme.textInputIconColorFocused, theme.textInputIconColorDisabled)
   const iconColor = useDerivedValue(() => interpolateIconColor(focusAnimation, disableAnimation))
 
-  const focusValue = useDerivedValue(() => (hasValue ? 1 : focusAnimation.value))
+  const focusValue = useDerivedValue(() => {
+    const hasValue = valueRef.current !== ''
+    return hasValue ? 1 : focusAnimation.value
+  })
 
   // Character Limit:
   const charactersLeft = maxLength === undefined ? '' : `${maxLength - value.length}`
@@ -311,6 +334,7 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
               returnKeyType={returnKeyType}
               accessibilityState={{ disabled }}
               autoFocus={autoFocus}
+              defaultValue={value}
               disableAnimation={disableAnimation}
               focusAnimation={focusAnimation}
               minDecimals={minDecimals}
@@ -321,7 +345,6 @@ export const FilledTextInput = React.forwardRef<FilledTextInputRef, FilledTextIn
               textAlignVertical="top"
               textsizeRem={textsizeRem}
               scale={scale}
-              value={value}
               // Callbacks:
               onBlur={handleBlur}
               onChangeText={handleChangeText}

--- a/src/components/themed/SimpleTextInput.tsx
+++ b/src/components/themed/SimpleTextInput.tsx
@@ -122,10 +122,16 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
   const themeRem = theme.rem(1)
 
   const hasIcon = Icon != null
-  const hasValue = value !== ''
   const isIos = Platform.OS === 'ios'
 
+  const valueRef = React.useRef(value)
+
   const [isFocused, setIsFocused] = React.useState(false)
+
+  const handleChangeText = (value: string) => {
+    valueRef.current = value
+    if (onChangeText != null) onChangeText(value)
+  }
 
   // Imperative methods:
   const inputRef = useAnimatedRef<TextInput>()
@@ -134,7 +140,7 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
   }
   function clear(): void {
     if (inputRef.current != null) inputRef.current.clear()
-    if (onChangeText != null) onChangeText('')
+    handleChangeText('')
     if (blurOnClear) blur()
     if (onClear != null) onClear()
   }
@@ -147,6 +153,18 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
   function setNativeProps(nativeProps: Object): void {
     if (inputRef.current != null) inputRef.current.setNativeProps(nativeProps)
   }
+
+  // This fixes RN bugs with controlled TextInput components.
+  // By avoiding the `value` prop for the TextInput, we can avoid the bugs.
+  // So an alternative to using the `value` prop, is to imperatively set the,
+  // TextInput's text value using `setNativeProps({ text: value })`.
+  // We do this only if the `value` prop from this component has changed.
+  React.useEffect(() => {
+    if (inputRef.current != null && value !== valueRef.current) {
+      valueRef.current = value
+      inputRef.current.setNativeProps({ text: value })
+    }
+  }, [inputRef, value])
 
   React.useImperativeHandle(ref, () => ({
     blur,
@@ -194,10 +212,14 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
   })
 
   const backIconSize = useDerivedValue(() => (isIos ? 0 : interpolate(focusAnimation.value, [0, 1], [0, themeRem])))
-  const leftIconSize = useDerivedValue(() =>
-    hasIcon ? (hasValue && (active == null || !active) ? 0 : interpolate(focusAnimation.value, [0, 1], [themeRem, 0])) : 0
-  )
-  const rightIconSize = useDerivedValue(() => (hasValue ? themeRem : focusAnimation.value * themeRem))
+  const leftIconSize = useDerivedValue(() => {
+    const hasValue = valueRef.current !== ''
+    return hasIcon ? (hasValue && (active == null || !active) ? 0 : interpolate(focusAnimation.value, [0, 1], [themeRem, 0])) : 0
+  })
+  const rightIconSize = useDerivedValue(() => {
+    const hasValue = valueRef.current !== ''
+    return hasValue ? themeRem : focusAnimation.value * themeRem
+  })
 
   const scale = useDerivedValue(() => scaleProp?.value ?? 1)
 
@@ -232,6 +254,7 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
               returnKeyType={returnKeyType}
               accessibilityState={{ disabled }}
               autoFocus={autoFocus}
+              defaultValue={value}
               disableAnimation={disableAnimation}
               focusAnimation={focusAnimation}
               placeholder={placeholder}
@@ -239,10 +262,9 @@ export const SimpleTextInput = React.forwardRef<SimpleTextInputRef, SimpleTextIn
               selectionColor={theme.textInputSelectionColor}
               testID={`${testID}.textInput`}
               textAlignVertical="top"
-              value={value}
               // Callbacks:
               onBlur={handleBlur}
-              onChangeText={onChangeText}
+              onChangeText={handleChangeText}
               onFocus={handleFocus}
               onSubmitEditing={handleSubmitEditing}
               maxLength={maxLength}


### PR DESCRIPTION
The reason for this change is to fix bugs on Android related to
controlled TextInput components. Cursor placement is not accurate when
entering text for a controlled TextInput on Android.

A semi-controlled component is one where the value of the input is
controlled by the component imperatively; not declaratively. This is
done via the `setNativeProps` method on the TextInput.

This is a nice solution because it abstracts away the imperative nature
of an uncontrolled component (TextInput) with a parent controlled
component (SimpleTextInput/FilledTextInput).

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209448569952172