### PR TITLE
Make bottom insets static if the scene does not `avoidKeyboard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added: Add PIVX.
 - added: Monero multi output support.
 - added: Moonpay Sell support for ACH.
+- fixed: `SceneWrapper` bottom inset calculations for scenes that do not `avoidKeyboard`
 
 ## 4.26.0 (2025-04-14)
 

--- a/src/components/common/SceneWrapper.tsx
+++ b/src/components/common/SceneWrapper.tsx
@@ -167,7 +167,7 @@ function SceneWrapperComponent(props: SceneWrapperProps): JSX.Element {
   // Ignore tab bar height when keyboard is open because it is rendered behind it
   const maybeTabBarHeight = hasTabs && !isKeyboardOpen ? MAX_TAB_BAR_HEIGHT : 0
   // Ignore inset bottom when keyboard is open because it is rendered behind it
-  const maybeInsetBottom = !isKeyboardOpen ? safeAreaInsets.bottom : 0
+  const maybeInsetBottom = !isKeyboardOpen || !avoidKeyboard ? safeAreaInsets.bottom : 0
   const insets: EdgeInsets = useMemo(
     () => ({
       top: hasHeader ? headerBarHeight : safeAreaInsets.top,


### PR DESCRIPTION
For scenes that don't avoid the keyboard, the scene boundaries should never change.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209438524785867
  - https://app.asana.com/0/0/1209551697973955