### PR TITLE
Fix `CryptoIcon's` secondary icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - changed: Simplify fake scene props implementation to reduce code duplication
 - fixed: Unstable text input cursor on Android for some instances.
 - fixed: Text used for sharing app split from one message into title and message
+- fixed: `CryptoIcon` not showing secondary/parent icon in some cases
 
 ## 4.23.0 (2025-03-01)
 

--- a/src/__tests__/components/__snapshots__/CurrencyIcon.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/CurrencyIcon.test.tsx.snap
@@ -65,6 +65,40 @@ exports[`CryptoIcon should render with loading props 1`] = `
         }
       />
     </View>
+    <View
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "bottom": 0,
+            "height": "50%",
+            "position": "absolute",
+            "right": 0,
+            "width": "50%",
+          },
+        ]
+      }
+    >
+      <FastImageView
+        resizeMode="cover"
+        source={
+          {
+            "uri": "https://content.edge.app/currencyIconsV3/bitcoin/bitcoin.png",
+          }
+        }
+        style={
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      />
+    </View>
   </View>
 </View>
 `;

--- a/src/__tests__/scenes/__snapshots__/CreateWalletEditNameScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletEditNameScene.test.tsx.snap
@@ -897,6 +897,40 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     }
                   />
                 </View>
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "bottom": 0,
+                        "height": "50%",
+                        "position": "absolute",
+                        "right": 0,
+                        "width": "50%",
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    source={
+                      {
+                        "uri": "https://content.edge.app/currencyIconsV3/ethereum/ethereum.png",
+                      }
+                    }
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
               </View>
             </View>
             <View

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -1043,6 +1043,40 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     }
                   />
                 </View>
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "bottom": 0,
+                        "height": "50%",
+                        "position": "absolute",
+                        "right": 0,
+                        "width": "50%",
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    source={
+                      {
+                        "uri": "https://content.edge.app/currencyIconsV3/ethereum/ethereum.png",
+                      }
+                    }
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
               </View>
             </View>
             <View
@@ -1234,6 +1268,40 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     source={
                       {
                         "uri": "https://content.edge.app/currencyIconsV3/ethereum/221657776846890989a759ba2973e427dff5c9bb.png",
+                      }
+                    }
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "bottom": 0,
+                        "height": "50%",
+                        "position": "absolute",
+                        "right": 0,
+                        "width": "50%",
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    source={
+                      {
+                        "uri": "https://content.edge.app/currencyIconsV3/ethereum/ethereum.png",
                       }
                     }
                     style={
@@ -1451,6 +1519,40 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     }
                   />
                 </View>
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "bottom": 0,
+                        "height": "50%",
+                        "position": "absolute",
+                        "right": 0,
+                        "width": "50%",
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    source={
+                      {
+                        "uri": "https://content.edge.app/currencyIconsV3/ethereum/ethereum.png",
+                      }
+                    }
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
               </View>
             </View>
             <View
@@ -1642,6 +1744,40 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     source={
                       {
                         "uri": "https://content.edge.app/currencyIconsV3/ethereum/6b175474e89094c44da98b954eedeac495271d0f.png",
+                      }
+                    }
+                    style={
+                      {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                  />
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "bottom": 0,
+                        "height": "50%",
+                        "position": "absolute",
+                        "right": 0,
+                        "width": "50%",
+                      },
+                    ]
+                  }
+                >
+                  <FastImageView
+                    resizeMode="cover"
+                    source={
+                      {
+                        "uri": "https://content.edge.app/currencyIconsV3/ethereum/ethereum.png",
                       }
                     }
                     style={

--- a/src/components/icons/CryptoIcon.tsx
+++ b/src/components/icons/CryptoIcon.tsx
@@ -17,7 +17,7 @@ export interface CryptoIconProps {
   // Image props
   hideSecondary?: boolean // Only show the currency icon for token (no secondary icon for the network)
   mono?: boolean // To use the mono dark icon logo
-  secondaryCurrencyIconProp?: number | { uri: string }
+  secondaryIconOverride?: number | { uri: string }
 
   // Styling props
   marginRem?: number | number[]
@@ -25,7 +25,7 @@ export interface CryptoIconProps {
 }
 
 export const CryptoIcon = (props: CryptoIconProps) => {
-  const { hideSecondary = false, marginRem, mono = false, secondaryCurrencyIconProp, sizeRem = 2, tokenId } = props
+  const { hideSecondary = false, marginRem, mono = false, secondaryIconOverride, sizeRem = 2, tokenId } = props
 
   const theme = useTheme()
   const styles = getStyles(theme)
@@ -40,8 +40,8 @@ export const CryptoIcon = (props: CryptoIconProps) => {
   const primaryCurrencyIcon = { uri: primaryCurrencyIconUrl }
 
   // Secondary (parent) currency icon (if it's a token)
-  let secondaryCurrencyIcon = secondaryCurrencyIconProp
-  if (tokenId != null && useChainIcon) {
+  let secondaryCurrencyIcon = secondaryIconOverride
+  if (secondaryIconOverride == null && (tokenId != null || useChainIcon)) {
     const icon = getCurrencyIconUris(pluginId, null)
     secondaryCurrencyIcon = { uri: mono ? icon.symbolImageDarkMono : icon.symbolImage }
   }

--- a/src/components/icons/WalletIcon.tsx
+++ b/src/components/icons/WalletIcon.tsx
@@ -31,7 +31,7 @@ export const WalletIcon = (props: WalletIconProps) => {
         size={size}
         wallet={wallet}
       />
-      <CryptoIcon {...props} pluginId={pluginId} secondaryCurrencyIconProp={compromised ? compromisedIcon : undefined} />
+      <CryptoIcon {...props} pluginId={pluginId} secondaryIconOverride={compromised ? compromisedIcon : undefined} />
     </View>
   )
 }


### PR DESCRIPTION
<img width="442" alt="image" src="https://github.com/user-attachments/assets/9d3b9bf0-f25b-42ce-b661-af0953950a28" />
<img width="442" alt="image" src="https://github.com/user-attachments/assets/d1883077-2f5e-4e3b-942c-7cc95d794679" />

Regressed from 0fdff1c

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209555807611142