### PR TITLE
Jon/fix/ios-carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added: Moonpay Sell support for ACH.
 - added: Maestro `testID` support in `NotificationCard`
 - changed: Scanning private key button copy updated from "Import" -> "Confirm"
+- fixed: iOS not immediately showing `EdgeCarousel` cards if only one card is present
 - fixed: `SceneWrapper` bottom inset calculations for scenes that do not `avoidKeyboard`
 
 ## 4.26.0 (2025-04-14)


### PR DESCRIPTION
In the previous change that attempted to fix flickering of the promo card, `dataLocal` as a dependency was causing an infinite loop for iOS repeatedly clearing the data every 500ms.

The rendering hacks was incorrectly verified as no longer being necessary.  and removed.

The hacks  are still necessary, but need only trigger once on mount.

Delay also reduced to be less perceptible.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210049206021043