### PR TITLE
Protect against unspendable staking transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 
 ## 4.25.0 (staging)
 
-- fixed: Fix yesterday rate lookup in `exchangeRates`
 - fixed: Crash on `StakeOverviewScene`
 - fixed: Fix race condition between reading and writing account settings
+- fixed: Fix yesterday rate lookup in `exchangeRates`
+- fixed: Intermittent staking/unstaking errors for Cardano
 - fixed: Prevent acceleration for swap transactions.
 
 ## 4.24.1 (staging)


### PR DESCRIPTION
Kiln can sometimes send Cardano transaction with spend UTXOs when Kiln's network state is out of sync. We can protect from this if the engine gives information about the spend-ability of the transaction.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-currency-accountbased/pull/914

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209540063113868