### PR TITLE
Jon/kav 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- added: `ReturnKeyTypeButton` to `FlipInputModal2`
+
 ## 4.32.0 (staging)
 
 - added: Support for Paybis ACH buy

--- a/src/__tests__/components/FilledTextInput.test.tsx
+++ b/src/__tests__/components/FilledTextInput.test.tsx
@@ -25,7 +25,6 @@ describe('FilledTextInput', () => {
           autoCapitalize="none"
           autoCorrect
           blurOnSubmit
-          inputAccessoryViewID="string"
           keyboardType="default"
           maxLength={11}
           onSubmitEditing={() => undefined}

--- a/src/__tests__/components/__snapshots__/Buttons.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/Buttons.test.tsx.snap
@@ -2864,7 +2864,6 @@ exports[`Buttons should render simple loose buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -2977,7 +2976,6 @@ exports[`Buttons should render simple loose buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -3090,7 +3088,6 @@ exports[`Buttons should render simple loose buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -3206,7 +3203,6 @@ exports[`Buttons should render simple loose buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -3320,7 +3316,6 @@ exports[`Buttons should render simple loose buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -3434,7 +3429,6 @@ exports[`Buttons should render simple loose buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -3556,7 +3550,6 @@ exports[`Buttons should render spinning buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -3694,7 +3687,6 @@ exports[`Buttons should render spinning buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -3832,7 +3824,6 @@ exports[`Buttons should render spinning buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -3973,7 +3964,6 @@ exports[`Buttons should render spinning buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -4112,7 +4102,6 @@ exports[`Buttons should render spinning buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -4251,7 +4240,6 @@ exports[`Buttons should render spinning buttons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -4398,7 +4386,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -4542,7 +4529,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -4686,7 +4672,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -4833,7 +4818,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -4978,7 +4962,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -5123,7 +5106,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -5271,7 +5253,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -5440,7 +5421,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -5609,7 +5589,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -5781,7 +5760,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -5951,7 +5929,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,
@@ -6121,7 +6098,6 @@ exports[`Buttons should render with child icons 1`] = `
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,

--- a/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FilledTextInput should render with some props 1`] = `
 <View
@@ -227,7 +227,6 @@ exports[`FilledTextInput should render with some props 1`] = `
             "value": 0,
           }
         }
-        inputAccessoryViewID="string"
         keyboardType="default"
         maxLength={11}
         multiline={true}

--- a/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AddressModalComponent should render with loaded props 1`] = `
 [
@@ -515,7 +515,6 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
       style={
         {
           "alignItems": "center",
-          "alignSelf": "center",
           "flexBasis": "auto",
           "flexGrow": 0,
           "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -757,7 +757,6 @@ exports[`CreateWalletAccountSelect renders 1`] = `
         style={
           {
             "alignItems": "center",
-            "alignSelf": "center",
             "flexBasis": "auto",
             "flexGrow": 0,
             "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -731,7 +731,6 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
         style={
           {
             "alignItems": "center",
-            "alignSelf": "center",
             "flexBasis": "auto",
             "flexGrow": 0,
             "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -1936,7 +1936,6 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "alignSelf": "center",
                   "flexBasis": "auto",
                   "flexGrow": 0,
                   "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`EdgeLoginScene should render with loading props 1`] = `
 <View
@@ -428,7 +428,6 @@ DO NOT accept this login unless you trust the application and person who provide
       style={
         {
           "alignItems": "center",
-          "alignSelf": "center",
           "flexBasis": "auto",
           "flexGrow": 0,
           "flexShrink": 0,
@@ -544,7 +543,6 @@ DO NOT accept this login unless you trust the application and person who provide
     style={
       {
         "alignItems": "center",
-        "alignSelf": "center",
         "flexBasis": "auto",
         "flexGrow": 0,
         "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/FioAddressDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressDetailsScene.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FioAddressDetails should render with loading props 1`] = `
 <View
@@ -744,7 +744,6 @@ exports[`FioAddressDetails should render with loading props 1`] = `
           style={
             {
               "alignItems": "center",
-              "alignSelf": "center",
               "flexBasis": "auto",
               "flexGrow": 0,
               "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/FioAddressRegisterScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressRegisterScene.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FioAddressRegister should render with loading props 1`] = `
 [
@@ -891,7 +891,6 @@ exports[`FioAddressRegister should render with loading props 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "alignSelf": "center",
                   "flexBasis": "auto",
                   "flexGrow": 0,
                   "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/FioAddressRegisterSelectWalletScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressRegisterSelectWalletScene.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FioAddressRegistered should render with loading props 1`] = `
 <View
@@ -323,7 +323,6 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
       style={
         {
           "alignItems": "center",
-          "alignSelf": "center",
           "flexBasis": "auto",
           "flexGrow": 0,
           "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/FioAddressRegisteredScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressRegisteredScene.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FioAddressRegistered should render with loading props 1`] = `
 <View
@@ -323,7 +323,6 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
       style={
         {
           "alignItems": "center",
-          "alignSelf": "center",
           "flexBasis": "auto",
           "flexGrow": 0,
           "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
@@ -396,7 +396,6 @@ Never share your username and password, and store your credentials securely!
         style={
           {
             "alignItems": "center",
-            "alignSelf": "center",
             "flexBasis": "auto",
             "flexGrow": 0,
             "flexShrink": 0,

--- a/src/__tests__/scenes/__snapshots__/SwapCreateScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SwapCreateScene.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SwapCreateScene should render with loading props 1`] = `
 [
@@ -271,7 +271,6 @@ exports[`SwapCreateScene should render with loading props 1`] = `
           style={
             {
               "alignItems": "center",
-              "alignSelf": "center",
               "flexBasis": "auto",
               "flexGrow": 0,
               "flexShrink": 0,
@@ -494,7 +493,6 @@ exports[`SwapCreateScene should render with loading props 1`] = `
           style={
             {
               "alignItems": "center",
-              "alignSelf": "center",
               "flexBasis": "auto",
               "flexGrow": 0,
               "flexShrink": 0,

--- a/src/components/buttons/EdgeButton.tsx
+++ b/src/components/buttons/EdgeButton.tsx
@@ -237,7 +237,6 @@ const getStyles = cacheStyles((theme: Theme) => {
       flexShrink: 0
     },
     touchContainerSolo: {
-      alignSelf: 'center',
       flexBasis: 'auto',
       flexGrow: 0,
       flexShrink: 0

--- a/src/components/buttons/ReturnKeyTypeButton.tsx
+++ b/src/components/buttons/ReturnKeyTypeButton.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import { View } from 'react-native'
+
+import { lstrings } from '../../locales/strings'
+import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
+import { FilledTextInputReturnKeyType } from '../themed/FilledTextInput'
+import { EdgeButton } from './EdgeButton'
+
+interface ReturnKeyTypeButtonProps {
+  returnKeyType: FilledTextInputReturnKeyType
+  onPress: () => void | Promise<void>
+}
+
+export const ReturnKeyTypeButton = (props: ReturnKeyTypeButtonProps) => {
+  const { returnKeyType, onPress } = props
+
+  const theme = useTheme()
+  const styles = getStyles(theme)
+
+  const getButtonLabel = (keyType: FilledTextInputReturnKeyType): string => {
+    switch (keyType) {
+      case 'done':
+        return lstrings.string_done_cap
+      case 'next':
+        return lstrings.string_next_capitalized
+      case 'go':
+        return lstrings.string_ok // Fallback to "OK" for go
+      case 'search':
+        return lstrings.string_ok // Fallback to "OK" for search
+      case 'send':
+        return lstrings.fragment_send_subtitle // Uses "Send"
+      case 'none':
+        return lstrings.string_ok // Fallback to "OK" for none
+      default:
+        return lstrings.string_ok
+    }
+  }
+
+  return (
+    <View style={styles.buttonContainer}>
+      <EdgeButton
+        type="primary"
+        mini
+        label={getButtonLabel(returnKeyType)}
+        layout="solo"
+        onPress={onPress}
+      />
+    </View>
+  )
+}
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  buttonContainer: {
+    marginRight: theme.rem(0.5),
+    marginBottom: theme.rem(0.5),
+    alignItems: 'flex-end'
+  }
+}))

--- a/src/components/keyboard/KavButton.tsx
+++ b/src/components/keyboard/KavButton.tsx
@@ -23,6 +23,9 @@ interface KavButtonProps {
  * A keyboard accessory button that spans most of the width of the screen,
  * positioned above the keyboard.
  *
+ * Collapsing the keyboard will animate the button to the bottom of the scene,
+ * taking into account any insets from tabs, notification cards, etc.
+ *
  * IMPORTANT: This component MUST be placed as a direct sibling of SceneWrapper
  * for proper keyboard positioning.
  *

--- a/src/components/modals/FlipInputModal2.tsx
+++ b/src/components/modals/FlipInputModal2.tsx
@@ -14,6 +14,7 @@ import { useWatch } from '../../hooks/useWatch'
 import { formatNumber } from '../../locales/intl'
 import { lstrings } from '../../locales/strings'
 import { DECIMAL_PRECISION } from '../../util/utils'
+import { ReturnKeyTypeButton } from '../buttons/ReturnKeyTypeButton'
 import { EdgeCard } from '../cards/EdgeCard'
 import { EdgeTouchableWithoutFeedback } from '../common/EdgeTouchableWithoutFeedback'
 import { ExchangeRate2 } from '../common/ExchangeRate2'
@@ -274,6 +275,7 @@ const FlipInputModal2Component = React.forwardRef<FlipInputModalRef, Props>(
             {renderErrorMessage()}
           </View>
         </EdgeTouchableWithoutFeedback>
+        <ReturnKeyTypeButton returnKeyType="done" onPress={handleCloseModal} />
       </EdgeModal>
     )
   }

--- a/src/components/modals/FlipInputModal2.tsx
+++ b/src/components/modals/FlipInputModal2.tsx
@@ -238,17 +238,17 @@ const FlipInputModal2Component = React.forwardRef<FlipInputModalRef, Props>(
       return (
         <EdgeCard marginRem={[0, 0.5, 0.5]}>
           <ExchangedFlipInput2
-            ref={exchangedFlipInputRef}
-            wallet={wallet}
-            tokenId={tokenId}
-            startNativeAmount={startNativeAmount}
             forceField={amounts.fieldChanged}
             headerText={flipInputHeaderText}
-            onAmountChanged={handleAmountsChanged}
-            keyboardVisible
-            onNext={handleCloseModal}
             hideMaxButton={hideMaxButton}
+            keyboardVisible
+            ref={exchangedFlipInputRef}
+            startNativeAmount={startNativeAmount}
+            tokenId={tokenId}
+            wallet={wallet}
+            onAmountChanged={handleAmountsChanged}
             onMaxPress={handleSendMaxAmount}
+            onNext={handleCloseModal}
           />
         </EdgeCard>
       )

--- a/src/components/modals/ListModal.tsx
+++ b/src/components/modals/ListModal.tsx
@@ -32,7 +32,6 @@ interface Props<T> {
     | 'email-address'
     | 'phone-pad' // Defaults to 'default'
   blurOnSubmit?: boolean // Defaults to 'true'
-  inputAccessoryViewID?: string
   maxLength?: number
   onSubmitEditing?: (text: string) => void
   secureTextEntry?: boolean // Defaults to 'false'

--- a/src/components/scenes/RequestScene.tsx
+++ b/src/components/scenes/RequestScene.tsx
@@ -132,8 +132,6 @@ interface AddressInfo {
   label: string
 }
 
-const inputAccessoryViewID: string = 'cancelHeaderId'
-
 export class RequestSceneComponent extends React.Component<
   Props & HookProps,
   State
@@ -542,9 +540,6 @@ export class RequestSceneComponent extends React.Component<
                 forceField="fiat"
                 headerCallback={this.handleOpenWalletListModal}
                 headerText={flipInputHeaderText}
-                inputAccessoryViewID={
-                  this.state.isFioMode ? inputAccessoryViewID : undefined
-                }
                 keyboardVisible={false}
                 onAmountChanged={this.onExchangeAmountChanged}
                 ref={this.flipInputRef}

--- a/src/components/themed/ExchangedFlipInput2.tsx
+++ b/src/components/themed/ExchangedFlipInput2.tsx
@@ -51,7 +51,6 @@ export interface Props {
   forceField?: 'fiat' | 'crypto'
   returnKeyType?: ReturnKeyType
   editable?: boolean
-  inputAccessoryViewID?: string
   headerCallback?: () => void | Promise<void>
   onAmountChanged: (amounts: ExchangedFlipInputAmounts) => unknown
   onBlur?: () => void
@@ -89,7 +88,6 @@ const ExchangedFlipInput2Component = React.forwardRef<
     forceField = 'crypto',
     keyboardVisible = true,
     editable,
-    inputAccessoryViewID,
     hideMaxButton = false,
     onMaxPress
   } = props
@@ -316,7 +314,6 @@ const ExchangedFlipInput2Component = React.forwardRef<
             fieldInfos={fieldInfos}
             returnKeyType={returnKeyType}
             forceFieldNum={forceFieldMap[overrideForceField]}
-            inputAccessoryViewID={inputAccessoryViewID}
             keyboardVisible={keyboardVisible}
             startAmounts={[renderDisplayAmount ?? '', renderFiatAmount]}
           />

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -94,7 +94,6 @@ export interface FilledTextInputBaseProps extends MarginRemProps {
   autoCorrect?: boolean
   /** Defaults to 'true' */
   blurOnSubmit?: boolean
-  inputAccessoryViewID?: string
   keyboardType?:
     | 'default'
     | 'number-pad'
@@ -207,7 +206,6 @@ export const FilledTextInput = React.forwardRef<
     blurOnClear = false,
     blurOnSubmit,
     disabled = false,
-    inputAccessoryViewID,
     keyboardType,
     maxLength,
     secureTextEntry,
@@ -472,7 +470,6 @@ export const FilledTextInput = React.forwardRef<
               autoCorrect={autoCorrect}
               autoComplete={autoComplete}
               blurOnSubmit={multiline ? false : blurOnSubmit}
-              inputAccessoryViewID={inputAccessoryViewID}
               secureTextEntry={
                 secureTextEntry === true ? hidePassword : undefined
               }

--- a/src/components/themed/FlipInput2.tsx
+++ b/src/components/themed/FlipInput2.tsx
@@ -52,7 +52,6 @@ export interface Props {
   disabled?: boolean
   fieldInfos: FlipInputFieldInfos
   forceFieldNum?: FieldNum
-  inputAccessoryViewID?: string
   keyboardVisible?: boolean
   placeholders?: [string, string]
   returnKeyType?: ReturnKeyType
@@ -88,7 +87,6 @@ export const FlipInput2 = React.forwardRef<FlipInputRef, Props>(
       disabled = false,
       fieldInfos,
       forceFieldNum = 0,
-      inputAccessoryViewID,
       keyboardVisible,
       placeholders = [lstrings.string_tap_to_edit, ''],
       returnKeyType = 'done',
@@ -210,7 +208,6 @@ export const FlipInput2 = React.forwardRef<FlipInputRef, Props>(
             autoFocus={primaryField === fieldNum && keyboardVisible}
             ref={inputRefs[fieldNum]}
             onSubmitEditing={onNext}
-            inputAccessoryViewID={inputAccessoryViewID}
             onFocus={handleBottomFocus}
             onBlur={handleBottomBlur}
           />

--- a/src/components/themed/FlipInput2.tsx
+++ b/src/components/themed/FlipInput2.tsx
@@ -89,7 +89,7 @@ export const FlipInput2 = React.forwardRef<FlipInputRef, Props>(
       forceFieldNum = 0,
       keyboardVisible,
       placeholders = [lstrings.string_tap_to_edit, ''],
-      returnKeyType = 'done',
+      returnKeyType,
       startAmounts,
 
       // Renders:

--- a/src/components/themed/SimpleTextInput.tsx
+++ b/src/components/themed/SimpleTextInput.tsx
@@ -57,7 +57,6 @@ export interface SimpleTextInputProps extends MarginRemProps {
   autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters' // Defaults to 'sentences'
   autoCorrect?: boolean // Defaults to 'true'
   blurOnSubmit?: boolean // Defaults to 'true'
-  inputAccessoryViewID?: string
   keyboardType?:
     | 'default'
     | 'number-pad'
@@ -130,7 +129,6 @@ export const SimpleTextInput = React.forwardRef<
     blurOnClear = false,
     blurOnSubmit,
     disabled = false,
-    inputAccessoryViewID,
     keyboardType,
     maxLength,
     returnKeyType,
@@ -339,7 +337,6 @@ export const SimpleTextInput = React.forwardRef<
               autoCapitalize={autoCapitalize}
               autoCorrect={autoCorrect}
               blurOnSubmit={blurOnSubmit}
-              inputAccessoryViewID={inputAccessoryViewID}
               secureTextEntry={secureTextEntry}
             />
           </InnerContainer>

--- a/src/components/themed/SwapInput.tsx
+++ b/src/components/themed/SwapInput.tsx
@@ -46,7 +46,6 @@ export interface Props {
   disabled?: boolean
   heading: string
   forceField?: 'fiat' | 'crypto'
-  inputAccessoryViewID?: string
   keyboardVisible?: boolean
   placeholders?: [string, string]
   returnKeyType?: ReturnKeyType
@@ -73,7 +72,6 @@ const SwapInputComponent = React.forwardRef<SwapInputCardInputRef, Props>(
       disabled,
       forceField = 'crypto',
       heading,
-      inputAccessoryViewID,
       keyboardVisible = true,
       placeholders,
       startNativeAmount,
@@ -329,7 +327,6 @@ const SwapInputComponent = React.forwardRef<SwapInputCardInputRef, Props>(
           disabled={disabled}
           fieldInfos={fieldInfos}
           forceFieldNum={forceFieldMap[overrideForceField]}
-          inputAccessoryViewID={inputAccessoryViewID}
           keyboardVisible={keyboardVisible}
           placeholders={placeholders}
           ref={flipInputRef}


### PR DESCRIPTION
Note: We aren't using any "KBAccessory View" in the GUI. The closest thing is an `InputAccessoryView`, which is iOS-specific, which we also aren't using. We set the `inputAccessoryViewID` in some components, but we don't link it to any defined `InputAccessoryView`.

We can't use `react-native-keyboard-accessory` as in the previous feature [✓ Implement KeyboardAccessoryView floating Next button](https://app.asana.com/1/9976422036640/task/1210145059006725), because it's impossible to render something absolutely above the airship modal. Doesn't make sense anyway since the modal avoids the keyboard already.

As such, we will simply be adding a new `ReturnKeyTypeButton` that sits on the modal itself (or any other component in the future) to replace the OS-level `returnKeyType` with an Edge-stylized version.

<img width="440" height="693" alt="image" src="https://github.com/user-attachments/assets/534dc1ec-4a91-4bf7-b4f5-77cc53ad23ae" />

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210662466433085