### PR TITLE
Remove iOS rendering hack in `EdgeCarousel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - changed: Newly created wallets are added to `mostRecentWallets`
 - fixed: `EdgeCarousel` not updating when data changes
 - fixed: Network error handling in `SwipeChart`
+- fixed: Flicking `EdgeCarousel` card on iOS when displaying only one card
 
 ## 4.25.0 (2025-03-31)
 

--- a/src/components/common/EdgeCarousel.tsx
+++ b/src/components/common/EdgeCarousel.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
-import { InteractionManager, ListRenderItem, Platform, View } from 'react-native'
+import { ListRenderItem, View } from 'react-native'
 import Carousel, { Pagination } from 'react-native-snap-carousel'
 
-import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { useHandler } from '../../hooks/useHandler'
 import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
 
@@ -27,47 +26,16 @@ export function EdgeCarousel<T>(props: Props<T>): JSX.Element {
   const carouselRef = React.useRef<Carousel<any>>(null)
 
   const [activeIndex, setActiveIndex] = useState(0)
-  const [dataLocal, setDataLocal] = useState(data)
-
-  React.useEffect(() => {
-    setDataLocal(data)
-  }, [data])
 
   const renderItem = useHandler<ListRenderItem<T>>(info => (
     <View style={[styles.childContainer, { width: width * 0.9, height }]}>{props.renderItem(info)}</View>
   ))
 
-  /**
-   * Carousel's FlatList bug workaround. Fixes the issue where items are
-   * hidden until scroll actions are performed either in the carousel or on the
-   * scene itself.
-   */
-  useAsyncEffect(
-    async () => {
-      // HACK: With 1 item, this is the only way to force a render in iOS
-      if (Platform.OS === 'ios' && dataLocal.length === 1) {
-        const tempData = [...dataLocal]
-        setDataLocal([])
-        setTimeout(() => {
-          setDataLocal(tempData)
-        }, 500)
-      }
-      // The built-in hack fn works for all other cases
-      else if (carouselRef.current != null) {
-        await InteractionManager.runAfterInteractions(() => {
-          carouselRef.current?.triggerRenderingHack()
-        })
-      }
-    },
-    [dataLocal], // Depend on dataLocal instead of data to avoid infinite loops
-    'triggerRenderingHack'
-  )
-
   return (
     <View style={styles.carouselContainer}>
       <Carousel
         ref={carouselRef}
-        data={dataLocal}
+        data={data}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
         sliderWidth={width}
@@ -87,7 +55,7 @@ export function EdgeCarousel<T>(props: Props<T>): JSX.Element {
           marginTop: -theme.rem(1),
           marginBottom: -theme.rem(1)
         }}
-        dotsLength={dataLocal.length}
+        dotsLength={data.length}
         activeDotIndex={activeIndex}
         tappableDots={carouselRef.current != null}
         dotStyle={styles.dotStyle}


### PR DESCRIPTION
This affects only iOS only when there is exactly one card. 

This is the conflict between the original rendering hack that was required to get iOS to work with exactly 1 card and the recent fix for: Home - Fix blogPostsGeo (swapix article) https://app.asana.com/0/1200234943382353/1208440993939949/f

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209868735707894