### PR TITLE
Fix Android crash in react-native-vision-camera

### DIFF
--- a/patches/react-native-vision-camera+4.7.1.patch
+++ b/patches/react-native-vision-camera+4.7.1.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt b/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
+index 21ac2b2..b0b2254 100644
+--- a/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
++++ b/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
+@@ -99,6 +99,7 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) :
+   }
+ 
+   fun sendAvailableDevicesChangedEvent() {
++    if (!reactContext.hasActiveCatalystInstance()) return;
+     val eventEmitter = reactContext.getJSModule(RCTDeviceEventEmitter::class.java)
+     val devices = getDevicesJson()
+     eventEmitter.emit("CameraDevicesChanged", devices)


### PR DESCRIPTION
They are trying to send a camera-update event before the React Native JS side is ready to receive it.

The upstream bug is: https://github.com/mrousavy/react-native-vision-camera/issues/3609

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211064422811771