### PR TITLE
Fix Android display bugs in DuressModeHowToScene

### DIFF
--- a/src/components/scenes/DuressModeHowToScene.tsx
+++ b/src/components/scenes/DuressModeHowToScene.tsx
@@ -9,7 +9,7 @@ import { EdgeCard } from '../cards/EdgeCard'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { styled } from '../hoc/styled'
 import { SceneContainer } from '../layout/SceneContainer'
-import { EdgeText, Paragraph } from '../themed/EdgeText'
+import { EdgeText } from '../themed/EdgeText'
 
 interface Props extends EdgeAppSceneProps<'duressModeHowTo'> {}
 
@@ -23,24 +23,16 @@ export const DuressModeHowToScene = (props: Props) => {
   return (
     <SceneWrapper scroll>
       <SceneContainer headerTitle={lstrings.how_duress_mode_works}>
-        <EdgeCard>
-          <Paragraph>{parseMarkdown(lstrings.how_duress_mode_works_description_md)}</Paragraph>
-        </EdgeCard>
+        <EdgeCard>{parseMarkdown(lstrings.how_duress_mode_works_description_md)}</EdgeCard>
 
         <CardHeadingText>{lstrings.how_duress_mode_return_to_normal_title}</CardHeadingText>
-        <EdgeCard>
-          <Paragraph>{parseMarkdown(lstrings.how_duress_mode_return_to_normal_description_md)}</Paragraph>
-        </EdgeCard>
+        <EdgeCard>{parseMarkdown(lstrings.how_duress_mode_return_to_normal_description_md)}</EdgeCard>
 
         <CardHeadingText>{lstrings.how_duress_mode_add_funds_to_account_title}</CardHeadingText>
-        <EdgeCard>
-          <Paragraph>{parseMarkdown(lstrings.how_duress_mode_add_funds_to_account_description_md)}</Paragraph>
-        </EdgeCard>
+        <EdgeCard>{parseMarkdown(lstrings.how_duress_mode_add_funds_to_account_description_md)}</EdgeCard>
 
         <CardHeadingText>{lstrings.how_duress_mode_when_to_use_title}</CardHeadingText>
-        <EdgeCard>
-          <Paragraph>{parseMarkdown(lstrings.how_duress_mode_when_to_use_description_md)}</Paragraph>
-        </EdgeCard>
+        <EdgeCard>{parseMarkdown(lstrings.how_duress_mode_when_to_use_description_md)}</EdgeCard>
 
         <ButtonsView
           layout="column"

--- a/src/util/parseMarkdown.tsx
+++ b/src/util/parseMarkdown.tsx
@@ -35,7 +35,7 @@ function tokenToReactNode(token: MarkedToken, key: string): React.ReactNode {
     }
     case 'paragraph': {
       console.log('P')
-      return <Paragraph>{subTokens ?? token.text}</Paragraph>
+      return <Paragraph>{subTokens ?? <EdgeText numberOfLines={1000}>{token.text}</EdgeText>}</Paragraph>
     }
     case 'em': {
       return <Em>{subTokens ?? token.text}</Em>
@@ -51,9 +51,7 @@ function tokenToReactNode(token: MarkedToken, key: string): React.ReactNode {
           <LiBullet>
             <EdgeText>{token.raw.match(/^[\s]*([*\-\d.]+)/)?.[1] ?? '*'}</EdgeText>
           </LiBullet>
-          <LiContent>
-            <EdgeText numberOfLines={1000}>{subTokens ?? token.text}</EdgeText>
-          </LiContent>
+          <LiContent>{subTokens ?? <EdgeText numberOfLines={1000}>{token.text}</EdgeText>}</LiContent>
         </Li>
       )
     }
@@ -67,11 +65,11 @@ function tokenToReactNode(token: MarkedToken, key: string): React.ReactNode {
 const Markdown = styled(View)(theme => ({
   flexDirection: 'column',
   alignItems: 'stretch',
-  justifyContent: 'flex-start'
+  justifyContent: 'flex-start',
+  margin: theme.rem(0.5)
 }))
 
 const Paragraph = styled(View)(theme => ({
-  // backgroundColor: 'pink',
   flexDirection: 'column',
   paddingVertical: theme.rem(0.25)
 }))
@@ -81,14 +79,12 @@ const Em = styled(Text)(theme => ({
 }))
 
 const Ol = styled(View)(theme => ({
-  // backgroundColor: 'lightblue',
   alignItems: 'flex-start',
   flexDirection: 'column',
   paddingVertical: theme.rem(0.25)
 }))
 
 const Li = styled(View)(theme => ({
-  // backgroundColor: 'lightgreen',
   alignItems: 'flex-start',
   flexDirection: 'row',
   justifyContent: 'flex-start',


### PR DESCRIPTION
The problem was caused by using Text element `Paragraph` as the container element for the entire markdown block. We shouldn't nest Text elements with the exception of inline-elements necessary for emphasis, bold, etc.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210118083810748