### PR TITLE
Fix max-spend logic

### DIFF
--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -366,10 +366,6 @@ const SendComponent = (props: Props) => {
     needsScrollToEnd.current = true
   }
 
-  const handleSetMax = (index: number) => () => {
-    setMaxSpendSetter(index)
-  }
-
   const handleFeesChange = useHandler(() => {
     if (coreWallet == null) return
 
@@ -395,7 +391,7 @@ const SendComponent = (props: Props) => {
         feeTokenId={null}
         forceField={fieldChanged}
         onAmountsChanged={handleAmountsChanged(spendTarget)}
-        onMaxSet={handleSetMax(index)}
+        onMaxSet={() => setMaxSpendSetter(index)}
         onFeesChange={noChangeMiningFee ? undefined : handleFeesChange}
         wallet={coreWallet}
         tokenId={tokenId}
@@ -1022,7 +1018,7 @@ const SendComponent = (props: Props) => {
       pendingInsufficientFees.current = undefined
       try {
         setProcessingAmountChanged(true)
-        if (spendInfo.spendTargets[0].publicAddress == null || spendInfo.spendTargets[0].nativeAmount == null) {
+        if (spendInfo.spendTargets[0].publicAddress == null) {
           setEdgeTransaction(null)
           setSpendingLimitExceeded(false)
           setMaxSpendSetter(-1)


### PR DESCRIPTION
This was broken in 257d25fd296a735c9a35031b8804ee89dae2f3f1. The goal was to short-circuit the transaction calculation, but we don't want this in the max-spend case.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
