### PR TITLE
Jon/fix/stake-options-scene

### DIFF
--- a/src/components/scenes/Staking/StakeOptionsScene.tsx
+++ b/src/components/scenes/Staking/StakeOptionsScene.tsx
@@ -15,7 +15,7 @@ import { StakePolicy } from '../../../plugins/stake-plugins/types'
 import { useSelector } from '../../../types/reactRedux'
 import { EdgeAppSceneProps } from '../../../types/routerTypes'
 import { getTokenIdForced } from '../../../util/CurrencyInfoHelpers'
-import { getPluginFromPolicy, getPolicyAssetName, getPolicyIconUris, getPolicyTitleName } from '../../../util/stakeUtils'
+import { getPluginFromPolicyId, getPolicyAssetName, getPolicyIconUris, getPolicyTitleName } from '../../../util/stakeUtils'
 import { darkenHexColor } from '../../../util/utils'
 import { StakingOptionCard } from '../../cards/StakingOptionCard'
 import { AccentColors } from '../../common/DotsBackground'
@@ -75,7 +75,7 @@ const StakeOptionsSceneComponent = (props: Props) => {
 
   const handleStakeOptionPress = (stakePolicy: StakePolicy) => {
     const { stakePolicyId } = stakePolicy
-    const stakePlugin = getPluginFromPolicy(stakePlugins, stakePolicy, {
+    const stakePlugin = getPluginFromPolicyId(stakePlugins, stakePolicyId, {
       pluginId
     })
     if (stakePlugin != null)

--- a/src/components/themed/TransactionListTop.tsx
+++ b/src/components/themed/TransactionListTop.tsx
@@ -35,7 +35,7 @@ import { GuiExchangeRates } from '../../types/types'
 import { CryptoAmount } from '../../util/CryptoAmount'
 import { isKeysOnlyPlugin } from '../../util/CurrencyInfoHelpers'
 import { triggerHaptic } from '../../util/haptic'
-import { getBestApyText, getFioStakingBalances, getPluginFromPolicy, getPositionAllocations, isStakingSupported } from '../../util/stakeUtils'
+import { getBestApyText, getFioStakingBalances, getPluginFromPolicyId, getPositionAllocations, isStakingSupported } from '../../util/stakeUtils'
 import { getUkCompliantString } from '../../util/ukComplianceUtils'
 import { convertNativeToDenomination, DECIMAL_PRECISION, removeIsoPrefix, zeroString } from '../../util/utils'
 import { IconButton } from '../buttons/IconButton'
@@ -583,7 +583,7 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
     if (stakePolicies.length === 1) {
       const [stakePolicy] = stakePolicies
       const { stakePolicyId } = stakePolicy
-      const stakePlugin = getPluginFromPolicy(stakePlugins, stakePolicy, {
+      const stakePlugin = getPluginFromPolicyId(stakePlugins, stakePolicy.stakePolicyId, {
         pluginId: wallet.currencyInfo.pluginId
       })
       if (stakePlugin != null)

--- a/src/components/themed/TransactionListTop.tsx
+++ b/src/components/themed/TransactionListTop.tsx
@@ -23,8 +23,8 @@ import { useWatch } from '../../hooks/useWatch'
 import { formatNumber } from '../../locales/intl'
 import { lstrings } from '../../locales/strings'
 import { getStakePlugins } from '../../plugins/stake-plugins/stakePlugins'
-import { PositionAllocation, StakePlugin } from '../../plugins/stake-plugins/types'
-import { defaultWalletStakingState, WalletStakingState } from '../../reducers/StakingReducer'
+import { PositionAllocation, StakePlugin, StakePolicy } from '../../plugins/stake-plugins/types'
+import { defaultWalletStakingState, StakePositionMap, WalletStakingState } from '../../reducers/StakingReducer'
 import { getExchangeDenomByCurrencyCode, selectDisplayDenomByCurrencyCode } from '../../selectors/DenominationSelectors'
 import { getExchangeRate } from '../../selectors/WalletSelectors'
 import { config } from '../../theme/appConfig'
@@ -93,8 +93,10 @@ interface StateProps {
   exchangeRates: GuiExchangeRates
   isAccountBalanceVisible: boolean
   stakePlugins: StakePlugin[]
+  stakePolicies: StakePolicy[]
+  stakePositionMap: StakePositionMap
+  lockedNativeAmount: string
   walletName: string
-  walletStakingState: WalletStakingState
 }
 
 interface DispatchProps {
@@ -123,7 +125,7 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
       // Update staked amount if the tokenId changes but the wallet remains the same
       let total = '0'
       let lockedNativeAmount = '0'
-      for (const stakePosition of Object.values(this.props.walletStakingState.stakePositionMap)) {
+      for (const stakePosition of Object.values(this.props.stakePositionMap)) {
         const { staked, earned } = getPositionAllocations(stakePosition)
         total = this.getTotalPosition(this.props.currencyCode, [...staked, ...earned])
         lockedNativeAmount = add(lockedNativeAmount, total)
@@ -454,7 +456,7 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
    * spinner.
    */
   renderStakedBalance() {
-    const { theme, wallet, defaultFiat, displayDenomination, exchangeDenomination, exchangeRate } = this.props
+    const { theme, wallet, defaultFiat, displayDenomination, exchangeDenomination, exchangeRate, lockedNativeAmount } = this.props
     const styles = getStyles(theme)
 
     if (SPECIAL_CURRENCY_INFO[wallet.currencyInfo.pluginId]?.isStakingSupported !== true) return null
@@ -464,7 +466,7 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
     const { locked } = getFioStakingBalances(wallet.stakingStatus)
 
     const walletBalanceLocked = locked
-    const nativeLocked = add(walletBalanceLocked, this.props.walletStakingState.lockedNativeAmount)
+    const nativeLocked = add(walletBalanceLocked, lockedNativeAmount)
     if (nativeLocked === '0') return null
 
     const stakingCryptoAmount = convertNativeToDenomination(displayDenomination.multiplier)(nativeLocked)
@@ -488,11 +490,11 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
   }
 
   renderButtons() {
-    const { theme, walletStakingState } = this.props
+    const { theme, stakePolicies } = this.props
     const styles = getStyles(theme)
     const { countryCode } = this.state
     const hideStaking = !isStakingSupported(this.props.wallet.currencyInfo.pluginId)
-    const bestApyText = getBestApyText(Object.values(walletStakingState.stakePolicies))
+    const bestApyText = getBestApyText(stakePolicies)
 
     return (
       <View style={styles.buttonsContainer}>
@@ -509,7 +511,7 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
             onPress={this.handleStakePress}
             superscriptLabel={bestApyText}
           >
-            {this.props.walletStakingState.isLoading ? (
+            {stakePolicies.length === 0 ? (
               <ActivityIndicator color={theme.primaryText} />
             ) : (
               <Feather name="percent" size={theme.rem(1.75)} color={theme.primaryText} />
@@ -525,7 +527,7 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
 
   isStakingPolicyAvailable = (): boolean => {
     return (
-      Object.keys(this.props.walletStakingState.stakePolicies).length > 0 ||
+      Object.keys(this.props.stakePolicies).length > 0 ||
       // FIO was the first staking-enabled currency and doesn't use staking policies yet
       this.props.wallet.currencyInfo.pluginId === 'fio'
     )
@@ -535,7 +537,7 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
    * nearest whole number if >= 10, and truncating to '>99%' if greater than 99%
    * */
   getBestApy = (): string | undefined => {
-    const stakePolicies = Object.values(this.props.walletStakingState.stakePolicies)
+    const { stakePolicies } = this.props
     if (stakePolicies.length === 0) return
     const bestApy = stakePolicies.reduce((prev, curr) => Math.max(prev, curr.apy ?? 0), 0)
     if (bestApy === 0) return
@@ -567,9 +569,8 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
 
   handleStakePress = () => {
     triggerHaptic('impactLight')
-    const { currencyCode, wallet, navigation, tokenId } = this.props
+    const { currencyCode, wallet, navigation, stakePolicies, tokenId } = this.props
     const { stakePlugins } = this.props
-    const stakePolicies = Object.values(this.props.walletStakingState.stakePolicies)
 
     // Handle FIO staking
     if (currencyCode === 'FIO') {
@@ -581,9 +582,8 @@ export class TransactionListTopComponent extends React.PureComponent<Props, Stat
 
     // Handle StakePlugin staking
     if (stakePolicies.length === 1) {
-      const [stakePolicy] = stakePolicies
-      const { stakePolicyId } = stakePolicy
-      const stakePlugin = getPluginFromPolicyId(stakePlugins, stakePolicy.stakePolicyId, {
+      const stakePolicyId = stakePolicies[0].stakePolicyId
+      const stakePlugin = getPluginFromPolicyId(stakePlugins, stakePolicyId, {
         pluginId: wallet.currencyInfo.pluginId
       })
       if (stakePlugin != null)
@@ -754,13 +754,23 @@ export function TransactionListTop(props: OwnProps) {
     // Fallback to a default state using the reducer if the wallet is not found
     state => state.staking.walletStakingMap[wallet.id] ?? defaultWalletStakingState
   )
-
-  const [stakePlugins] = useAsyncValue<StakePlugin[]>(async () => await getStakePlugins(wallet.currencyInfo.pluginId))
+  const { stakePositionMap, lockedNativeAmount } = walletStakingState
 
   const defaultFiat = removeIsoPrefix(defaultIsoFiat)
   const theme = useTheme()
 
   const { currencyCode } = tokenId == null ? wallet.currencyInfo : wallet.currencyConfig.allTokens[tokenId]
+
+  const [stakePlugins = []] = useAsyncValue<StakePlugin[]>(async () => await getStakePlugins(wallet.currencyInfo.pluginId))
+  const stakePolicies = stakePlugins.flatMap(stakePlugin =>
+    stakePlugin
+      .getPolicies({ pluginId: wallet.currencyInfo.pluginId })
+      .filter(
+        stakePolicy =>
+          !stakePolicy.deprecated &&
+          stakePolicy.stakeAssets.some(asset => asset.pluginId === wallet.currencyInfo.pluginId && asset.currencyCode === currencyCode)
+      )
+  )
 
   const displayDenomination = useSelector(state => selectDisplayDenomByCurrencyCode(state, wallet.currencyConfig, currencyCode))
   const exchangeDenomination = getExchangeDenomByCurrencyCode(wallet.currencyConfig, currencyCode)
@@ -793,8 +803,10 @@ export function TransactionListTop(props: OwnProps) {
       toggleBalanceVisibility={handleBalanceVisibility}
       theme={theme}
       walletName={walletName}
-      walletStakingState={walletStakingState}
-      stakePlugins={stakePlugins ?? []}
+      stakePlugins={stakePlugins}
+      stakePolicies={stakePolicies}
+      stakePositionMap={stakePositionMap}
+      lockedNativeAmount={lockedNativeAmount}
     />
   )
 }

--- a/src/reducers/StakingReducer.ts
+++ b/src/reducers/StakingReducer.ts
@@ -69,7 +69,22 @@ export interface WalletStakingStateMap {
 export interface WalletStakingState {
   isLoading: boolean
   lockedNativeAmount: string
+  /**
+   * @deprecated: Using this takes too long to load. Use `getStakePlugins`
+   * instead.
+   *
+   * TODO: Can probably remove this completely.
+   */
   stakePlugins: StakePlugin[]
+  /**
+   * @deprecated: Using this takes too long to load if all you are doing is
+   * trying to find policy information.
+   *
+   * Use `stakePositionMap` for position information, and `getStakePolicy` for
+   * policy information.
+   *
+   * TODO: Can probably remove this completely.
+   */
   stakePolicies: StakePolicyMap
   stakePositionMap: StakePositionMap
 }

--- a/src/util/stakeUtils.ts
+++ b/src/util/stakeUtils.ts
@@ -95,8 +95,8 @@ export const getPolicyIconUris = (
   return { stakeAssetUris, rewardAssetUris }
 }
 
-export const getPluginFromPolicy = (stakePlugins: StakePlugin[], stakePolicy: StakePolicy, filter?: StakePolicyFilter): StakePlugin | undefined => {
-  return stakePlugins.find(plugin => plugin.getPolicies(filter).find(policy => policy.stakePolicyId === stakePolicy.stakePolicyId))
+export const getPluginFromPolicyId = (stakePlugins: StakePlugin[], stakePolicyId: string, filter?: StakePolicyFilter): StakePlugin | undefined => {
+  return stakePlugins.find(plugin => plugin.getPolicies(filter).find(policy => policy.stakePolicyId === stakePolicyId))
 }
 
 /**


### PR DESCRIPTION
`StakeOptionsScene`, `TransactionListTop`: Reduce dependency on `walletStakingMap`

`CoinRankingDetailsScene`: Now limited by only the time it takes to read `countryCode` from `getFirstOpenInfo()`

General: Avoid relying on `stakePolicy` and `stakePlugins` from `walletStakingMap.` This map takes a while to load since it also checks open positions. The majority of what's required from `stakePolicy`/`stakePlugins` doesn't require position info and can be generated quickly by other means.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209683564147110