### PR TITLE
Fix ETH Kiln staking balance and unstaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - changed: `FiatPluginEnterAmountScene` next button to use `KavButton`
 - changed: `SendScene2` row/card grouping updated
 - changed: Fees are no longer estimated before amounts are entered in `SendScene2`
+- fixed: (ETH) Improper Kiln staking balance shown.
 
 ## 4.29.0 (staging)
 

--- a/src/plugins/stake-plugins/generic/util/KilnApi.ts
+++ b/src/plugins/stake-plugins/generic/util/KilnApi.ts
@@ -211,7 +211,7 @@ const asEthOnChainStake = asObject({
   // owner: asString,
   // integration: asString,
   integration_address: asString,
-  // balance: asString,
+  balance: asString,
   shares_balance: asString,
   rewards: asString
   // delegated_block: asNumber,


### PR DESCRIPTION
We should correctly show the balance value from Kiln which is in ETH to the user. This will break unstaking because `requestExit` expects a shares amount. So we implement a conversion from ETH to share tokens before unstaking.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210466283625657