### PR TITLE
Anchor the primary button on `GettingStartedScene`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased (develop)
 
-- removed: Disable Fantom transaction list
 - added: Add os version to the "OS" line of logs
+- fixed: Primary button transforming on the animation on `GettingStartedScene`
+- removed: Disable Fantom transaction list
 
 ## 4.27.0 (2025-05-08)
 

--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -310,7 +310,8 @@ export const GettingStartedScene = (props: Props) => {
 // -----------------------------------------------------------------------------
 
 const TertiaryTouchable = styled(EdgeTouchableOpacity)(theme => props => ({
-  marginVertical: theme.rem(0.5),
+  marginBottom: theme.rem(0.5),
+  marginTop: theme.rem(4.5),
   alignItems: 'center'
 }))
 
@@ -565,6 +566,10 @@ const Footnote = styled(EdgeText)(theme => ({
   includeFontPadding: false
 }))
 
-const ButtonFadeContainer = styled(View)({
-  position: 'relative'
-})
+const ButtonFadeContainer = styled(View)(theme => ({
+  position: 'absolute',
+  bottom: theme.rem(3.25),
+  left: 0,
+  right: 0,
+  zIndex: 1
+}))


### PR DESCRIPTION
Somehow the styling used was causing the button to move with the animation. Using an absolute style with some adjustments to retain the look of the scene before changes.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210151007813283