### PR TITLE
Add timestamp while syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed: `NotificationCenterScene` could crash if there was an undismissed new token notification and the associated wallet no longer existed
 - removed: Disable Fantom transaction list
 - fixed: Show the correct username in the "Forget Account" modal.
+- fixed: `TransactionListRow` missing timestamp while syncing
 
 ## 4.27.2 (2025-05-13)
 

--- a/src/components/themed/TransactionListRow.tsx
+++ b/src/components/themed/TransactionListRow.tsx
@@ -156,7 +156,7 @@ function TransactionViewInner(props: TransactionViewInnerProps) {
     )
 
   // Pending Text and Style
-  const timeText = transaction.confirmations === 'confirmed' ? unixToLocaleDateTime(transaction.date).time : null
+  const timeText = transaction.confirmations === 'confirmed' || transaction.confirmations === 'syncing' ? unixToLocaleDateTime(transaction.date).time : null
   const confirmationText = getConfirmationText(currencyInfo, transaction)
 
   const confirmationStyle =


### PR DESCRIPTION
We used to morph between sync text and a timestamp prior to https://github.com/EdgeApp/edge-react-gui/pull/5519. Now that we split those elements, we need to show them both at once.

<img width="373" alt="image" src="https://github.com/user-attachments/assets/7df2b447-4028-438c-a702-6aa3055de93b" />
<img width="359" alt="image" src="https://github.com/user-attachments/assets/c842bd99-fd18-40cc-b01c-b4675b21d6b3" />


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210252740635119