### PR TITLE
Add fallback handling for unsupported http://edge.app deep links

### DIFF
--- a/src/util/DeepLinkParser.ts
+++ b/src/util/DeepLinkParser.ts
@@ -273,7 +273,8 @@ function parseEdgeAppLink(url: URL<string>): DeepLink {
     }
   }
 
-  throw new SyntaxError('Unknown "edge.app" deep link format')
+  // No special handling supported. Open in browser.
+  return { type: 'other', protocol: url.protocol.replace(/:$/, ''), uri: url.href }
 }
 
 /**


### PR DESCRIPTION
Reinstate normal handling flow for http://edge.app links as a fallback instead of throwing.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
