### PR TITLE
Resolve names using `wallet.otherMethods.resolveName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- added: Support for Zano alias name resolution.
+
 ## 4.30.0 (staging)
 
 - added: Additional app review prompt triggers

--- a/src/components/tiles/AddressTile2.tsx
+++ b/src/components/tiles/AddressTile2.tsx
@@ -18,6 +18,7 @@ import { NavigationBase } from '../../types/routerTypes'
 import { getTokenId, getTokenIdForced } from '../../util/CurrencyInfoHelpers'
 import { parseDeepLink } from '../../util/DeepLinkParser'
 import { checkPubAddress } from '../../util/FioAddressUtils'
+import { resolveName } from '../../util/resolveName'
 import { isEmail } from '../../util/utils'
 import { EdgeAnim } from '../common/EdgeAnim'
 import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
@@ -197,9 +198,11 @@ export const AddressTile2 = React.forwardRef((props: Props, ref: React.Forwarded
   const handlePasteFromClipboard = useHandler(async () => {
     const clipboard = await Clipboard.getString()
     try {
+      const resolvedAddress = await resolveName(coreWallet, clipboard).catch(() => undefined)
+      const address = resolvedAddress ?? clipboard
       // Will throw in case uri is invalid
-      await coreWallet.parseUri(clipboard, currencyCode)
-      await changeAddress(clipboard, 'other')
+      await coreWallet.parseUri(address, currencyCode)
+      await changeAddress(address, 'other')
     } catch (error) {
       showError(error, { trackError: false })
     }
@@ -218,8 +221,11 @@ export const AddressTile2 = React.forwardRef((props: Props, ref: React.Forwarded
       />
     ))
       .then(async (result: string | undefined) => {
-        if (result) {
-          await changeAddress(result, 'scan')
+        if (result == null) return
+        const resolvedAddress = await resolveName(coreWallet, result).catch(() => undefined)
+        const address = resolvedAddress ?? result
+        if (address) {
+          await changeAddress(address, 'scan')
         }
       })
       .catch(error => {

--- a/src/util/resolveName.ts
+++ b/src/util/resolveName.ts
@@ -1,0 +1,13 @@
+import { EdgeCurrencyWallet } from 'edge-core-js'
+
+import { ResolutionError } from '../types/ResolutionError'
+
+export const resolveName = async (wallet: EdgeCurrencyWallet, name: string): Promise<string> => {
+  if (typeof wallet.otherMethods.resolveName !== 'function') {
+    throw new ResolutionError('UnsupportedDomain', { domain: name })
+  }
+
+  const address = await wallet.otherMethods.resolveName(name)
+  if (address == null) throw new ResolutionError('UnregisteredDomain', { domain: name })
+  return address
+}


### PR DESCRIPTION
This is to support name resolution from the plugin/wallet, specifically for Zano aliases. In the future, all name resolution can be handled by plugins via a standardized `.resolveName` method on the wallet object, but for now it's a drafted API via `otherMethods`.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210548343287631