### PR TITLE
Fix button spinner + label on async pending state

### DIFF
--- a/src/components/buttons/EdgeButton.tsx
+++ b/src/components/buttons/EdgeButton.tsx
@@ -116,9 +116,9 @@ export function EdgeButton(props: Props): React.ReactElement | null {
   const contentRowStyle = React.useMemo<ViewStyle>(
     () => ({
       ...styles.contentRow,
-      opacity: spinner ? 0 : 1
+      opacity: spinner || pending ? 0 : 1
     }),
-    [spinner, styles.contentRow]
+    [pending, spinner, styles.contentRow]
   )
 
   // Tappable area overshoot


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211115045783853

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change scoped to `EdgeButton` rendering state; minimal risk aside from potential visual regressions in button content visibility.
> 
> **Overview**
> Fixes `EdgeButton` visual behavior during async presses by treating `pending` (from `usePendingPress`) the same as the `spinner` prop.
> 
> When `pending` is true, the content row (icon/label) is hidden (`opacity: 0`) so the spinner overlay doesn’t display on top of the label; memo dependencies are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0014411668ee6545a322647a15b5bff4c842104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->