### PR TITLE
ecash integration 

### DIFF
--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -89,6 +89,7 @@ export const WALLET_LIST_MENU: Array<{
       'digibyte',
       'dogecoin',
       'eboost',
+      'ecash',
       'eos',
       'zcoin',
       'feathercoin',

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -40,6 +40,7 @@ export const CURRENCY_SETTINGS_KEYS = [
   'ethereumclassic',
   'dash',
   'litecoin',
+  'ecash',
   'bitcoinsv',
   'monero',
   'zcoin',
@@ -75,6 +76,7 @@ export const WALLET_TYPE_ORDER = [
   'wallet:ethereumclassic',
   'wallet:binance',
   'wallet:solana',
+  'wallet:ecash',
   'wallet:bitcoinsv',
   'wallet:litecoin',
   'wallet:eos',
@@ -259,6 +261,14 @@ export const SPECIAL_CURRENCY_INFO: {
     isImportKeySupported: true,
     isStakingSupported: true,
     unstoppableDomainsTicker: 'LTC'
+  },
+  ecash: {
+    maxSpendTargets: UTXO_MAX_SPEND_TARGETS,
+    initWalletName: lstrings.string_first_ecash_wallet_name,
+    chainCode: 'XEC',
+    isImportKeySupported: true,
+    isSplittingDisabled: true,
+    unstoppableDomainsTicker: 'XEC'
   },
   rsk: {
     initWalletName: lstrings.string_first_rsk_wallet_name,

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -551,6 +551,7 @@ const strings = {
   string_first_filecoin_wallet_name: 'My Filecoin',
   string_first_filecoin_fevm_wallet_name: 'My Filecoin FEVM',
   string_first_filecoin_fevm_calibratio_wallet_name: 'My Filecoin FEVM (Calibration)',
+  string_first_ecash_wallet_name: 'My eCash Wallet',
   string_first_bitcoin_wallet_name: 'My Bitcoin',
   string_first_bitcoin_testnet_wallet_name: 'My Bitcoin Testnet',
   string_first_bitcoincash_wallet_name: 'My Bitcoin Cash',

--- a/src/locales/strings/de.json
+++ b/src/locales/strings/de.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "Meine Bitcoin-Gold",
   "string_first_dash_wallet_name": "Mein Dash",
   "string_first_digibyte_wallet_name": "Mein DigiByte",
+  "string_first_ecash_wallet_name": "Mein eCash",
   "string_first_eos_wallet_name": "Meine EOS",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "Meine Telos",

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -483,6 +483,7 @@
   "string_first_filecoin_wallet_name": "My Filecoin",
   "string_first_filecoin_fevm_wallet_name": "My Filecoin FEVM",
   "string_first_filecoin_fevm_calibratio_wallet_name": "My Filecoin FEVM (Calibration)",
+  "string_first_ecash_wallet_name": "My eCash Wallet",
   "string_first_bitcoin_wallet_name": "My Bitcoin",
   "string_first_bitcoin_testnet_wallet_name": "My Bitcoin Testnet",
   "string_first_bitcoincash_wallet_name": "My Bitcoin Cash",

--- a/src/locales/strings/es.json
+++ b/src/locales/strings/es.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "Mi Bitcoin Gold",
   "string_first_dash_wallet_name": "Mi Dash",
   "string_first_digibyte_wallet_name": "Mi Digibyte",
+  "string_first_ecash_wallet_name": "Mi eCash",
   "string_first_eos_wallet_name": "Mi EOS",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "Mis Telos",

--- a/src/locales/strings/esMX.json
+++ b/src/locales/strings/esMX.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "Mi Bitcoin Gold",
   "string_first_dash_wallet_name": "Mi Dash",
   "string_first_digibyte_wallet_name": "Mi DigiByte",
+  "string_first_ecash_wallet_name": "Mi eCash",
   "string_first_eos_wallet_name": "Mi EOS",
   "string_first_holesky_wallet_name": "Mi Holesky",
   "string_first_telos_wallet_name": "Mis Telos",

--- a/src/locales/strings/fr.json
+++ b/src/locales/strings/fr.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "Mes Bitcoins Or",
   "string_first_dash_wallet_name": "Mes Dash",
   "string_first_digibyte_wallet_name": "Mes DigiBytes",
+  "string_first_ecash_wallet_name": "My eCash",
   "string_first_eos_wallet_name": "Mes EOS",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "My Telos",

--- a/src/locales/strings/it.json
+++ b/src/locales/strings/it.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "I miei Bitcoin Gold",
   "string_first_dash_wallet_name": "I miei Dash",
   "string_first_digibyte_wallet_name": "I miei DigiByte",
+  "string_first_ecash_wallet_name": "I miei eCash",
   "string_first_eos_wallet_name": "I miei EOS",
   "string_first_holesky_wallet_name": "I miei Holesky",
   "string_first_telos_wallet_name": "I miei Telos",

--- a/src/locales/strings/ja.json
+++ b/src/locales/strings/ja.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "My Bitcoin Gold",
   "string_first_dash_wallet_name": "My Dash",
   "string_first_digibyte_wallet_name": "My DigiByte",
+  "string_first_ecash_wallet_name": "My eCash",
   "string_first_eos_wallet_name": "My EOS",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "My Telos",

--- a/src/locales/strings/kaa.json
+++ b/src/locales/strings/kaa.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "My Bitcoin Gold",
   "string_first_dash_wallet_name": "My Dash",
   "string_first_digibyte_wallet_name": "My DigiByte",
+  "string_first_ecash_wallet_name": "My eCash",
   "string_first_eos_wallet_name": "My EOS",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "My Telos",

--- a/src/locales/strings/ko.json
+++ b/src/locales/strings/ko.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "My Bitcoin Gold",
   "string_first_dash_wallet_name": "My Dash",
   "string_first_digibyte_wallet_name": "My DigiByte (디지바이트)",
+  "string_first_ecash_wallet_name": "My eCash",
   "string_first_eos_wallet_name": "My EOS (이오스)",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "My Telos",

--- a/src/locales/strings/pt.json
+++ b/src/locales/strings/pt.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "Meu Bitcoin Gold",
   "string_first_dash_wallet_name": "Minha Dash",
   "string_first_digibyte_wallet_name": "Meu DigiByte",
+  "string_first_ecash_wallet_name": "Meu eCash",
   "string_first_eos_wallet_name": "Meu EOS",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "Meu Telos",

--- a/src/locales/strings/ru.json
+++ b/src/locales/strings/ru.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "Мой Bitcoin Gold",
   "string_first_dash_wallet_name": "Мой Dash",
   "string_first_digibyte_wallet_name": "Мой DigiByte",
+  "string_first_ecash_wallet_name": "Мой eCash",
   "string_first_eos_wallet_name": "Мой EOS",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "Мой Telos",

--- a/src/locales/strings/vi.json
+++ b/src/locales/strings/vi.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "Bitcoin Gold của tôi",
   "string_first_dash_wallet_name": "Dash của tôi",
   "string_first_digibyte_wallet_name": "DigiByte Của tôi",
+  "string_first_ecash_wallet_name": "eCash của tôi",
   "string_first_eos_wallet_name": "EOS của tôi",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "My Telos",

--- a/src/locales/strings/zh.json
+++ b/src/locales/strings/zh.json
@@ -490,6 +490,7 @@
   "string_first_bitcoin_gold_wallet_name": "我的比特黄金",
   "string_first_dash_wallet_name": "我的达世币",
   "string_first_digibyte_wallet_name": "我的极特币",
+  "string_first_ecash_wallet_name": "My eCash",
   "string_first_eos_wallet_name": "我的EOS",
   "string_first_holesky_wallet_name": "My Holesky",
   "string_first_telos_wallet_name": "My Telos",

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -63,6 +63,7 @@ export const currencyPlugins: EdgeCorePluginsInit = {
   dash: ENV.DASH_INIT,
   digibyte: ENV.DIGIBYTE_INIT,
   dogecoin: ENV.DOGE_INIT,
+  ecash: true,
   eboost: true,
   feathercoin: true,
   groestlcoin: ENV.GROESTLCOIN_INIT,


### PR DESCRIPTION
## Add eCash Support to Edge Wallet

### Description
This PR adds support for eCash (XEC) in Edge Wallet. Now, users will be able to send and receive eCash.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [X] Yes
- [ ] No

### Dependencies

This PR is related to [PR #424 in the other repo](https://github.com/EdgeApp/edge-currency-plugins/pull/424#issue-2941857720)

### Requirements

- [ ] Tested on iOS device
- [X] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [X] Tested on large-screen device (tablet)
