### PR TITLE
Fix numeric input mode for FilledTextInput

### DIFF
--- a/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
@@ -102,7 +102,6 @@ exports[`FilledTextInput should render with some props 1`] = `
             }
           }
           accessible={true}
-          animated={true}
           autoCapitalize="none"
           autoCorrect={true}
           autoFocus={true}

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -601,7 +601,6 @@ exports[`CategoryModal should render with a subcategory 1`] = `
               }
             }
             accessible={true}
-            animated={true}
             autoCapitalize="words"
             autoFocus={true}
             defaultValue="Paycheck"
@@ -1993,7 +1992,6 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
               }
             }
             accessible={true}
-            animated={true}
             autoCapitalize="words"
             autoFocus={true}
             defaultValue=""

--- a/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
@@ -343,7 +343,6 @@ exports[`CountryListModal should render with a country list 1`] = `
               }
             }
             accessible={true}
-            animated={true}
             autoCapitalize="words"
             autoCorrect={false}
             autoFocus={true}

--- a/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
@@ -527,7 +527,6 @@ exports[`LogsModal should render with a logs modal 1`] = `
                   }
                 }
                 accessible={true}
-                animated={true}
                 autoCorrect={true}
                 autoFocus={false}
                 defaultValue=""

--- a/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
@@ -306,7 +306,6 @@ exports[`TextInputModal should render with a blank input field 1`] = `
                 }
               }
               accessible={true}
-              animated={true}
               autoFocus={true}
               defaultValue=""
               disableAnimation={
@@ -872,7 +871,6 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                 }
               }
               accessible={true}
-              animated={true}
               autoFocus={true}
               defaultValue="initialValue"
               disableAnimation={

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -554,7 +554,6 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                 }
               }
               accessible={true}
-              animated={true}
               autoCapitalize="none"
               autoCorrect={false}
               autoFocus={true}

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -546,7 +546,6 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               }
             }
             accessible={true}
-            animated={true}
             autoCapitalize="none"
             autoComplete="off"
             autoCorrect={false}

--- a/src/__tests__/utils/intl.ts
+++ b/src/__tests__/utils/intl.ts
@@ -1,0 +1,37 @@
+import { formatNumberInput, formatToNativeNumber, isValidInput } from '../../locales/intl'
+
+describe('locales/intl.ts', function () {
+  test('formatNumberInput', function () {
+    expect(formatNumberInput('')).toBe('0')
+    expect(formatNumberInput('0')).toBe('0')
+    expect(formatNumberInput('100')).toBe('100')
+    expect(formatNumberInput('1000')).toBe('1,000')
+    expect(() => formatNumberInput('1,000')).toThrow()
+  })
+
+  test('formatToNativeNumber', function () {
+    // valid
+    expect(formatToNativeNumber('')).toBe('')
+    expect(formatToNativeNumber('0')).toBe('0')
+    expect(formatToNativeNumber('1,000')).toBe('1000')
+    expect(formatToNativeNumber('1.000')).toBe('1.000')
+    expect(formatToNativeNumber('', { minDecimals: 1, maxDecimals: 1 })).toBe('')
+    // odd but valid
+    expect(formatToNativeNumber('1.000,00')).toBe('1.00000')
+  })
+
+  test('isValidInput', function () {
+    // valid
+    expect(isValidInput('')).toBe(true)
+    expect(isValidInput('0')).toBe(true)
+    expect(isValidInput('1.5')).toBe(true)
+    expect(isValidInput('1,5')).toBe(true)
+    expect(isValidInput('1,500.0')).toBe(true)
+    expect(isValidInput('1.500,0')).toBe(true)
+    // odd, but valid
+    expect(isValidInput('1,5.0')).toBe(true)
+    expect(isValidInput('1.5,0')).toBe(true)
+    // invalid
+    expect(isValidInput('abc')).toBe(false)
+  })
+})

--- a/src/plugins/gui/scenes/FiatPluginEnterAmountScene.tsx
+++ b/src/plugins/gui/scenes/FiatPluginEnterAmountScene.tsx
@@ -23,7 +23,7 @@ import { FiatPluginEnterAmountResponse } from '../fiatPluginTypes'
 import { StateManager, useStateManager } from '../hooks/useStateManager'
 
 export interface FiatPluginEnterAmountParams {
-  initState?: Partial<any>
+  initState?: Partial<EnterAmountState>
   headerTitle: string
   label1: string
   label2: string


### PR DESCRIPTION
The `FilledTextInput` component was relying on a child component to handle its number formatting, but that component is incompatible with our new semi-controlled approach. Just use the intl utility functions to provide the same behavior directly.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209567077707086