### PR TITLE
Update pw banner dismissal to mimick modal dismissal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - added: Additional user information fields for Kado OTC orders
 - added: Apple AdServices integration and reporting
 - added: KeyboardAccessoryView-based `KavButton`
+- changed: Dismissing Password Reminder banner now behaves the same as dismissing the `PasswordReminderModal`
 - changed: Autocomplete `networkLocation` fields returned from `getTokenDetails` in `EditTokenScene`
 - changed: `FiatPluginEnterAmountScene` next button to use `KavButton`
 - changed: `SendScene2` row/card grouping updated

--- a/src/components/notification/NotificationView.tsx
+++ b/src/components/notification/NotificationView.tsx
@@ -22,6 +22,7 @@ import { EdgeAnim, fadeIn, fadeOut } from '../common/EdgeAnim'
 import { styled } from '../hoc/styled'
 import { PasswordReminderModal } from '../modals/PasswordReminderModal'
 import { Airship } from '../services/AirshipInstance'
+import { updateNotificationInfo } from '../services/NotificationService'
 import { useTheme } from '../services/ThemeContext'
 import { MAX_TAB_BAR_HEIGHT, MIN_TAB_BAR_HEIGHT } from '../themed/MenuTabs'
 import { NotificationCard } from './NotificationCard'
@@ -61,9 +62,17 @@ const NotificationViewComponent = (props: Props) => {
     await showBackupModal({ navigation: navigationDebounced })
   })
 
+  // For this specific notification, we overload the close button to also
+  // directly modify state.ui.passwordReminder.needsPasswordCheck.
+  // This is fine, because we have extensive logic to re-trigger the password
+  // reminder when needed, anyway.
   const handlePasswordReminderClose = useHandler(async () => {
-    await hideBanner(account, 'pwReminder')
+    await updateNotificationInfo(account, 'pwReminder', false)
+    dispatch({
+      type: 'PASSWORD_REMINDER/PASSWORD_REMINDER_POSTPONED'
+    })
   })
+
   const handlePasswordReminderPress = useHandler(async () => {
     await handlePasswordReminderClose()
     await Airship.show(bridge => <PasswordReminderModal bridge={bridge} navigation={navigationDebounced} />)


### PR DESCRIPTION
This change makes it so it's never possible to see the password reminder in the NotificationCenterScene, but it's ok because of the extensive pw reminder logic we already have.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210438561936187