### PR TITLE
React to data changes in `EdgeCarousel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added: `preferProviders` support to override default priority when selecting a fiat provider
 - added: "Asset Settings" option to `WalletListMenuModal`
 - changed: Buy/sell removed for UK
+- fixed: `EdgeCarousel` not updating when data changes
 
 ## 4.25.0 (staging)
 

--- a/src/components/common/EdgeCarousel.tsx
+++ b/src/components/common/EdgeCarousel.tsx
@@ -29,6 +29,10 @@ export function EdgeCarousel<T>(props: Props<T>): JSX.Element {
   const [activeIndex, setActiveIndex] = useState(0)
   const [dataLocal, setDataLocal] = useState(data)
 
+  React.useEffect(() => {
+    setDataLocal(data)
+  }, [data])
+
   const renderItem = useHandler<ListRenderItem<T>>(info => (
     <View style={[styles.childContainer, { width: width * 0.9, height }]}>{props.renderItem(info)}</View>
   ))
@@ -41,10 +45,11 @@ export function EdgeCarousel<T>(props: Props<T>): JSX.Element {
   useAsyncEffect(
     async () => {
       // HACK: With 1 item, this is the only way to force a render in iOS
-      if (Platform.OS === 'ios' && data.length === 1) {
+      if (Platform.OS === 'ios' && dataLocal.length === 1) {
+        const tempData = [...dataLocal]
         setDataLocal([])
         setTimeout(() => {
-          setDataLocal(data)
+          setDataLocal(tempData)
         }, 500)
       }
       // The built-in hack fn works for all other cases
@@ -54,7 +59,7 @@ export function EdgeCarousel<T>(props: Props<T>): JSX.Element {
         })
       }
     },
-    [],
+    [dataLocal], // Depend on dataLocal instead of data to avoid infinite loops
     'triggerRenderingHack'
   )
 


### PR DESCRIPTION
Locale-specific data isn't immediately avialable before `countryCode` loads and when this happens, `EdgeCarousel` doesn't react

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208440993939949