### PR TITLE
Add Maestro `testID` support in `NotificationCard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added: Add PIVX.
 - added: Monero multi output support.
 - added: Moonpay Sell support for ACH.
+- added: Maestro `testID` support in `NotificationCard`
 - fixed: `SceneWrapper` bottom inset calculations for scenes that do not `avoidKeyboard`
 
 ## 4.26.0 (2025-04-14)

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -22,6 +22,7 @@ interface Props {
    * visible if the body is tapped. Default false. */
   persistent?: boolean
   iconUri?: string
+  testID?: string
 
   onPress: () => void | Promise<void>
 
@@ -33,7 +34,7 @@ const NotificationCardComponent = (props: Props) => {
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const { title, type, message, persistent = false, onClose, onPress } = props
+  const { title, type, message, persistent = false, testID, onClose, onPress } = props
   const { iconUri = type === 'warning' ? getThemedIconUri(theme, 'notifications/icon-warning') : getThemedIconUri(theme, 'notifications/icon-info') } = props
 
   const opacity = useSharedValue(1)
@@ -78,7 +79,7 @@ const NotificationCardComponent = (props: Props) => {
     <ShadowedView style={Platform.OS === 'android' ? styles.shadowAndroid : styles.shadowIos}>
       <BlurBackground />
       <Animated.View style={[styles.cardContainer, animatedStyle]}>
-        <TouchableContents onPress={handlePress}>
+        <TouchableContents onPress={handlePress} testID={testID}>
           <Icon source={{ uri: iconUri }} />
           <TextView>
             {/* Android font scaling is too aggressive. 
@@ -95,7 +96,7 @@ const NotificationCardComponent = (props: Props) => {
           </TextView>
         </TouchableContents>
         {onClose != null ? (
-          <TouchableCloseButton onPress={handleClose}>
+          <TouchableCloseButton onPress={handleClose} testID={`${testID}.close`}>
             <AntDesignIcon color={theme.iconTappable} name="close" size={theme.rem(1.25)} />
           </TouchableCloseButton>
         ) : null}

--- a/src/components/notification/NotificationView.tsx
+++ b/src/components/notification/NotificationView.tsx
@@ -169,6 +169,7 @@ const NotificationViewComponent = (props: Props) => {
           persistent
           onPress={handleBackupPress}
           onClose={handleBackupClose}
+          testID="notifBackup"
         />
       </EdgeAnim>
       <EdgeAnim visible={autoDetectTokenCards.length > 0} enter={fadeIn} exit={fadeOut}>
@@ -181,6 +182,7 @@ const NotificationViewComponent = (props: Props) => {
           message={lstrings.notif_otp_message}
           onPress={handleOtpReminderPress}
           onClose={handleOtpReminderClose}
+          testID="notifOtp"
         />
       </EdgeAnim>
       <EdgeAnim visible={!pwReminder.isBannerHidden} enter={fadeIn} exit={fadeOut}>
@@ -190,6 +192,7 @@ const NotificationViewComponent = (props: Props) => {
           message={lstrings.password_reminder_card_body}
           onPress={handlePasswordReminderPress}
           onClose={handlePasswordReminderClose}
+          testID="notifPassword"
         />
       </EdgeAnim>
       <EdgeAnim visible={!ip2FaReminder.isBannerHidden} enter={fadeIn} exit={fadeOut}>


### PR DESCRIPTION
<img width="516" alt="image" src="https://github.com/user-attachments/assets/8a323b13-bcd4-413e-a618-2ed5f08d64e5" />
<img width="528" alt="image" src="https://github.com/user-attachments/assets/683dcff4-4828-4501-9cbf-733216874bce" />

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210037451254556