### PR TITLE
Reduce base rem to 14 dp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added: `PendingTxModal` to route to pending txs for acceleration
 - added: Added "Report Error" button to all `AlertDropdown`s from `showError`.
 - added: Handle `SwapAddressError` by auto-selecting an existing wallet with the same address or splitting if needed
+- changed: Decrease base font size from 16 to 14 dp, now that React Native respects font scaling.
 - changed: Duress mode copy
 - changed: Increased tappable area for the close button of `NotificationCard`
 - changed: Replaced 'react-native-camera' with 'react-native-vision-camera'

--- a/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
@@ -9,16 +9,16 @@ exports[`BalanceCard should render with loading props 1`] = `
         "borderRadius": 16,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
       {
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 10,
+        "paddingLeft": 10,
+        "paddingRight": 10,
+        "paddingTop": 10,
       },
       undefined,
     ]
@@ -45,7 +45,7 @@ exports[`BalanceCard should render with loading props 1`] = `
         {
           "color": "#FFFFFF",
           "fontFamily": "Quicksand-Medium",
-          "fontSize": 39,
+          "fontSize": 34,
           "includeFontPadding": false,
           "textShadowColor": "rgba(0, 0, 0, 0.514)",
           "textShadowOffset": {
@@ -93,7 +93,7 @@ exports[`BalanceCard should render with loading props 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       {
-        "margin": 11,
+        "margin": 10,
         "opacity": 1,
       }
     }
@@ -103,7 +103,7 @@ exports[`BalanceCard should render with loading props 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "marginBottom": 11,
+          "marginBottom": 10,
         }
       }
     >
@@ -116,7 +116,7 @@ exports[`BalanceCard should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -140,11 +140,11 @@ exports[`BalanceCard should render with loading props 1`] = `
           [
             {
               "color": "#00f1a2",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "alignSelf": "center",
-              "marginLeft": 6,
+              "marginLeft": 5,
               "marginRight": 0,
               "textShadowColor": "rgba(0, 0, 0, 0.514)",
               "textShadowOffset": {
@@ -170,7 +170,7 @@ exports[`BalanceCard should render with loading props 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "height": 56,
+          "height": 49,
         }
       }
     >
@@ -190,7 +190,7 @@ exports[`BalanceCard should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 39,
+                "fontSize": 34,
                 "includeFontPadding": false,
                 "textShadowColor": "rgba(0, 0, 0, 0.514)",
                 "textShadowOffset": {
@@ -213,7 +213,7 @@ exports[`BalanceCard should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 39,
+                "fontSize": 34,
                 "includeFontPadding": false,
                 "textShadowColor": "rgba(0, 0, 0, 0.514)",
                 "textShadowOffset": {
@@ -285,7 +285,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -318,7 +318,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -351,7 +351,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -384,7 +384,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -417,7 +417,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -450,7 +450,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -483,7 +483,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -516,7 +516,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -549,7 +549,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -582,7 +582,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -608,7 +608,7 @@ exports[`BalanceCard should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 39,
+                "fontSize": 34,
                 "includeFontPadding": false,
                 "textShadowColor": "rgba(0, 0, 0, 0.514)",
                 "textShadowOffset": {
@@ -680,7 +680,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -713,7 +713,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -746,7 +746,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -779,7 +779,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -812,7 +812,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -845,7 +845,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -878,7 +878,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -911,7 +911,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -944,7 +944,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -977,7 +977,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1052,7 +1052,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1085,7 +1085,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1118,7 +1118,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1151,7 +1151,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1184,7 +1184,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1217,7 +1217,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1250,7 +1250,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1283,7 +1283,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1316,7 +1316,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1349,7 +1349,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 39,
+                      "fontSize": 34,
                       "includeFontPadding": false,
                       "textShadowColor": "rgba(0, 0, 0, 0.514)",
                       "textShadowOffset": {
@@ -1375,7 +1375,7 @@ exports[`BalanceCard should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 39,
+                "fontSize": 34,
                 "includeFontPadding": false,
                 "textShadowColor": "rgba(0, 0, 0, 0.514)",
                 "textShadowOffset": {
@@ -1398,7 +1398,7 @@ exports[`BalanceCard should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 39,
+                "fontSize": 34,
                 "includeFontPadding": false,
                 "textShadowColor": "rgba(0, 0, 0, 0.514)",
                 "textShadowOffset": {
@@ -1421,7 +1421,7 @@ exports[`BalanceCard should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 39,
+                "fontSize": 34,
                 "includeFontPadding": false,
                 "textShadowColor": "rgba(0, 0, 0, 0.514)",
                 "textShadowOffset": {
@@ -1444,7 +1444,7 @@ exports[`BalanceCard should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 39,
+                "fontSize": 34,
                 "includeFontPadding": false,
                 "textShadowColor": "rgba(0, 0, 0, 0.514)",
                 "textShadowOffset": {
@@ -1474,8 +1474,8 @@ exports[`BalanceCard should render with loading props 1`] = `
         "flexGrow": 1,
         "flexShrink": 1,
         "justifyContent": "center",
-        "margin": 11,
-        "paddingHorizontal": 11,
+        "margin": 10,
+        "paddingHorizontal": 10,
       }
     }
   >
@@ -1515,7 +1515,7 @@ exports[`BalanceCard should render with loading props 1`] = `
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -1527,12 +1527,12 @@ exports[`BalanceCard should render with loading props 1`] = `
           {
             "alignItems": "center",
             "alignSelf": "stretch",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -1560,7 +1560,7 @@ exports[`BalanceCard should render with loading props 1`] = `
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -1588,7 +1588,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -1598,7 +1598,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -1619,10 +1619,10 @@ exports[`BalanceCard should render with loading props 1`] = `
           "flexDirection": "column",
           "flexGrow": undefined,
           "justifyContent": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     />
@@ -1662,7 +1662,7 @@ exports[`BalanceCard should render with loading props 1`] = `
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -1674,12 +1674,12 @@ exports[`BalanceCard should render with loading props 1`] = `
           {
             "alignItems": "center",
             "alignSelf": "stretch",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -1707,7 +1707,7 @@ exports[`BalanceCard should render with loading props 1`] = `
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -1735,7 +1735,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -1745,7 +1745,7 @@ exports[`BalanceCard should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],

--- a/src/__tests__/components/__snapshots__/Buttons.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/Buttons.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
         "alignItems": "stretch",
         "alignSelf": "center",
         "flexDirection": "column",
-        "margin": 11,
+        "margin": 10,
       }
     }
   >
@@ -61,7 +61,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -73,12 +73,12 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
           {
             "alignItems": "center",
             "alignSelf": "stretch",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -106,7 +106,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -134,7 +134,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -144,7 +144,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -165,10 +165,10 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
           "flexDirection": "column",
           "flexGrow": undefined,
           "justifyContent": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     />
@@ -213,7 +213,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -225,12 +225,12 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
           {
             "alignItems": "center",
             "alignSelf": "stretch",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -258,7 +258,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -286,7 +286,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -296,7 +296,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -317,10 +317,10 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
           "flexDirection": "column",
           "flexGrow": undefined,
           "justifyContent": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     />
@@ -365,7 +365,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -378,12 +378,12 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
             "alignItems": "center",
             "alignSelf": "stretch",
             "backgroundColor": "transparent",
-            "borderRadius": 34,
-            "height": 34,
+            "borderRadius": 29,
+            "height": 29,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 17,
+            "paddingHorizontal": 15,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -408,7 +408,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -418,7 +418,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
                   {
                     "color": "#00f1a2",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -440,7 +440,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
         "alignItems": "stretch",
         "alignSelf": "center",
         "flexDirection": "column",
-        "margin": 11,
+        "margin": 10,
       }
     }
   >
@@ -485,7 +485,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -497,12 +497,12 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
           {
             "alignItems": "center",
             "alignSelf": "stretch",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -530,7 +530,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -558,7 +558,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -568,7 +568,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -594,7 +594,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
       "alignItems": "stretch",
       "alignSelf": "center",
       "flexDirection": "column",
-      "margin": 11,
+      "margin": 10,
     }
   }
 >
@@ -639,7 +639,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -651,12 +651,12 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -684,7 +684,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -712,7 +712,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -722,7 +722,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -743,10 +743,10 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
         "flexDirection": "column",
         "flexGrow": undefined,
         "justifyContent": undefined,
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       }
     }
   />
@@ -791,7 +791,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -803,12 +803,12 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -836,7 +836,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -864,7 +864,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -874,7 +874,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -899,7 +899,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
       "alignItems": "stretch",
       "alignSelf": "center",
       "flexDirection": "column",
-      "margin": 11,
+      "margin": 10,
     }
   }
 >
@@ -944,7 +944,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -956,12 +956,12 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -989,7 +989,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -1017,7 +1017,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -1027,7 +1027,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -1048,10 +1048,10 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
         "flexDirection": "column",
         "flexGrow": undefined,
         "justifyContent": undefined,
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       }
     }
   />
@@ -1096,7 +1096,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -1108,12 +1108,12 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -1141,7 +1141,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -1169,7 +1169,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -1179,7 +1179,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -1204,7 +1204,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
       "alignItems": "stretch",
       "alignSelf": "center",
       "flexDirection": "column",
-      "margin": 11,
+      "margin": 10,
     }
   }
 >
@@ -1249,7 +1249,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -1261,12 +1261,12 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -1294,7 +1294,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -1322,7 +1322,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -1332,7 +1332,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -1353,10 +1353,10 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
         "flexDirection": "column",
         "flexGrow": undefined,
         "justifyContent": undefined,
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       }
     }
   />
@@ -1401,7 +1401,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -1413,12 +1413,12 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -1446,7 +1446,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -1474,7 +1474,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -1484,7 +1484,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -1505,10 +1505,10 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
         "flexDirection": "column",
         "flexGrow": undefined,
         "justifyContent": undefined,
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       }
     }
   />
@@ -1553,7 +1553,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -1566,12 +1566,12 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
           "alignItems": "center",
           "alignSelf": "stretch",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -1596,7 +1596,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -1606,7 +1606,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 3 button
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -1640,8 +1640,8 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
         "flexGrow": 1,
         "flexShrink": 1,
         "justifyContent": "center",
-        "margin": 11,
-        "paddingHorizontal": 11,
+        "margin": 10,
+        "paddingHorizontal": 10,
       }
     }
   >
@@ -1681,7 +1681,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -1693,12 +1693,12 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
           {
             "alignItems": "center",
             "alignSelf": "stretch",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -1726,7 +1726,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -1754,7 +1754,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -1764,7 +1764,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -1785,10 +1785,10 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
           "flexDirection": "column",
           "flexGrow": undefined,
           "justifyContent": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     />
@@ -1828,7 +1828,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -1840,12 +1840,12 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
           {
             "alignItems": "center",
             "alignSelf": "stretch",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -1873,7 +1873,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -1901,7 +1901,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -1911,7 +1911,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -1932,10 +1932,10 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
           "flexDirection": "column",
           "flexGrow": undefined,
           "justifyContent": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     />
@@ -1975,7 +1975,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -1987,12 +1987,12 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderRadius": 34,
-            "height": 34,
+            "borderRadius": 29,
+            "height": 29,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 17,
+            "paddingHorizontal": 15,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -2017,7 +2017,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -2027,7 +2027,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
                   {
                     "color": "#00f1a2",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -2051,8 +2051,8 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
         "flexGrow": 1,
         "flexShrink": 1,
         "justifyContent": "center",
-        "margin": 11,
-        "paddingHorizontal": 11,
+        "margin": 10,
+        "paddingHorizontal": 10,
       }
     }
   >
@@ -2092,7 +2092,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
         accessible={true}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -2104,12 +2104,12 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
           {
             "alignItems": "center",
             "alignSelf": "stretch",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -2137,7 +2137,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -2165,7 +2165,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -2175,7 +2175,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -2203,8 +2203,8 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
       "flexGrow": 1,
       "flexShrink": 1,
       "justifyContent": "center",
-      "margin": 11,
-      "paddingHorizontal": 11,
+      "margin": 10,
+      "paddingHorizontal": 10,
     }
   }
 >
@@ -2244,7 +2244,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -2256,12 +2256,12 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -2289,7 +2289,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -2317,7 +2317,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -2327,7 +2327,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -2348,10 +2348,10 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
         "flexDirection": "column",
         "flexGrow": undefined,
         "justifyContent": undefined,
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       }
     }
   />
@@ -2391,7 +2391,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -2403,12 +2403,12 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -2436,7 +2436,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -2464,7 +2464,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -2474,7 +2474,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -2501,8 +2501,8 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
       "flexGrow": 1,
       "flexShrink": 1,
       "justifyContent": "center",
-      "margin": 11,
-      "paddingHorizontal": 11,
+      "margin": 10,
+      "paddingHorizontal": 10,
     }
   }
 >
@@ -2542,7 +2542,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -2554,12 +2554,12 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -2587,7 +2587,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -2615,7 +2615,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -2625,7 +2625,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -2646,10 +2646,10 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
         "flexDirection": "column",
         "flexGrow": undefined,
         "justifyContent": undefined,
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       }
     }
   />
@@ -2689,7 +2689,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -2701,12 +2701,12 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -2734,7 +2734,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -2762,7 +2762,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -2772,7 +2772,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -2799,8 +2799,8 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
       "flexGrow": 1,
       "flexShrink": 1,
       "justifyContent": "center",
-      "margin": 11,
-      "paddingHorizontal": 11,
+      "margin": 10,
+      "paddingHorizontal": 10,
     }
   }
 >
@@ -2840,7 +2840,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -2852,12 +2852,12 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -2885,7 +2885,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -2913,7 +2913,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -2923,7 +2923,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -2944,10 +2944,10 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
         "flexDirection": "column",
         "flexGrow": undefined,
         "justifyContent": undefined,
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       }
     }
   />
@@ -2987,7 +2987,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -2999,12 +2999,12 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
         {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -3032,7 +3032,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -3060,7 +3060,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -3070,7 +3070,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -3091,10 +3091,10 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
         "flexDirection": "column",
         "flexGrow": undefined,
         "justifyContent": undefined,
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       }
     }
   />
@@ -3134,7 +3134,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
       accessible={true}
       collapsable={false}
       focusable={true}
-      hitSlop={11}
+      hitSlop={10}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -3146,12 +3146,12 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -3176,7 +3176,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -3186,7 +3186,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -3243,10 +3243,10 @@ exports[`Buttons should render simple loose buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -3259,12 +3259,12 @@ exports[`Buttons should render simple loose buttons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -3292,7 +3292,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -3320,7 +3320,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -3330,7 +3330,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -3382,10 +3382,10 @@ exports[`Buttons should render simple loose buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -3398,12 +3398,12 @@ exports[`Buttons should render simple loose buttons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -3431,7 +3431,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -3459,7 +3459,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -3469,7 +3469,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -3521,10 +3521,10 @@ exports[`Buttons should render simple loose buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -3538,12 +3538,12 @@ exports[`Buttons should render simple loose buttons 1`] = `
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -3568,7 +3568,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -3578,7 +3578,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -3630,10 +3630,10 @@ exports[`Buttons should render simple loose buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -3646,12 +3646,12 @@ exports[`Buttons should render simple loose buttons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 45,
+          "borderRadius": 29,
+          "height": 39,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 28,
+          "paddingHorizontal": 25,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -3679,7 +3679,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -3707,7 +3707,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -3717,7 +3717,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -3769,10 +3769,10 @@ exports[`Buttons should render simple loose buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -3785,12 +3785,12 @@ exports[`Buttons should render simple loose buttons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 45,
+          "borderRadius": 29,
+          "height": 39,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 28,
+          "paddingHorizontal": 25,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -3818,7 +3818,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -3846,7 +3846,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -3856,7 +3856,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -3908,10 +3908,10 @@ exports[`Buttons should render simple loose buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -3925,12 +3925,12 @@ exports[`Buttons should render simple loose buttons 1`] = `
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -3955,7 +3955,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -3965,7 +3965,7 @@ exports[`Buttons should render simple loose buttons 1`] = `
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -4022,10 +4022,10 @@ exports[`Buttons should render spinning buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -4038,12 +4038,12 @@ exports[`Buttons should render spinning buttons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -4071,7 +4071,7 @@ exports[`Buttons should render spinning buttons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -4099,7 +4099,7 @@ exports[`Buttons should render spinning buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -4109,7 +4109,7 @@ exports[`Buttons should render spinning buttons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -4179,10 +4179,10 @@ exports[`Buttons should render spinning buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -4195,12 +4195,12 @@ exports[`Buttons should render spinning buttons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -4228,7 +4228,7 @@ exports[`Buttons should render spinning buttons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -4256,7 +4256,7 @@ exports[`Buttons should render spinning buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -4266,7 +4266,7 @@ exports[`Buttons should render spinning buttons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -4336,10 +4336,10 @@ exports[`Buttons should render spinning buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -4353,12 +4353,12 @@ exports[`Buttons should render spinning buttons 1`] = `
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -4383,7 +4383,7 @@ exports[`Buttons should render spinning buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -4393,7 +4393,7 @@ exports[`Buttons should render spinning buttons 1`] = `
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -4463,10 +4463,10 @@ exports[`Buttons should render spinning buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -4479,12 +4479,12 @@ exports[`Buttons should render spinning buttons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 45,
+          "borderRadius": 29,
+          "height": 39,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 28,
+          "paddingHorizontal": 25,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -4512,7 +4512,7 @@ exports[`Buttons should render spinning buttons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -4540,7 +4540,7 @@ exports[`Buttons should render spinning buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -4550,7 +4550,7 @@ exports[`Buttons should render spinning buttons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -4620,10 +4620,10 @@ exports[`Buttons should render spinning buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -4636,12 +4636,12 @@ exports[`Buttons should render spinning buttons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 45,
+          "borderRadius": 29,
+          "height": 39,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 28,
+          "paddingHorizontal": 25,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -4669,7 +4669,7 @@ exports[`Buttons should render spinning buttons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -4697,7 +4697,7 @@ exports[`Buttons should render spinning buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -4707,7 +4707,7 @@ exports[`Buttons should render spinning buttons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -4777,10 +4777,10 @@ exports[`Buttons should render spinning buttons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -4794,12 +4794,12 @@ exports[`Buttons should render spinning buttons 1`] = `
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -4824,7 +4824,7 @@ exports[`Buttons should render spinning buttons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -4834,7 +4834,7 @@ exports[`Buttons should render spinning buttons 1`] = `
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],
@@ -4909,10 +4909,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -4925,12 +4925,12 @@ exports[`Buttons should render with child icons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -4958,7 +4958,7 @@ exports[`Buttons should render with child icons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -5024,7 +5024,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -5034,10 +5034,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -5088,10 +5088,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -5104,12 +5104,12 @@ exports[`Buttons should render with child icons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -5137,7 +5137,7 @@ exports[`Buttons should render with child icons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -5203,7 +5203,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -5213,10 +5213,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -5267,10 +5267,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -5284,12 +5284,12 @@ exports[`Buttons should render with child icons 1`] = `
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -5352,7 +5352,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -5362,10 +5362,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -5416,10 +5416,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -5432,12 +5432,12 @@ exports[`Buttons should render with child icons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 45,
+          "borderRadius": 29,
+          "height": 39,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 28,
+          "paddingHorizontal": 25,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -5465,7 +5465,7 @@ exports[`Buttons should render with child icons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -5531,7 +5531,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -5541,10 +5541,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -5595,10 +5595,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -5611,12 +5611,12 @@ exports[`Buttons should render with child icons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 45,
+          "borderRadius": 29,
+          "height": 39,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 28,
+          "paddingHorizontal": 25,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -5644,7 +5644,7 @@ exports[`Buttons should render with child icons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -5710,7 +5710,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -5720,10 +5720,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -5774,10 +5774,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -5791,12 +5791,12 @@ exports[`Buttons should render with child icons 1`] = `
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -5859,7 +5859,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -5869,10 +5869,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -5923,10 +5923,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -5939,12 +5939,12 @@ exports[`Buttons should render with child icons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -5972,7 +5972,7 @@ exports[`Buttons should render with child icons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -6038,7 +6038,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -6048,10 +6048,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -6120,10 +6120,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -6136,12 +6136,12 @@ exports[`Buttons should render with child icons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 67,
+          "borderRadius": 29,
+          "height": 59,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 34,
+          "paddingHorizontal": 29,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -6169,7 +6169,7 @@ exports[`Buttons should render with child icons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -6235,7 +6235,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -6245,10 +6245,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -6317,10 +6317,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -6334,12 +6334,12 @@ exports[`Buttons should render with child icons 1`] = `
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -6402,7 +6402,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -6412,10 +6412,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -6484,10 +6484,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -6500,12 +6500,12 @@ exports[`Buttons should render with child icons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 45,
+          "borderRadius": 29,
+          "height": 39,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 28,
+          "paddingHorizontal": 25,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -6533,7 +6533,7 @@ exports[`Buttons should render with child icons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -6599,7 +6599,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -6609,10 +6609,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -6681,10 +6681,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -6697,12 +6697,12 @@ exports[`Buttons should render with child icons 1`] = `
       style={
         {
           "alignItems": "center",
-          "borderRadius": 34,
-          "height": 45,
+          "borderRadius": 29,
+          "height": 39,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 28,
+          "paddingHorizontal": 25,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -6730,7 +6730,7 @@ exports[`Buttons should render with child icons 1`] = `
         }
         style={
           {
-            "borderRadius": 34,
+            "borderRadius": 29,
             "bottom": 0,
             "left": 0,
             "position": "absolute",
@@ -6796,7 +6796,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -6806,10 +6806,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,
@@ -6878,10 +6878,10 @@ exports[`Buttons should render with child icons 1`] = `
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -6895,12 +6895,12 @@ exports[`Buttons should render with child icons 1`] = `
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 0.7,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -6963,7 +6963,7 @@ exports[`Buttons should render with child icons 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -6973,10 +6973,10 @@ exports[`Buttons should render with child icons 1`] = `
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "marginLeft": 11,
+                  "marginLeft": 10,
                 },
               ],
               null,

--- a/src/__tests__/components/__snapshots__/BuyCrypto.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/BuyCrypto.test.tsx.snap
@@ -37,10 +37,10 @@ exports[`BuyCrypto should render with some props 1`] = `
         "marginRight": 0,
         "marginTop": 0,
         "opacity": 1,
-        "paddingBottom": 22,
-        "paddingLeft": 22,
-        "paddingRight": 22,
-        "paddingTop": 22,
+        "paddingBottom": 20,
+        "paddingLeft": 20,
+        "paddingRight": 20,
+        "paddingTop": 20,
       }
     }
   >
@@ -51,7 +51,7 @@ exports[`BuyCrypto should render with some props 1`] = `
           "backgroundColor": "rgba(255, 255, 255, 0)",
           "flex": 1,
           "justifyContent": "center",
-          "padding": 22,
+          "padding": 20,
         }
       }
     >
@@ -66,12 +66,12 @@ exports[`BuyCrypto should render with some props 1`] = `
         <View
           style={
             {
-              "height": 51,
-              "marginBottom": 6,
+              "height": 44,
+              "marginBottom": 5,
               "marginLeft": 0,
               "marginRight": 0,
-              "marginTop": 6,
-              "width": 51,
+              "marginTop": 5,
+              "width": 44,
             }
           }
         >
@@ -79,9 +79,9 @@ exports[`BuyCrypto should render with some props 1`] = `
             style={
               {
                 "backgroundColor": "#000000",
-                "borderRadius": 25.5,
+                "borderRadius": 22,
                 "elevation": 0,
-                "height": 51,
+                "height": 44,
                 "shadowColor": "#000000",
                 "shadowOffset": {
                   "height": 3,
@@ -89,7 +89,7 @@ exports[`BuyCrypto should render with some props 1`] = `
                 },
                 "shadowOpacity": 0.6,
                 "shadowRadius": 4,
-                "width": 51,
+                "width": 44,
               }
             }
           >
@@ -139,12 +139,12 @@ exports[`BuyCrypto should render with some props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "fontFamily": "Quicksand-Medium",
-                "marginVertical": 6,
+                "marginVertical": 5,
               },
               null,
             ]
@@ -161,7 +161,7 @@ exports[`BuyCrypto should render with some props 1`] = `
         "alignItems": "center",
         "flex": 1,
         "justifyContent": "center",
-        "marginVertical": 11,
+        "marginVertical": 10,
       }
     }
   >
@@ -174,11 +174,11 @@ exports[`BuyCrypto should render with some props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
-            "fontSize": 28,
+            "fontSize": 25,
             "textAlign": "center",
           },
           null,
@@ -196,7 +196,7 @@ exports[`BuyCrypto should render with some props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {

--- a/src/__tests__/components/__snapshots__/Card.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/Card.test.tsx.snap
@@ -9,16 +9,16 @@ exports[`Card should allow child elements to expand within the card 1`] = `
         "borderRadius": 16,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
       {
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 10,
+        "paddingLeft": 10,
+        "paddingRight": 10,
+        "paddingTop": 10,
       },
       undefined,
     ]
@@ -55,7 +55,7 @@ exports[`Card should allow child elements to expand within the card 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           undefined,
@@ -85,16 +85,16 @@ exports[`Card should expand both the card and its children to fill available spa
           "borderRadius": 16,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
         {
-          "paddingBottom": 11,
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "paddingTop": 11,
+          "paddingBottom": 10,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "paddingTop": 10,
         },
         {
           "flex": 1,
@@ -133,7 +133,7 @@ exports[`Card should expand both the card and its children to fill available spa
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             undefined,
@@ -164,16 +164,16 @@ exports[`Card should expand to fill its parent container 1`] = `
           "borderRadius": 16,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
         {
-          "paddingBottom": 11,
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "paddingTop": 11,
+          "paddingBottom": 10,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "paddingTop": 10,
         },
         undefined,
       ]
@@ -202,7 +202,7 @@ exports[`Card should expand to fill its parent container 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           undefined,
@@ -249,15 +249,15 @@ exports[`Card should handle press events 1`] = `
     {
       "alignSelf": "stretch",
       "borderRadius": 16,
-      "marginBottom": 11,
-      "marginLeft": 11,
-      "marginRight": 11,
-      "marginTop": 11,
+      "marginBottom": 10,
+      "marginLeft": 10,
+      "marginRight": 10,
+      "marginTop": 10,
       "opacity": 1,
-      "paddingBottom": 11,
-      "paddingLeft": 11,
-      "paddingRight": 11,
-      "paddingTop": 11,
+      "paddingBottom": 10,
+      "paddingLeft": 10,
+      "paddingRight": 10,
+      "paddingTop": 10,
     }
   }
   testID="card"
@@ -285,7 +285,7 @@ exports[`Card should handle press events 1`] = `
         {
           "color": "#FFFFFF",
           "fontFamily": "Quicksand-Regular",
-          "fontSize": 22,
+          "fontSize": 20,
           "includeFontPadding": false,
         },
         undefined,
@@ -307,16 +307,16 @@ exports[`Card should render sections correctly with multiple children 1`] = `
         "borderRadius": 16,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
       {
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 10,
+        "paddingLeft": 10,
+        "paddingRight": 10,
+        "paddingTop": 10,
       },
       undefined,
     ]
@@ -359,7 +359,7 @@ exports[`Card should render sections correctly with multiple children 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           undefined,
@@ -397,7 +397,7 @@ exports[`Card should render sections correctly with multiple children 1`] = `
             "height": 1,
           },
           {
-            "margin": 11,
+            "margin": 10,
           },
         ]
       }
@@ -411,7 +411,7 @@ exports[`Card should render sections correctly with multiple children 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           undefined,
@@ -434,16 +434,16 @@ exports[`Card should render with gradient background 1`] = `
         "borderRadius": 16,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
       {
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 10,
+        "paddingLeft": 10,
+        "paddingRight": 10,
+        "paddingTop": 10,
       },
       undefined,
     ]
@@ -504,7 +504,7 @@ exports[`Card should render with gradient background 1`] = `
         {
           "color": "#FFFFFF",
           "fontFamily": "Quicksand-Regular",
-          "fontSize": 22,
+          "fontSize": 20,
           "includeFontPadding": false,
         },
         undefined,
@@ -526,16 +526,16 @@ exports[`Card should render with icon URI 1`] = `
         "borderRadius": 16,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
       {
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 10,
+        "paddingLeft": 10,
+        "paddingRight": 10,
+        "paddingTop": 10,
       },
       undefined,
     ]
@@ -570,7 +570,7 @@ exports[`Card should render with icon URI 1`] = `
         {
           "alignContent": "center",
           "justifyContent": "center",
-          "margin": 6,
+          "margin": 5,
         }
       }
     >
@@ -581,9 +581,9 @@ exports[`Card should render with icon URI 1`] = `
               "overflow": "hidden",
             },
             {
-              "height": 34,
+              "height": 29,
               "resizeMode": "contain",
-              "width": 34,
+              "width": 29,
             },
           ]
         }
@@ -617,7 +617,7 @@ exports[`Card should render with icon URI 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           undefined,
@@ -640,16 +640,16 @@ exports[`Card should render with node background 1`] = `
         "borderRadius": 16,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
       {
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 10,
+        "paddingLeft": 10,
+        "paddingRight": 10,
+        "paddingTop": 10,
       },
       undefined,
     ]
@@ -688,7 +688,7 @@ exports[`Card should render with node background 1`] = `
         {
           "color": "#FFFFFF",
           "fontFamily": "Quicksand-Regular",
-          "fontSize": 22,
+          "fontSize": 20,
           "includeFontPadding": false,
         },
         undefined,

--- a/src/__tests__/components/__snapshots__/CreateWalletSelectCryptoRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/CreateWalletSelectCryptoRow.test.tsx.snap
@@ -34,22 +34,22 @@ exports[`WalletListRow should render with loading props 1`] = `
       "alignItems": "center",
       "flexDirection": "row",
       "justifyContent": "center",
-      "marginHorizontal": -11,
-      "minHeight": 96,
+      "marginHorizontal": -10,
+      "minHeight": 84,
       "opacity": 1,
-      "paddingHorizontal": 11,
+      "paddingHorizontal": 10,
     }
   }
 >
   <View
     style={
       {
-        "height": 45,
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
-        "width": 45,
+        "height": 39,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
+        "width": 39,
       }
     }
   >
@@ -57,9 +57,9 @@ exports[`WalletListRow should render with loading props 1`] = `
       style={
         {
           "backgroundColor": "#000000",
-          "borderRadius": 22.5,
+          "borderRadius": 19.5,
           "elevation": 0,
-          "height": 45,
+          "height": 39,
           "shadowColor": "#000000",
           "shadowOffset": {
             "height": 3,
@@ -67,7 +67,7 @@ exports[`WalletListRow should render with loading props 1`] = `
           },
           "shadowOpacity": 0.6,
           "shadowRadius": 4,
-          "width": 45,
+          "width": 39,
         }
       }
     >
@@ -114,7 +114,7 @@ exports[`WalletListRow should render with loading props 1`] = `
         "flexDirection": "column",
         "flexGrow": 1,
         "flexShrink": 1,
-        "marginHorizontal": 11,
+        "marginHorizontal": 10,
       }
     }
   >
@@ -127,7 +127,7 @@ exports[`WalletListRow should render with loading props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
@@ -150,12 +150,12 @@ exports[`WalletListRow should render with loading props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "color": "#3dd9f4",
-            "fontSize": 17,
+            "fontSize": 15,
           },
           null,
         ]
@@ -167,7 +167,7 @@ exports[`WalletListRow should render with loading props 1`] = `
   <View
     style={
       {
-        "paddingRight": 11,
+        "paddingRight": 10,
       }
     }
   >

--- a/src/__tests__/components/__snapshots__/CurrencyIcon.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/CurrencyIcon.test.tsx.snap
@@ -4,12 +4,12 @@ exports[`CryptoIcon should render with loading props 1`] = `
 <View
   style={
     {
-      "height": 45,
-      "marginBottom": 22,
-      "marginLeft": 22,
-      "marginRight": 22,
-      "marginTop": 22,
-      "width": 45,
+      "height": 39,
+      "marginBottom": 20,
+      "marginLeft": 20,
+      "marginRight": 20,
+      "marginTop": 20,
+      "width": 39,
     }
   }
 >
@@ -17,9 +17,9 @@ exports[`CryptoIcon should render with loading props 1`] = `
     style={
       {
         "backgroundColor": "#000000",
-        "borderRadius": 22.5,
+        "borderRadius": 19.5,
         "elevation": 0,
-        "height": 45,
+        "height": 39,
         "shadowColor": "#000000",
         "shadowOffset": {
           "height": 3,
@@ -27,7 +27,7 @@ exports[`CryptoIcon should render with loading props 1`] = `
         },
         "shadowOpacity": 0.6,
         "shadowRadius": 4,
-        "width": 45,
+        "width": 39,
       }
     }
   >

--- a/src/__tests__/components/__snapshots__/EdgeText.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/EdgeText.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`EdgeText should render with some props 1`] = `
 <Text
@@ -11,7 +11,7 @@ exports[`EdgeText should render with some props 1`] = `
       {
         "color": "#FFFFFF",
         "fontFamily": "Quicksand-Regular",
-        "fontSize": 22,
+        "fontSize": 20,
         "includeFontPadding": false,
       },
       {},

--- a/src/__tests__/components/__snapshots__/ExchangeQuoteComponent.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/ExchangeQuoteComponent.test.tsx.snap
@@ -9,16 +9,16 @@ exports[`ExchangeQuote should render with loading props 1`] = `
         "borderRadius": 16,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
       {
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 10,
+        "paddingLeft": 10,
+        "paddingRight": 10,
+        "paddingTop": 10,
       },
       undefined,
     ]
@@ -47,10 +47,10 @@ exports[`ExchangeQuote should render with loading props 1`] = `
           "justifyContent": "center",
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -58,10 +58,10 @@ exports[`ExchangeQuote should render with loading props 1`] = `
     <View>
       <RNSVGSvgView
         align="xMidYMid"
-        bbHeight={61}
-        bbWidth={61}
+        bbHeight={55}
+        bbWidth={55}
         focusable={false}
-        height={61}
+        height={55}
         meetOrSlice={0}
         minX={-8}
         minY={-8}
@@ -83,8 +83,8 @@ exports[`ExchangeQuote should render with loading props 1`] = `
             },
             {
               "flex": 0,
-              "height": 61,
-              "width": 61,
+              "height": 55,
+              "width": 55,
             },
           ]
         }
@@ -95,9 +95,9 @@ exports[`ExchangeQuote should render with loading props 1`] = `
             },
           ]
         }
-        vbHeight={61}
-        vbWidth={61}
-        width={61}
+        vbHeight={55}
+        vbWidth={55}
+        width={55}
       >
         <RNSVGGroup
           fill={
@@ -108,8 +108,8 @@ exports[`ExchangeQuote should render with loading props 1`] = `
           }
         >
           <RNSVGCircle
-            cx={22.5}
-            cy={22.5}
+            cx={19.5}
+            cy={19.5}
             fill={
               {
                 "payload": 0,
@@ -127,7 +127,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
                 "strokeLinecap",
               ]
             }
-            r={24}
+            r={21}
             stroke={
               {
                 "payload": 4278251938,
@@ -136,11 +136,11 @@ exports[`ExchangeQuote should render with loading props 1`] = `
             }
             strokeDasharray={
               [
-                150.79644737231007,
-                150.79644737231007,
+                131.94689145077132,
+                131.94689145077132,
               ]
             }
-            strokeDashoffset={147.78051842486386}
+            strokeDashoffset={129.3079536217559}
             strokeLinecap={1}
             strokeWidth={4}
           />
@@ -149,12 +149,12 @@ exports[`ExchangeQuote should render with loading props 1`] = `
       <View
         style={
           {
-            "height": 45,
+            "height": 39,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
             "marginTop": 0,
-            "width": 45,
+            "width": 39,
           }
         }
       >
@@ -162,9 +162,9 @@ exports[`ExchangeQuote should render with loading props 1`] = `
           style={
             {
               "backgroundColor": "#000000",
-              "borderRadius": 22.5,
+              "borderRadius": 19.5,
               "elevation": 0,
-              "height": 45,
+              "height": 39,
               "shadowColor": "#000000",
               "shadowOffset": {
                 "height": 3,
@@ -172,7 +172,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
               },
               "shadowOpacity": 0.6,
               "shadowRadius": 4,
-              "width": 45,
+              "width": 39,
             }
           }
         >
@@ -220,8 +220,8 @@ exports[`ExchangeQuote should render with loading props 1`] = `
           "flexDirection": "column",
           "flexGrow": 1,
           "flexShrink": 1,
-          "marginLeft": 11,
-          "marginRight": 6,
+          "marginLeft": 10,
+          "marginRight": 5,
         }
       }
     >
@@ -244,7 +244,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
@@ -267,12 +267,12 @@ exports[`ExchangeQuote should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
+              "fontSize": 15,
             },
             null,
           ]
@@ -298,7 +298,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             undefined,
@@ -315,7 +315,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               undefined,
@@ -345,12 +345,12 @@ exports[`ExchangeQuote should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "color": "#3dd9f4",
-                "fontSize": 17,
+                "fontSize": 15,
               },
               null,
             ]
@@ -364,7 +364,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
   <View
     style={
       {
-        "margin": 11,
+        "margin": 10,
         "marginTop": 0,
       }
     }
@@ -380,7 +380,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
-            "marginTop": 17,
+            "marginTop": 15,
           },
         ]
       }
@@ -403,12 +403,12 @@ exports[`ExchangeQuote should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "fontSize": 17,
-                "marginTop": 6,
+                "fontSize": 15,
+                "marginTop": 5,
               },
               null,
             ]
@@ -420,7 +420,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
       <View
         style={
           {
-            "marginLeft": 6,
+            "marginLeft": 5,
             "textAlign": "right",
           }
         }
@@ -434,12 +434,12 @@ exports[`ExchangeQuote should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "fontSize": 17,
-                "marginTop": 6,
+                "fontSize": 15,
+                "marginTop": 5,
               },
               null,
             ]
@@ -478,12 +478,12 @@ exports[`ExchangeQuote should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "fontSize": 17,
-                "marginTop": 6,
+                "fontSize": 15,
+                "marginTop": 5,
               },
               null,
             ]
@@ -495,7 +495,7 @@ exports[`ExchangeQuote should render with loading props 1`] = `
       <View
         style={
           {
-            "marginLeft": 6,
+            "marginLeft": 5,
             "textAlign": "right",
           }
         }
@@ -509,12 +509,12 @@ exports[`ExchangeQuote should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "fontSize": 17,
-                "marginTop": 6,
+                "fontSize": 15,
+                "marginTop": 5,
               },
               null,
             ]

--- a/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/FilledTextInput.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`FilledTextInput should render with some props 1`] = `
           "borderColor": "rgba(0, 241, 162, 0)",
           "marginHorizontal": 0,
           "opacity": 1,
-          "paddingVertical": 22,
+          "paddingVertical": 20,
         },
       }
     }
@@ -57,12 +57,12 @@ exports[`FilledTextInput should render with some props 1`] = `
       [
         {
           "alignItems": "stretch",
-          "borderRadius": 11,
+          "borderRadius": 10,
           "borderWidth": 1,
           "flexDirection": "row",
           "flexGrow": 1,
           "flexShrink": 1,
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
         },
       ]
     }
@@ -79,19 +79,19 @@ exports[`FilledTextInput should render with some props 1`] = `
       [
         {
           "alignItems": "stretch",
-          "borderRadius": 11,
+          "borderRadius": 10,
           "borderWidth": 1,
           "flexDirection": "row",
           "flexGrow": 1,
           "flexShrink": 1,
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
         },
         {
           "backgroundColor": "rgba(255, 255, 255, 0.2)",
           "borderColor": "rgba(0, 241, 162, 0)",
           "marginHorizontal": 0,
           "opacity": 1,
-          "paddingVertical": 22,
+          "paddingVertical": 20,
         },
       ]
     }
@@ -182,8 +182,8 @@ exports[`FilledTextInput should render with some props 1`] = `
       jestAnimatedStyle={
         {
           "value": {
-            "marginBottom": -11,
-            "marginTop": 11,
+            "marginBottom": -10,
+            "marginTop": 10,
           },
         }
       }
@@ -209,8 +209,8 @@ exports[`FilledTextInput should render with some props 1`] = `
             "left": 0,
           },
           {
-            "marginBottom": -11,
-            "marginTop": 11,
+            "marginBottom": -10,
+            "marginTop": 10,
           },
         ]
       }
@@ -227,10 +227,10 @@ exports[`FilledTextInput should render with some props 1`] = `
             "value": {
               "transform": [
                 {
-                  "translateY": -22,
+                  "translateY": -20,
                 },
                 {
-                  "translateX": -8.8,
+                  "translateX": -8,
                 },
               ],
             },
@@ -241,7 +241,7 @@ exports[`FilledTextInput should render with some props 1`] = `
             {
               "alignItems": "center",
               "justifyContent": "center",
-              "left": 8.8,
+              "left": 8,
               "margin": 0,
               "paddingHorizontal": 0,
               "paddingVertical": 0,
@@ -257,7 +257,7 @@ exports[`FilledTextInput should render with some props 1`] = `
             {
               "alignItems": "center",
               "justifyContent": "center",
-              "left": 8.8,
+              "left": 8,
               "margin": 0,
               "paddingHorizontal": 0,
               "paddingVertical": 0,
@@ -267,10 +267,10 @@ exports[`FilledTextInput should render with some props 1`] = `
             {
               "transform": [
                 {
-                  "translateY": -22,
+                  "translateY": -20,
                 },
                 {
-                  "translateX": -8.8,
+                  "translateX": -8,
                 },
               ],
             },
@@ -290,7 +290,7 @@ exports[`FilledTextInput should render with some props 1`] = `
             {
               "value": {
                 "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                "fontSize": 16.5,
+                "fontSize": 15,
               },
             }
           }
@@ -298,7 +298,7 @@ exports[`FilledTextInput should render with some props 1`] = `
             [
               {
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
             ]
@@ -310,12 +310,12 @@ exports[`FilledTextInput should render with some props 1`] = `
             [
               {
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                "fontSize": 16.5,
+                "fontSize": 15,
               },
             ]
           }
@@ -349,7 +349,7 @@ exports[`FilledTextInput should render with some props 1`] = `
           {
             "value": {
               "color": "rgba(255, 255, 255, 1)",
-              "fontSize": 22,
+              "fontSize": 20,
             },
           }
         }
@@ -401,7 +401,7 @@ exports[`FilledTextInput should render with some props 1`] = `
             },
             {
               "color": "rgba(255, 255, 255, 1)",
-              "fontSize": 22,
+              "fontSize": 20,
             },
           ]
         }
@@ -439,11 +439,11 @@ exports[`FilledTextInput should render with some props 1`] = `
       onStartShouldSetResponder={[Function]}
       style={
         {
-          "marginHorizontal": -22,
-          "marginVertical": -28,
+          "marginHorizontal": -20,
+          "marginVertical": -25,
           "opacity": 1,
-          "paddingHorizontal": 22,
-          "paddingVertical": 28,
+          "paddingHorizontal": 20,
+          "paddingVertical": 25,
         }
       }
       testID="string.clearIcon"
@@ -458,8 +458,8 @@ exports[`FilledTextInput should render with some props 1`] = `
         jestAnimatedStyle={
           {
             "value": {
-              "opacity": 22,
-              "width": 22,
+              "opacity": 20,
+              "width": 20,
             },
           }
         }
@@ -472,7 +472,7 @@ exports[`FilledTextInput should render with some props 1`] = `
           ]
         }
         nativeID="7"
-        scale={22}
+        scale={20}
         style={
           [
             {
@@ -480,8 +480,8 @@ exports[`FilledTextInput should render with some props 1`] = `
               "aspectRatio": 1,
             },
             {
-              "opacity": 22,
-              "width": 22,
+              "opacity": 20,
+              "width": 20,
             },
           ]
         }
@@ -498,7 +498,7 @@ exports[`FilledTextInput should render with some props 1`] = `
               "value": {
                 "color": "rgba(255, 255, 255, 0.5019607843137255)",
                 "fontFamily": "anticon",
-                "fontSize": 22,
+                "fontSize": 20,
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -511,7 +511,7 @@ exports[`FilledTextInput should render with some props 1`] = `
               {
                 "color": "rgba(255, 255, 255, 0.5019607843137255)",
                 "fontFamily": "anticon",
-                "fontSize": 22,
+                "fontSize": 20,
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -539,9 +539,9 @@ exports[`FilledTextInput should render with some props 1`] = `
       [
         {
           "flexDirection": "row",
-          "height": 22,
+          "height": 20,
           "justifyContent": "space-between",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
         },
         {},
       ]
@@ -552,9 +552,9 @@ exports[`FilledTextInput should render with some props 1`] = `
       [
         {
           "flexDirection": "row",
-          "height": 22,
+          "height": 20,
           "justifyContent": "space-between",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
         },
         {},
       ]
@@ -567,7 +567,7 @@ exports[`FilledTextInput should render with some props 1`] = `
           {
             "color": "#E85466",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 17,
+            "fontSize": 15,
             "includeFontPadding": false,
           },
         ]
@@ -581,7 +581,7 @@ exports[`FilledTextInput should render with some props 1`] = `
           {
             "color": "#3dd9f4",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 17,
+            "fontSize": 15,
             "includeFontPadding": false,
           },
         ]

--- a/src/__tests__/components/__snapshots__/LineTextDivider.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/LineTextDivider.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`LineTextDivider should render with loading props 1`] = `
 <View
@@ -8,8 +8,8 @@ exports[`LineTextDivider should render with loading props 1`] = `
       "flexDirection": "row",
       "flexGrow": 1,
       "justifyContent": "space-between",
-      "marginVertical": 11,
-      "paddingHorizontal": 11,
+      "marginVertical": 10,
+      "paddingHorizontal": 10,
     }
   }
 >
@@ -31,15 +31,15 @@ exports[`LineTextDivider should render with loading props 1`] = `
         {
           "color": "#FFFFFF",
           "fontFamily": "Quicksand-Regular",
-          "fontSize": 22,
+          "fontSize": 20,
           "includeFontPadding": false,
         },
         [
           {
             "color": "#3dd9f4",
             "fontFamily": "Quicksand-Medium",
-            "fontSize": 22,
-            "paddingHorizontal": 17,
+            "fontSize": 20,
+            "paddingHorizontal": 15,
           },
           {
             "textTransform": "lowercase",

--- a/src/__tests__/components/__snapshots__/MenuTabs.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/MenuTabs.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`MenuTabs should render with loading props 1`] = `
         },
       ]
     }
-    tabLabelHeight={25}
+    tabLabelHeight={22}
   >
     <BlurView
       blurType="dark"
@@ -193,7 +193,7 @@ exports[`MenuTabs should render with loading props 1`] = `
         },
       ]
     }
-    tabLabelHeight={25}
+    tabLabelHeight={22}
   />
 </View>
 `;

--- a/src/__tests__/components/__snapshots__/Row.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/Row.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`RowUi4 renders correctly with an icon 1`] = `
 <View
@@ -12,10 +12,10 @@ exports[`RowUi4 renders correctly with an icon 1`] = `
         "flexShrink": 1,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
     ]
   }
@@ -44,13 +44,13 @@ exports[`RowUi4 renders correctly with an icon 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "color": "#3dd9f4",
-            "fontSize": 17,
-            "paddingRight": 22,
+            "fontSize": 15,
+            "paddingRight": 20,
           },
           null,
         ]
@@ -68,12 +68,12 @@ exports[`RowUi4 renders correctly with an icon 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "color": "#FFFFFF",
-            "fontSize": 22,
+            "fontSize": 20,
           },
           null,
         ]
@@ -104,10 +104,10 @@ exports[`RowUi4 renders correctly with an icon in a flex view 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -136,13 +136,13 @@ exports[`RowUi4 renders correctly with an icon in a flex view 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -160,12 +160,12 @@ exports[`RowUi4 renders correctly with an icon in a flex view 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -191,10 +191,10 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -222,13 +222,13 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -257,10 +257,10 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -289,13 +289,13 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -324,10 +324,10 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -341,7 +341,7 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -356,13 +356,13 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -426,11 +426,11 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -457,10 +457,10 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -474,7 +474,7 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -489,13 +489,13 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -559,11 +559,11 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -590,10 +590,10 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -607,7 +607,7 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -622,13 +622,13 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -692,11 +692,11 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -723,10 +723,10 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -740,7 +740,7 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -755,13 +755,13 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -825,11 +825,11 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -856,10 +856,10 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -873,7 +873,7 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -888,13 +888,13 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -958,11 +958,11 @@ exports[`RowUi4 renders correctly with flex: 1 children 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -1002,10 +1002,10 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -1033,13 +1033,13 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -1057,12 +1057,12 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -1083,10 +1083,10 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -1115,13 +1115,13 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -1139,12 +1139,12 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -1165,10 +1165,10 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -1182,7 +1182,7 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -1197,13 +1197,13 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -1221,12 +1221,12 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -1282,11 +1282,11 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -1313,10 +1313,10 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -1330,7 +1330,7 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -1345,13 +1345,13 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -1369,12 +1369,12 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -1430,11 +1430,11 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -1461,10 +1461,10 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -1478,7 +1478,7 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -1493,13 +1493,13 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -1517,12 +1517,12 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -1578,11 +1578,11 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -1611,10 +1611,10 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -1628,7 +1628,7 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -1643,13 +1643,13 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -1667,12 +1667,12 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -1728,11 +1728,11 @@ exports[`RowUi4 renders correctly with multiple rows in a flex: 1 View 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -1763,10 +1763,10 @@ exports[`RowUi4 should handle press events 1`] = `
         "flexShrink": 1,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
     ]
   }
@@ -1779,7 +1779,7 @@ exports[`RowUi4 should handle press events 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginRight": 34,
+          "marginRight": 29,
         },
       ]
     }
@@ -1794,13 +1794,13 @@ exports[`RowUi4 should handle press events 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "color": "#3dd9f4",
-            "fontSize": 17,
-            "paddingRight": 22,
+            "fontSize": 15,
+            "paddingRight": 20,
           },
           null,
         ]
@@ -1818,12 +1818,12 @@ exports[`RowUi4 should handle press events 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "color": "#FFFFFF",
-            "fontSize": 22,
+            "fontSize": 20,
           },
           null,
         ]
@@ -1880,11 +1880,11 @@ exports[`RowUi4 should handle press events 1`] = `
         [
           {
             "color": undefined,
-            "fontSize": 22,
+            "fontSize": 20,
           },
           {
             "color": "#00f1a2",
-            "marginLeft": 11,
+            "marginLeft": 10,
             "textAlign": "center",
           },
           {
@@ -1916,10 +1916,10 @@ exports[`RowUi4 should render a basic row 1`] = `
         "flexShrink": 1,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
     ]
   }
@@ -1947,13 +1947,13 @@ exports[`RowUi4 should render a basic row 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "color": "#3dd9f4",
-            "fontSize": 17,
-            "paddingRight": 22,
+            "fontSize": 15,
+            "paddingRight": 20,
           },
           null,
         ]
@@ -1971,12 +1971,12 @@ exports[`RowUi4 should render a basic row 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "color": "#FFFFFF",
-            "fontSize": 22,
+            "fontSize": 20,
           },
           null,
         ]
@@ -1997,16 +1997,16 @@ exports[`RowUi4 should render a row in a card 1`] = `
         "borderRadius": 16,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
       {
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 10,
+        "paddingLeft": 10,
+        "paddingRight": 10,
+        "paddingTop": 10,
       },
       undefined,
     ]
@@ -2037,10 +2037,10 @@ exports[`RowUi4 should render a row in a card 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -2068,13 +2068,13 @@ exports[`RowUi4 should render a row in a card 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -2092,12 +2092,12 @@ exports[`RowUi4 should render a row in a card 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -2123,10 +2123,10 @@ exports[`RowUi4 should render a row with a right button 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -2139,7 +2139,7 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -2154,13 +2154,13 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -2178,12 +2178,12 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -2239,11 +2239,11 @@ exports[`RowUi4 should render a row with a right button 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -2270,10 +2270,10 @@ exports[`RowUi4 should render a row with a right button 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -2286,7 +2286,7 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -2301,13 +2301,13 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -2325,12 +2325,12 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -2386,11 +2386,11 @@ exports[`RowUi4 should render a row with a right button 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -2417,10 +2417,10 @@ exports[`RowUi4 should render a row with a right button 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -2433,7 +2433,7 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -2448,13 +2448,13 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -2472,12 +2472,12 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -2533,11 +2533,11 @@ exports[`RowUi4 should render a row with a right button 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {
@@ -2566,10 +2566,10 @@ exports[`RowUi4 should render a row with a right button 1`] = `
           "flexShrink": 1,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
       ]
     }
@@ -2582,7 +2582,7 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginRight": 34,
+            "marginRight": 29,
           },
         ]
       }
@@ -2597,13 +2597,13 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
-              "paddingRight": 22,
+              "fontSize": 15,
+              "paddingRight": 20,
             },
             null,
           ]
@@ -2621,12 +2621,12 @@ exports[`RowUi4 should render a row with a right button 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#FFFFFF",
-              "fontSize": 22,
+              "fontSize": 20,
             },
             null,
           ]
@@ -2682,11 +2682,11 @@ exports[`RowUi4 should render a row with a right button 1`] = `
           [
             {
               "color": undefined,
-              "fontSize": 22,
+              "fontSize": 20,
             },
             {
               "color": "#00f1a2",
-              "marginLeft": 11,
+              "marginLeft": 10,
               "textAlign": "center",
             },
             {

--- a/src/__tests__/components/__snapshots__/SceneHeader.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/SceneHeader.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SceneHeader should render with loading props 1`] = `
 [
@@ -7,11 +7,11 @@ exports[`SceneHeader should render with loading props 1`] = `
       [
         {
           "justifyContent": "center",
-          "marginHorizontal": 22,
-          "paddingBottom": 22,
+          "marginHorizontal": 20,
+          "paddingBottom": 20,
         },
         {
-          "marginTop": 22,
+          "marginTop": 20,
         },
         undefined,
       ]
@@ -35,12 +35,12 @@ exports[`SceneHeader should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
+              "fontSize": 24,
             },
             null,
           ]
@@ -79,7 +79,7 @@ exports[`SceneHeader should render with loading props 1`] = `
         },
         {
           "marginBottom": 0,
-          "marginLeft": 22,
+          "marginLeft": 20,
           "marginRight": 0,
           "marginTop": 0,
         },

--- a/src/__tests__/components/__snapshots__/SelectableRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/SelectableRow.test.tsx.snap
@@ -33,15 +33,15 @@ exports[`SelectableRow should render with loading props 1`] = `
     {
       "alignSelf": "stretch",
       "borderRadius": 16,
-      "marginBottom": 11,
-      "marginLeft": 11,
-      "marginRight": 11,
-      "marginTop": 11,
+      "marginBottom": 10,
+      "marginLeft": 10,
+      "marginRight": 10,
+      "marginTop": 10,
       "opacity": 1,
-      "paddingBottom": 11,
-      "paddingLeft": 11,
-      "paddingRight": 11,
-      "paddingTop": 11,
+      "paddingBottom": 10,
+      "paddingLeft": 10,
+      "paddingRight": 10,
+      "paddingTop": 10,
     }
   }
 >
@@ -72,7 +72,7 @@ exports[`SelectableRow should render with loading props 1`] = `
     <View
       style={
         {
-          "margin": 11,
+          "margin": 10,
         }
       }
     />
@@ -82,7 +82,7 @@ exports[`SelectableRow should render with loading props 1`] = `
           "alignItems": "flex-start",
           "flex": 1,
           "flexDirection": "column",
-          "margin": 11,
+          "margin": 10,
         }
       }
     >
@@ -95,7 +95,7 @@ exports[`SelectableRow should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             undefined,

--- a/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListRow.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TransactionListRow should render with loading props 1`] = `
 <View
@@ -33,15 +33,15 @@ exports[`TransactionListRow should render with loading props 1`] = `
     {
       "alignSelf": "stretch",
       "borderRadius": 16,
-      "marginBottom": 11,
-      "marginLeft": 11,
-      "marginRight": 11,
-      "marginTop": 11,
+      "marginBottom": 10,
+      "marginLeft": 10,
+      "marginRight": 10,
+      "marginTop": 10,
       "opacity": 1,
-      "paddingBottom": 11,
-      "paddingLeft": 11,
-      "paddingRight": 11,
-      "paddingTop": 11,
+      "paddingBottom": 10,
+      "paddingLeft": 10,
+      "paddingRight": 10,
+      "paddingTop": 10,
     }
   }
 >
@@ -74,7 +74,7 @@ exports[`TransactionListRow should render with loading props 1`] = `
         {
           "alignContent": "center",
           "justifyContent": "center",
-          "margin": 6,
+          "margin": 5,
         }
       }
     >
@@ -87,9 +87,9 @@ exports[`TransactionListRow should render with loading props 1`] = `
             },
             {
               "alignItems": "center",
-              "borderRadius": 28,
+              "borderRadius": 25,
               "elevation": 0,
-              "height": 45,
+              "height": 39,
               "justifyContent": "center",
               "shadowColor": "#000000",
               "shadowOffset": {
@@ -98,7 +98,7 @@ exports[`TransactionListRow should render with loading props 1`] = `
               },
               "shadowOpacity": 0.6,
               "shadowRadius": 4,
-              "width": 45,
+              "width": 39,
             },
           ]
         }
@@ -110,7 +110,7 @@ exports[`TransactionListRow should render with loading props 1`] = `
             [
               {
                 "color": "#E84D65",
-                "fontSize": 28,
+                "fontSize": 25,
               },
               {
                 "shadowColor": "rgba(0, 0, 0, 0.7)",
@@ -149,10 +149,10 @@ exports[`TransactionListRow should render with loading props 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginBottom": 6,
-            "marginLeft": 6,
-            "marginRight": 6,
-            "marginTop": 6,
+            "marginBottom": 5,
+            "marginLeft": 5,
+            "marginRight": 5,
+            "marginTop": 5,
           },
         ]
       }
@@ -176,14 +176,14 @@ exports[`TransactionListRow should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "alignSelf": "center",
                 "flexShrink": 1,
                 "fontFamily": "Quicksand-Medium",
-                "marginRight": 22,
+                "marginRight": 20,
               },
               null,
             ]
@@ -200,7 +200,7 @@ exports[`TransactionListRow should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
@@ -234,14 +234,14 @@ exports[`TransactionListRow should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "color": "#3dd9f4",
                 "flexShrink": 1,
-                "fontSize": 17,
-                "marginRight": 22,
+                "fontSize": 15,
+                "marginRight": 20,
               },
               null,
             ]
@@ -258,12 +258,12 @@ exports[`TransactionListRow should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "color": "#3dd9f4",
-                "fontSize": 17,
+                "fontSize": 15,
                 "textAlign": "right",
               },
               null,
@@ -292,15 +292,15 @@ exports[`TransactionListRow should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
                 {
                   "color": "#3dd9f4",
                   "flexShrink": 1,
-                  "fontSize": 17,
-                  "marginRight": 22,
+                  "fontSize": 15,
+                  "marginRight": 20,
                 },
                 {
                   "color": "#F1AA19",

--- a/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionListTop.test.tsx.snap
@@ -10,16 +10,16 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           "borderRadius": 16,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
         {
-          "paddingBottom": 22,
-          "paddingLeft": 22,
-          "paddingRight": 22,
-          "paddingTop": 22,
+          "paddingBottom": 20,
+          "paddingLeft": 20,
+          "paddingRight": 20,
+          "paddingTop": 20,
         },
         undefined,
       ]
@@ -44,7 +44,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
         {
           "flexDirection": "row",
           "justifyContent": "space-between",
-          "marginBottom": 11,
+          "marginBottom": 10,
         }
       }
     >
@@ -83,20 +83,20 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             "borderRadius": 100,
             "flexDirection": "row",
             "flexShrink": 1,
-            "marginRight": 11,
+            "marginRight": 10,
             "opacity": 1,
-            "paddingHorizontal": 17,
-            "paddingVertical": 6,
+            "paddingHorizontal": 15,
+            "paddingVertical": 5,
           }
         }
       >
         <View>
           <RNSVGSvgView
             align="xMidYMid"
-            bbHeight={38}
-            bbWidth={38}
+            bbHeight={36}
+            bbWidth={36}
             focusable={false}
-            height={38}
+            height={36}
             meetOrSlice={0}
             minX={-8}
             minY={-8}
@@ -118,8 +118,8 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
                 },
                 {
                   "flex": 0,
-                  "height": 38,
-                  "width": 38,
+                  "height": 36,
+                  "width": 36,
                 },
               ]
             }
@@ -130,9 +130,9 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
                 },
               ]
             }
-            vbHeight={38}
-            vbWidth={38}
-            width={38}
+            vbHeight={36}
+            vbWidth={36}
+            width={36}
           >
             <RNSVGGroup
               fill={
@@ -143,8 +143,8 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
               }
             >
               <RNSVGCircle
-                cx={11}
-                cy={11}
+                cx={10}
+                cy={10}
                 fill={
                   {
                     "payload": 0,
@@ -162,7 +162,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
                     "strokeLinecap",
                   ]
                 }
-                r={13}
+                r={12}
                 stroke={
                   {
                     "payload": 4278251938,
@@ -171,8 +171,8 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
                 }
                 strokeDasharray={
                   [
-                    81.68140899333463,
-                    81.68140899333463,
+                    75.39822368615503,
+                    75.39822368615503,
                   ]
                 }
                 strokeDashoffset={null}
@@ -184,12 +184,12 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           <View
             style={
               {
-                "height": 22,
+                "height": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
-                "marginRight": 6,
+                "marginRight": 5,
                 "marginTop": 0,
-                "width": 22,
+                "width": 20,
               }
             }
           >
@@ -197,9 +197,9 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
               style={
                 {
                   "backgroundColor": "#000000",
-                  "borderRadius": 11,
+                  "borderRadius": 10,
                   "elevation": 0,
-                  "height": 22,
+                  "height": 20,
                   "shadowColor": "#000000",
                   "shadowOffset": {
                     "height": 3,
@@ -207,7 +207,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
                   },
                   "shadowOpacity": 0.6,
                   "shadowRadius": 4,
-                  "width": 22,
+                  "width": 20,
                 }
               }
             >
@@ -259,13 +259,13 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "flexShrink": 1,
-                "fontSize": 17,
-                "lineHeight": 34,
+                "fontSize": 15,
+                "lineHeight": 29,
               },
               null,
             ]
@@ -305,11 +305,11 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
         style={
           {
             "alignSelf": "center",
-            "margin": -17,
-            "marginRight": -17,
+            "margin": -15,
+            "marginRight": -15,
             "opacity": 1,
-            "padding": 17,
-            "paddingRight": 11,
+            "padding": 15,
+            "paddingRight": 10,
           }
         }
         testID="gearIcon"
@@ -322,7 +322,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             [
               {
                 "color": "#FFFFFF",
-                "fontSize": 22,
+                "fontSize": 20,
               },
               undefined,
               {
@@ -391,13 +391,13 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "flexShrink": 1,
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 39,
+                "fontSize": 34,
               },
               null,
             ]
@@ -412,12 +412,12 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             [
               {
                 "color": "#00f1a2",
-                "fontSize": 26,
+                "fontSize": 23,
               },
               {
                 "alignSelf": "center",
                 "flexGrow": 1,
-                "marginLeft": 11,
+                "marginLeft": 10,
                 "marginRight": 0,
                 "textShadowColor": "rgba(0, 0, 0, 0.514)",
                 "textShadowOffset": {
@@ -448,11 +448,11 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
-              "fontSize": 28,
+              "fontSize": 25,
             },
             null,
           ]
@@ -504,10 +504,10 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           "alignItems": "center",
           "flexShrink": 1,
           "justifyContent": "center",
-          "marginHorizontal": -22,
-          "marginVertical": 11,
+          "marginHorizontal": -20,
+          "marginVertical": 10,
           "opacity": 1,
-          "paddingHorizontal": 22,
+          "paddingHorizontal": 20,
         }
       }
     >
@@ -517,8 +517,8 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             "alignItems": "center",
             "flexShrink": 1,
             "justifyContent": "center",
-            "marginBottom": 6,
-            "paddingTop": 11,
+            "marginBottom": 5,
+            "paddingTop": 10,
           }
         }
       >
@@ -527,10 +527,10 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             {
               "alignItems": "center",
               "backgroundColor": "rgba(255, 255, 255, .1)",
-              "borderRadius": 33.5,
-              "height": 67,
+              "borderRadius": 29.5,
+              "height": 59,
               "justifyContent": "center",
-              "width": 67,
+              "width": 59,
             }
           }
         >
@@ -541,7 +541,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
               [
                 {
                   "color": "#FFFFFF",
-                  "fontSize": 45,
+                  "fontSize": 39,
                 },
                 undefined,
                 {
@@ -566,7 +566,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -612,10 +612,10 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           "alignItems": "center",
           "flexShrink": 1,
           "justifyContent": "center",
-          "marginHorizontal": -22,
-          "marginVertical": 11,
+          "marginHorizontal": -20,
+          "marginVertical": 10,
           "opacity": 1,
-          "paddingHorizontal": 22,
+          "paddingHorizontal": 20,
         }
       }
     >
@@ -625,8 +625,8 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             "alignItems": "center",
             "flexShrink": 1,
             "justifyContent": "center",
-            "marginBottom": 6,
-            "paddingTop": 11,
+            "marginBottom": 5,
+            "paddingTop": 10,
           }
         }
       >
@@ -635,10 +635,10 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             {
               "alignItems": "center",
               "backgroundColor": "rgba(255, 255, 255, .1)",
-              "borderRadius": 33.5,
-              "height": 67,
+              "borderRadius": 29.5,
+              "height": 59,
               "justifyContent": "center",
-              "width": 67,
+              "width": 59,
             }
           }
         >
@@ -649,7 +649,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
               [
                 {
                   "color": "#FFFFFF",
-                  "fontSize": 45,
+                  "fontSize": 39,
                 },
                 undefined,
                 {
@@ -674,7 +674,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -720,10 +720,10 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           "alignItems": "center",
           "flexShrink": 1,
           "justifyContent": "center",
-          "marginHorizontal": -22,
-          "marginVertical": 11,
+          "marginHorizontal": -20,
+          "marginVertical": 10,
           "opacity": 1,
-          "paddingHorizontal": 22,
+          "paddingHorizontal": 20,
         }
       }
     >
@@ -733,8 +733,8 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             "alignItems": "center",
             "flexShrink": 1,
             "justifyContent": "center",
-            "marginBottom": 6,
-            "paddingTop": 11,
+            "marginBottom": 5,
+            "paddingTop": 10,
           }
         }
       >
@@ -743,10 +743,10 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             {
               "alignItems": "center",
               "backgroundColor": "rgba(255, 255, 255, .1)",
-              "borderRadius": 33.5,
-              "height": 67,
+              "borderRadius": 29.5,
+              "height": 59,
               "justifyContent": "center",
-              "width": 67,
+              "width": 59,
             }
           }
         >
@@ -757,7 +757,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
               [
                 {
                   "color": "#FFFFFF",
-                  "fontSize": 45,
+                  "fontSize": 39,
                 },
                 undefined,
                 {
@@ -782,7 +782,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -804,10 +804,10 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           "borderRadius": 16,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
         {
           "paddingBottom": 0,
@@ -866,7 +866,7 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
           "alignItems": "center",
           "flexDirection": "row",
           "opacity": 1,
-          "padding": 11,
+          "padding": 10,
         }
       }
     >
@@ -877,9 +877,9 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
               "overflow": "hidden",
             },
             {
-              "height": 45,
-              "margin": 11,
-              "width": 45,
+              "height": 39,
+              "margin": 10,
+              "width": 39,
             },
           ]
         }
@@ -912,11 +912,11 @@ exports[`TransactionListTop should render (with ENABLE_VISA_PROGRAM) 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
-              "marginLeft": 11,
+              "marginLeft": 10,
             },
             null,
           ]
@@ -939,16 +939,16 @@ exports[`TransactionListTop should render 1`] = `
           "borderRadius": 16,
         },
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         },
         {
-          "paddingBottom": 22,
-          "paddingLeft": 22,
-          "paddingRight": 22,
-          "paddingTop": 22,
+          "paddingBottom": 20,
+          "paddingLeft": 20,
+          "paddingRight": 20,
+          "paddingTop": 20,
         },
         undefined,
       ]
@@ -973,7 +973,7 @@ exports[`TransactionListTop should render 1`] = `
         {
           "flexDirection": "row",
           "justifyContent": "space-between",
-          "marginBottom": 11,
+          "marginBottom": 10,
         }
       }
     >
@@ -1012,20 +1012,20 @@ exports[`TransactionListTop should render 1`] = `
             "borderRadius": 100,
             "flexDirection": "row",
             "flexShrink": 1,
-            "marginRight": 11,
+            "marginRight": 10,
             "opacity": 1,
-            "paddingHorizontal": 17,
-            "paddingVertical": 6,
+            "paddingHorizontal": 15,
+            "paddingVertical": 5,
           }
         }
       >
         <View>
           <RNSVGSvgView
             align="xMidYMid"
-            bbHeight={38}
-            bbWidth={38}
+            bbHeight={36}
+            bbWidth={36}
             focusable={false}
-            height={38}
+            height={36}
             meetOrSlice={0}
             minX={-8}
             minY={-8}
@@ -1047,8 +1047,8 @@ exports[`TransactionListTop should render 1`] = `
                 },
                 {
                   "flex": 0,
-                  "height": 38,
-                  "width": 38,
+                  "height": 36,
+                  "width": 36,
                 },
               ]
             }
@@ -1059,9 +1059,9 @@ exports[`TransactionListTop should render 1`] = `
                 },
               ]
             }
-            vbHeight={38}
-            vbWidth={38}
-            width={38}
+            vbHeight={36}
+            vbWidth={36}
+            width={36}
           >
             <RNSVGGroup
               fill={
@@ -1072,8 +1072,8 @@ exports[`TransactionListTop should render 1`] = `
               }
             >
               <RNSVGCircle
-                cx={11}
-                cy={11}
+                cx={10}
+                cy={10}
                 fill={
                   {
                     "payload": 0,
@@ -1091,7 +1091,7 @@ exports[`TransactionListTop should render 1`] = `
                     "strokeLinecap",
                   ]
                 }
-                r={13}
+                r={12}
                 stroke={
                   {
                     "payload": 4278251938,
@@ -1100,8 +1100,8 @@ exports[`TransactionListTop should render 1`] = `
                 }
                 strokeDasharray={
                   [
-                    81.68140899333463,
-                    81.68140899333463,
+                    75.39822368615503,
+                    75.39822368615503,
                   ]
                 }
                 strokeDashoffset={null}
@@ -1113,12 +1113,12 @@ exports[`TransactionListTop should render 1`] = `
           <View
             style={
               {
-                "height": 22,
+                "height": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
-                "marginRight": 6,
+                "marginRight": 5,
                 "marginTop": 0,
-                "width": 22,
+                "width": 20,
               }
             }
           >
@@ -1126,9 +1126,9 @@ exports[`TransactionListTop should render 1`] = `
               style={
                 {
                   "backgroundColor": "#000000",
-                  "borderRadius": 11,
+                  "borderRadius": 10,
                   "elevation": 0,
-                  "height": 22,
+                  "height": 20,
                   "shadowColor": "#000000",
                   "shadowOffset": {
                     "height": 3,
@@ -1136,7 +1136,7 @@ exports[`TransactionListTop should render 1`] = `
                   },
                   "shadowOpacity": 0.6,
                   "shadowRadius": 4,
-                  "width": 22,
+                  "width": 20,
                 }
               }
             >
@@ -1188,13 +1188,13 @@ exports[`TransactionListTop should render 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "flexShrink": 1,
-                "fontSize": 17,
-                "lineHeight": 34,
+                "fontSize": 15,
+                "lineHeight": 29,
               },
               null,
             ]
@@ -1234,11 +1234,11 @@ exports[`TransactionListTop should render 1`] = `
         style={
           {
             "alignSelf": "center",
-            "margin": -17,
-            "marginRight": -17,
+            "margin": -15,
+            "marginRight": -15,
             "opacity": 1,
-            "padding": 17,
-            "paddingRight": 11,
+            "padding": 15,
+            "paddingRight": 10,
           }
         }
         testID="gearIcon"
@@ -1251,7 +1251,7 @@ exports[`TransactionListTop should render 1`] = `
             [
               {
                 "color": "#FFFFFF",
-                "fontSize": 22,
+                "fontSize": 20,
               },
               undefined,
               {
@@ -1320,13 +1320,13 @@ exports[`TransactionListTop should render 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "flexShrink": 1,
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 39,
+                "fontSize": 34,
               },
               null,
             ]
@@ -1341,12 +1341,12 @@ exports[`TransactionListTop should render 1`] = `
             [
               {
                 "color": "#00f1a2",
-                "fontSize": 26,
+                "fontSize": 23,
               },
               {
                 "alignSelf": "center",
                 "flexGrow": 1,
-                "marginLeft": 11,
+                "marginLeft": 10,
                 "marginRight": 0,
                 "textShadowColor": "rgba(0, 0, 0, 0.514)",
                 "textShadowOffset": {
@@ -1377,11 +1377,11 @@ exports[`TransactionListTop should render 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
-              "fontSize": 28,
+              "fontSize": 25,
             },
             null,
           ]
@@ -1433,10 +1433,10 @@ exports[`TransactionListTop should render 1`] = `
           "alignItems": "center",
           "flexShrink": 1,
           "justifyContent": "center",
-          "marginHorizontal": -22,
-          "marginVertical": 11,
+          "marginHorizontal": -20,
+          "marginVertical": 10,
           "opacity": 1,
-          "paddingHorizontal": 22,
+          "paddingHorizontal": 20,
         }
       }
     >
@@ -1446,8 +1446,8 @@ exports[`TransactionListTop should render 1`] = `
             "alignItems": "center",
             "flexShrink": 1,
             "justifyContent": "center",
-            "marginBottom": 6,
-            "paddingTop": 11,
+            "marginBottom": 5,
+            "paddingTop": 10,
           }
         }
       >
@@ -1456,10 +1456,10 @@ exports[`TransactionListTop should render 1`] = `
             {
               "alignItems": "center",
               "backgroundColor": "rgba(255, 255, 255, .1)",
-              "borderRadius": 33.5,
-              "height": 67,
+              "borderRadius": 29.5,
+              "height": 59,
               "justifyContent": "center",
-              "width": 67,
+              "width": 59,
             }
           }
         >
@@ -1470,7 +1470,7 @@ exports[`TransactionListTop should render 1`] = `
               [
                 {
                   "color": "#FFFFFF",
-                  "fontSize": 45,
+                  "fontSize": 39,
                 },
                 undefined,
                 {
@@ -1495,7 +1495,7 @@ exports[`TransactionListTop should render 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -1541,10 +1541,10 @@ exports[`TransactionListTop should render 1`] = `
           "alignItems": "center",
           "flexShrink": 1,
           "justifyContent": "center",
-          "marginHorizontal": -22,
-          "marginVertical": 11,
+          "marginHorizontal": -20,
+          "marginVertical": 10,
           "opacity": 1,
-          "paddingHorizontal": 22,
+          "paddingHorizontal": 20,
         }
       }
     >
@@ -1554,8 +1554,8 @@ exports[`TransactionListTop should render 1`] = `
             "alignItems": "center",
             "flexShrink": 1,
             "justifyContent": "center",
-            "marginBottom": 6,
-            "paddingTop": 11,
+            "marginBottom": 5,
+            "paddingTop": 10,
           }
         }
       >
@@ -1564,10 +1564,10 @@ exports[`TransactionListTop should render 1`] = `
             {
               "alignItems": "center",
               "backgroundColor": "rgba(255, 255, 255, .1)",
-              "borderRadius": 33.5,
-              "height": 67,
+              "borderRadius": 29.5,
+              "height": 59,
               "justifyContent": "center",
-              "width": 67,
+              "width": 59,
             }
           }
         >
@@ -1578,7 +1578,7 @@ exports[`TransactionListTop should render 1`] = `
               [
                 {
                   "color": "#FFFFFF",
-                  "fontSize": 45,
+                  "fontSize": 39,
                 },
                 undefined,
                 {
@@ -1603,7 +1603,7 @@ exports[`TransactionListTop should render 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -1649,10 +1649,10 @@ exports[`TransactionListTop should render 1`] = `
           "alignItems": "center",
           "flexShrink": 1,
           "justifyContent": "center",
-          "marginHorizontal": -22,
-          "marginVertical": 11,
+          "marginHorizontal": -20,
+          "marginVertical": 10,
           "opacity": 1,
-          "paddingHorizontal": 22,
+          "paddingHorizontal": 20,
         }
       }
     >
@@ -1662,8 +1662,8 @@ exports[`TransactionListTop should render 1`] = `
             "alignItems": "center",
             "flexShrink": 1,
             "justifyContent": "center",
-            "marginBottom": 6,
-            "paddingTop": 11,
+            "marginBottom": 5,
+            "paddingTop": 10,
           }
         }
       >
@@ -1672,10 +1672,10 @@ exports[`TransactionListTop should render 1`] = `
             {
               "alignItems": "center",
               "backgroundColor": "rgba(255, 255, 255, .1)",
-              "borderRadius": 33.5,
-              "height": 67,
+              "borderRadius": 29.5,
+              "height": 59,
               "justifyContent": "center",
-              "width": 67,
+              "width": 59,
             }
           }
         >
@@ -1686,7 +1686,7 @@ exports[`TransactionListTop should render 1`] = `
               [
                 {
                   "color": "#FFFFFF",
-                  "fontSize": 45,
+                  "fontSize": 39,
                 },
                 undefined,
                 {
@@ -1711,7 +1711,7 @@ exports[`TransactionListTop should render 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {

--- a/src/__tests__/components/__snapshots__/WalletListSortableRow.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/WalletListSortableRow.test.tsx.snap
@@ -5,13 +5,13 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
   style={
     [
       {
-        "paddingHorizontal": 22,
+        "paddingHorizontal": 20,
       },
       {
         "alignItems": "center",
         "backgroundColor": "rgba(255, 255, 255, 0)",
         "flexDirection": "row",
-        "height": 96,
+        "height": 84,
         "justifyContent": "center",
       },
     ]
@@ -47,9 +47,9 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       {
-        "margin": -11,
+        "margin": -10,
         "opacity": 1,
-        "padding": 11,
+        "padding": 10,
       }
     }
   >
@@ -58,8 +58,8 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
         {
           "alignItems": "center",
           "justifyContent": "center",
-          "marginRight": 22,
-          "width": 28,
+          "marginRight": 20,
+          "width": 25,
         }
       }
     >
@@ -70,7 +70,7 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
           [
             {
               "color": "#FFFFFF",
-              "fontSize": 28,
+              "fontSize": 25,
             },
             undefined,
             {
@@ -91,20 +91,20 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
       {
         "alignItems": "center",
         "justifyContent": "center",
-        "marginRight": 22,
-        "width": 28,
+        "marginRight": 20,
+        "width": 25,
       }
     }
   >
     <View
       style={
         {
-          "height": 45,
+          "height": 39,
           "marginBottom": 0,
           "marginLeft": 0,
           "marginRight": 0,
           "marginTop": 0,
-          "width": 45,
+          "width": 39,
         }
       }
     >
@@ -112,9 +112,9 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
         style={
           {
             "backgroundColor": "#000000",
-            "borderRadius": 22.5,
+            "borderRadius": 19.5,
             "elevation": 0,
-            "height": 45,
+            "height": 39,
             "shadowColor": "#000000",
             "shadowOffset": {
               "height": 3,
@@ -122,7 +122,7 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
             },
             "shadowOpacity": 0.6,
             "shadowRadius": 4,
-            "width": 45,
+            "width": 39,
           }
         }
       >
@@ -190,7 +190,7 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -211,7 +211,7 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -242,13 +242,13 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
               "flex": 1,
-              "fontSize": 17,
+              "fontSize": 15,
             },
             null,
           ]
@@ -265,12 +265,12 @@ exports[`WalletListSortableRow should render with fake wallet 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#3dd9f4",
-              "fontSize": 17,
+              "fontSize": 15,
               "textAlign": "right",
             },
             null,
@@ -316,7 +316,7 @@ exports[`WalletListSortableRow should render with loading wallet 1`] = `
   style={
     {
       "opacity": 1,
-      "paddingHorizontal": 22,
+      "paddingHorizontal": 20,
     }
   }
 >
@@ -327,7 +327,7 @@ exports[`WalletListSortableRow should render with loading wallet 1`] = `
           "alignItems": "center",
           "backgroundColor": "rgba(255, 255, 255, 0)",
           "flexDirection": "row",
-          "height": 96,
+          "height": 84,
           "justifyContent": "center",
         },
         {

--- a/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -194,14 +194,14 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -218,14 +218,14 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           },
           false,
           null,
@@ -237,8 +237,8 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
     <View
       style={
         {
-          "marginVertical": 11,
-          "maxHeight": 449,
+          "marginVertical": 10,
+          "maxHeight": 393,
         }
       }
     >
@@ -253,10 +253,10 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
               "flexShrink": 1,
             },
             {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             },
           ]
         }
@@ -284,13 +284,13 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "color": "#3dd9f4",
-                  "fontSize": 17,
-                  "paddingRight": 22,
+                  "fontSize": 15,
+                  "paddingRight": 20,
                 },
                 null,
               ]
@@ -308,12 +308,12 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "color": "#FFFFFF",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ]
@@ -334,10 +334,10 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
               "flexShrink": 1,
             },
             {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             },
           ]
         }
@@ -365,13 +365,13 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "color": "#3dd9f4",
-                  "fontSize": 17,
-                  "paddingRight": 22,
+                  "fontSize": 15,
+                  "paddingRight": 20,
                 },
                 null,
               ]
@@ -389,12 +389,12 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "color": "#FFFFFF",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ]
@@ -408,8 +408,8 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
     <View
       style={
         {
-          "marginVertical": 11,
-          "maxHeight": 449,
+          "marginVertical": 10,
+          "maxHeight": 393,
         }
       }
     >
@@ -547,11 +547,11 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
                 [
                   {
                     "color": undefined,
-                    "fontSize": 34,
+                    "fontSize": 29,
                   },
                   {
                     "color": "#1a1a1a",
-                    "fontSize": 51,
+                    "fontSize": 44,
                   },
                   {
                     "fontFamily": "Entypo",
@@ -574,13 +574,13 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "alignSelf": "center",
                   "color": "#FFFFFF",
-                  "fontSize": 17,
+                  "fontSize": 15,
                   "lineHeight": 55,
                   "position": "absolute",
                   "zIndex": 1,

--- a/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AddressModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -194,14 +194,14 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -213,10 +213,10 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
     <View
       marginRemStyle={
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
       multiline={false}
@@ -224,10 +224,10 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
         {
           "flexGrow": undefined,
           "flexShrink": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     >
@@ -258,7 +258,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           }
         }
@@ -266,12 +266,12 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
           ]
         }
@@ -288,19 +288,19 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
             {
               "backgroundColor": "rgba(255, 255, 255, 0.2)",
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           ]
         }
@@ -414,7 +414,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -430,7 +430,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -463,7 +463,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
                 {
                   "value": {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 }
               }
@@ -471,7 +471,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                 ]
@@ -483,12 +483,12 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 ]
               }
@@ -521,7 +521,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
               {
                 "value": {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               }
             }
@@ -570,7 +570,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
                 },
                 {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               ]
             }
@@ -608,11 +608,11 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             {
-              "marginHorizontal": -22,
-              "marginVertical": -28,
+              "marginHorizontal": -20,
+              "marginVertical": -25,
               "opacity": 1,
-              "paddingHorizontal": 22,
-              "paddingVertical": 28,
+              "paddingHorizontal": 20,
+              "paddingVertical": 25,
             }
           }
           testID="undefined.clearIcon"
@@ -715,10 +715,10 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
             "justifyContent": "center",
           },
           {
-            "marginBottom": 45,
+            "marginBottom": 39,
             "marginLeft": 0,
             "marginRight": 0,
-            "marginTop": 22,
+            "marginTop": 20,
           },
         ]
       }
@@ -746,10 +746,10 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
         focusable={true}
         hitSlop={
           {
-            "bottom": 11,
+            "bottom": 10,
             "left": 10000,
             "right": 10000,
-            "top": 11,
+            "top": 10,
           }
         }
         onClick={[Function]}
@@ -762,12 +762,12 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
         style={
           {
             "alignItems": "center",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -795,7 +795,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -823,7 +823,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -833,7 +833,7 @@ exports[`AddressModalComponent should render with loaded props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],

--- a/src/__tests__/modals/__snapshots__/AdvancedDetailsCard.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AdvancedDetailsCard.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AdvancedDetailsCard should render with loading props 1`] = `
 <View
@@ -9,16 +9,16 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
         "borderRadius": 16,
       },
       {
-        "marginBottom": 11,
-        "marginLeft": 11,
-        "marginRight": 11,
-        "marginTop": 11,
+        "marginBottom": 10,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 10,
       },
       {
-        "paddingBottom": 11,
-        "paddingLeft": 11,
-        "paddingRight": 11,
-        "paddingTop": 11,
+        "paddingBottom": 10,
+        "paddingLeft": 10,
+        "paddingRight": 10,
+        "paddingTop": 10,
       },
       undefined,
     ]
@@ -63,10 +63,10 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
             "flexShrink": 1,
           },
           {
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           },
         ]
       }
@@ -79,7 +79,7 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
               "flexShrink": 1,
             },
             {
-              "marginRight": 34,
+              "marginRight": 29,
             },
           ]
         }
@@ -94,13 +94,13 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "color": "#3dd9f4",
-                "fontSize": 17,
-                "paddingRight": 22,
+                "fontSize": 15,
+                "paddingRight": 20,
               },
               null,
             ]
@@ -118,12 +118,12 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "color": "#FFFFFF",
-                "fontSize": 22,
+                "fontSize": 20,
               },
               null,
             ]
@@ -179,11 +179,11 @@ exports[`AdvancedDetailsCard should render with loading props 1`] = `
             [
               {
                 "color": undefined,
-                "fontSize": 22,
+                "fontSize": 20,
               },
               {
                 "color": "#00f1a2",
-                "marginLeft": 11,
+                "marginLeft": 10,
                 "textAlign": "center",
               },
               {

--- a/src/__tests__/modals/__snapshots__/AutoLogoutModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AutoLogoutModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -194,14 +194,14 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -661,9 +661,9 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
           "alignItems": "stretch",
           "alignSelf": "center",
           "flexDirection": "column",
-          "margin": 11,
-          "marginBottom": 22,
-          "marginTop": 45,
+          "margin": 10,
+          "marginBottom": 20,
+          "marginTop": 39,
         }
       }
     >
@@ -708,7 +708,7 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
           accessible={true}
           collapsable={false}
           focusable={true}
-          hitSlop={11}
+          hitSlop={10}
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -720,12 +720,12 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
             {
               "alignItems": "center",
               "alignSelf": "stretch",
-              "borderRadius": 34,
-              "height": 67,
+              "borderRadius": 29,
+              "height": 59,
               "justifyContent": "center",
               "opacity": 1,
               "overflow": "visible",
-              "paddingHorizontal": 34,
+              "paddingHorizontal": 29,
               "paddingVertical": 0,
               "position": "relative",
             }
@@ -753,7 +753,7 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
             }
             style={
               {
-                "borderRadius": 34,
+                "borderRadius": 29,
                 "bottom": 0,
                 "left": 0,
                 "position": "absolute",
@@ -781,7 +781,7 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
@@ -791,7 +791,7 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     null,
                   ],

--- a/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CategoryModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`CategoryModal should render with a subcategory 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`CategoryModal should render with a subcategory 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`CategoryModal should render with a subcategory 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -194,14 +194,14 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -216,7 +216,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           "alignItems": "center",
           "flexDirection": "row",
           "justifyContent": "space-between",
-          "margin": 11,
+          "margin": 10,
         }
       }
     >
@@ -253,7 +253,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             "alignItems": "center",
             "backgroundColor": "hsla(0, 0%, 100%, 0.20)",
             "borderColor": "hsla(0, 0%, 100%, 0.20)",
-            "borderRadius": 4,
+            "borderRadius": 3,
             "borderWidth": 1,
             "flexDirection": "row",
             "justifyContent": "center",
@@ -262,7 +262,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             "marginRight": 0,
             "marginTop": 0,
             "opacity": 1,
-            "padding": 7,
+            "padding": 6,
           }
         }
       >
@@ -274,8 +274,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Bold",
-              "fontSize": 14,
-              "marginHorizontal": 7,
+              "fontSize": 12,
+              "marginHorizontal": 6,
             }
           }
         >
@@ -315,7 +315,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderColor": "rgba(255, 255, 255, 0)",
-            "borderRadius": 4,
+            "borderRadius": 3,
             "borderWidth": 1,
             "flexDirection": "row",
             "justifyContent": "center",
@@ -324,7 +324,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             "marginRight": 0,
             "marginTop": 0,
             "opacity": 1,
-            "padding": 7,
+            "padding": 6,
           }
         }
       >
@@ -336,8 +336,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Bold",
-              "fontSize": 14,
-              "marginHorizontal": 7,
+              "fontSize": 12,
+              "marginHorizontal": 6,
             }
           }
         >
@@ -377,7 +377,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderColor": "rgba(255, 255, 255, 0)",
-            "borderRadius": 4,
+            "borderRadius": 3,
             "borderWidth": 1,
             "flexDirection": "row",
             "justifyContent": "center",
@@ -386,7 +386,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             "marginRight": 0,
             "marginTop": 0,
             "opacity": 1,
-            "padding": 7,
+            "padding": 6,
           }
         }
       >
@@ -398,8 +398,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Bold",
-              "fontSize": 14,
-              "marginHorizontal": 7,
+              "fontSize": 12,
+              "marginHorizontal": 6,
             }
           }
         >
@@ -439,7 +439,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderColor": "rgba(255, 255, 255, 0)",
-            "borderRadius": 4,
+            "borderRadius": 3,
             "borderWidth": 1,
             "flexDirection": "row",
             "justifyContent": "center",
@@ -448,7 +448,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             "marginRight": 0,
             "marginTop": 0,
             "opacity": 1,
-            "padding": 7,
+            "padding": 6,
           }
         }
       >
@@ -460,8 +460,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Bold",
-              "fontSize": 14,
-              "marginHorizontal": 7,
+              "fontSize": 12,
+              "marginHorizontal": 6,
             }
           }
         >
@@ -472,10 +472,10 @@ exports[`CategoryModal should render with a subcategory 1`] = `
     <View
       marginRemStyle={
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
       multiline={false}
@@ -483,10 +483,10 @@ exports[`CategoryModal should render with a subcategory 1`] = `
         {
           "flexGrow": undefined,
           "flexShrink": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     >
@@ -517,7 +517,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           }
         }
@@ -525,12 +525,12 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
           ]
         }
@@ -547,19 +547,19 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
             {
               "backgroundColor": "rgba(255, 255, 255, 0.2)",
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           ]
         }
@@ -614,8 +614,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           jestAnimatedStyle={
             {
               "value": {
-                "marginBottom": -11,
-                "marginTop": 11,
+                "marginBottom": -10,
+                "marginTop": 10,
               },
             }
           }
@@ -641,8 +641,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 "left": 0,
               },
               {
-                "marginBottom": -11,
-                "marginTop": 11,
+                "marginBottom": -10,
+                "marginTop": 10,
               },
             ]
           }
@@ -659,10 +659,10 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 "value": {
                   "transform": [
                     {
-                      "translateY": -22,
+                      "translateY": -20,
                     },
                     {
-                      "translateX": -8.8,
+                      "translateX": -8,
                     },
                   ],
                 },
@@ -673,7 +673,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -689,7 +689,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -699,10 +699,10 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 {
                   "transform": [
                     {
-                      "translateY": -22,
+                      "translateY": -20,
                     },
                     {
-                      "translateX": -8.8,
+                      "translateX": -8,
                     },
                   ],
                 },
@@ -722,7 +722,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 {
                   "value": {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 16.5,
+                    "fontSize": 15,
                   },
                 }
               }
@@ -730,7 +730,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                 ]
@@ -742,12 +742,12 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 16.5,
+                    "fontSize": 15,
                   },
                 ]
               }
@@ -779,7 +779,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
               {
                 "value": {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               }
             }
@@ -828,7 +828,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                 },
                 {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               ]
             }
@@ -866,11 +866,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             {
-              "marginHorizontal": -22,
-              "marginVertical": -28,
+              "marginHorizontal": -20,
+              "marginVertical": -25,
               "opacity": 1,
-              "paddingHorizontal": 22,
-              "paddingVertical": 28,
+              "paddingHorizontal": 20,
+              "paddingVertical": 25,
             }
           }
           testID="undefined.clearIcon"
@@ -885,8 +885,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
             jestAnimatedStyle={
               {
                 "value": {
-                  "opacity": 22,
-                  "width": 22,
+                  "opacity": 20,
+                  "width": 20,
                 },
               }
             }
@@ -899,7 +899,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
               ]
             }
             nativeID="18"
-            scale={22}
+            scale={20}
             style={
               [
                 {
@@ -907,8 +907,8 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                   "aspectRatio": 1,
                 },
                 {
-                  "opacity": 22,
-                  "width": 22,
+                  "opacity": 20,
+                  "width": 20,
                 },
               ]
             }
@@ -925,7 +925,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                   "value": {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
                     "fontFamily": "anticon",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "fontStyle": "normal",
                     "fontWeight": "normal",
                   },
@@ -938,7 +938,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                   {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
                     "fontFamily": "anticon",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "fontStyle": "normal",
                     "fontWeight": "normal",
                   },
@@ -962,7 +962,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
         collapsable={false}
         contentContainerStyle={
           {
-            "paddingBottom": 67,
+            "paddingBottom": 59,
           }
         }
         data={
@@ -1057,9 +1057,9 @@ exports[`CategoryModal should render with a subcategory 1`] = `
               style={
                 {
                   "flex": 1,
-                  "height": 70,
+                  "height": 61,
                   "opacity": 1,
-                  "paddingLeft": 13,
+                  "paddingLeft": 12,
                 }
               }
             >
@@ -1091,11 +1091,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -1120,11 +1120,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -1163,7 +1163,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                     {
                       "marginBottom": 0,
                       "marginLeft": 0,
-                      "marginRight": -22,
+                      "marginRight": -20,
                       "marginTop": 0,
                     },
                   ]
@@ -1207,9 +1207,9 @@ exports[`CategoryModal should render with a subcategory 1`] = `
               style={
                 {
                   "flex": 1,
-                  "height": 70,
+                  "height": 61,
                   "opacity": 1,
-                  "paddingLeft": 13,
+                  "paddingLeft": 12,
                 }
               }
             >
@@ -1241,11 +1241,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -1270,11 +1270,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -1313,7 +1313,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                     {
                       "marginBottom": 0,
                       "marginLeft": 0,
-                      "marginRight": -22,
+                      "marginRight": -20,
                       "marginTop": 0,
                     },
                   ]
@@ -1357,9 +1357,9 @@ exports[`CategoryModal should render with a subcategory 1`] = `
               style={
                 {
                   "flex": 1,
-                  "height": 70,
+                  "height": 61,
                   "opacity": 1,
-                  "paddingLeft": 13,
+                  "paddingLeft": 12,
                 }
               }
             >
@@ -1391,11 +1391,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -1420,11 +1420,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -1463,7 +1463,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                     {
                       "marginBottom": 0,
                       "marginLeft": 0,
-                      "marginRight": -22,
+                      "marginRight": -20,
                       "marginTop": 0,
                     },
                   ]
@@ -1507,9 +1507,9 @@ exports[`CategoryModal should render with a subcategory 1`] = `
               style={
                 {
                   "flex": 1,
-                  "height": 70,
+                  "height": 61,
                   "opacity": 1,
-                  "paddingLeft": 13,
+                  "paddingLeft": 12,
                 }
               }
             >
@@ -1541,11 +1541,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -1570,11 +1570,11 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -1613,7 +1613,7 @@ exports[`CategoryModal should render with a subcategory 1`] = `
                     {
                       "marginBottom": 0,
                       "marginLeft": 0,
-                      "marginRight": -22,
+                      "marginRight": -20,
                       "marginTop": 0,
                     },
                   ]
@@ -1713,19 +1713,19 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -1736,13 +1736,13 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -1754,8 +1754,8 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -1795,10 +1795,10 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -1808,8 +1808,8 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -1822,14 +1822,14 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -1844,7 +1844,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           "alignItems": "center",
           "flexDirection": "row",
           "justifyContent": "space-between",
-          "margin": 11,
+          "margin": 10,
         }
       }
     >
@@ -1881,7 +1881,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderColor": "rgba(255, 255, 255, 0)",
-            "borderRadius": 4,
+            "borderRadius": 3,
             "borderWidth": 1,
             "flexDirection": "row",
             "justifyContent": "center",
@@ -1890,7 +1890,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             "marginRight": 0,
             "marginTop": 0,
             "opacity": 1,
-            "padding": 7,
+            "padding": 6,
           }
         }
       >
@@ -1902,8 +1902,8 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Bold",
-              "fontSize": 14,
-              "marginHorizontal": 7,
+              "fontSize": 12,
+              "marginHorizontal": 6,
             }
           }
         >
@@ -1943,7 +1943,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderColor": "rgba(255, 255, 255, 0)",
-            "borderRadius": 4,
+            "borderRadius": 3,
             "borderWidth": 1,
             "flexDirection": "row",
             "justifyContent": "center",
@@ -1952,7 +1952,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             "marginRight": 0,
             "marginTop": 0,
             "opacity": 1,
-            "padding": 7,
+            "padding": 6,
           }
         }
       >
@@ -1964,8 +1964,8 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Bold",
-              "fontSize": 14,
-              "marginHorizontal": 7,
+              "fontSize": 12,
+              "marginHorizontal": 6,
             }
           }
         >
@@ -2005,7 +2005,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             "alignItems": "center",
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "borderColor": "rgba(255, 255, 255, 0)",
-            "borderRadius": 4,
+            "borderRadius": 3,
             "borderWidth": 1,
             "flexDirection": "row",
             "justifyContent": "center",
@@ -2014,7 +2014,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             "marginRight": 0,
             "marginTop": 0,
             "opacity": 1,
-            "padding": 7,
+            "padding": 6,
           }
         }
       >
@@ -2026,8 +2026,8 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Bold",
-              "fontSize": 14,
-              "marginHorizontal": 7,
+              "fontSize": 12,
+              "marginHorizontal": 6,
             }
           }
         >
@@ -2067,7 +2067,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             "alignItems": "center",
             "backgroundColor": "hsla(0, 0%, 100%, 0.20)",
             "borderColor": "hsla(0, 0%, 100%, 0.20)",
-            "borderRadius": 4,
+            "borderRadius": 3,
             "borderWidth": 1,
             "flexDirection": "row",
             "justifyContent": "center",
@@ -2076,7 +2076,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             "marginRight": 0,
             "marginTop": 0,
             "opacity": 1,
-            "padding": 7,
+            "padding": 6,
           }
         }
       >
@@ -2088,8 +2088,8 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Bold",
-              "fontSize": 14,
-              "marginHorizontal": 7,
+              "fontSize": 12,
+              "marginHorizontal": 6,
             }
           }
         >
@@ -2100,10 +2100,10 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
     <View
       marginRemStyle={
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
       multiline={false}
@@ -2111,10 +2111,10 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
         {
           "flexGrow": undefined,
           "flexShrink": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     >
@@ -2145,7 +2145,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           }
         }
@@ -2153,12 +2153,12 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
           ]
         }
@@ -2175,19 +2175,19 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
             {
               "backgroundColor": "rgba(255, 255, 255, 0.2)",
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           ]
         }
@@ -2301,7 +2301,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -2317,7 +2317,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -2350,7 +2350,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                 {
                   "value": {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 }
               }
@@ -2358,7 +2358,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                 ]
@@ -2370,12 +2370,12 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 ]
               }
@@ -2407,7 +2407,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
               {
                 "value": {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               }
             }
@@ -2456,7 +2456,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                 },
                 {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               ]
             }
@@ -2494,11 +2494,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             {
-              "marginHorizontal": -22,
-              "marginVertical": -28,
+              "marginHorizontal": -20,
+              "marginVertical": -25,
               "opacity": 1,
-              "paddingHorizontal": 22,
-              "paddingVertical": 28,
+              "paddingHorizontal": 20,
+              "paddingVertical": 25,
             }
           }
           testID="undefined.clearIcon"
@@ -2590,7 +2590,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
         collapsable={false}
         contentContainerStyle={
           {
-            "paddingBottom": 67,
+            "paddingBottom": 59,
           }
         }
         data={
@@ -2685,9 +2685,9 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
               style={
                 {
                   "flex": 1,
-                  "height": 70,
+                  "height": 61,
                   "opacity": 1,
-                  "paddingLeft": 13,
+                  "paddingLeft": 12,
                 }
               }
             >
@@ -2719,11 +2719,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -2762,7 +2762,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                     {
                       "marginBottom": 0,
                       "marginLeft": 0,
-                      "marginRight": -22,
+                      "marginRight": -20,
                       "marginTop": 0,
                     },
                   ]
@@ -2806,9 +2806,9 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
               style={
                 {
                   "flex": 1,
-                  "height": 70,
+                  "height": 61,
                   "opacity": 1,
-                  "paddingLeft": 13,
+                  "paddingLeft": 12,
                 }
               }
             >
@@ -2840,11 +2840,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -2883,7 +2883,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                     {
                       "marginBottom": 0,
                       "marginLeft": 0,
-                      "marginRight": -22,
+                      "marginRight": -20,
                       "marginTop": 0,
                     },
                   ]
@@ -2927,9 +2927,9 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
               style={
                 {
                   "flex": 1,
-                  "height": 70,
+                  "height": 61,
                   "opacity": 1,
-                  "paddingLeft": 13,
+                  "paddingLeft": 12,
                 }
               }
             >
@@ -2961,11 +2961,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -3004,7 +3004,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                     {
                       "marginBottom": 0,
                       "marginLeft": 0,
-                      "marginRight": -22,
+                      "marginRight": -20,
                       "marginTop": 0,
                     },
                   ]
@@ -3048,9 +3048,9 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
               style={
                 {
                   "flex": 1,
-                  "height": 70,
+                  "height": 61,
                   "opacity": 1,
-                  "paddingLeft": 13,
+                  "paddingLeft": 12,
                 }
               }
             >
@@ -3082,11 +3082,11 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 21,
+                          "fontSize": 19,
                         },
                         null,
                       ]
@@ -3125,7 +3125,7 @@ exports[`CategoryModal should render with an empty subcategory 1`] = `
                     {
                       "marginBottom": 0,
                       "marginLeft": 0,
-                      "marginRight": -22,
+                      "marginRight": -20,
                       "marginTop": 0,
                     },
                   ]

--- a/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/CountryListModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`CountryListModal should render with a country list 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`CountryListModal should render with a country list 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`CountryListModal should render with a country list 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`CountryListModal should render with a country list 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`CountryListModal should render with a country list 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -194,14 +194,14 @@ exports[`CountryListModal should render with a country list 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -213,10 +213,10 @@ exports[`CountryListModal should render with a country list 1`] = `
     <View
       marginRemStyle={
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
       multiline={false}
@@ -224,10 +224,10 @@ exports[`CountryListModal should render with a country list 1`] = `
         {
           "flexGrow": undefined,
           "flexShrink": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     >
@@ -258,7 +258,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           }
         }
@@ -266,12 +266,12 @@ exports[`CountryListModal should render with a country list 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
           ]
         }
@@ -288,19 +288,19 @@ exports[`CountryListModal should render with a country list 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
             {
               "backgroundColor": "rgba(255, 255, 255, 0.2)",
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           ]
         }
@@ -415,7 +415,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -431,7 +431,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -464,7 +464,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                 {
                   "value": {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 }
               }
@@ -472,7 +472,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                 ]
@@ -484,12 +484,12 @@ exports[`CountryListModal should render with a country list 1`] = `
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 ]
               }
@@ -522,7 +522,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "value": {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               }
             }
@@ -571,7 +571,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                 },
                 {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               ]
             }
@@ -609,11 +609,11 @@ exports[`CountryListModal should render with a country list 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             {
-              "marginHorizontal": -22,
-              "marginVertical": -28,
+              "marginHorizontal": -20,
+              "marginVertical": -25,
               "opacity": 1,
-              "paddingHorizontal": 22,
-              "paddingVertical": 28,
+              "paddingHorizontal": 20,
+              "paddingVertical": 25,
             }
           }
           testID="Select your region.clearIcon"
@@ -698,8 +698,8 @@ exports[`CountryListModal should render with a country list 1`] = `
       collapsable={false}
       contentContainerStyle={
         {
-          "marginTop": 11,
-          "paddingBottom": 67,
+          "marginTop": 10,
+          "paddingBottom": 59,
         }
       }
       data={
@@ -2188,15 +2188,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -2227,7 +2227,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2238,8 +2238,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -2270,7 +2270,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2283,7 +2283,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -2302,13 +2302,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]
@@ -2357,15 +2357,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -2396,7 +2396,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2407,8 +2407,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -2439,7 +2439,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2452,7 +2452,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -2471,13 +2471,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]
@@ -2526,15 +2526,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -2565,7 +2565,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2576,8 +2576,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -2608,7 +2608,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2621,7 +2621,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -2640,13 +2640,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]
@@ -2695,15 +2695,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -2734,7 +2734,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2745,8 +2745,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -2777,7 +2777,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2790,7 +2790,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -2809,13 +2809,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]
@@ -2864,15 +2864,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -2903,7 +2903,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2914,8 +2914,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -2946,7 +2946,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -2959,7 +2959,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -2978,13 +2978,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]
@@ -3033,15 +3033,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -3072,7 +3072,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3083,8 +3083,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -3115,7 +3115,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3128,7 +3128,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -3147,13 +3147,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]
@@ -3202,15 +3202,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -3241,7 +3241,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3252,8 +3252,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -3284,7 +3284,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3297,7 +3297,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -3316,13 +3316,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]
@@ -3371,15 +3371,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -3410,7 +3410,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3421,8 +3421,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -3453,7 +3453,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3466,7 +3466,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -3485,13 +3485,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]
@@ -3540,15 +3540,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -3579,7 +3579,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3590,8 +3590,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -3622,7 +3622,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3635,7 +3635,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -3654,13 +3654,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]
@@ -3709,15 +3709,15 @@ exports[`CountryListModal should render with a country list 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -3748,7 +3748,7 @@ exports[`CountryListModal should render with a country list 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3759,8 +3759,8 @@ exports[`CountryListModal should render with a country list 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -3791,7 +3791,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -3804,7 +3804,7 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -3823,13 +3823,13 @@ exports[`CountryListModal should render with a country list 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]

--- a/src/__tests__/modals/__snapshots__/DateModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/DateModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DateModalIos should render with loading props 1`] = `
 [
@@ -110,9 +110,9 @@ exports[`DateModalIos should render with loading props 1`] = `
         style={
           {
             "color": "#0073D9",
-            "fontSize": 22,
-            "paddingHorizontal": 22,
-            "paddingVertical": 11,
+            "fontSize": 20,
+            "paddingHorizontal": 20,
+            "paddingVertical": 10,
             "textAlign": "right",
           }
         }

--- a/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`HelpModal should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 86,
+          "marginBottom": -84,
+          "paddingBottom": 84,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`HelpModal should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`HelpModal should render with loading props 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 86,
+          "marginBottom": -84,
+          "paddingBottom": 84,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`HelpModal should render with loading props 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`HelpModal should render with loading props 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -192,7 +192,7 @@ exports[`HelpModal should render with loading props 1`] = `
             "flexDirection": "column",
             "flexGrow": 1,
             "justifyContent": "center",
-            "marginVertical": 6,
+            "marginVertical": 5,
           }
         }
       >
@@ -205,8 +205,8 @@ exports[`HelpModal should render with loading props 1`] = `
           }
           style={
             {
-              "height": 51,
-              "marginVertical": 11,
+              "height": 44,
+              "marginVertical": 10,
             }
           }
         />
@@ -215,7 +215,7 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "alignItems": "center",
               "flexDirection": "row",
-              "marginHorizontal": 11,
+              "marginHorizontal": 10,
             }
           }
         >
@@ -225,7 +225,7 @@ exports[`HelpModal should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 27,
+                  "fontSize": 24,
                 },
                 {
                   "flexGrow": 1,
@@ -299,15 +299,15 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "alignSelf": "stretch",
               "borderRadius": 16,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
               "opacity": 1,
-              "paddingBottom": 11,
-              "paddingLeft": 11,
-              "paddingRight": 11,
-              "paddingTop": 11,
+              "paddingBottom": 10,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 10,
             }
           }
         >
@@ -338,7 +338,7 @@ exports[`HelpModal should render with loading props 1`] = `
             <View
               style={
                 {
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -349,7 +349,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   [
                     {
                       "color": "#00f1a2",
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     undefined,
                     {
@@ -370,7 +370,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   "alignItems": "flex-start",
                   "flex": 1,
                   "flexDirection": "column",
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -383,7 +383,7 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     undefined,
@@ -402,13 +402,13 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
-                      "marginTop": 6,
+                      "fontSize": 15,
+                      "marginTop": 5,
                     },
                     null,
                   ]
@@ -451,15 +451,15 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "alignSelf": "stretch",
               "borderRadius": 16,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
               "opacity": 1,
-              "paddingBottom": 11,
-              "paddingLeft": 11,
-              "paddingRight": 11,
-              "paddingTop": 11,
+              "paddingBottom": 10,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 10,
             }
           }
         >
@@ -490,7 +490,7 @@ exports[`HelpModal should render with loading props 1`] = `
             <View
               style={
                 {
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -501,7 +501,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   [
                     {
                       "color": "#00f1a2",
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     undefined,
                     {
@@ -522,7 +522,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   "alignItems": "flex-start",
                   "flex": 1,
                   "flexDirection": "column",
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -535,7 +535,7 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     undefined,
@@ -554,13 +554,13 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
-                      "marginTop": 6,
+                      "fontSize": 15,
+                      "marginTop": 5,
                     },
                     null,
                   ]
@@ -603,15 +603,15 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "alignSelf": "stretch",
               "borderRadius": 16,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
               "opacity": 1,
-              "paddingBottom": 11,
-              "paddingLeft": 11,
-              "paddingRight": 11,
-              "paddingTop": 11,
+              "paddingBottom": 10,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 10,
             }
           }
         >
@@ -642,7 +642,7 @@ exports[`HelpModal should render with loading props 1`] = `
             <View
               style={
                 {
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -653,7 +653,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   [
                     {
                       "color": "#00f1a2",
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     undefined,
                     {
@@ -674,7 +674,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   "alignItems": "flex-start",
                   "flex": 1,
                   "flexDirection": "column",
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -687,7 +687,7 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     undefined,
@@ -706,13 +706,13 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
-                      "marginTop": 6,
+                      "fontSize": 15,
+                      "marginTop": 5,
                     },
                     null,
                   ]
@@ -755,15 +755,15 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "alignSelf": "stretch",
               "borderRadius": 16,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
               "opacity": 1,
-              "paddingBottom": 11,
-              "paddingLeft": 11,
-              "paddingRight": 11,
-              "paddingTop": 11,
+              "paddingBottom": 10,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 10,
             }
           }
         >
@@ -794,7 +794,7 @@ exports[`HelpModal should render with loading props 1`] = `
             <View
               style={
                 {
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -805,7 +805,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   [
                     {
                       "color": "#00f1a2",
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     undefined,
                     {
@@ -826,7 +826,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   "alignItems": "flex-start",
                   "flex": 1,
                   "flexDirection": "column",
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -839,7 +839,7 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     undefined,
@@ -858,13 +858,13 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
-                      "marginTop": 6,
+                      "fontSize": 15,
+                      "marginTop": 5,
                     },
                     null,
                   ]
@@ -907,15 +907,15 @@ exports[`HelpModal should render with loading props 1`] = `
             {
               "alignSelf": "stretch",
               "borderRadius": 16,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
               "opacity": 1,
-              "paddingBottom": 11,
-              "paddingLeft": 11,
-              "paddingRight": 11,
-              "paddingTop": 11,
+              "paddingBottom": 10,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 10,
             }
           }
         >
@@ -946,7 +946,7 @@ exports[`HelpModal should render with loading props 1`] = `
             <View
               style={
                 {
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -957,7 +957,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   [
                     {
                       "color": "#00f1a2",
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     undefined,
                     {
@@ -978,7 +978,7 @@ exports[`HelpModal should render with loading props 1`] = `
                   "alignItems": "flex-start",
                   "flex": 1,
                   "flexDirection": "column",
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -991,7 +991,7 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     undefined,
@@ -1010,13 +1010,13 @@ exports[`HelpModal should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
-                      "marginTop": 6,
+                      "fontSize": 15,
+                      "marginTop": 5,
                     },
                     null,
                   ]
@@ -1034,7 +1034,7 @@ exports[`HelpModal should render with loading props 1`] = `
               "flexDirection": "column",
               "justifyContent": "center",
               "marginTop": 0,
-              "paddingVertical": 11,
+              "paddingVertical": 10,
             }
           }
         >
@@ -1047,7 +1047,7 @@ exports[`HelpModal should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
@@ -1068,7 +1068,7 @@ exports[`HelpModal should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {

--- a/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`LogsModal should render with a logs modal 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 86,
+          "marginBottom": -84,
+          "paddingBottom": 84,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`LogsModal should render with a logs modal 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`LogsModal should render with a logs modal 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 86,
+          "marginBottom": -84,
+          "paddingBottom": 84,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`LogsModal should render with a logs modal 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`LogsModal should render with a logs modal 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -194,14 +194,14 @@ exports[`LogsModal should render with a logs modal 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -239,14 +239,14 @@ exports[`LogsModal should render with a logs modal 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               false,
               null,
@@ -263,16 +263,16 @@ exports[`LogsModal should render with a logs modal 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -328,7 +328,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
           <View
             style={
               {
-                "margin": 11,
+                "margin": 10,
               }
             }
           >
@@ -347,7 +347,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                   [
                     {
                       "color": "#FFFFFF",
-                      "fontSize": 28,
+                      "fontSize": 25,
                     },
                     {
                       "marginRight": 4,
@@ -372,7 +372,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -392,10 +392,10 @@ exports[`LogsModal should render with a logs modal 1`] = `
         <View
           marginRemStyle={
             {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             }
           }
           multiline={false}
@@ -403,10 +403,10 @@ exports[`LogsModal should render with a logs modal 1`] = `
             {
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             }
           }
         >
@@ -437,7 +437,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                   "borderColor": "rgba(0, 241, 162, 0)",
                   "marginHorizontal": 0,
                   "opacity": 1,
-                  "paddingVertical": 22,
+                  "paddingVertical": 20,
                 },
               }
             }
@@ -445,12 +445,12 @@ exports[`LogsModal should render with a logs modal 1`] = `
               [
                 {
                   "alignItems": "center",
-                  "borderRadius": 11,
+                  "borderRadius": 10,
                   "borderWidth": 1,
                   "flexDirection": "row",
                   "flexGrow": undefined,
                   "flexShrink": undefined,
-                  "paddingHorizontal": 17,
+                  "paddingHorizontal": 15,
                 },
               ]
             }
@@ -467,19 +467,19 @@ exports[`LogsModal should render with a logs modal 1`] = `
               [
                 {
                   "alignItems": "center",
-                  "borderRadius": 11,
+                  "borderRadius": 10,
                   "borderWidth": 1,
                   "flexDirection": "row",
                   "flexGrow": undefined,
                   "flexShrink": undefined,
-                  "paddingHorizontal": 17,
+                  "paddingHorizontal": 15,
                 },
                 {
                   "backgroundColor": "rgba(255, 255, 255, 0.2)",
                   "borderColor": "rgba(0, 241, 162, 0)",
                   "marginHorizontal": 0,
                   "opacity": 1,
-                  "paddingVertical": 22,
+                  "paddingVertical": 20,
                 },
               ]
             }
@@ -593,7 +593,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                     {
                       "alignItems": "center",
                       "justifyContent": "center",
-                      "left": 8.8,
+                      "left": 8,
                       "margin": 0,
                       "paddingHorizontal": 0,
                       "paddingVertical": 0,
@@ -609,7 +609,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                     {
                       "alignItems": "center",
                       "justifyContent": "center",
-                      "left": 8.8,
+                      "left": 8,
                       "margin": 0,
                       "paddingHorizontal": 0,
                       "paddingVertical": 0,
@@ -642,7 +642,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                     {
                       "value": {
                         "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                     }
                   }
@@ -650,7 +650,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                     [
                       {
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                     ]
@@ -662,12 +662,12 @@ exports[`LogsModal should render with a logs modal 1`] = `
                     [
                       {
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                     ]
                   }
@@ -699,7 +699,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                   {
                     "value": {
                       "color": "rgba(255, 255, 255, 1)",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                   }
                 }
@@ -749,7 +749,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                     },
                     {
                       "color": "rgba(255, 255, 255, 1)",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                   ]
                 }
@@ -787,11 +787,11 @@ exports[`LogsModal should render with a logs modal 1`] = `
               onStartShouldSetResponder={[Function]}
               style={
                 {
-                  "marginHorizontal": -22,
-                  "marginVertical": -28,
+                  "marginHorizontal": -20,
+                  "marginVertical": -25,
                   "opacity": 1,
-                  "paddingHorizontal": 22,
-                  "paddingVertical": 28,
+                  "paddingHorizontal": 20,
+                  "paddingVertical": 25,
                 }
               }
               testID="undefined.clearIcon"
@@ -887,9 +887,9 @@ exports[`LogsModal should render with a logs modal 1`] = `
               [
                 {
                   "flexDirection": "row",
-                  "height": 22,
+                  "height": 20,
                   "justifyContent": "space-between",
-                  "paddingHorizontal": 11,
+                  "paddingHorizontal": 10,
                 },
                 {},
               ]
@@ -900,9 +900,9 @@ exports[`LogsModal should render with a logs modal 1`] = `
               [
                 {
                   "flexDirection": "row",
-                  "height": 22,
+                  "height": 20,
                   "justifyContent": "space-between",
-                  "paddingHorizontal": 11,
+                  "paddingHorizontal": 10,
                 },
                 {},
               ]
@@ -915,7 +915,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                   {
                     "color": "#3dd9f4",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 17,
+                    "fontSize": 15,
                     "includeFontPadding": false,
                   },
                 ]
@@ -927,7 +927,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                   {
                     "color": "#3dd9f4",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 17,
+                    "fontSize": 15,
                     "includeFontPadding": false,
                   },
                 ]
@@ -946,9 +946,9 @@ exports[`LogsModal should render with a logs modal 1`] = `
               "alignItems": "stretch",
               "alignSelf": "center",
               "flexDirection": "column",
-              "margin": 11,
-              "marginBottom": 22,
-              "marginTop": 45,
+              "margin": 10,
+              "marginBottom": 20,
+              "marginTop": 39,
             }
           }
         >
@@ -993,7 +993,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
               accessible={true}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1005,12 +1005,12 @@ exports[`LogsModal should render with a logs modal 1`] = `
                 {
                   "alignItems": "center",
                   "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "height": 67,
+                  "borderRadius": 29,
+                  "height": 59,
                   "justifyContent": "center",
                   "opacity": 1,
                   "overflow": "visible",
-                  "paddingHorizontal": 34,
+                  "paddingHorizontal": 29,
                   "paddingVertical": 0,
                   "position": "relative",
                 }
@@ -1038,7 +1038,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                 }
                 style={
                   {
-                    "borderRadius": 34,
+                    "borderRadius": 29,
                     "bottom": 0,
                     "left": 0,
                     "position": "absolute",
@@ -1066,7 +1066,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       [
@@ -1076,7 +1076,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Medium",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ],
@@ -1097,10 +1097,10 @@ exports[`LogsModal should render with a logs modal 1`] = `
                 "flexDirection": "column",
                 "flexGrow": undefined,
                 "justifyContent": undefined,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               }
             }
           />
@@ -1145,7 +1145,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
               accessible={true}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1157,12 +1157,12 @@ exports[`LogsModal should render with a logs modal 1`] = `
                 {
                   "alignItems": "center",
                   "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "height": 67,
+                  "borderRadius": 29,
+                  "height": 59,
                   "justifyContent": "center",
                   "opacity": 1,
                   "overflow": "visible",
-                  "paddingHorizontal": 34,
+                  "paddingHorizontal": 29,
                   "paddingVertical": 0,
                   "position": "relative",
                 }
@@ -1190,7 +1190,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                 }
                 style={
                   {
-                    "borderRadius": 34,
+                    "borderRadius": 29,
                     "bottom": 0,
                     "left": 0,
                     "position": "absolute",
@@ -1218,7 +1218,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       [
@@ -1228,7 +1228,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ],

--- a/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -194,14 +194,14 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -218,14 +218,14 @@ exports[`PasswordReminderModal should render with loading props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           },
           false,
           null,
@@ -239,10 +239,10 @@ Please enter your password below. A successful verification will prevent this wa
     <View
       marginRemStyle={
         {
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
       multiline={false}
@@ -250,10 +250,10 @@ Please enter your password below. A successful verification will prevent this wa
         {
           "flexGrow": undefined,
           "flexShrink": undefined,
-          "marginBottom": 11,
-          "marginLeft": 11,
-          "marginRight": 11,
-          "marginTop": 11,
+          "marginBottom": 10,
+          "marginLeft": 10,
+          "marginRight": 10,
+          "marginTop": 10,
         }
       }
     >
@@ -284,7 +284,7 @@ Please enter your password below. A successful verification will prevent this wa
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           }
         }
@@ -292,12 +292,12 @@ Please enter your password below. A successful verification will prevent this wa
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
           ]
         }
@@ -314,19 +314,19 @@ Please enter your password below. A successful verification will prevent this wa
           [
             {
               "alignItems": "center",
-              "borderRadius": 11,
+              "borderRadius": 10,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": undefined,
               "flexShrink": undefined,
-              "paddingHorizontal": 17,
+              "paddingHorizontal": 15,
             },
             {
               "backgroundColor": "rgba(255, 255, 255, 0.2)",
               "borderColor": "rgba(0, 241, 162, 0)",
               "marginHorizontal": 0,
               "opacity": 1,
-              "paddingVertical": 22,
+              "paddingVertical": 20,
             },
           ]
         }
@@ -440,7 +440,7 @@ Please enter your password below. A successful verification will prevent this wa
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -456,7 +456,7 @@ Please enter your password below. A successful verification will prevent this wa
                 {
                   "alignItems": "center",
                   "justifyContent": "center",
-                  "left": 8.8,
+                  "left": 8,
                   "margin": 0,
                   "paddingHorizontal": 0,
                   "paddingVertical": 0,
@@ -489,7 +489,7 @@ Please enter your password below. A successful verification will prevent this wa
                 {
                   "value": {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 }
               }
@@ -497,7 +497,7 @@ Please enter your password below. A successful verification will prevent this wa
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                 ]
@@ -509,12 +509,12 @@ Please enter your password below. A successful verification will prevent this wa
                 [
                   {
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 ]
               }
@@ -546,7 +546,7 @@ Please enter your password below. A successful verification will prevent this wa
               {
                 "value": {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               }
             }
@@ -595,7 +595,7 @@ Please enter your password below. A successful verification will prevent this wa
                 },
                 {
                   "color": "rgba(255, 255, 255, 1)",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               ]
             }
@@ -633,11 +633,11 @@ Please enter your password below. A successful verification will prevent this wa
           onStartShouldSetResponder={[Function]}
           style={
             {
-              "marginLeft": -22,
-              "marginVertical": -28,
+              "marginLeft": -20,
+              "marginVertical": -25,
               "opacity": 1,
-              "paddingLeft": 22,
-              "paddingVertical": 28,
+              "paddingLeft": 20,
+              "paddingVertical": 25,
             }
           }
           testID="undefined.eyeIcon"
@@ -645,7 +645,7 @@ Please enter your password below. A successful verification will prevent this wa
           <View
             style={
               {
-                "paddingHorizontal": 6,
+                "paddingHorizontal": 5,
               }
             }
           >
@@ -662,7 +662,7 @@ Please enter your password below. A successful verification will prevent this wa
                   "value": {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
                     "fontFamily": "Ionicons",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "fontStyle": "normal",
                     "fontWeight": "normal",
                   },
@@ -675,7 +675,7 @@ Please enter your password below. A successful verification will prevent this wa
                   {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
                     "fontFamily": "Ionicons",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "fontStyle": "normal",
                     "fontWeight": "normal",
                   },
@@ -716,11 +716,11 @@ Please enter your password below. A successful verification will prevent this wa
           onStartShouldSetResponder={[Function]}
           style={
             {
-              "marginRight": -22,
-              "marginVertical": -28,
+              "marginRight": -20,
+              "marginVertical": -25,
               "opacity": 1,
-              "paddingRight": 22,
-              "paddingVertical": 28,
+              "paddingRight": 20,
+              "paddingVertical": 25,
             }
           }
           testID="undefined.clearIcon"
@@ -810,9 +810,9 @@ Please enter your password below. A successful verification will prevent this wa
           "alignItems": "stretch",
           "alignSelf": "center",
           "flexDirection": "column",
-          "margin": 11,
-          "marginBottom": 22,
-          "marginTop": 45,
+          "margin": 10,
+          "marginBottom": 20,
+          "marginTop": 39,
         }
       }
     >
@@ -857,7 +857,7 @@ Please enter your password below. A successful verification will prevent this wa
           accessible={true}
           collapsable={false}
           focusable={false}
-          hitSlop={11}
+          hitSlop={10}
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -869,12 +869,12 @@ Please enter your password below. A successful verification will prevent this wa
             {
               "alignItems": "center",
               "alignSelf": "stretch",
-              "borderRadius": 34,
-              "height": 67,
+              "borderRadius": 29,
+              "height": 59,
               "justifyContent": "center",
               "opacity": 0.3,
               "overflow": "visible",
-              "paddingHorizontal": 34,
+              "paddingHorizontal": 29,
               "paddingVertical": 0,
               "position": "relative",
             }
@@ -902,7 +902,7 @@ Please enter your password below. A successful verification will prevent this wa
             }
             style={
               {
-                "borderRadius": 34,
+                "borderRadius": 29,
                 "bottom": 0,
                 "left": 0,
                 "position": "absolute",
@@ -930,7 +930,7 @@ Please enter your password below. A successful verification will prevent this wa
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
@@ -940,7 +940,7 @@ Please enter your password below. A successful verification will prevent this wa
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     null,
                   ],
@@ -961,10 +961,10 @@ Please enter your password below. A successful verification will prevent this wa
             "flexDirection": "column",
             "flexGrow": undefined,
             "justifyContent": undefined,
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           }
         }
       />
@@ -1009,7 +1009,7 @@ Please enter your password below. A successful verification will prevent this wa
           accessible={true}
           collapsable={false}
           focusable={true}
-          hitSlop={11}
+          hitSlop={10}
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1021,12 +1021,12 @@ Please enter your password below. A successful verification will prevent this wa
             {
               "alignItems": "center",
               "alignSelf": "stretch",
-              "borderRadius": 34,
-              "height": 67,
+              "borderRadius": 29,
+              "height": 59,
               "justifyContent": "center",
               "opacity": 1,
               "overflow": "visible",
-              "paddingHorizontal": 34,
+              "paddingHorizontal": 29,
               "paddingVertical": 0,
               "position": "relative",
             }
@@ -1054,7 +1054,7 @@ Please enter your password below. A successful verification will prevent this wa
             }
             style={
               {
-                "borderRadius": 34,
+                "borderRadius": 29,
                 "bottom": 0,
                 "left": 0,
                 "position": "absolute",
@@ -1082,7 +1082,7 @@ Please enter your password below. A successful verification will prevent this wa
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
@@ -1092,7 +1092,7 @@ Please enter your password below. A successful verification will prevent this wa
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     null,
                   ],

--- a/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`TextInputModal should render with a blank input field 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`TextInputModal should render with a blank input field 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`TextInputModal should render with a blank input field 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`TextInputModal should render with a blank input field 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`TextInputModal should render with a blank input field 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -194,14 +194,14 @@ exports[`TextInputModal should render with a blank input field 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -227,14 +227,14 @@ exports[`TextInputModal should render with a blank input field 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             },
             false,
             null,
@@ -246,10 +246,10 @@ exports[`TextInputModal should render with a blank input field 1`] = `
       <View
         marginRemStyle={
           {
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           }
         }
         multiline={false}
@@ -257,10 +257,10 @@ exports[`TextInputModal should render with a blank input field 1`] = `
           {
             "flexGrow": undefined,
             "flexShrink": undefined,
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           }
         }
       >
@@ -291,7 +291,7 @@ exports[`TextInputModal should render with a blank input field 1`] = `
                 "borderColor": "rgba(0, 241, 162, 0)",
                 "marginHorizontal": 0,
                 "opacity": 1,
-                "paddingVertical": 22,
+                "paddingVertical": 20,
               },
             }
           }
@@ -299,12 +299,12 @@ exports[`TextInputModal should render with a blank input field 1`] = `
             [
               {
                 "alignItems": "center",
-                "borderRadius": 11,
+                "borderRadius": 10,
                 "borderWidth": 1,
                 "flexDirection": "row",
                 "flexGrow": undefined,
                 "flexShrink": undefined,
-                "paddingHorizontal": 17,
+                "paddingHorizontal": 15,
               },
             ]
           }
@@ -321,19 +321,19 @@ exports[`TextInputModal should render with a blank input field 1`] = `
             [
               {
                 "alignItems": "center",
-                "borderRadius": 11,
+                "borderRadius": 10,
                 "borderWidth": 1,
                 "flexDirection": "row",
                 "flexGrow": undefined,
                 "flexShrink": undefined,
-                "paddingHorizontal": 17,
+                "paddingHorizontal": 15,
               },
               {
                 "backgroundColor": "rgba(255, 255, 255, 0.2)",
                 "borderColor": "rgba(0, 241, 162, 0)",
                 "marginHorizontal": 0,
                 "opacity": 1,
-                "paddingVertical": 22,
+                "paddingVertical": 20,
               },
             ]
           }
@@ -444,7 +444,7 @@ exports[`TextInputModal should render with a blank input field 1`] = `
                 {
                   "value": {
                     "color": "rgba(255, 255, 255, 1)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 }
               }
@@ -492,7 +492,7 @@ exports[`TextInputModal should render with a blank input field 1`] = `
                   },
                   {
                     "color": "rgba(255, 255, 255, 1)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 ]
               }
@@ -530,11 +530,11 @@ exports[`TextInputModal should render with a blank input field 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               {
-                "marginHorizontal": -22,
-                "marginVertical": -28,
+                "marginHorizontal": -20,
+                "marginVertical": -25,
                 "opacity": 1,
-                "paddingHorizontal": 22,
-                "paddingVertical": 28,
+                "paddingHorizontal": 20,
+                "paddingVertical": 25,
               }
             }
             testID="undefined.clearIcon"
@@ -624,9 +624,9 @@ exports[`TextInputModal should render with a blank input field 1`] = `
             "alignItems": "stretch",
             "alignSelf": "center",
             "flexDirection": "column",
-            "margin": 11,
-            "marginBottom": 22,
-            "marginTop": 45,
+            "margin": 10,
+            "marginBottom": 20,
+            "marginTop": 39,
           }
         }
       >
@@ -671,7 +671,7 @@ exports[`TextInputModal should render with a blank input field 1`] = `
             accessible={true}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -683,12 +683,12 @@ exports[`TextInputModal should render with a blank input field 1`] = `
               {
                 "alignItems": "center",
                 "alignSelf": "stretch",
-                "borderRadius": 34,
-                "height": 67,
+                "borderRadius": 29,
+                "height": 59,
                 "justifyContent": "center",
                 "opacity": 1,
                 "overflow": "visible",
-                "paddingHorizontal": 34,
+                "paddingHorizontal": 29,
                 "paddingVertical": 0,
                 "position": "relative",
               }
@@ -716,7 +716,7 @@ exports[`TextInputModal should render with a blank input field 1`] = `
               }
               style={
                 {
-                  "borderRadius": 34,
+                  "borderRadius": 29,
                   "bottom": 0,
                   "left": 0,
                   "position": "absolute",
@@ -744,7 +744,7 @@ exports[`TextInputModal should render with a blank input field 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     [
@@ -754,7 +754,7 @@ exports[`TextInputModal should render with a blank input field 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Medium",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ],
@@ -858,19 +858,19 @@ exports[`TextInputModal should render with a populated input field 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -881,13 +881,13 @@ exports[`TextInputModal should render with a populated input field 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -899,8 +899,8 @@ exports[`TextInputModal should render with a populated input field 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -940,10 +940,10 @@ exports[`TextInputModal should render with a populated input field 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -953,8 +953,8 @@ exports[`TextInputModal should render with a populated input field 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -967,14 +967,14 @@ exports[`TextInputModal should render with a populated input field 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -1000,14 +1000,14 @@ exports[`TextInputModal should render with a populated input field 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             },
             false,
             null,
@@ -1019,10 +1019,10 @@ exports[`TextInputModal should render with a populated input field 1`] = `
       <View
         marginRemStyle={
           {
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           }
         }
         multiline={false}
@@ -1030,10 +1030,10 @@ exports[`TextInputModal should render with a populated input field 1`] = `
           {
             "flexGrow": undefined,
             "flexShrink": undefined,
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           }
         }
       >
@@ -1064,7 +1064,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                 "borderColor": "rgba(0, 241, 162, 0)",
                 "marginHorizontal": 0,
                 "opacity": 1,
-                "paddingVertical": 22,
+                "paddingVertical": 20,
               },
             }
           }
@@ -1072,12 +1072,12 @@ exports[`TextInputModal should render with a populated input field 1`] = `
             [
               {
                 "alignItems": "center",
-                "borderRadius": 11,
+                "borderRadius": 10,
                 "borderWidth": 1,
                 "flexDirection": "row",
                 "flexGrow": undefined,
                 "flexShrink": undefined,
-                "paddingHorizontal": 17,
+                "paddingHorizontal": 15,
               },
             ]
           }
@@ -1094,19 +1094,19 @@ exports[`TextInputModal should render with a populated input field 1`] = `
             [
               {
                 "alignItems": "center",
-                "borderRadius": 11,
+                "borderRadius": 10,
                 "borderWidth": 1,
                 "flexDirection": "row",
                 "flexGrow": undefined,
                 "flexShrink": undefined,
-                "paddingHorizontal": 17,
+                "paddingHorizontal": 15,
               },
               {
                 "backgroundColor": "rgba(255, 255, 255, 0.2)",
                 "borderColor": "rgba(0, 241, 162, 0)",
                 "marginHorizontal": 0,
                 "opacity": 1,
-                "paddingVertical": 22,
+                "paddingVertical": 20,
               },
             ]
           }
@@ -1217,7 +1217,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                 {
                   "value": {
                     "color": "rgba(255, 255, 255, 1)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 }
               }
@@ -1265,7 +1265,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                   },
                   {
                     "color": "rgba(255, 255, 255, 1)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 ]
               }
@@ -1303,11 +1303,11 @@ exports[`TextInputModal should render with a populated input field 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               {
-                "marginHorizontal": -22,
-                "marginVertical": -28,
+                "marginHorizontal": -20,
+                "marginVertical": -25,
                 "opacity": 1,
-                "paddingHorizontal": 22,
-                "paddingVertical": 28,
+                "paddingHorizontal": 20,
+                "paddingVertical": 25,
               }
             }
             testID="undefined.clearIcon"
@@ -1322,8 +1322,8 @@ exports[`TextInputModal should render with a populated input field 1`] = `
               jestAnimatedStyle={
                 {
                   "value": {
-                    "opacity": 22,
-                    "width": 22,
+                    "opacity": 20,
+                    "width": 20,
                   },
                 }
               }
@@ -1336,7 +1336,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                 ]
               }
               nativeID="14"
-              scale={22}
+              scale={20}
               style={
                 [
                   {
@@ -1344,8 +1344,8 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                     "aspectRatio": 1,
                   },
                   {
-                    "opacity": 22,
-                    "width": 22,
+                    "opacity": 20,
+                    "width": 20,
                   },
                 ]
               }
@@ -1362,7 +1362,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                     "value": {
                       "color": "rgba(255, 255, 255, 0.5019607843137255)",
                       "fontFamily": "anticon",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "fontStyle": "normal",
                       "fontWeight": "normal",
                     },
@@ -1375,7 +1375,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                     {
                       "color": "rgba(255, 255, 255, 0.5019607843137255)",
                       "fontFamily": "anticon",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "fontStyle": "normal",
                       "fontWeight": "normal",
                     },
@@ -1397,9 +1397,9 @@ exports[`TextInputModal should render with a populated input field 1`] = `
             "alignItems": "stretch",
             "alignSelf": "center",
             "flexDirection": "column",
-            "margin": 11,
-            "marginBottom": 22,
-            "marginTop": 45,
+            "margin": 10,
+            "marginBottom": 20,
+            "marginTop": 39,
           }
         }
       >
@@ -1444,7 +1444,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
             accessible={true}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -1456,12 +1456,12 @@ exports[`TextInputModal should render with a populated input field 1`] = `
               {
                 "alignItems": "center",
                 "alignSelf": "stretch",
-                "borderRadius": 34,
-                "height": 67,
+                "borderRadius": 29,
+                "height": 59,
                 "justifyContent": "center",
                 "opacity": 1,
                 "overflow": "visible",
-                "paddingHorizontal": 34,
+                "paddingHorizontal": 29,
                 "paddingVertical": 0,
                 "position": "relative",
               }
@@ -1489,7 +1489,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
               }
               style={
                 {
-                  "borderRadius": 34,
+                  "borderRadius": 29,
                   "bottom": 0,
                   "left": 0,
                   "position": "absolute",
@@ -1517,7 +1517,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     [
@@ -1527,7 +1527,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Medium",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ],

--- a/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`WalletListModal should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`WalletListModal should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`WalletListModal should render with loading props 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`WalletListModal should render with loading props 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`WalletListModal should render with loading props 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -198,7 +198,7 @@ exports[`WalletListModal should render with loading props 1`] = `
             {
               "alignItems": "center",
               "flexDirection": "row",
-              "marginHorizontal": 11,
+              "marginHorizontal": 10,
             }
           }
         >
@@ -208,7 +208,7 @@ exports[`WalletListModal should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 27,
+                  "fontSize": 24,
                 },
                 null,
                 {
@@ -233,10 +233,10 @@ exports[`WalletListModal should render with loading props 1`] = `
           style={
             [
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
                 "alignItems": "center",
@@ -284,13 +284,13 @@ exports[`WalletListModal should render with loading props 1`] = `
               [
                 {
                   "alignItems": "center",
-                  "borderRadius": 2247,
+                  "borderRadius": 1966,
                   "borderWidth": 1,
                   "flexDirection": "row",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "paddingHorizontal": 22,
-                  "paddingVertical": 17,
+                  "paddingHorizontal": 20,
+                  "paddingVertical": 15,
                 },
               ]
             }
@@ -306,13 +306,13 @@ exports[`WalletListModal should render with loading props 1`] = `
               [
                 {
                   "alignItems": "center",
-                  "borderRadius": 2247,
+                  "borderRadius": 1966,
                   "borderWidth": 1,
                   "flexDirection": "row",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "paddingHorizontal": 22,
-                  "paddingVertical": 17,
+                  "paddingHorizontal": 20,
+                  "paddingVertical": 15,
                 },
                 {
                   "backgroundColor": "rgba(255, 255, 255, 0.2)",
@@ -337,8 +337,8 @@ exports[`WalletListModal should render with loading props 1`] = `
               jestAnimatedStyle={
                 {
                   "value": {
-                    "opacity": 22,
-                    "width": 22,
+                    "opacity": 20,
+                    "width": 20,
                   },
                 }
               }
@@ -351,7 +351,7 @@ exports[`WalletListModal should render with loading props 1`] = `
                 ]
               }
               nativeID="3"
-              size={22}
+              size={20}
               style={
                 [
                   {
@@ -359,8 +359,8 @@ exports[`WalletListModal should render with loading props 1`] = `
                     "aspectRatio": 1,
                   },
                   {
-                    "opacity": 22,
-                    "width": 22,
+                    "opacity": 20,
+                    "width": 20,
                   },
                 ]
               }
@@ -377,7 +377,7 @@ exports[`WalletListModal should render with loading props 1`] = `
                     "value": {
                       "color": "rgba(255, 255, 255, 0.5019607843137255)",
                       "fontFamily": "anticon",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "fontStyle": "normal",
                       "fontWeight": "normal",
                     },
@@ -390,7 +390,7 @@ exports[`WalletListModal should render with loading props 1`] = `
                     {
                       "color": "rgba(255, 255, 255, 0.5019607843137255)",
                       "fontFamily": "anticon",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "fontStyle": "normal",
                       "fontWeight": "normal",
                     },
@@ -421,7 +421,7 @@ exports[`WalletListModal should render with loading props 1`] = `
               accessible={true}
               collapsable={false}
               focusable={true}
-              hitSlop={17}
+              hitSlop={15}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -548,9 +548,9 @@ exports[`WalletListModal should render with loading props 1`] = `
                       "flexGrow": 1,
                       "flexShrink": 1,
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "margin": 0,
-                      "paddingHorizontal": 11,
+                      "paddingHorizontal": 10,
                       "paddingVertical": 0,
                     },
                   ]
@@ -570,9 +570,9 @@ exports[`WalletListModal should render with loading props 1`] = `
                       "flexGrow": 1,
                       "flexShrink": 1,
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "margin": 0,
-                      "paddingHorizontal": 11,
+                      "paddingHorizontal": 10,
                       "paddingVertical": 0,
                     },
                     {
@@ -605,7 +605,7 @@ exports[`WalletListModal should render with loading props 1`] = `
               accessible={true}
               collapsable={false}
               focusable={true}
-              hitSlop={17}
+              hitSlop={15}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -615,9 +615,9 @@ exports[`WalletListModal should render with loading props 1`] = `
               onStartShouldSetResponder={[Function]}
               style={
                 {
-                  "margin": -22,
+                  "margin": -20,
                   "opacity": 1,
-                  "padding": 22,
+                  "padding": 20,
                 }
               }
               testID="undefined.clearIcon"
@@ -704,7 +704,7 @@ exports[`WalletListModal should render with loading props 1`] = `
       collapsable={false}
       contentContainerStyle={
         {
-          "paddingBottom": 67,
+          "paddingBottom": 59,
         }
       }
       data={[]}

--- a/src/__tests__/modals/__snapshots__/WalletListSortModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/WalletListSortModal.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -108,13 +108,13 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
         {
           "alignSelf": "flex-end",
           "backgroundColor": "rgba(255, 255, 255, .37)",
-          "borderTopLeftRadius": 22,
-          "borderTopRightRadius": 22,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
           "flexShrink": 1,
           "overflow": "hidden",
-          "paddingLeft": 11,
-          "paddingRight": 11,
-          "width": 674,
+          "paddingLeft": 10,
+          "paddingRight": 10,
+          "width": 590,
         },
         {
           "transform": [
@@ -126,8 +126,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
         {
           "borderColor": "rgba(255, 255, 255, 0)",
           "borderWidth": 0,
-          "marginBottom": -86,
-          "paddingBottom": 97,
+          "marginBottom": -84,
+          "paddingBottom": 94,
           "paddingTop": 0,
         },
       ]
@@ -167,10 +167,10 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
         style={
           {
             "backgroundColor": "hsla(0, 0%, 53%, 0.3)",
-            "borderRadius": 3,
-            "height": 6,
-            "marginTop": 6,
-            "width": 67,
+            "borderRadius": 2,
+            "height": 5,
+            "marginTop": 5,
+            "width": 59,
           }
         }
       />
@@ -180,8 +180,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
         {
           "alignItems": "flex-start",
           "flexDirection": "row",
-          "marginBottom": 11,
-          "marginTop": 28,
+          "marginBottom": 10,
+          "marginTop": 25,
         }
       }
     >
@@ -194,14 +194,14 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
-              "marginHorizontal": 11,
+              "fontSize": 24,
+              "marginHorizontal": 10,
             },
             null,
           ]
@@ -214,8 +214,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
       collapsable={false}
       contentContainerStyle={
         {
-          "marginTop": 11,
-          "paddingBottom": 67,
+          "marginTop": 10,
+          "paddingBottom": 59,
         }
       }
       data={
@@ -301,7 +301,7 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
             accessible={false}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -315,9 +315,9 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                 "backgroundColor": "rgba(255, 255, 255, 0)",
                 "flexDirection": "row",
                 "marginBottom": 1,
-                "minHeight": 67,
+                "minHeight": 59,
                 "opacity": 1,
-                "padding": 11,
+                "padding": 10,
               }
             }
           >
@@ -328,8 +328,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "paddingHorizontal": 11,
+                  "fontSize": 20,
+                  "paddingHorizontal": 10,
                   "textAlign": "left",
                 }
               }
@@ -381,8 +381,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   color="#00f1a2"
                   style={
                     {
-                      "height": 34,
-                      "marginHorizontal": 11,
+                      "height": 29,
+                      "marginHorizontal": 10,
                     }
                   }
                 />
@@ -423,8 +423,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                       },
                       {
                         "color": "#00f1a2",
-                        "fontSize": 22,
-                        "marginHorizontal": 11,
+                        "fontSize": 20,
+                        "marginHorizontal": 10,
                       },
                       {
                         "fontFamily": "FontAwesome5Free-Solid",
@@ -469,7 +469,7 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
             accessible={false}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -483,9 +483,9 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                 "backgroundColor": "rgba(255, 255, 255, 0)",
                 "flexDirection": "row",
                 "marginBottom": 1,
-                "minHeight": 67,
+                "minHeight": 59,
                 "opacity": 1,
-                "padding": 11,
+                "padding": 10,
               }
             }
           >
@@ -496,8 +496,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "paddingHorizontal": 11,
+                  "fontSize": 20,
+                  "paddingHorizontal": 10,
                   "textAlign": "left",
                 }
               }
@@ -549,8 +549,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   color="#00f1a2"
                   style={
                     {
-                      "height": 34,
-                      "marginHorizontal": 11,
+                      "height": 29,
+                      "marginHorizontal": 10,
                     }
                   }
                 />
@@ -593,8 +593,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                       },
                       {
                         "color": "#00f1a2",
-                        "fontSize": 28,
-                        "marginHorizontal": 11,
+                        "fontSize": 25,
+                        "marginHorizontal": 10,
                       },
                       {
                         "fontFamily": "Ionicons",
@@ -637,7 +637,7 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
             accessible={false}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -651,9 +651,9 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                 "backgroundColor": "rgba(255, 255, 255, 0)",
                 "flexDirection": "row",
                 "marginBottom": 1,
-                "minHeight": 67,
+                "minHeight": 59,
                 "opacity": 1,
-                "padding": 11,
+                "padding": 10,
               }
             }
           >
@@ -664,8 +664,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "paddingHorizontal": 11,
+                  "fontSize": 20,
+                  "paddingHorizontal": 10,
                   "textAlign": "left",
                 }
               }
@@ -717,8 +717,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   color="#00f1a2"
                   style={
                     {
-                      "height": 34,
-                      "marginHorizontal": 11,
+                      "height": 29,
+                      "marginHorizontal": 10,
                     }
                   }
                 />
@@ -761,8 +761,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                       },
                       {
                         "color": "#00f1a2",
-                        "fontSize": 28,
-                        "marginHorizontal": 11,
+                        "fontSize": 25,
+                        "marginHorizontal": 10,
                       },
                       {
                         "fontFamily": "Ionicons",
@@ -805,7 +805,7 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
             accessible={false}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -819,9 +819,9 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                 "backgroundColor": "rgba(255, 255, 255, 0)",
                 "flexDirection": "row",
                 "marginBottom": 1,
-                "minHeight": 67,
+                "minHeight": 59,
                 "opacity": 1,
-                "padding": 11,
+                "padding": 10,
               }
             }
           >
@@ -832,8 +832,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "paddingHorizontal": 11,
+                  "fontSize": 20,
+                  "paddingHorizontal": 10,
                   "textAlign": "left",
                 }
               }
@@ -885,8 +885,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   color="#00f1a2"
                   style={
                     {
-                      "height": 34,
-                      "marginHorizontal": 11,
+                      "height": 29,
+                      "marginHorizontal": 10,
                     }
                   }
                 />
@@ -929,8 +929,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                       },
                       {
                         "color": "#00f1a2",
-                        "fontSize": 28,
-                        "marginHorizontal": 11,
+                        "fontSize": 25,
+                        "marginHorizontal": 10,
                       },
                       {
                         "fontFamily": "Ionicons",
@@ -973,7 +973,7 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
             accessible={false}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -987,9 +987,9 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                 "backgroundColor": "rgba(255, 255, 255, 0)",
                 "flexDirection": "row",
                 "marginBottom": 1,
-                "minHeight": 67,
+                "minHeight": 59,
                 "opacity": 1,
-                "padding": 11,
+                "padding": 10,
               }
             }
           >
@@ -1000,8 +1000,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "paddingHorizontal": 11,
+                  "fontSize": 20,
+                  "paddingHorizontal": 10,
                   "textAlign": "left",
                 }
               }
@@ -1053,8 +1053,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   color="#00f1a2"
                   style={
                     {
-                      "height": 34,
-                      "marginHorizontal": 11,
+                      "height": 29,
+                      "marginHorizontal": 10,
                     }
                   }
                 />
@@ -1097,8 +1097,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                       },
                       {
                         "color": "#00f1a2",
-                        "fontSize": 28,
-                        "marginHorizontal": 11,
+                        "fontSize": 25,
+                        "marginHorizontal": 10,
                       },
                       {
                         "fontFamily": "Ionicons",
@@ -1141,7 +1141,7 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
             accessible={false}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -1155,9 +1155,9 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                 "backgroundColor": "rgba(255, 255, 255, 0)",
                 "flexDirection": "row",
                 "marginBottom": 1,
-                "minHeight": 67,
+                "minHeight": 59,
                 "opacity": 1,
-                "padding": 11,
+                "padding": 10,
               }
             }
           >
@@ -1168,8 +1168,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
-                  "paddingHorizontal": 11,
+                  "fontSize": 20,
+                  "paddingHorizontal": 10,
                   "textAlign": "left",
                 }
               }
@@ -1221,8 +1221,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                   color="#00f1a2"
                   style={
                     {
-                      "height": 34,
-                      "marginHorizontal": 11,
+                      "height": 29,
+                      "marginHorizontal": 10,
                     }
                   }
                 />
@@ -1265,8 +1265,8 @@ exports[`WalletListSortModalComponent should render with loading props 1`] = `
                       },
                       {
                         "color": "#00f1a2",
-                        "fontSize": 28,
-                        "marginHorizontal": 11,
+                        "fontSize": 25,
+                        "marginHorizontal": 10,
                       },
                       {
                         "fontFamily": "Ionicons",

--- a/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletAccountSetupScene.test.tsx.snap
@@ -279,12 +279,12 @@ exports[`CreateWalletAccountSelect renders 1`] = `
         <View
           style={
             {
-              "height": 90,
-              "marginBottom": 22,
-              "marginLeft": 22,
-              "marginRight": 22,
-              "marginTop": 22,
-              "width": 90,
+              "height": 79,
+              "marginBottom": 20,
+              "marginLeft": 20,
+              "marginRight": 20,
+              "marginTop": 20,
+              "width": 79,
             }
           }
         >
@@ -292,9 +292,9 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             style={
               {
                 "backgroundColor": "#000000",
-                "borderRadius": 45,
+                "borderRadius": 39.5,
                 "elevation": 0,
-                "height": 90,
+                "height": 79,
                 "shadowColor": "#000000",
                 "shadowOffset": {
                   "height": 3,
@@ -302,7 +302,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                 },
                 "shadowOpacity": 0.6,
                 "shadowRadius": 4,
-                "width": 90,
+                "width": 79,
               }
             }
           >
@@ -352,14 +352,14 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             },
             false,
             null,
@@ -376,14 +376,14 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             },
             false,
             null,
@@ -397,10 +397,10 @@ exports[`CreateWalletAccountSelect renders 1`] = `
       <View
         marginRemStyle={
           {
-            "marginBottom": 45,
-            "marginLeft": 22,
-            "marginRight": 22,
-            "marginTop": 22,
+            "marginBottom": 39,
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 20,
           }
         }
         multiline={false}
@@ -408,10 +408,10 @@ exports[`CreateWalletAccountSelect renders 1`] = `
           {
             "flexGrow": undefined,
             "flexShrink": undefined,
-            "marginBottom": 45,
-            "marginLeft": 22,
-            "marginRight": 22,
-            "marginTop": 22,
+            "marginBottom": 39,
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 20,
           }
         }
       >
@@ -442,7 +442,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                 "borderColor": "rgba(0, 241, 162, 0)",
                 "marginHorizontal": 0,
                 "opacity": 1,
-                "paddingVertical": 22,
+                "paddingVertical": 20,
               },
             }
           }
@@ -450,12 +450,12 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             [
               {
                 "alignItems": "center",
-                "borderRadius": 11,
+                "borderRadius": 10,
                 "borderWidth": 1,
                 "flexDirection": "row",
                 "flexGrow": undefined,
                 "flexShrink": undefined,
-                "paddingHorizontal": 17,
+                "paddingHorizontal": 15,
               },
             ]
           }
@@ -472,19 +472,19 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             [
               {
                 "alignItems": "center",
-                "borderRadius": 11,
+                "borderRadius": 10,
                 "borderWidth": 1,
                 "flexDirection": "row",
                 "flexGrow": undefined,
                 "flexShrink": undefined,
-                "paddingHorizontal": 17,
+                "paddingHorizontal": 15,
               },
               {
                 "backgroundColor": "rgba(255, 255, 255, 0.2)",
                 "borderColor": "rgba(0, 241, 162, 0)",
                 "marginHorizontal": 0,
                 "opacity": 1,
-                "paddingVertical": 22,
+                "paddingVertical": 20,
               },
             ]
           }
@@ -598,7 +598,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                   {
                     "alignItems": "center",
                     "justifyContent": "center",
-                    "left": 8.8,
+                    "left": 8,
                     "margin": 0,
                     "paddingHorizontal": 0,
                     "paddingVertical": 0,
@@ -614,7 +614,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                   {
                     "alignItems": "center",
                     "justifyContent": "center",
-                    "left": 8.8,
+                    "left": 8,
                     "margin": 0,
                     "paddingHorizontal": 0,
                     "paddingVertical": 0,
@@ -647,7 +647,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                   {
                     "value": {
                       "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                   }
                 }
@@ -655,7 +655,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                   [
                     {
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                   ]
@@ -667,12 +667,12 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                   [
                     {
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                   ]
                 }
@@ -705,7 +705,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                 {
                   "value": {
                     "color": "rgba(255, 255, 255, 1)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 }
               }
@@ -755,7 +755,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                   },
                   {
                     "color": "rgba(255, 255, 255, 1)",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                 ]
               }
@@ -793,11 +793,11 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               {
-                "marginHorizontal": -22,
-                "marginVertical": -28,
+                "marginHorizontal": -20,
+                "marginVertical": -25,
                 "opacity": 1,
-                "paddingHorizontal": 22,
-                "paddingVertical": 28,
+                "paddingHorizontal": 20,
+                "paddingVertical": 25,
               }
             }
             testID="undefined.clearIcon"
@@ -893,9 +893,9 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             [
               {
                 "flexDirection": "row",
-                "height": 22,
+                "height": 20,
                 "justifyContent": "space-between",
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               },
               {},
             ]
@@ -906,9 +906,9 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             [
               {
                 "flexDirection": "row",
-                "height": 22,
+                "height": 20,
                 "justifyContent": "space-between",
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               },
               {},
             ]
@@ -921,7 +921,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                 {
                   "color": "#3dd9f4",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 17,
+                  "fontSize": 15,
                   "includeFontPadding": false,
                 },
               ]
@@ -933,7 +933,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                 {
                   "color": "#3dd9f4",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 17,
+                  "fontSize": 15,
                   "includeFontPadding": false,
                 },
               ]
@@ -951,10 +951,10 @@ exports[`CreateWalletAccountSelect renders 1`] = `
               "justifyContent": "center",
             },
             {
-              "marginBottom": 22,
-              "marginLeft": 22,
-              "marginRight": 22,
-              "marginTop": 22,
+              "marginBottom": 20,
+              "marginLeft": 20,
+              "marginRight": 20,
+              "marginTop": 20,
             },
           ]
         }
@@ -982,10 +982,10 @@ exports[`CreateWalletAccountSelect renders 1`] = `
           focusable={false}
           hitSlop={
             {
-              "bottom": 11,
+              "bottom": 10,
               "left": 10000,
               "right": 10000,
-              "top": 11,
+              "top": 10,
             }
           }
           onClick={[Function]}
@@ -998,12 +998,12 @@ exports[`CreateWalletAccountSelect renders 1`] = `
           style={
             {
               "alignItems": "center",
-              "borderRadius": 34,
-              "height": 67,
+              "borderRadius": 29,
+              "height": 59,
               "justifyContent": "center",
               "opacity": 0.3,
               "overflow": "visible",
-              "paddingHorizontal": 34,
+              "paddingHorizontal": 29,
               "paddingVertical": 0,
               "position": "relative",
             }
@@ -1031,7 +1031,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
             }
             style={
               {
-                "borderRadius": 34,
+                "borderRadius": 29,
                 "bottom": 0,
                 "left": 0,
                 "position": "absolute",
@@ -1059,7 +1059,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
@@ -1069,7 +1069,7 @@ exports[`CreateWalletAccountSelect renders 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     null,
                   ],

--- a/src/__tests__/scenes/__snapshots__/CreateWalletEditNameScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletEditNameScene.test.tsx.snap
@@ -236,11 +236,11 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
       [
         {
           "justifyContent": "center",
-          "marginHorizontal": 22,
-          "paddingBottom": 22,
+          "marginHorizontal": 20,
+          "paddingBottom": 20,
         },
         {
-          "marginTop": 22,
+          "marginTop": 20,
         },
         undefined,
       ]
@@ -264,12 +264,12 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
+              "fontSize": 24,
             },
             null,
           ]
@@ -283,7 +283,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
     style={
       {
         "flex": 1,
-        "margin": 11,
+        "margin": 10,
         "marginTop": 0,
       }
     }
@@ -297,13 +297,13 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "color": "#FFFFFF",
-            "fontSize": 17,
-            "paddingHorizontal": 11,
+            "fontSize": 15,
+            "paddingHorizontal": 10,
             "textAlign": "left",
           },
           null,
@@ -420,22 +420,22 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                 "alignItems": "center",
                 "flexDirection": "row",
                 "justifyContent": "center",
-                "marginHorizontal": -11,
-                "minHeight": 96,
+                "marginHorizontal": -10,
+                "minHeight": 84,
                 "opacity": 1,
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               }
             }
           >
             <View
               style={
                 {
-                  "height": 45,
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
-                  "width": 45,
+                  "height": 39,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
+                  "width": 39,
                 }
               }
             >
@@ -443,9 +443,9 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                 style={
                   {
                     "backgroundColor": "#000000",
-                    "borderRadius": 22.5,
+                    "borderRadius": 19.5,
                     "elevation": 0,
-                    "height": 45,
+                    "height": 39,
                     "shadowColor": "#000000",
                     "shadowOffset": {
                       "height": 3,
@@ -453,7 +453,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     },
                     "shadowOpacity": 0.6,
                     "shadowRadius": 4,
-                    "width": 45,
+                    "width": 39,
                   }
                 }
               >
@@ -500,7 +500,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                 }
               }
             >
@@ -513,7 +513,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -536,12 +536,12 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
+                      "fontSize": 15,
                     },
                     null,
                   ]
@@ -553,7 +553,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
             <View
               style={
                 {
-                  "paddingRight": 11,
+                  "paddingRight": 10,
                 }
               }
             >
@@ -564,7 +564,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                   [
                     {
                       "color": "#00f1a2",
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     undefined,
                     {
@@ -619,22 +619,22 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                 "alignItems": "center",
                 "flexDirection": "row",
                 "justifyContent": "center",
-                "marginHorizontal": -11,
-                "minHeight": 96,
+                "marginHorizontal": -10,
+                "minHeight": 84,
                 "opacity": 1,
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               }
             }
           >
             <View
               style={
                 {
-                  "height": 45,
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
-                  "width": 45,
+                  "height": 39,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
+                  "width": 39,
                 }
               }
             >
@@ -642,9 +642,9 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                 style={
                   {
                     "backgroundColor": "#000000",
-                    "borderRadius": 22.5,
+                    "borderRadius": 19.5,
                     "elevation": 0,
-                    "height": 45,
+                    "height": 39,
                     "shadowColor": "#000000",
                     "shadowOffset": {
                       "height": 3,
@@ -652,7 +652,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     },
                     "shadowOpacity": 0.6,
                     "shadowRadius": 4,
-                    "width": 45,
+                    "width": 39,
                   }
                 }
               >
@@ -699,7 +699,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                 }
               }
             >
@@ -712,7 +712,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -735,12 +735,12 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
+                      "fontSize": 15,
                     },
                     null,
                   ]
@@ -752,7 +752,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
             <View
               style={
                 {
-                  "paddingRight": 11,
+                  "paddingRight": 10,
                 }
               }
             >
@@ -763,7 +763,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                   [
                     {
                       "color": "#00f1a2",
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     undefined,
                     {
@@ -818,22 +818,22 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                 "alignItems": "center",
                 "flexDirection": "row",
                 "justifyContent": "center",
-                "marginHorizontal": -11,
-                "minHeight": 96,
+                "marginHorizontal": -10,
+                "minHeight": 84,
                 "opacity": 1,
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               }
             }
           >
             <View
               style={
                 {
-                  "height": 45,
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
-                  "width": 45,
+                  "height": 39,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
+                  "width": 39,
                 }
               }
             >
@@ -841,9 +841,9 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                 style={
                   {
                     "backgroundColor": "#000000",
-                    "borderRadius": 22.5,
+                    "borderRadius": 19.5,
                     "elevation": 0,
-                    "height": 45,
+                    "height": 39,
                     "shadowColor": "#000000",
                     "shadowOffset": {
                       "height": 3,
@@ -851,7 +851,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     },
                     "shadowOpacity": 0.6,
                     "shadowRadius": 4,
-                    "width": 45,
+                    "width": 39,
                   }
                 }
               >
@@ -933,7 +933,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                 }
               }
             >
@@ -946,7 +946,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -969,12 +969,12 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
+                      "fontSize": 15,
                     },
                     null,
                   ]
@@ -986,7 +986,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
             <View
               style={
                 {
-                  "paddingRight": 11,
+                  "paddingRight": 10,
                 }
               }
             />
@@ -1002,7 +1002,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
           "alignItems": "stretch",
           "alignSelf": "center",
           "flexDirection": "column",
-          "margin": 11,
+          "margin": 10,
         }
       }
     >
@@ -1047,7 +1047,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
           accessible={true}
           collapsable={false}
           focusable={true}
-          hitSlop={11}
+          hitSlop={10}
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1059,12 +1059,12 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
             {
               "alignItems": "center",
               "alignSelf": "stretch",
-              "borderRadius": 34,
-              "height": 67,
+              "borderRadius": 29,
+              "height": 59,
               "justifyContent": "center",
               "opacity": 1,
               "overflow": "visible",
-              "paddingHorizontal": 34,
+              "paddingHorizontal": 29,
               "paddingVertical": 0,
               "position": "relative",
             }
@@ -1092,7 +1092,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
             }
             style={
               {
-                "borderRadius": 34,
+                "borderRadius": 29,
                 "bottom": 0,
                 "left": 0,
                 "position": "absolute",
@@ -1120,7 +1120,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
@@ -1130,7 +1130,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     null,
                   ],
@@ -1151,10 +1151,10 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
             "flexDirection": "column",
             "flexGrow": undefined,
             "justifyContent": undefined,
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           }
         }
       />
@@ -1199,7 +1199,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
           accessible={true}
           collapsable={false}
           focusable={true}
-          hitSlop={11}
+          hitSlop={10}
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1211,12 +1211,12 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
             {
               "alignItems": "center",
               "alignSelf": "stretch",
-              "borderRadius": 34,
-              "height": 67,
+              "borderRadius": 29,
+              "height": 59,
               "justifyContent": "center",
               "opacity": 1,
               "overflow": "visible",
-              "paddingHorizontal": 34,
+              "paddingHorizontal": 29,
               "paddingVertical": 0,
               "position": "relative",
             }
@@ -1244,7 +1244,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
             }
             style={
               {
-                "borderRadius": 34,
+                "borderRadius": 29,
                 "bottom": 0,
                 "left": 0,
                 "position": "absolute",
@@ -1272,7 +1272,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
@@ -1282,7 +1282,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     null,
                   ],

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
     style={
       {
         "flexShrink": 1,
-        "margin": 11,
+        "margin": 10,
       }
     }
   >
@@ -244,7 +244,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
         {
           "justifyContent": "center",
           "overflow": "visible",
-          "paddingBottom": 11,
+          "paddingBottom": 10,
         }
       }
     >
@@ -254,8 +254,8 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
             "alignItems": "center",
             "flexDirection": "row",
             "justifyContent": "space-between",
-            "marginBottom": 11,
-            "marginHorizontal": 11,
+            "marginBottom": 10,
+            "marginHorizontal": 10,
           }
         }
       >
@@ -268,12 +268,12 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 27,
+                "fontSize": 24,
               },
               null,
             ]
@@ -310,8 +310,8 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               "height": 1,
             },
             {
-              "margin": 11,
-              "marginRight": -22,
+              "margin": 10,
+              "marginRight": -20,
             },
           ]
         }
@@ -324,7 +324,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
             {
               "flexDirection": "row",
               "justifyContent": "center",
-              "marginVertical": 45,
+              "marginVertical": 39,
             }
           }
         >
@@ -343,14 +343,14 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               false,
               null,
@@ -362,10 +362,10 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
         <View
           marginRemStyle={
             {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             }
           }
           multiline={true}
@@ -373,10 +373,10 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
             {
               "flexGrow": 1,
               "flexShrink": 1,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             }
           }
         >
@@ -407,7 +407,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                   "borderColor": "rgba(0, 241, 162, 0)",
                   "marginHorizontal": 0,
                   "opacity": 1,
-                  "paddingVertical": 22,
+                  "paddingVertical": 20,
                 },
               }
             }
@@ -415,12 +415,12 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               [
                 {
                   "alignItems": "stretch",
-                  "borderRadius": 11,
+                  "borderRadius": 10,
                   "borderWidth": 1,
                   "flexDirection": "row",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "paddingHorizontal": 17,
+                  "paddingHorizontal": 15,
                 },
               ]
             }
@@ -437,19 +437,19 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               [
                 {
                   "alignItems": "stretch",
-                  "borderRadius": 11,
+                  "borderRadius": 10,
                   "borderWidth": 1,
                   "flexDirection": "row",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "paddingHorizontal": 17,
+                  "paddingHorizontal": 15,
                 },
                 {
                   "backgroundColor": "rgba(255, 255, 255, 0.2)",
                   "borderColor": "rgba(0, 241, 162, 0)",
                   "marginHorizontal": 0,
                   "opacity": 1,
-                  "paddingVertical": 22,
+                  "paddingVertical": 20,
                 },
               ]
             }
@@ -563,7 +563,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                     {
                       "alignItems": "center",
                       "justifyContent": "center",
-                      "left": 8.8,
+                      "left": 8,
                       "margin": 0,
                       "paddingHorizontal": 0,
                       "paddingVertical": 0,
@@ -579,7 +579,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                     {
                       "alignItems": "center",
                       "justifyContent": "center",
-                      "left": 8.8,
+                      "left": 8,
                       "margin": 0,
                       "paddingHorizontal": 0,
                       "paddingVertical": 0,
@@ -612,7 +612,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                     {
                       "value": {
                         "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                     }
                   }
@@ -620,7 +620,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                     [
                       {
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                     ]
@@ -632,12 +632,12 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                     [
                       {
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                     ]
                   }
@@ -672,7 +672,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                   {
                     "value": {
                       "color": "rgba(255, 255, 255, 1)",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                   }
                 }
@@ -722,7 +722,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                     },
                     {
                       "color": "rgba(255, 255, 255, 1)",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                   ]
                 }
@@ -760,11 +760,11 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               onStartShouldSetResponder={[Function]}
               style={
                 {
-                  "marginHorizontal": -22,
-                  "marginVertical": -28,
+                  "marginHorizontal": -20,
+                  "marginVertical": -25,
                   "opacity": 1,
-                  "paddingHorizontal": 22,
-                  "paddingVertical": 28,
+                  "paddingHorizontal": 20,
+                  "paddingVertical": 25,
                 }
               }
               testID="undefined.clearIcon"
@@ -855,10 +855,10 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               "flexGrow": 1,
               "flexShrink": 0,
               "justifyContent": "flex-end",
-              "margin": 11,
-              "marginBottom": 67,
-              "marginHorizontal": 11,
-              "marginTop": 22,
+              "margin": 10,
+              "marginBottom": 59,
+              "marginHorizontal": 10,
+              "marginTop": 20,
             }
           }
         >
@@ -901,10 +901,10 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               focusable={true}
               hitSlop={
                 {
-                  "bottom": 11,
+                  "bottom": 10,
                   "left": 10000,
                   "right": 10000,
-                  "top": 11,
+                  "top": 10,
                 }
               }
               onClick={[Function]}
@@ -917,12 +917,12 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "borderRadius": 34,
-                  "height": 67,
+                  "borderRadius": 29,
+                  "height": 59,
                   "justifyContent": "center",
                   "opacity": 1,
                   "overflow": "visible",
-                  "paddingHorizontal": 34,
+                  "paddingHorizontal": 29,
                   "paddingVertical": 0,
                   "position": "relative",
                 }
@@ -950,7 +950,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                 }
                 style={
                   {
-                    "borderRadius": 34,
+                    "borderRadius": 29,
                     "bottom": 0,
                     "left": 0,
                     "position": "absolute",
@@ -978,7 +978,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       [
@@ -988,7 +988,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Medium",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ],

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -286,11 +286,11 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
         [
           {
             "justifyContent": "center",
-            "marginHorizontal": 22,
-            "paddingBottom": 22,
+            "marginHorizontal": 20,
+            "paddingBottom": 20,
           },
           {
-            "marginTop": 22,
+            "marginTop": 20,
           },
           undefined,
         ]
@@ -314,12 +314,12 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 27,
+                "fontSize": 24,
               },
               null,
             ]
@@ -339,10 +339,10 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
       style={
         [
           {
-            "marginBottom": 11,
-            "marginLeft": 22,
-            "marginRight": 22,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 10,
           },
           {
             "alignItems": "center",
@@ -390,13 +390,13 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 2247,
+              "borderRadius": 1966,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": 1,
               "flexShrink": 1,
-              "paddingHorizontal": 22,
-              "paddingVertical": 17,
+              "paddingHorizontal": 20,
+              "paddingVertical": 15,
             },
           ]
         }
@@ -412,13 +412,13 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 2247,
+              "borderRadius": 1966,
               "borderWidth": 1,
               "flexDirection": "row",
               "flexGrow": 1,
               "flexShrink": 1,
-              "paddingHorizontal": 22,
-              "paddingVertical": 17,
+              "paddingHorizontal": 20,
+              "paddingVertical": 15,
             },
             {
               "backgroundColor": "rgba(255, 255, 255, 0.2)",
@@ -443,8 +443,8 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
           jestAnimatedStyle={
             {
               "value": {
-                "opacity": 22,
-                "width": 22,
+                "opacity": 20,
+                "width": 20,
               },
             }
           }
@@ -457,7 +457,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             ]
           }
           nativeID="2"
-          size={22}
+          size={20}
           style={
             [
               {
@@ -465,8 +465,8 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 "aspectRatio": 1,
               },
               {
-                "opacity": 22,
-                "width": 22,
+                "opacity": 20,
+                "width": 20,
               },
             ]
           }
@@ -483,7 +483,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 "value": {
                   "color": "rgba(255, 255, 255, 0.5019607843137255)",
                   "fontFamily": "anticon",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "fontStyle": "normal",
                   "fontWeight": "normal",
                 },
@@ -496,7 +496,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 {
                   "color": "rgba(255, 255, 255, 0.5019607843137255)",
                   "fontFamily": "anticon",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "fontStyle": "normal",
                   "fontWeight": "normal",
                 },
@@ -527,7 +527,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
           accessible={true}
           collapsable={false}
           focusable={true}
-          hitSlop={17}
+          hitSlop={15}
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -656,9 +656,9 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "margin": 0,
-                  "paddingHorizontal": 11,
+                  "paddingHorizontal": 10,
                   "paddingVertical": 0,
                 },
               ]
@@ -677,9 +677,9 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "margin": 0,
-                  "paddingHorizontal": 11,
+                  "paddingHorizontal": 10,
                   "paddingVertical": 0,
                 },
                 {
@@ -712,7 +712,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
           accessible={true}
           collapsable={false}
           focusable={true}
-          hitSlop={17}
+          hitSlop={15}
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -722,9 +722,9 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             {
-              "margin": -22,
+              "margin": -20,
               "opacity": 1,
-              "padding": 22,
+              "padding": 20,
             }
           }
           testID="undefined.clearIcon"
@@ -810,8 +810,8 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
       collapsable={false}
       contentContainerStyle={
         {
-          "marginHorizontal": 11,
-          "paddingBottom": 112,
+          "marginHorizontal": 10,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
@@ -956,22 +956,22 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 "alignItems": "center",
                 "flexDirection": "row",
                 "justifyContent": "center",
-                "marginHorizontal": -11,
-                "minHeight": 96,
+                "marginHorizontal": -10,
+                "minHeight": 84,
                 "opacity": 1,
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               }
             }
           >
             <View
               style={
                 {
-                  "height": 45,
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
-                  "width": 45,
+                  "height": 39,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
+                  "width": 39,
                 }
               }
             >
@@ -979,9 +979,9 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 style={
                   {
                     "backgroundColor": "#000000",
-                    "borderRadius": 22.5,
+                    "borderRadius": 19.5,
                     "elevation": 0,
-                    "height": 45,
+                    "height": 39,
                     "shadowColor": "#000000",
                     "shadowOffset": {
                       "height": 3,
@@ -989,7 +989,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     },
                     "shadowOpacity": 0.6,
                     "shadowRadius": 4,
-                    "width": 45,
+                    "width": 39,
                   }
                 }
               >
@@ -1036,7 +1036,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                 }
               }
             >
@@ -1049,7 +1049,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -1072,12 +1072,12 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
+                      "fontSize": 15,
                     },
                     null,
                   ]
@@ -1089,7 +1089,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             <View
               style={
                 {
-                  "paddingRight": 11,
+                  "paddingRight": 10,
                 }
               }
             >
@@ -1161,22 +1161,22 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 "alignItems": "center",
                 "flexDirection": "row",
                 "justifyContent": "center",
-                "marginHorizontal": -11,
-                "minHeight": 96,
+                "marginHorizontal": -10,
+                "minHeight": 84,
                 "opacity": 1,
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               }
             }
           >
             <View
               style={
                 {
-                  "height": 45,
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
-                  "width": 45,
+                  "height": 39,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
+                  "width": 39,
                 }
               }
             >
@@ -1184,9 +1184,9 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 style={
                   {
                     "backgroundColor": "#000000",
-                    "borderRadius": 22.5,
+                    "borderRadius": 19.5,
                     "elevation": 0,
-                    "height": 45,
+                    "height": 39,
                     "shadowColor": "#000000",
                     "shadowOffset": {
                       "height": 3,
@@ -1194,7 +1194,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     },
                     "shadowOpacity": 0.6,
                     "shadowRadius": 4,
-                    "width": 45,
+                    "width": 39,
                   }
                 }
               >
@@ -1276,7 +1276,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                 }
               }
             >
@@ -1289,7 +1289,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -1312,12 +1312,12 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
+                      "fontSize": 15,
                     },
                     null,
                   ]
@@ -1329,7 +1329,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             <View
               style={
                 {
-                  "paddingRight": 11,
+                  "paddingRight": 10,
                 }
               }
             >
@@ -1401,22 +1401,22 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 "alignItems": "center",
                 "flexDirection": "row",
                 "justifyContent": "center",
-                "marginHorizontal": -11,
-                "minHeight": 96,
+                "marginHorizontal": -10,
+                "minHeight": 84,
                 "opacity": 1,
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               }
             }
           >
             <View
               style={
                 {
-                  "height": 45,
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
-                  "width": 45,
+                  "height": 39,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
+                  "width": 39,
                 }
               }
             >
@@ -1424,9 +1424,9 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 style={
                   {
                     "backgroundColor": "#000000",
-                    "borderRadius": 22.5,
+                    "borderRadius": 19.5,
                     "elevation": 0,
-                    "height": 45,
+                    "height": 39,
                     "shadowColor": "#000000",
                     "shadowOffset": {
                       "height": 3,
@@ -1434,7 +1434,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     },
                     "shadowOpacity": 0.6,
                     "shadowRadius": 4,
-                    "width": 45,
+                    "width": 39,
                   }
                 }
               >
@@ -1516,7 +1516,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                 }
               }
             >
@@ -1529,7 +1529,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -1552,12 +1552,12 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
+                      "fontSize": 15,
                     },
                     null,
                   ]
@@ -1569,7 +1569,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             <View
               style={
                 {
-                  "paddingRight": 11,
+                  "paddingRight": 10,
                 }
               }
             >
@@ -1641,22 +1641,22 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 "alignItems": "center",
                 "flexDirection": "row",
                 "justifyContent": "center",
-                "marginHorizontal": -11,
-                "minHeight": 96,
+                "marginHorizontal": -10,
+                "minHeight": 84,
                 "opacity": 1,
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               }
             }
           >
             <View
               style={
                 {
-                  "height": 45,
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
-                  "width": 45,
+                  "height": 39,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
+                  "width": 39,
                 }
               }
             >
@@ -1664,9 +1664,9 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 style={
                   {
                     "backgroundColor": "#000000",
-                    "borderRadius": 22.5,
+                    "borderRadius": 19.5,
                     "elevation": 0,
-                    "height": 45,
+                    "height": 39,
                     "shadowColor": "#000000",
                     "shadowOffset": {
                       "height": 3,
@@ -1674,7 +1674,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     },
                     "shadowOpacity": 0.6,
                     "shadowRadius": 4,
-                    "width": 45,
+                    "width": 39,
                   }
                 }
               >
@@ -1756,7 +1756,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                 }
               }
             >
@@ -1769,7 +1769,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -1792,12 +1792,12 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
+                      "fontSize": 15,
                     },
                     null,
                   ]
@@ -1809,7 +1809,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             <View
               style={
                 {
-                  "paddingRight": 11,
+                  "paddingRight": 10,
                 }
               }
             >
@@ -1881,22 +1881,22 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 "alignItems": "center",
                 "flexDirection": "row",
                 "justifyContent": "center",
-                "marginHorizontal": -11,
-                "minHeight": 96,
+                "marginHorizontal": -10,
+                "minHeight": 84,
                 "opacity": 1,
-                "paddingHorizontal": 11,
+                "paddingHorizontal": 10,
               }
             }
           >
             <View
               style={
                 {
-                  "height": 45,
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
-                  "width": 45,
+                  "height": 39,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
+                  "width": 39,
                 }
               }
             >
@@ -1904,9 +1904,9 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 style={
                   {
                     "backgroundColor": "#000000",
-                    "borderRadius": 22.5,
+                    "borderRadius": 19.5,
                     "elevation": 0,
-                    "height": 45,
+                    "height": 39,
                     "shadowColor": "#000000",
                     "shadowOffset": {
                       "height": 3,
@@ -1914,7 +1914,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     },
                     "shadowOpacity": 0.6,
                     "shadowRadius": 4,
-                    "width": 45,
+                    "width": 39,
                   }
                 }
               >
@@ -1996,7 +1996,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                 }
               }
             >
@@ -2009,7 +2009,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -2032,12 +2032,12 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
+                      "fontSize": 15,
                     },
                     null,
                   ]
@@ -2049,7 +2049,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
             <View
               style={
                 {
-                  "paddingRight": 11,
+                  "paddingRight": 10,
                 }
               }
             >
@@ -2138,10 +2138,10 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                     "justifyContent": "center",
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -2169,10 +2169,10 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 focusable={true}
                 hitSlop={
                   {
-                    "bottom": 11,
+                    "bottom": 10,
                     "left": 10000,
                     "right": 10000,
-                    "top": 11,
+                    "top": 10,
                   }
                 }
                 onClick={[Function]}
@@ -2185,12 +2185,12 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 style={
                   {
                     "alignItems": "center",
-                    "borderRadius": 34,
-                    "height": 67,
+                    "borderRadius": 29,
+                    "height": 59,
                     "justifyContent": "center",
                     "opacity": 1,
                     "overflow": "visible",
-                    "paddingHorizontal": 34,
+                    "paddingHorizontal": 29,
                     "paddingVertical": 0,
                     "position": "relative",
                   }
@@ -2218,7 +2218,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   }
                   style={
                     {
-                      "borderRadius": 34,
+                      "borderRadius": 29,
                       "bottom": 0,
                       "left": 0,
                       "position": "absolute",
@@ -2246,7 +2246,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         [
@@ -2256,7 +2256,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           null,
                         ],

--- a/src/__tests__/scenes/__snapshots__/CurrencyNotificationScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CurrencyNotificationScene.test.tsx.snap
@@ -290,7 +290,7 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
         accessible={false}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -304,9 +304,9 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "flexDirection": "row",
             "marginBottom": 1,
-            "minHeight": 67,
+            "minHeight": 59,
             "opacity": 1,
-            "padding": 11,
+            "padding": 10,
           }
         }
       >
@@ -317,8 +317,8 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
               "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "paddingHorizontal": 11,
+              "fontSize": 20,
+              "paddingHorizontal": 10,
               "textAlign": "left",
             }
           }
@@ -370,8 +370,8 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
               color="#00f1a2"
               style={
                 {
-                  "height": 34,
-                  "marginHorizontal": 11,
+                  "height": 29,
+                  "marginHorizontal": 10,
                 }
               }
             />
@@ -405,7 +405,7 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
               pointerEvents="none"
               style={
                 {
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                   "padding": 0,
                 }
               }
@@ -456,7 +456,7 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
         accessible={false}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -470,9 +470,9 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "flexDirection": "row",
             "marginBottom": 1,
-            "minHeight": 67,
+            "minHeight": 59,
             "opacity": 1,
-            "padding": 11,
+            "padding": 10,
           }
         }
       >
@@ -483,8 +483,8 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
               "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "paddingHorizontal": 11,
+              "fontSize": 20,
+              "paddingHorizontal": 10,
               "textAlign": "left",
             }
           }
@@ -536,8 +536,8 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
               color="#00f1a2"
               style={
                 {
-                  "height": 34,
-                  "marginHorizontal": 11,
+                  "height": 29,
+                  "marginHorizontal": 10,
                 }
               }
             />
@@ -571,7 +571,7 @@ exports[`CurrencyNotificationComponent should render with loading props 1`] = `
               pointerEvents="none"
               style={
                 {
-                  "marginHorizontal": 11,
+                  "marginHorizontal": 10,
                   "padding": 0,
                 }
               }

--- a/src/__tests__/scenes/__snapshots__/CurrencySettings.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CurrencySettings.ui.test.tsx.snap
@@ -274,7 +274,7 @@ exports[`CurrencySettings should render 1`] = `
           {
             "alignItems": "center",
             "flexDirection": "row",
-            "margin": 11,
+            "margin": 10,
           }
         }
       >
@@ -287,7 +287,7 @@ exports[`CurrencySettings should render 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
@@ -295,7 +295,7 @@ exports[`CurrencySettings should render 1`] = `
                 "flexGrow": 1,
                 "flexShrink": 1,
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 22,
+                "fontSize": 20,
                 "textAlign": "left",
               },
               null,
@@ -326,7 +326,7 @@ exports[`CurrencySettings should render 1`] = `
         accessible={false}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -340,9 +340,9 @@ exports[`CurrencySettings should render 1`] = `
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "flexDirection": "row",
             "marginBottom": 1,
-            "minHeight": 67,
+            "minHeight": 59,
             "opacity": 1,
-            "padding": 11,
+            "padding": 10,
           }
         }
       >
@@ -352,8 +352,8 @@ exports[`CurrencySettings should render 1`] = `
               "color": "#FFFFFF",
               "flexShrink": 1,
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "paddingHorizontal": 11,
+              "fontSize": 20,
+              "paddingHorizontal": 10,
               "textAlign": "left",
             }
           }
@@ -376,8 +376,8 @@ exports[`CurrencySettings should render 1`] = `
               "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "paddingHorizontal": 11,
+              "fontSize": 20,
+              "paddingHorizontal": 10,
               "textAlign": "left",
             }
           }
@@ -427,8 +427,8 @@ exports[`CurrencySettings should render 1`] = `
               color="#00f1a2"
               style={
                 {
-                  "height": 34,
-                  "marginHorizontal": 11,
+                  "height": 29,
+                  "marginHorizontal": 10,
                 }
               }
             />
@@ -471,8 +471,8 @@ exports[`CurrencySettings should render 1`] = `
                   },
                   {
                     "color": "#00f1a2",
-                    "fontSize": 28,
-                    "marginHorizontal": 11,
+                    "fontSize": 25,
+                    "marginHorizontal": 10,
                   },
                   {
                     "fontFamily": "Ionicons",
@@ -509,7 +509,7 @@ exports[`CurrencySettings should render 1`] = `
         accessible={false}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -523,9 +523,9 @@ exports[`CurrencySettings should render 1`] = `
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "flexDirection": "row",
             "marginBottom": 1,
-            "minHeight": 67,
+            "minHeight": 59,
             "opacity": 1,
-            "padding": 11,
+            "padding": 10,
           }
         }
       >
@@ -535,8 +535,8 @@ exports[`CurrencySettings should render 1`] = `
               "color": "#FFFFFF",
               "flexShrink": 1,
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "paddingHorizontal": 11,
+              "fontSize": 20,
+              "paddingHorizontal": 10,
               "textAlign": "left",
             }
           }
@@ -559,8 +559,8 @@ exports[`CurrencySettings should render 1`] = `
               "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "paddingHorizontal": 11,
+              "fontSize": 20,
+              "paddingHorizontal": 10,
               "textAlign": "left",
             }
           }
@@ -610,8 +610,8 @@ exports[`CurrencySettings should render 1`] = `
               color="#00f1a2"
               style={
                 {
-                  "height": 34,
-                  "marginHorizontal": 11,
+                  "height": 29,
+                  "marginHorizontal": 10,
                 }
               }
             />
@@ -654,8 +654,8 @@ exports[`CurrencySettings should render 1`] = `
                   },
                   {
                     "color": "#00f1a2",
-                    "fontSize": 28,
-                    "marginHorizontal": 11,
+                    "fontSize": 25,
+                    "marginHorizontal": 10,
                   },
                   {
                     "fontFamily": "Ionicons",
@@ -692,7 +692,7 @@ exports[`CurrencySettings should render 1`] = `
         accessible={false}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -706,9 +706,9 @@ exports[`CurrencySettings should render 1`] = `
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "flexDirection": "row",
             "marginBottom": 1,
-            "minHeight": 67,
+            "minHeight": 59,
             "opacity": 1,
-            "padding": 11,
+            "padding": 10,
           }
         }
       >
@@ -718,8 +718,8 @@ exports[`CurrencySettings should render 1`] = `
               "color": "#FFFFFF",
               "flexShrink": 1,
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "paddingHorizontal": 11,
+              "fontSize": 20,
+              "paddingHorizontal": 10,
               "textAlign": "left",
             }
           }
@@ -742,8 +742,8 @@ exports[`CurrencySettings should render 1`] = `
               "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "paddingHorizontal": 11,
+              "fontSize": 20,
+              "paddingHorizontal": 10,
               "textAlign": "left",
             }
           }
@@ -793,8 +793,8 @@ exports[`CurrencySettings should render 1`] = `
               color="#00f1a2"
               style={
                 {
-                  "height": 34,
-                  "marginHorizontal": 11,
+                  "height": 29,
+                  "marginHorizontal": 10,
                 }
               }
             />
@@ -837,8 +837,8 @@ exports[`CurrencySettings should render 1`] = `
                   },
                   {
                     "color": "#00f1a2",
-                    "fontSize": 28,
-                    "marginHorizontal": 11,
+                    "fontSize": 25,
+                    "marginHorizontal": 10,
                   },
                   {
                     "fontFamily": "Ionicons",

--- a/src/__tests__/scenes/__snapshots__/DefaultFiatSettingScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/DefaultFiatSettingScene.test.tsx.snap
@@ -286,11 +286,11 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
         [
           {
             "justifyContent": "center",
-            "marginHorizontal": 22,
-            "paddingBottom": 22,
+            "marginHorizontal": 20,
+            "paddingBottom": 20,
           },
           {
-            "marginTop": 22,
+            "marginTop": 20,
           },
           undefined,
         ]
@@ -314,12 +314,12 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "fontFamily": "Quicksand-Medium",
-                "fontSize": 27,
+                "fontSize": 24,
               },
               null,
             ]
@@ -339,9 +339,9 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
           [
             {
               "marginBottom": 0,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 22,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 20,
             },
             {
               "alignItems": "center",
@@ -389,13 +389,13 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
             [
               {
                 "alignItems": "center",
-                "borderRadius": 2247,
+                "borderRadius": 1966,
                 "borderWidth": 1,
                 "flexDirection": "row",
                 "flexGrow": 1,
                 "flexShrink": 1,
-                "paddingHorizontal": 22,
-                "paddingVertical": 17,
+                "paddingHorizontal": 20,
+                "paddingVertical": 15,
               },
             ]
           }
@@ -411,13 +411,13 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
             [
               {
                 "alignItems": "center",
-                "borderRadius": 2247,
+                "borderRadius": 1966,
                 "borderWidth": 1,
                 "flexDirection": "row",
                 "flexGrow": 1,
                 "flexShrink": 1,
-                "paddingHorizontal": 22,
-                "paddingVertical": 17,
+                "paddingHorizontal": 20,
+                "paddingVertical": 15,
               },
               {
                 "backgroundColor": "rgba(255, 255, 255, 0.2)",
@@ -442,8 +442,8 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
             jestAnimatedStyle={
               {
                 "value": {
-                  "opacity": 22,
-                  "width": 22,
+                  "opacity": 20,
+                  "width": 20,
                 },
               }
             }
@@ -456,7 +456,7 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
               ]
             }
             nativeID="2"
-            size={22}
+            size={20}
             style={
               [
                 {
@@ -464,8 +464,8 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
                   "aspectRatio": 1,
                 },
                 {
-                  "opacity": 22,
-                  "width": 22,
+                  "opacity": 20,
+                  "width": 20,
                 },
               ]
             }
@@ -482,7 +482,7 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
                   "value": {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
                     "fontFamily": "anticon",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "fontStyle": "normal",
                     "fontWeight": "normal",
                   },
@@ -495,7 +495,7 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
                   {
                     "color": "rgba(255, 255, 255, 0.5019607843137255)",
                     "fontFamily": "anticon",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "fontStyle": "normal",
                     "fontWeight": "normal",
                   },
@@ -526,7 +526,7 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
             accessible={true}
             collapsable={false}
             focusable={true}
-            hitSlop={17}
+            hitSlop={15}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -655,9 +655,9 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "margin": 0,
-                    "paddingHorizontal": 11,
+                    "paddingHorizontal": 10,
                     "paddingVertical": 0,
                   },
                 ]
@@ -677,9 +677,9 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "margin": 0,
-                    "paddingHorizontal": 11,
+                    "paddingHorizontal": 10,
                     "paddingVertical": 0,
                   },
                   {
@@ -712,7 +712,7 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
             accessible={true}
             collapsable={false}
             focusable={true}
-            hitSlop={17}
+            hitSlop={15}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -722,9 +722,9 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               {
-                "margin": -22,
+                "margin": -20,
                 "opacity": 1,
-                "padding": 22,
+                "padding": 20,
               }
             }
             testID="undefined.clearIcon"
@@ -834,7 +834,7 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
           },
           {
             "marginBottom": 0,
-            "marginLeft": 22,
+            "marginLeft": 20,
             "marginRight": 0,
             "marginTop": 0,
           },
@@ -926,15 +926,15 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -965,7 +965,7 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
               <View
                 style={
                   {
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -976,10 +976,10 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
                         "overflow": "hidden",
                       },
                       {
-                        "borderRadius": 22,
-                        "height": 45,
-                        "marginLeft": 6,
-                        "width": 45,
+                        "borderRadius": 20,
+                        "height": 39,
+                        "marginLeft": 5,
+                        "width": 39,
                       },
                     ]
                   }
@@ -1010,7 +1010,7 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
                     "alignItems": "flex-start",
                     "flex": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                   }
                 }
               >
@@ -1023,7 +1023,7 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -1042,13 +1042,13 @@ exports[`DefaultFiatSettingComponent should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "marginTop": 6,
+                        "fontSize": 15,
+                        "marginTop": 5,
                       },
                       null,
                     ]

--- a/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/EdgeLoginScene.test.tsx.snap
@@ -329,19 +329,19 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
             "borderColor": "#F1AA19",
             "borderRadius": 16,
             "borderWidth": 1,
-            "margin": 22,
+            "margin": 20,
           },
           {
-            "marginBottom": 22,
-            "marginLeft": 22,
-            "marginRight": 22,
-            "marginTop": 22,
+            "marginBottom": 20,
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 20,
           },
           {
-            "paddingBottom": 22,
-            "paddingLeft": 22,
-            "paddingRight": 22,
-            "paddingTop": 22,
+            "paddingBottom": 20,
+            "paddingLeft": 20,
+            "paddingRight": 20,
+            "paddingTop": 20,
           },
         ]
       }
@@ -362,10 +362,10 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
             [
               {
                 "color": "#F1AA19",
-                "fontSize": 18,
+                "fontSize": 16,
               },
               {
-                "marginRight": 11,
+                "marginRight": 10,
               },
               {
                 "fontFamily": "Ionicons",
@@ -387,14 +387,14 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
                 "color": "#F1AA19",
                 "fontFamily": "Quicksand-Bold",
-                "fontSize": 17,
-                "marginLeft": 6,
+                "fontSize": 15,
+                "marginLeft": 5,
               },
               null,
             ]
@@ -412,14 +412,14 @@ exports[`EdgeLoginScene should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "color": "#F1AA19",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 17,
-              "marginTop": 22,
+              "fontSize": 15,
+              "marginTop": 20,
             },
             null,
           ]
@@ -464,10 +464,10 @@ DO NOT accept this login unless you trust the application and person who provide
             "justifyContent": "center",
           },
           {
-            "marginBottom": 22,
-            "marginLeft": 22,
-            "marginRight": 22,
-            "marginTop": 22,
+            "marginBottom": 20,
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 20,
           },
         ]
       }
@@ -495,10 +495,10 @@ DO NOT accept this login unless you trust the application and person who provide
         focusable={true}
         hitSlop={
           {
-            "bottom": 11,
+            "bottom": 10,
             "left": 10000,
             "right": 10000,
-            "top": 11,
+            "top": 10,
           }
         }
         onClick={[Function]}
@@ -511,12 +511,12 @@ DO NOT accept this login unless you trust the application and person who provide
         style={
           {
             "alignItems": "center",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -544,7 +544,7 @@ DO NOT accept this login unless you trust the application and person who provide
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -572,7 +572,7 @@ DO NOT accept this login unless you trust the application and person who provide
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -582,7 +582,7 @@ DO NOT accept this login unless you trust the application and person who provide
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],
@@ -604,9 +604,9 @@ DO NOT accept this login unless you trust the application and person who provide
           "justifyContent": "center",
         },
         {
-          "marginBottom": 22,
-          "marginLeft": 22,
-          "marginRight": 22,
+          "marginBottom": 20,
+          "marginLeft": 20,
+          "marginRight": 20,
           "marginTop": 0,
         },
       ]
@@ -635,10 +635,10 @@ DO NOT accept this login unless you trust the application and person who provide
       focusable={true}
       hitSlop={
         {
-          "bottom": 11,
+          "bottom": 10,
           "left": 10000,
           "right": 10000,
-          "top": 11,
+          "top": 10,
         }
       }
       onClick={[Function]}
@@ -652,12 +652,12 @@ DO NOT accept this login unless you trust the application and person who provide
         {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 34,
-          "height": 34,
+          "borderRadius": 29,
+          "height": 29,
           "justifyContent": "center",
           "opacity": 1,
           "overflow": "visible",
-          "paddingHorizontal": 17,
+          "paddingHorizontal": 15,
           "paddingVertical": 0,
           "position": "relative",
         }
@@ -682,7 +682,7 @@ DO NOT accept this login unless you trust the application and person who provide
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
@@ -692,7 +692,7 @@ DO NOT accept this login unless you trust the application and person who provide
                 {
                   "color": "#00f1a2",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ],

--- a/src/__tests__/scenes/__snapshots__/FioAddressDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressDetailsScene.test.tsx.snap
@@ -236,11 +236,11 @@ exports[`FioAddressDetails should render with loading props 1`] = `
       [
         {
           "justifyContent": "center",
-          "marginHorizontal": 22,
-          "paddingBottom": 22,
+          "marginHorizontal": 20,
+          "paddingBottom": 20,
         },
         {
-          "marginTop": 22,
+          "marginTop": 20,
         },
         undefined,
       ]
@@ -264,12 +264,12 @@ exports[`FioAddressDetails should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
+              "fontSize": 24,
             },
             null,
           ]
@@ -307,7 +307,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
         },
         {
           "marginBottom": 0,
-          "marginLeft": 22,
+          "marginLeft": 20,
           "marginRight": 0,
           "marginTop": 0,
         },
@@ -318,7 +318,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
     style={
       {
         "flexGrow": 1,
-        "paddingHorizontal": 11,
+        "paddingHorizontal": 10,
       }
     }
   >
@@ -331,13 +331,13 @@ exports[`FioAddressDetails should render with loading props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "color": "#FFFFFF",
-            "fontSize": 22,
-            "margin": 11,
+            "fontSize": 20,
+            "margin": 10,
           },
           null,
         ]
@@ -353,16 +353,16 @@ exports[`FioAddressDetails should render with loading props 1`] = `
             "borderRadius": 16,
           },
           {
-            "marginBottom": 11,
-            "marginLeft": 11,
-            "marginRight": 11,
-            "marginTop": 11,
+            "marginBottom": 10,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "marginTop": 10,
           },
           {
-            "paddingBottom": 6,
-            "paddingLeft": 6,
-            "paddingRight": 6,
-            "paddingTop": 6,
+            "paddingBottom": 5,
+            "paddingLeft": 5,
+            "paddingRight": 5,
+            "paddingTop": 5,
           },
           undefined,
         ]
@@ -403,7 +403,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
         accessible={false}
         collapsable={false}
         focusable={true}
-        hitSlop={11}
+        hitSlop={10}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -417,9 +417,9 @@ exports[`FioAddressDetails should render with loading props 1`] = `
             "backgroundColor": "rgba(255, 255, 255, 0)",
             "flexDirection": "row",
             "marginBottom": 1,
-            "minHeight": 67,
+            "minHeight": 59,
             "opacity": 1,
-            "padding": 11,
+            "padding": 10,
           }
         }
       >
@@ -430,8 +430,8 @@ exports[`FioAddressDetails should render with loading props 1`] = `
               "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
-              "paddingHorizontal": 11,
+              "fontSize": 20,
+              "paddingHorizontal": 10,
               "textAlign": "left",
             }
           }
@@ -483,8 +483,8 @@ exports[`FioAddressDetails should render with loading props 1`] = `
               color="#00f1a2"
               style={
                 {
-                  "height": 34,
-                  "marginHorizontal": 11,
+                  "height": 29,
+                  "marginHorizontal": 10,
                 }
               }
             />
@@ -525,8 +525,8 @@ exports[`FioAddressDetails should render with loading props 1`] = `
                   },
                   {
                     "color": "#00f1a2",
-                    "fontSize": 22,
-                    "marginHorizontal": 11,
+                    "fontSize": 20,
+                    "marginHorizontal": 10,
                   },
                   {
                     "fontFamily": "custom",
@@ -548,14 +548,14 @@ exports[`FioAddressDetails should render with loading props 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "margin": 11,
+          "margin": 10,
         }
       }
     >
       <View
         style={
           {
-            "paddingRight": 17,
+            "paddingRight": 15,
           }
         }
       >
@@ -566,7 +566,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
             [
               {
                 "color": "#FFFFFF",
-                "fontSize": 34,
+                "fontSize": 29,
               },
               undefined,
               {
@@ -590,7 +590,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -598,7 +598,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
               "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 22,
+              "fontSize": 20,
               "textAlign": "left",
             },
             null,
@@ -624,16 +624,16 @@ exports[`FioAddressDetails should render with loading props 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -689,7 +689,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
           <View
             style={
               {
-                "margin": 11,
+                "margin": 10,
               }
             }
           >
@@ -708,7 +708,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
                   [
                     {
                       "color": "#FFFFFF",
-                      "fontSize": 28,
+                      "fontSize": 25,
                     },
                     {
                       "marginRight": 4,
@@ -733,7 +733,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
@@ -756,7 +756,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
           {
             "alignSelf": "center",
             "bottom": 0,
-            "padding": 22,
+            "padding": 20,
             "position": "absolute",
           }
         }
@@ -800,10 +800,10 @@ exports[`FioAddressDetails should render with loading props 1`] = `
             focusable={false}
             hitSlop={
               {
-                "bottom": 11,
+                "bottom": 10,
                 "left": 10000,
                 "right": 10000,
-                "top": 11,
+                "top": 10,
               }
             }
             onClick={[Function]}
@@ -816,12 +816,12 @@ exports[`FioAddressDetails should render with loading props 1`] = `
             style={
               {
                 "alignItems": "center",
-                "borderRadius": 34,
-                "height": 67,
+                "borderRadius": 29,
+                "height": 59,
                 "justifyContent": "center",
                 "opacity": 0.3,
                 "overflow": "visible",
-                "paddingHorizontal": 34,
+                "paddingHorizontal": 29,
                 "paddingVertical": 0,
                 "position": "relative",
               }
@@ -849,7 +849,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
               }
               style={
                 {
-                  "borderRadius": 34,
+                  "borderRadius": 29,
                   "bottom": 0,
                   "left": 0,
                   "position": "absolute",
@@ -877,7 +877,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     [
@@ -887,7 +887,7 @@ exports[`FioAddressDetails should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Medium",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ],

--- a/src/__tests__/scenes/__snapshots__/FioAddressListScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressListScene.test.tsx.snap
@@ -255,11 +255,11 @@ exports[`FioAddressList should render with loading props 1`] = `
             [
               {
                 "justifyContent": "center",
-                "marginHorizontal": 22,
-                "paddingBottom": 22,
+                "marginHorizontal": 20,
+                "paddingBottom": 20,
               },
               {
-                "marginTop": 22,
+                "marginTop": 20,
               },
               undefined,
             ]
@@ -283,12 +283,12 @@ exports[`FioAddressList should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   {
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 27,
+                    "fontSize": 24,
                   },
                   null,
                 ]
@@ -326,7 +326,7 @@ exports[`FioAddressList should render with loading props 1`] = `
               },
               {
                 "marginBottom": 0,
-                "marginLeft": 22,
+                "marginLeft": 20,
                 "marginRight": 0,
                 "marginTop": 0,
               },
@@ -338,8 +338,8 @@ exports[`FioAddressList should render with loading props 1`] = `
             {
               "display": "flex",
               "flexDirection": "column",
-              "marginHorizontal": 11,
-              "paddingTop": 11,
+              "marginHorizontal": 10,
+              "paddingTop": 10,
             }
           }
         >
@@ -351,16 +351,16 @@ exports[`FioAddressList should render with loading props 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -391,10 +391,10 @@ exports[`FioAddressList should render with loading props 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -404,8 +404,8 @@ exports[`FioAddressList should render with loading props 1`] = `
                   {
                     "alignItems": "center",
                     "justifyContent": "center",
-                    "marginRight": 11,
-                    "width": 34,
+                    "marginRight": 10,
+                    "width": 29,
                   }
                 }
               >
@@ -417,7 +417,7 @@ exports[`FioAddressList should render with loading props 1`] = `
                   }
                   style={
                     {
-                      "height": 51,
+                      "height": 44,
                     }
                   }
                 />
@@ -430,7 +430,7 @@ exports[`FioAddressList should render with loading props 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -451,12 +451,12 @@ exports[`FioAddressList should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -473,12 +473,12 @@ exports[`FioAddressList should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
+                          "fontSize": 15,
                         },
                         null,
                       ]
@@ -535,11 +535,11 @@ exports[`FioAddressList should render with loading props 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -564,11 +564,11 @@ exports[`FioAddressList should render with loading props 1`] = `
             [
               {
                 "justifyContent": "center",
-                "marginHorizontal": 22,
-                "paddingBottom": 22,
+                "marginHorizontal": 20,
+                "paddingBottom": 20,
               },
               {
-                "marginTop": 22,
+                "marginTop": 20,
               },
               undefined,
             ]
@@ -592,12 +592,12 @@ exports[`FioAddressList should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   {
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 27,
+                    "fontSize": 24,
                   },
                   null,
                 ]
@@ -635,7 +635,7 @@ exports[`FioAddressList should render with loading props 1`] = `
               },
               {
                 "marginBottom": 0,
-                "marginLeft": 22,
+                "marginLeft": 20,
                 "marginRight": 0,
                 "marginTop": 0,
               },
@@ -647,8 +647,8 @@ exports[`FioAddressList should render with loading props 1`] = `
             {
               "display": "flex",
               "flexDirection": "column",
-              "marginHorizontal": 11,
-              "paddingTop": 11,
+              "marginHorizontal": 10,
+              "paddingTop": 10,
             }
           }
         >
@@ -660,16 +660,16 @@ exports[`FioAddressList should render with loading props 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -700,10 +700,10 @@ exports[`FioAddressList should render with loading props 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -713,8 +713,8 @@ exports[`FioAddressList should render with loading props 1`] = `
                   {
                     "alignItems": "center",
                     "justifyContent": "center",
-                    "marginRight": 11,
-                    "width": 34,
+                    "marginRight": 10,
+                    "width": 29,
                   }
                 }
               >
@@ -725,7 +725,7 @@ exports[`FioAddressList should render with loading props 1`] = `
                     [
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 34,
+                        "fontSize": 29,
                       },
                       {
                         "textAlign": "center",
@@ -750,7 +750,7 @@ exports[`FioAddressList should render with loading props 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -771,12 +771,12 @@ exports[`FioAddressList should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -793,12 +793,12 @@ exports[`FioAddressList should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
+                          "fontSize": 15,
                         },
                         null,
                       ]
@@ -855,11 +855,11 @@ exports[`FioAddressList should render with loading props 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -885,8 +885,8 @@ exports[`FioAddressList should render with loading props 1`] = `
       style={
         {
           "alignSelf": "center",
-          "marginBottom": 22,
-          "marginHorizontal": 11,
+          "marginBottom": 20,
+          "marginHorizontal": 10,
         }
       }
     >
@@ -898,7 +898,7 @@ exports[`FioAddressList should render with loading props 1`] = `
             "alignItems": "stretch",
             "alignSelf": "center",
             "flexDirection": "column",
-            "margin": 11,
+            "margin": 10,
           }
         }
       >
@@ -943,7 +943,7 @@ exports[`FioAddressList should render with loading props 1`] = `
             accessible={true}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -955,12 +955,12 @@ exports[`FioAddressList should render with loading props 1`] = `
               {
                 "alignItems": "center",
                 "alignSelf": "stretch",
-                "borderRadius": 34,
-                "height": 67,
+                "borderRadius": 29,
+                "height": 59,
                 "justifyContent": "center",
                 "opacity": 1,
                 "overflow": "visible",
-                "paddingHorizontal": 34,
+                "paddingHorizontal": 29,
                 "paddingVertical": 0,
                 "position": "relative",
               }
@@ -988,7 +988,7 @@ exports[`FioAddressList should render with loading props 1`] = `
               }
               style={
                 {
-                  "borderRadius": 34,
+                  "borderRadius": 29,
                   "bottom": 0,
                   "left": 0,
                   "position": "absolute",
@@ -1016,7 +1016,7 @@ exports[`FioAddressList should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     [
@@ -1026,7 +1026,7 @@ exports[`FioAddressList should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Medium",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ],
@@ -1047,10 +1047,10 @@ exports[`FioAddressList should render with loading props 1`] = `
               "flexDirection": "column",
               "flexGrow": undefined,
               "justifyContent": undefined,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             }
           }
         />
@@ -1095,7 +1095,7 @@ exports[`FioAddressList should render with loading props 1`] = `
             accessible={true}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -1107,12 +1107,12 @@ exports[`FioAddressList should render with loading props 1`] = `
               {
                 "alignItems": "center",
                 "alignSelf": "stretch",
-                "borderRadius": 34,
-                "height": 67,
+                "borderRadius": 29,
+                "height": 59,
                 "justifyContent": "center",
                 "opacity": 1,
                 "overflow": "visible",
-                "paddingHorizontal": 34,
+                "paddingHorizontal": 29,
                 "paddingVertical": 0,
                 "position": "relative",
               }
@@ -1140,7 +1140,7 @@ exports[`FioAddressList should render with loading props 1`] = `
               }
               style={
                 {
-                  "borderRadius": 34,
+                  "borderRadius": 29,
                   "bottom": 0,
                   "left": 0,
                   "position": "absolute",
@@ -1168,7 +1168,7 @@ exports[`FioAddressList should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     [
@@ -1178,7 +1178,7 @@ exports[`FioAddressList should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ],
@@ -1219,7 +1219,7 @@ exports[`FioAddressList should render with loading props 1`] = `
           {
             "alignSelf": "center",
             "flex": 1,
-            "marginTop": 56,
+            "marginTop": 49,
           },
         ]
       }

--- a/src/__tests__/scenes/__snapshots__/FioAddressRegisterScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressRegisterScene.test.tsx.snap
@@ -274,17 +274,17 @@ exports[`FioAddressRegister should render with loading props 1`] = `
           [
             {
               "justifyContent": "center",
-              "marginHorizontal": 22,
-              "paddingBottom": 22,
+              "marginHorizontal": 20,
+              "paddingBottom": 20,
             },
             {
-              "marginTop": 22,
+              "marginTop": 20,
             },
             {
               "flexDirection": "row-reverse",
               "justifyContent": "flex-end",
-              "marginRight": 22,
-              "marginTop": 11,
+              "marginRight": 20,
+              "marginTop": 10,
             },
           ]
         }
@@ -307,12 +307,12 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 27,
+                  "fontSize": 24,
                 },
                 null,
               ]
@@ -330,9 +330,9 @@ exports[`FioAddressRegister should render with loading props 1`] = `
           }
           style={
             {
-              "height": 34,
-              "marginRight": 11,
-              "width": 37,
+              "height": 29,
+              "marginRight": 10,
+              "width": 32,
             }
           }
         />
@@ -365,7 +365,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
             },
             {
               "marginBottom": 0,
-              "marginLeft": 22,
+              "marginLeft": 20,
               "marginRight": 0,
               "marginTop": 0,
             },
@@ -375,7 +375,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
       <View
         style={
           {
-            "marginHorizontal": 11,
+            "marginHorizontal": 10,
           }
         }
       >
@@ -383,11 +383,11 @@ exports[`FioAddressRegister should render with loading props 1`] = `
           style={
             [
               {
-                "paddingBottom": 22,
-                "paddingHorizontal": 11,
+                "paddingBottom": 20,
+                "paddingHorizontal": 10,
               },
               {
-                "paddingTop": 34,
+                "paddingTop": 29,
               },
             ]
           }
@@ -401,12 +401,12 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "color": "#FFFFFF",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 null,
               ]
@@ -418,8 +418,8 @@ exports[`FioAddressRegister should render with loading props 1`] = `
         <View
           style={
             {
-              "paddingBottom": 22,
-              "paddingHorizontal": 11,
+              "paddingBottom": 20,
+              "paddingHorizontal": 10,
             }
           }
         >
@@ -432,12 +432,12 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "color": "#3dd9f4",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "textAlign": "left",
                 },
                 null,
@@ -452,8 +452,8 @@ exports[`FioAddressRegister should render with loading props 1`] = `
         <View
           style={
             {
-              "paddingBottom": 22,
-              "paddingHorizontal": 11,
+              "paddingBottom": 20,
+              "paddingHorizontal": 10,
             }
           }
         >
@@ -466,12 +466,12 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "color": "#3dd9f4",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "textAlign": "left",
                 },
                 null,
@@ -492,16 +492,16 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -546,10 +546,10 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -562,7 +562,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -577,13 +577,13 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -607,7 +607,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
@@ -668,11 +668,11 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -716,7 +716,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -732,10 +732,10 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -748,7 +748,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -763,13 +763,13 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -787,12 +787,12 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -848,11 +848,11 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -876,7 +876,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
         <View
           style={
             {
-              "marginTop": 34,
+              "marginTop": 29,
             }
           }
         >
@@ -889,8 +889,8 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                 "flexGrow": 1,
                 "flexShrink": 1,
                 "justifyContent": "center",
-                "margin": 11,
-                "marginHorizontal": 11,
+                "margin": 10,
+                "marginHorizontal": 10,
               }
             }
           >
@@ -933,10 +933,10 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                 focusable={false}
                 hitSlop={
                   {
-                    "bottom": 11,
+                    "bottom": 10,
                     "left": 10000,
                     "right": 10000,
-                    "top": 11,
+                    "top": 10,
                   }
                 }
                 onClick={[Function]}
@@ -949,12 +949,12 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                 style={
                   {
                     "alignItems": "center",
-                    "borderRadius": 34,
-                    "height": 67,
+                    "borderRadius": 29,
+                    "height": 59,
                     "justifyContent": "center",
                     "opacity": 0.3,
                     "overflow": "visible",
-                    "paddingHorizontal": 34,
+                    "paddingHorizontal": 29,
                     "paddingVertical": 0,
                     "position": "relative",
                   }
@@ -982,7 +982,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                   }
                   style={
                     {
-                      "borderRadius": 34,
+                      "borderRadius": 29,
                       "bottom": 0,
                       "left": 0,
                       "position": "absolute",
@@ -1010,7 +1010,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         [
@@ -1020,7 +1020,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Medium",
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           null,
                         ],
@@ -1038,7 +1038,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
         <View
           style={
             {
-              "paddingBottom": 674,
+              "paddingBottom": 590,
             }
           }
         />

--- a/src/__tests__/scenes/__snapshots__/FioAddressRegisterSelectWalletScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressRegisterSelectWalletScene.test.tsx.snap
@@ -237,7 +237,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
         "flex": 2,
         "flexDirection": "column",
         "justifyContent": "space-between",
-        "paddingHorizontal": 22,
+        "paddingHorizontal": 20,
       }
     }
   >
@@ -248,15 +248,15 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
           "display": "flex",
           "flex": 1,
           "justifyContent": "center",
-          "marginBottom": 56,
+          "marginBottom": 49,
         }
       }
     >
       <View
         style={
           {
-            "marginBottom": 67,
-            "marginLeft": 6,
+            "marginBottom": 59,
+            "marginLeft": 5,
           }
         }
       >
@@ -273,7 +273,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
           }
         }
       >
@@ -283,9 +283,9 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
         style={
           {
             "color": "#FFFFFF",
-            "fontSize": 39,
-            "marginBottom": 17,
-            "marginTop": 28,
+            "fontSize": 34,
+            "marginBottom": 15,
+            "marginTop": 25,
           }
         }
       >
@@ -300,10 +300,10 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
             "justifyContent": "center",
           },
           {
-            "marginBottom": 45,
+            "marginBottom": 39,
             "marginLeft": 0,
             "marginRight": 0,
-            "marginTop": 90,
+            "marginTop": 79,
           },
         ]
       }
@@ -331,10 +331,10 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
         focusable={true}
         hitSlop={
           {
-            "bottom": 11,
+            "bottom": 10,
             "left": 10000,
             "right": 10000,
-            "top": 11,
+            "top": 10,
           }
         }
         onClick={[Function]}
@@ -347,12 +347,12 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
         style={
           {
             "alignItems": "center",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -380,7 +380,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -408,7 +408,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -418,7 +418,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],

--- a/src/__tests__/scenes/__snapshots__/FioAddressRegisteredScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressRegisteredScene.test.tsx.snap
@@ -237,7 +237,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
         "flex": 2,
         "flexDirection": "column",
         "justifyContent": "space-between",
-        "paddingHorizontal": 22,
+        "paddingHorizontal": 20,
       }
     }
   >
@@ -248,15 +248,15 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
           "display": "flex",
           "flex": 1,
           "justifyContent": "center",
-          "marginBottom": 56,
+          "marginBottom": 49,
         }
       }
     >
       <View
         style={
           {
-            "marginBottom": 67,
-            "marginLeft": 6,
+            "marginBottom": 59,
+            "marginLeft": 5,
           }
         }
       >
@@ -273,7 +273,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
           }
         }
       >
@@ -283,9 +283,9 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
         style={
           {
             "color": "#FFFFFF",
-            "fontSize": 39,
-            "marginBottom": 17,
-            "marginTop": 28,
+            "fontSize": 34,
+            "marginBottom": 15,
+            "marginTop": 25,
           }
         }
       >
@@ -300,10 +300,10 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
             "justifyContent": "center",
           },
           {
-            "marginBottom": 45,
+            "marginBottom": 39,
             "marginLeft": 0,
             "marginRight": 0,
-            "marginTop": 90,
+            "marginTop": 79,
           },
         ]
       }
@@ -331,10 +331,10 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
         focusable={true}
         hitSlop={
           {
-            "bottom": 11,
+            "bottom": 10,
             "left": 10000,
             "right": 10000,
-            "top": 11,
+            "top": 10,
           }
         }
         onClick={[Function]}
@@ -347,12 +347,12 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
         style={
           {
             "alignItems": "center",
-            "borderRadius": 34,
-            "height": 67,
+            "borderRadius": 29,
+            "height": 59,
             "justifyContent": "center",
             "opacity": 1,
             "overflow": "visible",
-            "paddingHorizontal": 34,
+            "paddingHorizontal": 29,
             "paddingVertical": 0,
             "position": "relative",
           }
@@ -380,7 +380,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
           }
           style={
             {
-              "borderRadius": 34,
+              "borderRadius": 29,
               "bottom": 0,
               "left": 0,
               "position": "absolute",
@@ -408,7 +408,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 [
@@ -418,7 +418,7 @@ exports[`FioAddressRegistered should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Medium",
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   null,
                 ],

--- a/src/__tests__/scenes/__snapshots__/FioAddressSettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressSettingsScene.test.tsx.snap
@@ -274,11 +274,11 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
           [
             {
               "justifyContent": "center",
-              "marginHorizontal": 22,
-              "paddingBottom": 22,
+              "marginHorizontal": 20,
+              "paddingBottom": 20,
             },
             {
-              "marginTop": 22,
+              "marginTop": 20,
             },
             undefined,
           ]
@@ -302,12 +302,12 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 27,
+                  "fontSize": 24,
                 },
                 null,
               ]
@@ -345,7 +345,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
             },
             {
               "marginBottom": 0,
-              "marginLeft": 22,
+              "marginLeft": 20,
               "marginRight": 0,
               "marginTop": 0,
             },
@@ -355,7 +355,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
       <View
         style={
           {
-            "margin": 11,
+            "margin": 10,
           }
         }
       >
@@ -367,16 +367,16 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -421,10 +421,10 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -452,13 +452,13 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -476,12 +476,12 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -501,7 +501,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
               "alignItems": "stretch",
               "alignSelf": "center",
               "flexDirection": "column",
-              "margin": 11,
+              "margin": 10,
             }
           }
         >
@@ -546,7 +546,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
               accessible={true}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -558,12 +558,12 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                 {
                   "alignItems": "center",
                   "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "height": 67,
+                  "borderRadius": 29,
+                  "height": 59,
                   "justifyContent": "center",
                   "opacity": 1,
                   "overflow": "visible",
-                  "paddingHorizontal": 34,
+                  "paddingHorizontal": 29,
                   "paddingVertical": 0,
                   "position": "relative",
                 }
@@ -591,7 +591,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                 }
                 style={
                   {
-                    "borderRadius": 34,
+                    "borderRadius": 29,
                     "bottom": 0,
                     "left": 0,
                     "position": "absolute",
@@ -619,7 +619,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       [
@@ -629,7 +629,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ],
@@ -650,10 +650,10 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                 "flexDirection": "column",
                 "flexGrow": undefined,
                 "justifyContent": undefined,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               }
             }
           />
@@ -698,7 +698,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
               accessible={true}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -710,12 +710,12 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                 {
                   "alignItems": "center",
                   "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "height": 67,
+                  "borderRadius": 29,
+                  "height": 59,
                   "justifyContent": "center",
                   "opacity": 1,
                   "overflow": "visible",
-                  "paddingHorizontal": 34,
+                  "paddingHorizontal": 29,
                   "paddingVertical": 0,
                   "position": "relative",
                 }
@@ -743,7 +743,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                 }
                 style={
                   {
-                    "borderRadius": 34,
+                    "borderRadius": 29,
                     "bottom": 0,
                     "left": 0,
                     "position": "absolute",
@@ -771,7 +771,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       [
@@ -781,7 +781,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ],

--- a/src/__tests__/scenes/__snapshots__/FioConnectWalletConfirmScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioConnectWalletConfirmScene.test.tsx.snap
@@ -274,11 +274,11 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
           [
             {
               "justifyContent": "center",
-              "marginHorizontal": 22,
-              "paddingBottom": 22,
+              "marginHorizontal": 20,
+              "paddingBottom": 20,
             },
             {
-              "marginTop": 22,
+              "marginTop": 20,
             },
             undefined,
           ]
@@ -302,12 +302,12 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 27,
+                  "fontSize": 24,
                 },
                 null,
               ]
@@ -345,7 +345,7 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
             },
             {
               "marginBottom": 0,
-              "marginLeft": 22,
+              "marginLeft": 20,
               "marginRight": 0,
               "marginTop": 0,
             },
@@ -355,7 +355,7 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
       <View
         style={
           {
-            "padding": 11,
+            "padding": 10,
           }
         }
       >
@@ -367,16 +367,16 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -421,10 +421,10 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -452,13 +452,13 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -476,12 +476,12 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -498,15 +498,15 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
             [
               {
                 "marginBottom": 0,
-                "marginLeft": 45,
-                "marginRight": 45,
-                "marginTop": 45,
+                "marginLeft": 39,
+                "marginRight": 39,
+                "marginTop": 39,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
             ]
           }
@@ -564,7 +564,7 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
                   [
                     {
                       "color": "#FFFFFF",
-                      "fontSize": 28,
+                      "fontSize": 25,
                     },
                     undefined,
                     {
@@ -587,13 +587,13 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#FFFFFF",
-                      "fontSize": 17,
-                      "marginLeft": 22,
+                      "fontSize": 15,
+                      "marginLeft": 20,
                     },
                     null,
                   ]
@@ -608,7 +608,7 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
           style={
             [
               {
-                "paddingVertical": 45,
+                "paddingVertical": 39,
               },
               {
                 "alignItems": "center",
@@ -746,11 +746,11 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -773,14 +773,14 @@ exports[`FioConnectWalletConfirm should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,

--- a/src/__tests__/scenes/__snapshots__/FioDomainRegisterScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioDomainRegisterScene.test.tsx.snap
@@ -274,17 +274,17 @@ exports[`FioDomainRegister should render with loading props 1`] = `
           [
             {
               "justifyContent": "center",
-              "marginHorizontal": 22,
-              "paddingBottom": 22,
+              "marginHorizontal": 20,
+              "paddingBottom": 20,
             },
             {
-              "marginTop": 22,
+              "marginTop": 20,
             },
             {
               "flexDirection": "row-reverse",
               "justifyContent": "flex-end",
-              "marginRight": 22,
-              "marginTop": 11,
+              "marginRight": 20,
+              "marginTop": 10,
             },
           ]
         }
@@ -307,12 +307,12 @@ exports[`FioDomainRegister should render with loading props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 27,
+                  "fontSize": 24,
                 },
                 null,
               ]
@@ -328,10 +328,10 @@ exports[`FioDomainRegister should render with loading props 1`] = `
             [
               {
                 "color": "#FFFFFF",
-                "fontSize": 34,
+                "fontSize": 29,
               },
               {
-                "marginRight": 11,
+                "marginRight": 10,
               },
               {
                 "fontFamily": "Ionicons",
@@ -373,7 +373,7 @@ exports[`FioDomainRegister should render with loading props 1`] = `
             },
             {
               "marginBottom": 0,
-              "marginLeft": 22,
+              "marginLeft": 20,
               "marginRight": 0,
               "marginTop": 0,
             },
@@ -383,7 +383,7 @@ exports[`FioDomainRegister should render with loading props 1`] = `
       <View
         style={
           {
-            "marginHorizontal": 11,
+            "marginHorizontal": 10,
           }
         }
       >
@@ -396,20 +396,20 @@ exports[`FioDomainRegister should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
                 {
-                  "paddingBottom": 22,
-                  "paddingHorizontal": 11,
+                  "paddingBottom": 20,
+                  "paddingHorizontal": 10,
                 },
                 {
                   "color": "#3dd9f4",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
                 {
-                  "paddingTop": 34,
+                  "paddingTop": 29,
                 },
               ],
               null,
@@ -427,17 +427,17 @@ exports[`FioDomainRegister should render with loading props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               [
                 {
-                  "paddingBottom": 22,
-                  "paddingHorizontal": 11,
+                  "paddingBottom": 20,
+                  "paddingHorizontal": 10,
                 },
                 {
                   "color": "#3dd9f4",
-                  "fontSize": 22,
+                  "fontSize": 20,
                 },
               ],
               null,
@@ -454,16 +454,16 @@ exports[`FioDomainRegister should render with loading props 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -494,10 +494,10 @@ exports[`FioDomainRegister should render with loading props 1`] = `
                   "flexShrink": 1,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
               ]
             }
@@ -510,7 +510,7 @@ exports[`FioDomainRegister should render with loading props 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginRight": 34,
+                    "marginRight": 29,
                   },
                 ]
               }
@@ -525,13 +525,13 @@ exports[`FioDomainRegister should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
-                      "paddingRight": 22,
+                      "fontSize": 15,
+                      "paddingRight": 20,
                     },
                     null,
                   ]
@@ -555,12 +555,12 @@ exports[`FioDomainRegister should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "marginRight": 11,
+                        "marginRight": 10,
                       },
                       null,
                     ]
@@ -575,7 +575,7 @@ exports[`FioDomainRegister should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
@@ -634,11 +634,11 @@ exports[`FioDomainRegister should render with loading props 1`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     {
                       "color": "#00f1a2",
-                      "marginLeft": 11,
+                      "marginLeft": 10,
                       "textAlign": "center",
                     },
                     {

--- a/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
@@ -236,11 +236,11 @@ exports[`Request should render a blank scene with loaded props 1`] = `
       [
         {
           "justifyContent": "center",
-          "marginHorizontal": 22,
-          "paddingBottom": 22,
+          "marginHorizontal": 20,
+          "paddingBottom": 20,
         },
         {
-          "marginTop": 22,
+          "marginTop": 20,
         },
         undefined,
       ]
@@ -264,12 +264,12 @@ exports[`Request should render a blank scene with loaded props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 27,
+              "fontSize": 24,
             },
             null,
           ]
@@ -307,7 +307,7 @@ exports[`Request should render a blank scene with loaded props 1`] = `
         },
         {
           "marginBottom": 0,
-          "marginLeft": 22,
+          "marginLeft": 20,
           "marginRight": 0,
           "marginTop": 0,
         },
@@ -319,7 +319,7 @@ exports[`Request should render a blank scene with loaded props 1`] = `
       {
         "flex": 1,
         "justifyContent": "flex-start",
-        "paddingHorizontal": 22,
+        "paddingHorizontal": 20,
       }
     }
   >
@@ -332,13 +332,13 @@ exports[`Request should render a blank scene with loaded props 1`] = `
           {
             "color": "#FFFFFF",
             "fontFamily": "Quicksand-Regular",
-            "fontSize": 22,
+            "fontSize": 20,
             "includeFontPadding": false,
           },
           {
             "flexGrow": 1,
             "flexShrink": 0,
-            "marginTop": 22,
+            "marginTop": 20,
           },
           null,
         ]
@@ -358,10 +358,10 @@ Never share your username and password, and store your credentials securely!
           "flexGrow": 1,
           "flexShrink": 0,
           "justifyContent": "flex-end",
-          "margin": 11,
-          "marginBottom": 67,
-          "marginHorizontal": 11,
-          "marginTop": 22,
+          "margin": 10,
+          "marginBottom": 59,
+          "marginHorizontal": 10,
+          "marginTop": 20,
         }
       }
     >
@@ -404,10 +404,10 @@ Never share your username and password, and store your credentials securely!
           focusable={true}
           hitSlop={
             {
-              "bottom": 11,
+              "bottom": 10,
               "left": 10000,
               "right": 10000,
-              "top": 11,
+              "top": 10,
             }
           }
           onClick={[Function]}
@@ -420,12 +420,12 @@ Never share your username and password, and store your credentials securely!
           style={
             {
               "alignItems": "center",
-              "borderRadius": 34,
-              "height": 67,
+              "borderRadius": 29,
+              "height": 59,
               "justifyContent": "center",
               "opacity": 1,
               "overflow": "visible",
-              "paddingHorizontal": 34,
+              "paddingHorizontal": 29,
               "paddingVertical": 0,
               "position": "relative",
             }
@@ -453,7 +453,7 @@ Never share your username and password, and store your credentials securely!
             }
             style={
               {
-                "borderRadius": 34,
+                "borderRadius": 29,
                 "bottom": 0,
                 "left": 0,
                 "position": "absolute",
@@ -481,7 +481,7 @@ Never share your username and password, and store your credentials securely!
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
@@ -491,7 +491,7 @@ Never share your username and password, and store your credentials securely!
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     null,
                   ],
@@ -700,7 +700,7 @@ exports[`Request should render with loaded props 1`] = `
       {
         "flex": 1,
         "justifyContent": "flex-start",
-        "paddingHorizontal": 22,
+        "paddingHorizontal": 20,
       }
     }
   >
@@ -766,12 +766,12 @@ exports[`Request should render with loaded props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
               "fontFamily": "Quicksand-Medium",
-              "fontSize": 45,
+              "fontSize": 39,
             },
             null,
           ]
@@ -788,7 +788,7 @@ exports[`Request should render with loaded props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -836,7 +836,7 @@ exports[`Request should render with loaded props 1`] = `
         {
           "flexDirection": "row",
           "justifyContent": "space-between",
-          "marginBottom": 11,
+          "marginBottom": 10,
         }
       }
       layout={
@@ -853,7 +853,7 @@ exports[`Request should render with loaded props 1`] = `
           {
             "flexDirection": "row",
             "justifyContent": "space-between",
-            "marginBottom": 11,
+            "marginBottom": 10,
           },
         ]
       }
@@ -890,7 +890,7 @@ exports[`Request should render with loaded props 1`] = `
           {
             "flex": 1,
             "justifyContent": "center",
-            "marginRight": 6,
+            "marginRight": 5,
             "opacity": 1,
           }
         }
@@ -904,7 +904,7 @@ exports[`Request should render with loaded props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               undefined,
@@ -924,7 +924,7 @@ exports[`Request should render with loaded props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
@@ -992,10 +992,10 @@ exports[`Request should render with loaded props 1`] = `
               "marginTop": 0,
             },
             {
-              "paddingBottom": 11,
-              "paddingLeft": 11,
-              "paddingRight": 11,
-              "paddingTop": 11,
+              "paddingBottom": 10,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 10,
             },
             undefined,
           ]
@@ -1026,10 +1026,10 @@ exports[`Request should render with loaded props 1`] = `
                 "flexShrink": 1,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
             ]
           }
@@ -1037,12 +1037,12 @@ exports[`Request should render with loaded props 1`] = `
           <View
             style={
               {
-                "height": 34,
+                "height": 29,
                 "marginBottom": 0,
                 "marginLeft": 0,
-                "marginRight": 11,
+                "marginRight": 10,
                 "marginTop": 0,
-                "width": 34,
+                "width": 29,
               }
             }
           >
@@ -1050,9 +1050,9 @@ exports[`Request should render with loaded props 1`] = `
               style={
                 {
                   "backgroundColor": "#000000",
-                  "borderRadius": 17,
+                  "borderRadius": 14.5,
                   "elevation": 0,
-                  "height": 34,
+                  "height": 29,
                   "shadowColor": "#000000",
                   "shadowOffset": {
                     "height": 3,
@@ -1060,7 +1060,7 @@ exports[`Request should render with loaded props 1`] = `
                   },
                   "shadowOpacity": 0.6,
                   "shadowRadius": 4,
-                  "width": 34,
+                  "width": 29,
                 }
               }
             >
@@ -1109,7 +1109,7 @@ exports[`Request should render with loaded props 1`] = `
                   "flexShrink": 1,
                 },
                 {
-                  "marginRight": 34,
+                  "marginRight": 29,
                 },
               ]
             }
@@ -1123,11 +1123,11 @@ exports[`Request should render with loaded props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   {
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "fontWeight": "600",
                   },
                   null,
@@ -1184,11 +1184,11 @@ exports[`Request should render with loaded props 1`] = `
                 [
                   {
                     "color": undefined,
-                    "fontSize": 22,
+                    "fontSize": 20,
                   },
                   {
                     "color": "#00f1a2",
-                    "marginLeft": 11,
+                    "marginLeft": 10,
                     "textAlign": "center",
                   },
                   {
@@ -1242,10 +1242,10 @@ exports[`Request should render with loaded props 1`] = `
                 [
                   {
                     "alignItems": "stretch",
-                    "borderRadius": 11,
+                    "borderRadius": 10,
                     "borderWidth": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                     "overflow": "hidden",
                   },
                 ]
@@ -1255,10 +1255,10 @@ exports[`Request should render with loaded props 1`] = `
                 [
                   {
                     "alignItems": "stretch",
-                    "borderRadius": 11,
+                    "borderRadius": 10,
                     "borderWidth": 1,
                     "flexDirection": "column",
-                    "margin": 11,
+                    "margin": 10,
                     "overflow": "hidden",
                   },
                   {
@@ -1311,10 +1311,10 @@ exports[`Request should render with loaded props 1`] = `
                       "marginRight": 0,
                       "marginTop": 0,
                       "opacity": 1,
-                      "paddingBottom": 22,
-                      "paddingLeft": 22,
-                      "paddingRight": 11,
-                      "paddingTop": 22,
+                      "paddingBottom": 20,
+                      "paddingLeft": 20,
+                      "paddingRight": 10,
+                      "paddingTop": 20,
                     }
                   }
                 >
@@ -1330,7 +1330,7 @@ exports[`Request should render with loaded props 1`] = `
                         },
                         {
                           "color": "#00f1a2",
-                          "fontSize": 34,
+                          "fontSize": 29,
                         },
                         {
                           "fontFamily": "Ionicons",
@@ -1418,8 +1418,8 @@ exports[`Request should render with loaded props 1`] = `
                       [
                         {
                           "backfaceVisibility": "hidden",
-                          "paddingRight": 22,
-                          "paddingVertical": 11,
+                          "paddingRight": 20,
+                          "paddingVertical": 10,
                         },
                       ]
                     }
@@ -1429,8 +1429,8 @@ exports[`Request should render with loaded props 1`] = `
                       [
                         {
                           "backfaceVisibility": "hidden",
-                          "paddingRight": 22,
-                          "paddingVertical": 11,
+                          "paddingRight": 20,
+                          "paddingVertical": 10,
                         },
                         {
                           "transform": [
@@ -1470,7 +1470,7 @@ exports[`Request should render with loaded props 1`] = `
                             "alignSelf": "flex-start",
                             "color": "rgba(255, 255, 255, .5)",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 18,
+                            "fontSize": 16,
                             "includeFontPadding": false,
                           },
                         ]
@@ -1508,7 +1508,7 @@ exports[`Request should render with loaded props 1`] = `
                           [
                             {
                               "fontFamily": "Quicksand-Medium",
-                              "fontSize": 34,
+                              "fontSize": 29,
                               "includeFontPadding": false,
                               "marginRight": 0,
                               "padding": 0,
@@ -1525,7 +1525,7 @@ exports[`Request should render with loaded props 1`] = `
                           [
                             {
                               "fontFamily": "Quicksand-Medium",
-                              "fontSize": 34,
+                              "fontSize": 29,
                               "includeFontPadding": false,
                               "marginRight": 0,
                               "padding": 0,
@@ -1553,7 +1553,7 @@ exports[`Request should render with loaded props 1`] = `
                           {
                             "color": "rgba(255, 255, 255, .5)",
                             "fontFamily": "Quicksand-Medium",
-                            "fontSize": 34,
+                            "fontSize": 29,
                             "includeFontPadding": false,
                             "left": 0,
                             "position": "absolute",
@@ -1566,7 +1566,7 @@ exports[`Request should render with loaded props 1`] = `
                             {
                               "color": "rgba(255, 255, 255, .5)",
                               "fontFamily": "Quicksand-Medium",
-                              "fontSize": 34,
+                              "fontSize": 29,
                               "includeFontPadding": false,
                               "left": 0,
                               "position": "absolute",
@@ -1604,8 +1604,8 @@ exports[`Request should render with loaded props 1`] = `
                           "backfaceVisibility": "hidden",
                           "bottom": 0,
                           "left": 0,
-                          "paddingRight": 22,
-                          "paddingVertical": 11,
+                          "paddingRight": 20,
+                          "paddingVertical": 10,
                           "position": "absolute",
                           "right": 0,
                           "top": 0,
@@ -1620,8 +1620,8 @@ exports[`Request should render with loaded props 1`] = `
                           "backfaceVisibility": "hidden",
                           "bottom": 0,
                           "left": 0,
-                          "paddingRight": 22,
-                          "paddingVertical": 11,
+                          "paddingRight": 20,
+                          "paddingVertical": 10,
                           "position": "absolute",
                           "right": 0,
                           "top": 0,
@@ -1664,7 +1664,7 @@ exports[`Request should render with loaded props 1`] = `
                             "alignSelf": "flex-start",
                             "color": "rgba(255, 255, 255, .5)",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 18,
+                            "fontSize": 16,
                             "includeFontPadding": false,
                           },
                         ]
@@ -1702,7 +1702,7 @@ exports[`Request should render with loaded props 1`] = `
                           [
                             {
                               "fontFamily": "Quicksand-Medium",
-                              "fontSize": 34,
+                              "fontSize": 29,
                               "includeFontPadding": false,
                               "marginRight": 0,
                               "padding": 0,
@@ -1719,7 +1719,7 @@ exports[`Request should render with loaded props 1`] = `
                           [
                             {
                               "fontFamily": "Quicksand-Medium",
-                              "fontSize": 34,
+                              "fontSize": 29,
                               "includeFontPadding": false,
                               "marginRight": 0,
                               "padding": 0,
@@ -1747,7 +1747,7 @@ exports[`Request should render with loaded props 1`] = `
                           {
                             "color": "rgba(255, 255, 255, .5)",
                             "fontFamily": "Quicksand-Medium",
-                            "fontSize": 34,
+                            "fontSize": 29,
                             "includeFontPadding": false,
                             "left": 0,
                             "position": "absolute",
@@ -1760,7 +1760,7 @@ exports[`Request should render with loaded props 1`] = `
                             {
                               "color": "rgba(255, 255, 255, .5)",
                               "fontFamily": "Quicksand-Medium",
-                              "fontSize": 34,
+                              "fontSize": 29,
                               "includeFontPadding": false,
                               "left": 0,
                               "position": "absolute",
@@ -1797,7 +1797,7 @@ exports[`Request should render with loaded props 1`] = `
                       {
                         "alignSelf": "stretch",
                         "justifyContent": "center",
-                        "paddingHorizontal": 22,
+                        "paddingHorizontal": 20,
                       },
                     ]
                   }
@@ -1808,7 +1808,7 @@ exports[`Request should render with loaded props 1`] = `
                       {
                         "alignSelf": "stretch",
                         "justifyContent": "center",
-                        "paddingHorizontal": 22,
+                        "paddingHorizontal": 20,
                       },
                       {
                         "transform": [
@@ -1866,7 +1866,7 @@ exports[`Request should render with loaded props 1`] = `
                           "value": {
                             "color": "rgba(255, 255, 255, 0.5019607843137255)",
                             "fontFamily": "anticon",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "fontStyle": "normal",
                             "fontWeight": "normal",
                           },
@@ -1879,7 +1879,7 @@ exports[`Request should render with loaded props 1`] = `
                           {
                             "color": "rgba(255, 255, 255, 0.5019607843137255)",
                             "fontFamily": "anticon",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "fontStyle": "normal",
                             "fontWeight": "normal",
                           },
@@ -1921,7 +1921,7 @@ exports[`Request should render with loaded props 1`] = `
             "alignSelf": "center",
             "flex": 1,
             "flexDirection": "row",
-            "paddingTop": 22,
+            "paddingTop": 20,
           },
         ]
       }
@@ -1932,7 +1932,7 @@ exports[`Request should render with loaded props 1`] = `
             "alignSelf": "center",
             "flex": 1,
             "flexDirection": "row",
-            "paddingTop": 22,
+            "paddingTop": 20,
           },
           {
             "maxWidth": 1,
@@ -1951,7 +1951,7 @@ exports[`Request should render with loaded props 1`] = `
           "alignItems": "center",
           "flexDirection": "row",
           "justifyContent": "center",
-          "padding": 22,
+          "padding": 20,
         }
       }
     />
@@ -2045,7 +2045,7 @@ exports[`Request should render with loaded props 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 undefined,
@@ -2062,7 +2062,7 @@ exports[`Request should render with loaded props 1`] = `
               [
                 {
                   "color": "#00f1a2",
-                  "fontSize": 34,
+                  "fontSize": 29,
                 },
                 undefined,
                 {
@@ -2086,11 +2086,11 @@ exports[`Request should render with loaded props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "fontSize": 17,
+                "fontSize": 15,
               },
               null,
             ]
@@ -2145,9 +2145,9 @@ exports[`Request should render with loaded props 1`] = `
         {
           "flexDirection": "row",
           "justifyContent": "center",
-          "marginBottom": 22,
-          "marginTop": 22,
-          "marginVertical": 22,
+          "marginBottom": 20,
+          "marginTop": 20,
+          "marginVertical": 20,
         }
       }
     >
@@ -2195,10 +2195,10 @@ exports[`Request should render with loaded props 1`] = `
             [
               {
                 "color": "#00f1a2",
-                "fontSize": 34,
+                "fontSize": 29,
               },
               {
-                "marginBottom": 11,
+                "marginBottom": 10,
               },
               {
                 "fontFamily": "custom",
@@ -2220,11 +2220,11 @@ exports[`Request should render with loaded props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "fontSize": 17,
+                "fontSize": 15,
                 "textAlign": "center",
               },
               null,
@@ -2278,10 +2278,10 @@ exports[`Request should render with loaded props 1`] = `
             [
               {
                 "color": "#00f1a2",
-                "fontSize": 34,
+                "fontSize": 29,
               },
               {
-                "marginBottom": 11,
+                "marginBottom": 10,
               },
               {
                 "fontFamily": "custom",
@@ -2303,11 +2303,11 @@ exports[`Request should render with loaded props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "fontSize": 17,
+                "fontSize": 15,
                 "textAlign": "center",
               },
               null,
@@ -2361,10 +2361,10 @@ exports[`Request should render with loaded props 1`] = `
             [
               {
                 "color": "#00f1a2",
-                "fontSize": 34,
+                "fontSize": 29,
               },
               {
-                "marginBottom": 11,
+                "marginBottom": 10,
               },
               {
                 "fontFamily": "custom",
@@ -2386,11 +2386,11 @@ exports[`Request should render with loaded props 1`] = `
               {
                 "color": "#FFFFFF",
                 "fontFamily": "Quicksand-Regular",
-                "fontSize": 22,
+                "fontSize": 20,
                 "includeFontPadding": false,
               },
               {
-                "fontSize": 17,
+                "fontSize": 15,
                 "textAlign": "center",
               },
               null,

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -190,14 +190,14 @@ exports[`SendScene2 1 spendTarget 1`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -206,7 +206,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -259,16 +259,16 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -313,10 +313,10 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -329,7 +329,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -344,13 +344,13 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -368,12 +368,12 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -429,11 +429,11 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -499,16 +499,16 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -553,10 +553,10 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -569,7 +569,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -584,13 +584,13 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -649,7 +649,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -708,11 +708,11 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -756,7 +756,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -814,10 +814,10 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -830,7 +830,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -845,13 +845,13 @@ exports[`SendScene2 1 spendTarget 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -868,12 +868,12 @@ exports[`SendScene2 1 spendTarget 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           [
                             {
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                           ],
@@ -892,7 +892,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -950,11 +950,11 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -1021,16 +1021,16 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -1075,10 +1075,10 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -1091,7 +1091,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -1106,13 +1106,13 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -1168,11 +1168,11 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -1240,16 +1240,16 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -1294,10 +1294,10 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -1310,7 +1310,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -1325,13 +1325,13 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -1348,7 +1348,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -1408,11 +1408,11 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -1480,7 +1480,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -1666,11 +1666,11 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -1693,14 +1693,14 @@ exports[`SendScene2 1 spendTarget 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -1746,9 +1746,9 @@ exports[`SendScene2 1 spendTarget 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -1759,9 +1759,9 @@ exports[`SendScene2 1 spendTarget 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -1798,7 +1798,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -1967,14 +1967,14 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -1983,7 +1983,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -2036,16 +2036,16 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -2090,10 +2090,10 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -2106,7 +2106,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -2121,13 +2121,13 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -2145,12 +2145,12 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -2206,11 +2206,11 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -2276,16 +2276,16 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -2330,10 +2330,10 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -2346,7 +2346,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -2361,13 +2361,13 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -2426,7 +2426,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -2485,11 +2485,11 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -2533,7 +2533,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -2591,10 +2591,10 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -2607,7 +2607,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -2622,13 +2622,13 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -2645,12 +2645,12 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           [
                             {
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                           ],
@@ -2669,7 +2669,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -2727,11 +2727,11 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -2798,16 +2798,16 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -2852,10 +2852,10 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -2868,7 +2868,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -2883,13 +2883,13 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -2945,11 +2945,11 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -3017,16 +3017,16 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -3071,10 +3071,10 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -3087,7 +3087,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -3102,13 +3102,13 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -3125,7 +3125,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -3185,11 +3185,11 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -3235,7 +3235,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -3251,10 +3251,10 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -3282,13 +3282,13 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -3306,12 +3306,12 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -3349,7 +3349,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -3365,10 +3365,10 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -3396,13 +3396,13 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -3420,12 +3420,12 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -3485,7 +3485,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -3671,11 +3671,11 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -3698,14 +3698,14 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -3751,9 +3751,9 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -3764,9 +3764,9 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -3803,7 +3803,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -3972,14 +3972,14 @@ exports[`SendScene2 2 spendTargets 1`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -3988,7 +3988,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -4041,16 +4041,16 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -4095,10 +4095,10 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -4111,7 +4111,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -4126,13 +4126,13 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -4150,12 +4150,12 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -4211,11 +4211,11 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -4281,16 +4281,16 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -4377,10 +4377,10 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -4393,7 +4393,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -4408,13 +4408,13 @@ exports[`SendScene2 2 spendTargets 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -4432,12 +4432,12 @@ exports[`SendScene2 2 spendTargets 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#FFFFFF",
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           null,
                         ]
@@ -4493,11 +4493,11 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -4542,7 +4542,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -4558,10 +4558,10 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -4574,7 +4574,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -4589,13 +4589,13 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -4654,7 +4654,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -4713,11 +4713,11 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -4761,7 +4761,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -4819,10 +4819,10 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -4835,7 +4835,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -4850,13 +4850,13 @@ exports[`SendScene2 2 spendTargets 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -4873,12 +4873,12 @@ exports[`SendScene2 2 spendTargets 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           [
                             {
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                           ],
@@ -4897,7 +4897,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -4955,11 +4955,11 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -5026,16 +5026,16 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -5080,10 +5080,10 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -5096,7 +5096,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -5111,13 +5111,13 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -5173,11 +5173,11 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -5245,16 +5245,16 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -5299,10 +5299,10 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -5315,7 +5315,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -5330,13 +5330,13 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -5353,7 +5353,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -5413,11 +5413,11 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -5485,7 +5485,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -5671,11 +5671,11 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -5698,14 +5698,14 @@ exports[`SendScene2 2 spendTargets 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -5751,9 +5751,9 @@ exports[`SendScene2 2 spendTargets 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -5764,9 +5764,9 @@ exports[`SendScene2 2 spendTargets 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -5803,7 +5803,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -5972,14 +5972,14 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -5988,7 +5988,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -6041,16 +6041,16 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -6095,10 +6095,10 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -6111,7 +6111,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -6126,13 +6126,13 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -6150,12 +6150,12 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -6211,11 +6211,11 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -6281,16 +6281,16 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -6377,10 +6377,10 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -6393,7 +6393,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -6408,13 +6408,13 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -6432,12 +6432,12 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#FFFFFF",
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           null,
                         ]
@@ -6493,11 +6493,11 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -6542,7 +6542,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -6600,10 +6600,10 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -6616,7 +6616,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -6631,13 +6631,13 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -6654,12 +6654,12 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           [
                             {
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                           ],
@@ -6678,7 +6678,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -6736,11 +6736,11 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -6846,16 +6846,16 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -6900,10 +6900,10 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -6916,7 +6916,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -6931,13 +6931,13 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -6954,7 +6954,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -7014,11 +7014,11 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -7086,7 +7086,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -7272,11 +7272,11 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -7299,14 +7299,14 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -7352,9 +7352,9 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -7365,9 +7365,9 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -7404,7 +7404,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -7573,14 +7573,14 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -7589,7 +7589,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -7642,16 +7642,16 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -7696,10 +7696,10 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -7712,7 +7712,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -7727,13 +7727,13 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -7751,12 +7751,12 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -7812,11 +7812,11 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -7882,16 +7882,16 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -7978,10 +7978,10 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -7994,7 +7994,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -8009,13 +8009,13 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -8033,12 +8033,12 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#FFFFFF",
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           null,
                         ]
@@ -8094,11 +8094,11 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -8143,7 +8143,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -8159,10 +8159,10 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -8175,7 +8175,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -8190,13 +8190,13 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -8255,7 +8255,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -8314,11 +8314,11 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -8423,16 +8423,16 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -8477,10 +8477,10 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -8493,7 +8493,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -8508,13 +8508,13 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -8531,7 +8531,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -8591,11 +8591,11 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -8663,7 +8663,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -8849,11 +8849,11 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -8876,14 +8876,14 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -8929,9 +8929,9 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -8942,9 +8942,9 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -8981,7 +8981,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -9150,14 +9150,14 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -9166,7 +9166,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -9219,16 +9219,16 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -9273,10 +9273,10 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -9289,7 +9289,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -9304,13 +9304,13 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -9328,12 +9328,12 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -9389,11 +9389,11 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -9459,16 +9459,16 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -9555,10 +9555,10 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -9571,7 +9571,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -9586,13 +9586,13 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -9610,12 +9610,12 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#FFFFFF",
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           null,
                         ]
@@ -9671,11 +9671,11 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -9781,16 +9781,16 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -9835,10 +9835,10 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -9851,7 +9851,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -9866,13 +9866,13 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -9889,7 +9889,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -9949,11 +9949,11 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -10021,7 +10021,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -10207,11 +10207,11 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -10234,14 +10234,14 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -10287,9 +10287,9 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -10300,9 +10300,9 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -10339,7 +10339,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -10508,14 +10508,14 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -10524,7 +10524,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -10577,16 +10577,16 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -10631,10 +10631,10 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -10647,7 +10647,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -10662,13 +10662,13 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -10686,12 +10686,12 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -10747,11 +10747,11 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -10817,16 +10817,16 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -10913,10 +10913,10 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -10929,7 +10929,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -10944,13 +10944,13 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -10968,12 +10968,12 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#FFFFFF",
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           null,
                         ]
@@ -11029,11 +11029,11 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -11078,7 +11078,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -11094,10 +11094,10 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -11125,13 +11125,13 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -11190,7 +11190,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -11231,7 +11231,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -11289,10 +11289,10 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -11305,7 +11305,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                           "flexShrink": 1,
                         },
                         {
-                          "marginRight": 34,
+                          "marginRight": 29,
                         },
                       ]
                     }
@@ -11320,13 +11320,13 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -11343,12 +11343,12 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           [
                             {
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                           ],
@@ -11367,7 +11367,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -11425,11 +11425,11 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         [
                           {
                             "color": undefined,
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           {
                             "color": "#00f1a2",
-                            "marginLeft": 11,
+                            "marginLeft": 10,
                             "textAlign": "center",
                           },
                           {
@@ -11535,16 +11535,16 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -11589,10 +11589,10 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -11605,7 +11605,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -11620,13 +11620,13 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -11643,7 +11643,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -11703,11 +11703,11 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -11775,7 +11775,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -11961,11 +11961,11 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -11988,14 +11988,14 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -12041,9 +12041,9 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -12054,9 +12054,9 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -12093,7 +12093,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -12262,14 +12262,14 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -12278,7 +12278,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -12331,16 +12331,16 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -12385,10 +12385,10 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -12401,7 +12401,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -12416,13 +12416,13 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -12440,12 +12440,12 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -12501,11 +12501,11 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -12571,16 +12571,16 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -12691,10 +12691,10 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       "backgroundColor": "rgba(255, 255, 255, 0)",
                       "flexDirection": "row",
                       "flexShrink": 1,
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                       "opacity": 1,
                     }
                   }
@@ -12722,13 +12722,13 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -12746,12 +12746,12 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#FFFFFF",
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           null,
                         ]
@@ -12790,7 +12790,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -12806,10 +12806,10 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -12822,7 +12822,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -12837,13 +12837,13 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -12902,7 +12902,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -12961,11 +12961,11 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -13009,7 +13009,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -13067,10 +13067,10 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -13098,13 +13098,13 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -13121,12 +13121,12 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           [
                             {
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                           ],
@@ -13145,7 +13145,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -13247,16 +13247,16 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -13301,10 +13301,10 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -13317,7 +13317,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -13332,13 +13332,13 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -13355,7 +13355,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -13415,11 +13415,11 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -13487,7 +13487,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -13673,11 +13673,11 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -13700,14 +13700,14 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -13753,9 +13753,9 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -13766,9 +13766,9 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -13805,7 +13805,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -13974,14 +13974,14 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -13990,7 +13990,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -14043,16 +14043,16 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -14097,10 +14097,10 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -14113,7 +14113,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -14128,13 +14128,13 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -14152,12 +14152,12 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -14213,11 +14213,11 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -14283,16 +14283,16 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -14403,10 +14403,10 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                       "backgroundColor": "rgba(255, 255, 255, 0)",
                       "flexDirection": "row",
                       "flexShrink": 1,
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                       "opacity": 1,
                     }
                   }
@@ -14434,13 +14434,13 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -14458,12 +14458,12 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#FFFFFF",
-                            "fontSize": 22,
+                            "fontSize": 20,
                           },
                           null,
                         ]
@@ -14502,7 +14502,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -14518,10 +14518,10 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -14549,13 +14549,13 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -14614,7 +14614,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -14655,7 +14655,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                       "height": 1,
                     },
                     {
-                      "margin": 11,
+                      "margin": 10,
                     },
                   ]
                 }
@@ -14713,10 +14713,10 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginBottom": 11,
-                        "marginLeft": 11,
-                        "marginRight": 11,
-                        "marginTop": 11,
+                        "marginBottom": 10,
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                        "marginTop": 10,
                       },
                     ]
                   }
@@ -14744,13 +14744,13 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
-                            "paddingRight": 22,
+                            "fontSize": 15,
+                            "paddingRight": 20,
                           },
                           null,
                         ]
@@ -14767,12 +14767,12 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           [
                             {
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                           ],
@@ -14791,7 +14791,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           undefined,
@@ -14893,16 +14893,16 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -14947,10 +14947,10 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -14963,7 +14963,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -14978,13 +14978,13 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -15001,7 +15001,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -15061,11 +15061,11 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -15133,7 +15133,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -15319,11 +15319,11 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 34,
+                      "fontSize": 29,
                     },
                     {
                       "color": "#1a1a1a",
-                      "fontSize": 51,
+                      "fontSize": 44,
                     },
                     {
                       "fontFamily": "Entypo",
@@ -15346,14 +15346,14 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -15399,9 +15399,9 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -15412,9 +15412,9 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -15451,7 +15451,7 @@ exports[`SendScene2 Render SendScene 1`] = `
           "paddingTop": 64,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -15620,14 +15620,14 @@ exports[`SendScene2 Render SendScene 1`] = `
     <RCTScrollView
       contentContainerStyle={
         {
-          "paddingBottom": 112,
+          "paddingBottom": 98,
           "paddingLeft": 0,
           "paddingRight": 0,
           "paddingTop": 0,
         }
       }
       enableOnAndroid={true}
-      extraScrollHeight={62}
+      extraScrollHeight={54}
       innerRef={[Function]}
       scrollIndicatorInsets={
         {
@@ -15636,7 +15636,7 @@ exports[`SendScene2 Render SendScene 1`] = `
       }
       style={
         {
-          "margin": 11,
+          "margin": 10,
           "marginBottom": 0,
         }
       }
@@ -15689,16 +15689,16 @@ exports[`SendScene2 Render SendScene 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -15743,10 +15743,10 @@ exports[`SendScene2 Render SendScene 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -15759,7 +15759,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                         "flexShrink": 1,
                       },
                       {
-                        "marginRight": 34,
+                        "marginRight": 29,
                       },
                     ]
                   }
@@ -15774,13 +15774,13 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -15798,12 +15798,12 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#FFFFFF",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ]
@@ -15859,11 +15859,11 @@ exports[`SendScene2 Render SendScene 1`] = `
                       [
                         {
                           "color": undefined,
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         {
                           "color": "#00f1a2",
-                          "marginLeft": 11,
+                          "marginLeft": 10,
                           "textAlign": "center",
                         },
                         {
@@ -15929,16 +15929,16 @@ exports[`SendScene2 Render SendScene 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -15983,10 +15983,10 @@ exports[`SendScene2 Render SendScene 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginBottom": 11,
-                      "marginLeft": 11,
-                      "marginRight": 11,
-                      "marginTop": 11,
+                      "marginBottom": 10,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                      "marginTop": 10,
                     },
                   ]
                 }
@@ -16014,13 +16014,13 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
-                          "paddingRight": 22,
+                          "fontSize": 15,
+                          "paddingRight": 20,
                         },
                         null,
                       ]
@@ -16066,7 +16066,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                         "alignSelf": "stretch",
                         "flexDirection": "row",
                         "justifyContent": "space-between",
-                        "paddingTop": 17,
+                        "paddingTop": 15,
                       }
                     }
                     layout={
@@ -16085,7 +16085,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                           "alignSelf": "stretch",
                           "flexDirection": "row",
                           "justifyContent": "space-between",
-                          "paddingTop": 17,
+                          "paddingTop": 15,
                         },
                       ]
                     }
@@ -16123,7 +16123,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                           "alignItems": "center",
                           "flex": 1,
                           "flexDirection": "column",
-                          "height": 67,
+                          "height": 59,
                           "justifyContent": "space-evenly",
                           "opacity": 1,
                         }
@@ -16136,7 +16136,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                           [
                             {
                               "color": "#00f1a2",
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                             {
@@ -16159,14 +16159,14 @@ exports[`SendScene2 Render SendScene 1`] = `
                             {
                               "color": "#FFFFFF",
                               "fontFamily": "Quicksand-Regular",
-                              "fontSize": 22,
+                              "fontSize": 20,
                               "includeFontPadding": false,
                             },
                             {
                               "alignSelf": "center",
                               "color": "#00f1a2",
-                              "fontSize": 17,
-                              "marginTop": 6,
+                              "fontSize": 15,
+                              "marginTop": 5,
                             },
                             null,
                           ]
@@ -16208,7 +16208,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                           "alignItems": "center",
                           "flex": 1,
                           "flexDirection": "column",
-                          "height": 67,
+                          "height": 59,
                           "justifyContent": "space-evenly",
                           "opacity": 1,
                         }
@@ -16221,7 +16221,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                           [
                             {
                               "color": "#00f1a2",
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                             {
@@ -16246,14 +16246,14 @@ exports[`SendScene2 Render SendScene 1`] = `
                             {
                               "color": "#FFFFFF",
                               "fontFamily": "Quicksand-Regular",
-                              "fontSize": 22,
+                              "fontSize": 20,
                               "includeFontPadding": false,
                             },
                             {
                               "alignSelf": "center",
                               "color": "#00f1a2",
-                              "fontSize": 17,
-                              "marginTop": 6,
+                              "fontSize": 15,
+                              "marginTop": 5,
                             },
                             null,
                           ]
@@ -16295,7 +16295,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                           "alignItems": "center",
                           "flex": 1,
                           "flexDirection": "column",
-                          "height": 67,
+                          "height": 59,
                           "justifyContent": "space-evenly",
                           "opacity": 1,
                         }
@@ -16308,7 +16308,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                           [
                             {
                               "color": "#00f1a2",
-                              "fontSize": 45,
+                              "fontSize": 39,
                             },
                             undefined,
                             {
@@ -16333,14 +16333,14 @@ exports[`SendScene2 Render SendScene 1`] = `
                             {
                               "color": "#FFFFFF",
                               "fontFamily": "Quicksand-Regular",
-                              "fontSize": 22,
+                              "fontSize": 20,
                               "includeFontPadding": false,
                             },
                             {
                               "alignSelf": "center",
                               "color": "#00f1a2",
-                              "fontSize": 17,
-                              "marginTop": 6,
+                              "fontSize": 15,
+                              "marginTop": 5,
                             },
                             null,
                           ]
@@ -16480,16 +16480,16 @@ exports[`SendScene2 Render SendScene 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 34,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 34,
+                  "marginBottom": 29,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 29,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -16545,7 +16545,7 @@ exports[`SendScene2 Render SendScene 1`] = `
             <View
               style={
                 {
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -16564,7 +16564,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                     [
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 28,
+                        "fontSize": 25,
                       },
                       {
                         "marginRight": 4,
@@ -16589,7 +16589,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
@@ -16607,7 +16607,7 @@ exports[`SendScene2 Render SendScene 1`] = `
               <View
                 style={
                   {
-                    "marginTop": 11,
+                    "marginTop": 10,
                   }
                 }
               >
@@ -16627,11 +16627,11 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
+                          "fontSize": 15,
                           "marginLeft": 4,
                         },
                         null,
@@ -16649,11 +16649,11 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
+                          "fontSize": 15,
                           "marginLeft": 4,
                         },
                         null,
@@ -16679,11 +16679,11 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
+                          "fontSize": 15,
                           "marginLeft": 4,
                         },
                         null,
@@ -16701,11 +16701,11 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
+                          "fontSize": 15,
                           "marginLeft": 4,
                         },
                         null,
@@ -16731,11 +16731,11 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
+                          "fontSize": 15,
                           "marginLeft": 4,
                         },
                         null,
@@ -16753,11 +16753,11 @@ exports[`SendScene2 Render SendScene 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
+                          "fontSize": 15,
                           "marginLeft": 4,
                         },
                         null,
@@ -16777,13 +16777,13 @@ exports[`SendScene2 Render SendScene 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
-                      "fontSize": 17,
-                      "marginHorizontal": 6,
-                      "marginTop": 11,
+                      "fontSize": 15,
+                      "marginHorizontal": 5,
+                      "marginTop": 10,
                     },
                     null,
                   ]
@@ -16802,7 +16802,7 @@ exports[`SendScene2 Render SendScene 1`] = `
       style={
         {
           "alignItems": "center",
-          "bottom": 45,
+          "bottom": 39,
           "justifyContent": "center",
           "position": "absolute",
           "width": "100%",
@@ -16836,9 +16836,9 @@ exports[`SendScene2 Render SendScene 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -16849,9 +16849,9 @@ exports[`SendScene2 Render SendScene 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {

--- a/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
@@ -278,10 +278,10 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               "flexShrink": 1,
             },
             {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             },
           ]
         }
@@ -291,14 +291,14 @@ exports[`SettingsScene should render SettingsScene 1`] = `
             {
               "alignItems": "center",
               "flexDirection": "row",
-              "margin": 11,
+              "margin": 10,
             }
           }
         >
           <View
             style={
               {
-                "paddingRight": 17,
+                "paddingRight": 15,
               }
             }
           >
@@ -309,7 +309,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 [
                   {
                     "color": "#FFFFFF",
-                    "fontSize": 28,
+                    "fontSize": 25,
                   },
                   undefined,
                   {
@@ -333,7 +333,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
@@ -341,7 +341,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "textAlign": "left",
                 },
                 null,
@@ -359,16 +359,16 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -423,7 +423,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -437,9 +437,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -450,8 +450,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -503,8 +503,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -545,8 +545,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "#00f1a2",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "anticon",
@@ -590,7 +590,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -616,7 +616,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -630,9 +630,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -643,8 +643,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -696,8 +696,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -738,8 +738,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "rgba(255, 255, 255, .75)",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -785,7 +785,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -811,7 +811,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -825,9 +825,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -838,8 +838,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -891,8 +891,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -933,8 +933,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "rgba(255, 255, 255, .75)",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -980,7 +980,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -1006,7 +1006,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1020,9 +1020,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -1033,8 +1033,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -1086,8 +1086,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -1128,8 +1128,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "rgba(255, 255, 255, .75)",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -1175,7 +1175,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -1201,7 +1201,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1215,9 +1215,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -1228,8 +1228,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -1281,8 +1281,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -1323,8 +1323,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "rgba(255, 255, 255, .75)",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -1370,7 +1370,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -1396,7 +1396,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1410,9 +1410,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -1423,8 +1423,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -1476,8 +1476,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -1518,8 +1518,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "rgba(255, 255, 255, .75)",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -1565,7 +1565,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -1591,7 +1591,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1605,9 +1605,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -1618,8 +1618,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -1671,8 +1671,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -1713,8 +1713,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "rgba(255, 255, 255, .75)",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -1760,7 +1760,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -1786,7 +1786,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1800,9 +1800,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -1813,8 +1813,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -1866,8 +1866,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -1908,8 +1908,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "rgba(255, 255, 255, .75)",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -1955,7 +1955,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -1981,7 +1981,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1995,9 +1995,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -2008,8 +2008,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -2061,8 +2061,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -2103,8 +2103,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "rgba(255, 255, 255, .75)",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -2152,8 +2152,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 "height": 1,
               },
               {
-                "margin": 11,
-                "marginRight": -22,
+                "margin": 10,
+                "marginRight": -20,
               },
             ]
           }
@@ -2163,14 +2163,14 @@ exports[`SettingsScene should render SettingsScene 1`] = `
             {
               "alignItems": "center",
               "flexDirection": "row",
-              "margin": 11,
+              "margin": 10,
             }
           }
         >
           <View
             style={
               {
-                "paddingRight": 17,
+                "paddingRight": 15,
               }
             }
           >
@@ -2181,7 +2181,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 [
                   {
                     "color": "#FFFFFF",
-                    "fontSize": 28,
+                    "fontSize": 25,
                   },
                   undefined,
                   {
@@ -2205,7 +2205,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 {
                   "color": "#FFFFFF",
                   "fontFamily": "Quicksand-Regular",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "includeFontPadding": false,
                 },
                 {
@@ -2213,7 +2213,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "flexGrow": 1,
                   "flexShrink": 1,
                   "fontFamily": "Quicksand-Medium",
-                  "fontSize": 22,
+                  "fontSize": 20,
                   "textAlign": "left",
                 },
                 null,
@@ -2231,16 +2231,16 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -2295,7 +2295,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -2309,9 +2309,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -2322,8 +2322,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -2375,8 +2375,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -2417,8 +2417,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "#00f1a2",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -2464,7 +2464,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -2490,7 +2490,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -2504,9 +2504,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -2517,8 +2517,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -2570,8 +2570,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -2606,8 +2606,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                       {
                         "color": "#00f1a2",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
-                        "marginHorizontal": 11,
+                        "fontSize": 20,
+                        "marginHorizontal": 10,
                       }
                     }
                   >
@@ -2644,7 +2644,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -2670,7 +2670,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -2684,9 +2684,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -2697,8 +2697,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -2750,8 +2750,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -2786,8 +2786,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                       {
                         "color": "#00f1a2",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
-                        "marginHorizontal": 11,
+                        "fontSize": 20,
+                        "marginHorizontal": 10,
                       }
                     }
                   >
@@ -2824,7 +2824,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -2850,7 +2850,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -2864,9 +2864,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -2877,8 +2877,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -2930,8 +2930,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -2965,7 +2965,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     pointerEvents="none"
                     style={
                       {
-                        "marginHorizontal": 11,
+                        "marginHorizontal": 10,
                         "padding": 0,
                       }
                     }
@@ -3023,7 +3023,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -3049,7 +3049,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -3063,9 +3063,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -3076,8 +3076,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -3129,8 +3129,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -3164,7 +3164,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     pointerEvents="none"
                     style={
                       {
-                        "marginHorizontal": 11,
+                        "marginHorizontal": 10,
                         "padding": 0,
                       }
                     }
@@ -3222,7 +3222,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -3248,7 +3248,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -3262,9 +3262,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -3275,8 +3275,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -3328,8 +3328,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -3363,7 +3363,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     pointerEvents="none"
                     style={
                       {
-                        "marginHorizontal": 11,
+                        "marginHorizontal": 10,
                         "padding": 0,
                       }
                     }
@@ -3421,7 +3421,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -3447,7 +3447,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -3461,9 +3461,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -3474,8 +3474,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -3527,8 +3527,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -3569,8 +3569,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "#00f1a2",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -3616,7 +3616,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -3642,7 +3642,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -3656,9 +3656,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -3669,8 +3669,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -3722,8 +3722,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -3764,8 +3764,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "#00f1a2",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -3811,7 +3811,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -3837,7 +3837,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -3851,9 +3851,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -3864,8 +3864,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -3917,8 +3917,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -3959,8 +3959,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "#00f1a2",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -4006,7 +4006,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -4032,7 +4032,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -4046,9 +4046,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -4059,8 +4059,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -4112,8 +4112,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -4147,7 +4147,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     pointerEvents="none"
                     style={
                       {
-                        "marginHorizontal": 11,
+                        "marginHorizontal": 10,
                         "padding": 0,
                       }
                     }
@@ -4205,7 +4205,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -4231,7 +4231,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -4245,9 +4245,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -4258,8 +4258,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -4311,8 +4311,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -4353,8 +4353,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "rgba(255, 255, 255, .75)",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -4400,7 +4400,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -4426,7 +4426,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -4440,9 +4440,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -4453,8 +4453,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -4506,8 +4506,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -4548,8 +4548,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "#00f1a2",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -4595,7 +4595,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -4621,7 +4621,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -4635,9 +4635,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -4648,8 +4648,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -4701,8 +4701,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -4743,8 +4743,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                         },
                         {
                           "color": "#00f1a2",
-                          "fontSize": 22,
-                          "marginHorizontal": 11,
+                          "fontSize": 20,
+                          "marginHorizontal": 10,
                         },
                         {
                           "fontFamily": "FontAwesome5Free-Solid",
@@ -4790,7 +4790,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -4816,7 +4816,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -4830,9 +4830,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -4843,8 +4843,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -4896,8 +4896,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -4931,7 +4931,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     pointerEvents="none"
                     style={
                       {
-                        "marginHorizontal": 11,
+                        "marginHorizontal": 10,
                         "padding": 0,
                       }
                     }
@@ -4991,8 +4991,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 "height": 1,
               },
               {
-                "margin": 11,
-                "marginRight": -22,
+                "margin": 10,
+                "marginRight": -20,
               },
             ]
           }
@@ -5005,16 +5005,16 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -5069,7 +5069,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               accessible={false}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -5083,9 +5083,9 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                   "backgroundColor": "rgba(255, 255, 255, 0)",
                   "flexDirection": "row",
                   "marginBottom": 1,
-                  "minHeight": 67,
+                  "minHeight": 59,
                   "opacity": 1,
-                  "padding": 11,
+                  "padding": 10,
                 }
               }
             >
@@ -5096,8 +5096,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
-                    "paddingHorizontal": 11,
+                    "fontSize": 20,
+                    "paddingHorizontal": 10,
                     "textAlign": "left",
                   }
                 }
@@ -5149,8 +5149,8 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     color="#00f1a2"
                     style={
                       {
-                        "height": 34,
-                        "marginHorizontal": 11,
+                        "height": 29,
+                        "marginHorizontal": 10,
                       }
                     }
                   />
@@ -5184,7 +5184,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     pointerEvents="none"
                     style={
                       {
-                        "marginHorizontal": 11,
+                        "marginHorizontal": 10,
                         "padding": 0,
                       }
                     }
@@ -5225,7 +5225,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
             "alignItems": "stretch",
             "alignSelf": "center",
             "flexDirection": "column",
-            "margin": 11,
+            "margin": 10,
           }
         }
       >
@@ -5270,7 +5270,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
             accessible={true}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -5282,12 +5282,12 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               {
                 "alignItems": "center",
                 "alignSelf": "stretch",
-                "borderRadius": 34,
-                "height": 67,
+                "borderRadius": 29,
+                "height": 59,
                 "justifyContent": "center",
                 "opacity": 1,
                 "overflow": "visible",
-                "paddingHorizontal": 34,
+                "paddingHorizontal": 29,
                 "paddingVertical": 0,
                 "position": "relative",
               }
@@ -5315,7 +5315,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               }
               style={
                 {
-                  "borderRadius": 34,
+                  "borderRadius": 29,
                   "bottom": 0,
                   "left": 0,
                   "position": "absolute",
@@ -5343,7 +5343,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     [
@@ -5353,7 +5353,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Medium",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ],
@@ -5374,10 +5374,10 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               "flexDirection": "column",
               "flexGrow": undefined,
               "justifyContent": undefined,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "marginBottom": 10,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "marginTop": 10,
             }
           }
         />
@@ -5422,7 +5422,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
             accessible={true}
             collapsable={false}
             focusable={true}
-            hitSlop={11}
+            hitSlop={10}
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -5434,12 +5434,12 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               {
                 "alignItems": "center",
                 "alignSelf": "stretch",
-                "borderRadius": 34,
-                "height": 67,
+                "borderRadius": 29,
+                "height": 59,
                 "justifyContent": "center",
                 "opacity": 1,
                 "overflow": "visible",
-                "paddingHorizontal": 34,
+                "paddingHorizontal": 29,
                 "paddingVertical": 0,
                 "position": "relative",
               }
@@ -5467,7 +5467,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
               }
               style={
                 {
-                  "borderRadius": 34,
+                  "borderRadius": 29,
                   "bottom": 0,
                   "left": 0,
                   "position": "absolute",
@@ -5495,7 +5495,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     [
@@ -5505,7 +5505,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ],

--- a/src/__tests__/scenes/__snapshots__/SwapConfirmationScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SwapConfirmationScene.test.tsx.snap
@@ -272,8 +272,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
       <View
         style={
           {
-            "marginHorizontal": 11,
-            "paddingTop": 11,
+            "marginHorizontal": 10,
+            "paddingTop": 10,
           }
         }
       >
@@ -308,8 +308,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
           }
           jestInlineStyle={
             {
-              "marginBottom": 22,
-              "marginLeft": -11,
+              "marginBottom": 20,
+              "marginLeft": -10,
               "width": "100%",
             }
           }
@@ -325,8 +325,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
           style={
             [
               {
-                "marginBottom": 22,
-                "marginLeft": -11,
+                "marginBottom": 20,
+                "marginLeft": -10,
                 "width": "100%",
               },
             ]
@@ -337,11 +337,11 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
               [
                 {
                   "justifyContent": "center",
-                  "marginHorizontal": 22,
-                  "paddingBottom": 22,
+                  "marginHorizontal": 20,
+                  "paddingBottom": 20,
                 },
                 {
-                  "marginTop": 22,
+                  "marginTop": 20,
                 },
                 undefined,
               ]
@@ -365,12 +365,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 27,
+                      "fontSize": 24,
                     },
                     null,
                   ]
@@ -408,7 +408,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                 },
                 {
                   "marginBottom": 0,
-                  "marginLeft": 22,
+                  "marginLeft": 20,
                   "marginRight": 0,
                   "marginTop": 0,
                 },
@@ -463,16 +463,16 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -501,10 +501,10 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     "justifyContent": "center",
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -512,10 +512,10 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
               <View>
                 <RNSVGSvgView
                   align="xMidYMid"
-                  bbHeight={61}
-                  bbWidth={61}
+                  bbHeight={55}
+                  bbWidth={55}
                   focusable={false}
-                  height={61}
+                  height={55}
                   meetOrSlice={0}
                   minX={-8}
                   minY={-8}
@@ -537,8 +537,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       },
                       {
                         "flex": 0,
-                        "height": 61,
-                        "width": 61,
+                        "height": 55,
+                        "width": 55,
                       },
                     ]
                   }
@@ -549,9 +549,9 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       },
                     ]
                   }
-                  vbHeight={61}
-                  vbWidth={61}
-                  width={61}
+                  vbHeight={55}
+                  vbWidth={55}
+                  width={55}
                 >
                   <RNSVGGroup
                     fill={
@@ -562,8 +562,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     }
                   >
                     <RNSVGCircle
-                      cx={22.5}
-                      cy={22.5}
+                      cx={19.5}
+                      cy={19.5}
                       fill={
                         {
                           "payload": 0,
@@ -581,7 +581,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                           "strokeLinecap",
                         ]
                       }
-                      r={24}
+                      r={21}
                       stroke={
                         {
                           "payload": 4278251938,
@@ -590,11 +590,11 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       }
                       strokeDasharray={
                         [
-                          150.79644737231007,
-                          150.79644737231007,
+                          131.94689145077132,
+                          131.94689145077132,
                         ]
                       }
-                      strokeDashoffset={147.78051842486386}
+                      strokeDashoffset={129.3079536217559}
                       strokeLinecap={1}
                       strokeWidth={4}
                     />
@@ -603,12 +603,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                 <View
                   style={
                     {
-                      "height": 45,
+                      "height": 39,
                       "marginBottom": 0,
                       "marginLeft": 0,
                       "marginRight": 0,
                       "marginTop": 0,
-                      "width": 45,
+                      "width": 39,
                     }
                   }
                 >
@@ -616,9 +616,9 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     style={
                       {
                         "backgroundColor": "#000000",
-                        "borderRadius": 22.5,
+                        "borderRadius": 19.5,
                         "elevation": 0,
-                        "height": 45,
+                        "height": 39,
                         "shadowColor": "#000000",
                         "shadowOffset": {
                           "height": 3,
@@ -626,7 +626,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         },
                         "shadowOpacity": 0.6,
                         "shadowRadius": 4,
-                        "width": 45,
+                        "width": 39,
                       }
                     }
                   >
@@ -674,8 +674,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     "flexDirection": "column",
                     "flexGrow": 1,
                     "flexShrink": 1,
-                    "marginLeft": 11,
-                    "marginRight": 6,
+                    "marginLeft": 10,
+                    "marginRight": 5,
                   }
                 }
               >
@@ -698,7 +698,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -721,12 +721,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
+                        "fontSize": 15,
                       },
                       null,
                     ]
@@ -752,7 +752,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -769,7 +769,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -799,12 +799,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
+                          "fontSize": 15,
                         },
                         null,
                       ]
@@ -818,7 +818,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
             <View
               style={
                 {
-                  "margin": 11,
+                  "margin": 10,
                   "marginTop": 0,
                 }
               }
@@ -834,7 +834,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       "marginBottom": 0,
                       "marginLeft": 0,
                       "marginRight": 0,
-                      "marginTop": 17,
+                      "marginTop": 15,
                     },
                   ]
                 }
@@ -857,12 +857,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
-                          "marginTop": 6,
+                          "fontSize": 15,
+                          "marginTop": 5,
                         },
                         null,
                       ]
@@ -874,7 +874,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                 <View
                   style={
                     {
-                      "marginLeft": 6,
+                      "marginLeft": 5,
                       "textAlign": "right",
                     }
                   }
@@ -888,12 +888,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
-                          "marginTop": 6,
+                          "fontSize": 15,
+                          "marginTop": 5,
                         },
                         null,
                       ]
@@ -932,12 +932,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
-                          "marginTop": 6,
+                          "fontSize": 15,
+                          "marginTop": 5,
                         },
                         null,
                       ]
@@ -949,7 +949,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                 <View
                   style={
                     {
-                      "marginLeft": 6,
+                      "marginLeft": 5,
                       "textAlign": "right",
                     }
                   }
@@ -963,12 +963,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
-                          "fontSize": 17,
-                          "marginTop": 6,
+                          "fontSize": 15,
+                          "marginTop": 5,
                         },
                         null,
                       ]
@@ -1010,8 +1010,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                 "flexDirection": "row",
                 "flexGrow": 1,
                 "justifyContent": "space-between",
-                "marginVertical": 11,
-                "paddingHorizontal": 11,
+                "marginVertical": 10,
+                "paddingHorizontal": 10,
               }
             }
           >
@@ -1033,15 +1033,15 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                   {
                     "color": "#FFFFFF",
                     "fontFamily": "Quicksand-Regular",
-                    "fontSize": 22,
+                    "fontSize": 20,
                     "includeFontPadding": false,
                   },
                   [
                     {
                       "color": "#3dd9f4",
                       "fontFamily": "Quicksand-Medium",
-                      "fontSize": 22,
-                      "paddingHorizontal": 17,
+                      "fontSize": 20,
+                      "paddingHorizontal": 15,
                     },
                     {
                       "textTransform": "lowercase",
@@ -1111,16 +1111,16 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                   "borderRadius": 16,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
                 {
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 },
                 undefined,
               ]
@@ -1149,10 +1149,10 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     "justifyContent": "center",
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -1160,10 +1160,10 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
               <View>
                 <RNSVGSvgView
                   align="xMidYMid"
-                  bbHeight={61}
-                  bbWidth={61}
+                  bbHeight={55}
+                  bbWidth={55}
                   focusable={false}
-                  height={61}
+                  height={55}
                   meetOrSlice={0}
                   minX={-8}
                   minY={-8}
@@ -1185,8 +1185,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       },
                       {
                         "flex": 0,
-                        "height": 61,
-                        "width": 61,
+                        "height": 55,
+                        "width": 55,
                       },
                     ]
                   }
@@ -1197,9 +1197,9 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       },
                     ]
                   }
-                  vbHeight={61}
-                  vbWidth={61}
-                  width={61}
+                  vbHeight={55}
+                  vbWidth={55}
+                  width={55}
                 >
                   <RNSVGGroup
                     fill={
@@ -1210,8 +1210,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     }
                   >
                     <RNSVGCircle
-                      cx={22.5}
-                      cy={22.5}
+                      cx={19.5}
+                      cy={19.5}
                       fill={
                         {
                           "payload": 0,
@@ -1229,7 +1229,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                           "strokeLinecap",
                         ]
                       }
-                      r={24}
+                      r={21}
                       stroke={
                         {
                           "payload": 4278251938,
@@ -1238,11 +1238,11 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       }
                       strokeDasharray={
                         [
-                          150.79644737231007,
-                          150.79644737231007,
+                          131.94689145077132,
+                          131.94689145077132,
                         ]
                       }
-                      strokeDashoffset={147.78051842486386}
+                      strokeDashoffset={129.3079536217559}
                       strokeLinecap={1}
                       strokeWidth={4}
                     />
@@ -1251,12 +1251,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                 <View
                   style={
                     {
-                      "height": 45,
+                      "height": 39,
                       "marginBottom": 0,
                       "marginLeft": 0,
                       "marginRight": 0,
                       "marginTop": 0,
-                      "width": 45,
+                      "width": 39,
                     }
                   }
                 >
@@ -1264,9 +1264,9 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     style={
                       {
                         "backgroundColor": "#000000",
-                        "borderRadius": 22.5,
+                        "borderRadius": 19.5,
                         "elevation": 0,
-                        "height": 45,
+                        "height": 39,
                         "shadowColor": "#000000",
                         "shadowOffset": {
                           "height": 3,
@@ -1274,7 +1274,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         },
                         "shadowOpacity": 0.6,
                         "shadowRadius": 4,
-                        "width": 45,
+                        "width": 39,
                       }
                     }
                   >
@@ -1322,8 +1322,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     "flexDirection": "column",
                     "flexGrow": 1,
                     "flexShrink": 1,
-                    "marginLeft": 11,
-                    "marginRight": 6,
+                    "marginLeft": 10,
+                    "marginRight": 5,
                   }
                 }
               >
@@ -1346,7 +1346,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -1369,12 +1369,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
+                        "fontSize": 15,
                       },
                       null,
                     ]
@@ -1400,7 +1400,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       undefined,
@@ -1417,7 +1417,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -1447,12 +1447,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
                           "color": "#3dd9f4",
-                          "fontSize": 17,
+                          "fontSize": 15,
                         },
                         null,
                       ]
@@ -1545,15 +1545,15 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                 {
                   "alignSelf": "stretch",
                   "borderRadius": 16,
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                   "opacity": 1,
-                  "paddingBottom": 11,
-                  "paddingLeft": 11,
-                  "paddingRight": 11,
-                  "paddingTop": 11,
+                  "paddingBottom": 10,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
                 }
               }
             >
@@ -1576,7 +1576,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                   {
                     "alignItems": "center",
                     "flexDirection": "row",
-                    "marginHorizontal": 6,
+                    "marginHorizontal": 5,
                   }
                 }
               >
@@ -1588,8 +1588,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       },
                       {
                         "aspectRatio": 1,
-                        "height": 45,
-                        "width": 45,
+                        "height": 39,
+                        "width": 39,
                       },
                     ]
                   }
@@ -1617,7 +1617,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                   style={
                     {
                       "flexDirection": "column",
-                      "paddingHorizontal": 11,
+                      "paddingHorizontal": 10,
                     }
                   }
                 >
@@ -1637,12 +1637,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
+                            "fontSize": 15,
                           },
                           null,
                         ]
@@ -1659,12 +1659,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#3dd9f4",
-                            "fontSize": 17,
+                            "fontSize": 15,
                           },
                           null,
                         ]
@@ -1687,12 +1687,12 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                           {
                             "color": "#FFFFFF",
                             "fontFamily": "Quicksand-Regular",
-                            "fontSize": 22,
+                            "fontSize": 20,
                             "includeFontPadding": false,
                           },
                           {
                             "color": "#888888",
-                            "fontSize": 17,
+                            "fontSize": 15,
                           },
                           null,
                         ]
@@ -1709,7 +1709,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     [
                       {
                         "color": "#00f1a2",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       undefined,
                       {
@@ -1800,15 +1800,15 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
               {
                 "alignSelf": "stretch",
                 "borderRadius": 16,
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
                 "opacity": 1,
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -1862,7 +1862,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
             <View
               style={
                 {
-                  "margin": 11,
+                  "margin": 10,
                 }
               }
             >
@@ -1881,7 +1881,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     [
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 28,
+                        "fontSize": 25,
                       },
                       {
                         "marginRight": 4,
@@ -1906,7 +1906,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
@@ -1930,13 +1930,13 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
-                      "fontSize": 17,
-                      "marginHorizontal": 6,
-                      "marginTop": 11,
+                      "fontSize": 15,
+                      "marginHorizontal": 5,
+                      "marginTop": 10,
                     },
                     null,
                   ]
@@ -1990,8 +1990,8 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
             style={
               [
                 {
-                  "marginBottom": 67,
-                  "marginTop": 22,
+                  "marginBottom": 59,
+                  "marginTop": 20,
                 },
                 {
                   "alignItems": "center",
@@ -2123,11 +2123,11 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 34,
+                        "fontSize": 29,
                       },
                       {
                         "color": "#1a1a1a",
-                        "fontSize": 51,
+                        "fontSize": 44,
                       },
                       {
                         "fontFamily": "Entypo",
@@ -2150,13 +2150,13 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "alignSelf": "center",
                       "color": "#FFFFFF",
-                      "fontSize": 17,
+                      "fontSize": 15,
                       "lineHeight": 55,
                       "position": "absolute",
                       "zIndex": 1,
@@ -2199,9 +2199,9 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -2212,9 +2212,9 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {

--- a/src/__tests__/scenes/__snapshots__/SwapCreateScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SwapCreateScene.test.tsx.snap
@@ -237,7 +237,7 @@ exports[`SwapCreateScene should render with loading props 1`] = `
           "width": 750,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -264,7 +264,7 @@ exports[`SwapCreateScene should render with loading props 1`] = `
           "maxHeight": 1334,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -317,10 +317,10 @@ exports[`SwapCreateScene should render with loading props 1`] = `
                 "justifyContent": "center",
               },
               {
-                "marginBottom": 22,
+                "marginBottom": 20,
                 "marginLeft": 0,
                 "marginRight": 0,
-                "marginTop": 22,
+                "marginTop": 20,
               },
             ]
           }
@@ -348,10 +348,10 @@ exports[`SwapCreateScene should render with loading props 1`] = `
             focusable={true}
             hitSlop={
               {
-                "bottom": 11,
+                "bottom": 10,
                 "left": 10000,
                 "right": 10000,
-                "top": 11,
+                "top": 10,
               }
             }
             onClick={[Function]}
@@ -364,12 +364,12 @@ exports[`SwapCreateScene should render with loading props 1`] = `
             style={
               {
                 "alignItems": "center",
-                "borderRadius": 34,
-                "height": 67,
+                "borderRadius": 29,
+                "height": 59,
                 "justifyContent": "center",
                 "opacity": 1,
                 "overflow": "visible",
-                "paddingHorizontal": 34,
+                "paddingHorizontal": 29,
                 "paddingVertical": 0,
                 "position": "relative",
               }
@@ -397,7 +397,7 @@ exports[`SwapCreateScene should render with loading props 1`] = `
               }
               style={
                 {
-                  "borderRadius": 34,
+                  "borderRadius": 29,
                   "bottom": 0,
                   "left": 0,
                   "position": "absolute",
@@ -425,7 +425,7 @@ exports[`SwapCreateScene should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     [
@@ -435,7 +435,7 @@ exports[`SwapCreateScene should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ],
@@ -478,8 +478,8 @@ exports[`SwapCreateScene should render with loading props 1`] = `
               "flexDirection": "row",
               "flexGrow": 1,
               "justifyContent": "space-between",
-              "marginVertical": 11,
-              "paddingHorizontal": 11,
+              "marginVertical": 10,
+              "paddingHorizontal": 10,
             }
           }
         >
@@ -528,8 +528,8 @@ exports[`SwapCreateScene should render with loading props 1`] = `
                 "marginTop": 0,
                 "opacity": 1,
                 "paddingBottom": 0,
-                "paddingLeft": 11,
-                "paddingRight": 11,
+                "paddingLeft": 10,
+                "paddingRight": 10,
                 "paddingTop": 0,
               }
             }
@@ -546,7 +546,7 @@ exports[`SwapCreateScene should render with loading props 1`] = `
                   },
                   {
                     "color": "#00f1a2",
-                    "fontSize": 45,
+                    "fontSize": 39,
                   },
                   {
                     "fontFamily": "Ionicons",
@@ -618,10 +618,10 @@ exports[`SwapCreateScene should render with loading props 1`] = `
                 "justifyContent": "center",
               },
               {
-                "marginBottom": 22,
+                "marginBottom": 20,
                 "marginLeft": 0,
                 "marginRight": 0,
-                "marginTop": 22,
+                "marginTop": 20,
               },
             ]
           }
@@ -649,10 +649,10 @@ exports[`SwapCreateScene should render with loading props 1`] = `
             focusable={true}
             hitSlop={
               {
-                "bottom": 11,
+                "bottom": 10,
                 "left": 10000,
                 "right": 10000,
-                "top": 11,
+                "top": 10,
               }
             }
             onClick={[Function]}
@@ -665,12 +665,12 @@ exports[`SwapCreateScene should render with loading props 1`] = `
             style={
               {
                 "alignItems": "center",
-                "borderRadius": 34,
-                "height": 67,
+                "borderRadius": 29,
+                "height": 59,
                 "justifyContent": "center",
                 "opacity": 1,
                 "overflow": "visible",
-                "paddingHorizontal": 34,
+                "paddingHorizontal": 29,
                 "paddingVertical": 0,
                 "position": "relative",
               }
@@ -698,7 +698,7 @@ exports[`SwapCreateScene should render with loading props 1`] = `
               }
               style={
                 {
-                  "borderRadius": 34,
+                  "borderRadius": 29,
                   "bottom": 0,
                   "left": 0,
                   "position": "absolute",
@@ -726,7 +726,7 @@ exports[`SwapCreateScene should render with loading props 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     [
@@ -736,7 +736,7 @@ exports[`SwapCreateScene should render with loading props 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ],
@@ -856,9 +856,9 @@ exports[`SwapCreateScene should render with loading props 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -869,9 +869,9 @@ exports[`SwapCreateScene should render with loading props 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {

--- a/src/__tests__/scenes/__snapshots__/SwapSuccessScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SwapSuccessScene.test.tsx.snap
@@ -251,13 +251,13 @@ exports[`SwapSuccessSceneComponent should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
-              "fontSize": 28,
+              "fontSize": 25,
               "fontWeight": "600",
-              "marginBottom": 28,
+              "marginBottom": 25,
               "textAlign": "center",
               "width": "100%",
             },
@@ -276,14 +276,14 @@ exports[`SwapSuccessSceneComponent should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             {
-              "fontSize": 17,
+              "fontSize": 15,
               "fontWeight": "600",
-              "marginBottom": 34,
-              "maxWidth": 225,
+              "marginBottom": 29,
+              "maxWidth": 197,
               "textAlign": "center",
             },
             null,
@@ -301,19 +301,19 @@ exports[`SwapSuccessSceneComponent should render with loading props 1`] = `
             {
               "color": "#FFFFFF",
               "fontFamily": "Quicksand-Regular",
-              "fontSize": 22,
+              "fontSize": 20,
               "includeFontPadding": false,
             },
             [
               {
-                "fontSize": 17,
+                "fontSize": 15,
                 "fontWeight": "600",
-                "marginBottom": 34,
-                "maxWidth": 225,
+                "marginBottom": 29,
+                "maxWidth": 197,
                 "textAlign": "center",
               },
               {
-                "maxWidth": 213,
+                "maxWidth": 187,
               },
             ],
             null,
@@ -350,9 +350,9 @@ exports[`SwapSuccessSceneComponent should render with loading props 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -363,9 +363,9 @@ exports[`SwapSuccessSceneComponent should render with loading props 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {

--- a/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`TransactionDetailsScene should render 1`] = `
           "width": 750,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -218,7 +218,7 @@ exports[`TransactionDetailsScene should render 1`] = `
           "maxHeight": 1334,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -271,16 +271,16 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -311,10 +311,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                   "flexShrink": 1,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
               ]
             }
@@ -326,10 +326,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "overflow": "hidden",
                   },
                   {
-                    "borderRadius": 22,
-                    "height": 45,
-                    "marginRight": 11,
-                    "width": 45,
+                    "borderRadius": 20,
+                    "height": 39,
+                    "marginRight": 10,
+                    "width": 39,
                   },
                 ]
               }
@@ -361,7 +361,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginRight": 34,
+                    "marginRight": 29,
                   },
                 ]
               }
@@ -376,13 +376,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
-                      "paddingRight": 22,
+                      "fontSize": 15,
+                      "paddingRight": 20,
                     },
                     null,
                   ]
@@ -399,7 +399,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     undefined,
@@ -457,11 +457,11 @@ exports[`TransactionDetailsScene should render 1`] = `
                   [
                     {
                       "color": undefined,
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     {
                       "color": "#00f1a2",
-                      "marginLeft": 11,
+                      "marginLeft": 10,
                       "textAlign": "center",
                     },
                     {
@@ -526,16 +526,16 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -580,10 +580,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -611,13 +611,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -635,12 +635,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -678,7 +678,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -694,10 +694,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -710,7 +710,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -725,13 +725,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -756,7 +756,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -775,7 +775,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -834,11 +834,11 @@ exports[`TransactionDetailsScene should render 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -882,7 +882,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -898,10 +898,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -929,13 +929,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -960,7 +960,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -979,7 +979,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -998,7 +998,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -1041,7 +1041,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -1057,10 +1057,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -1088,13 +1088,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -1112,12 +1112,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -1155,7 +1155,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -1171,10 +1171,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -1202,13 +1202,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -1226,12 +1226,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -1291,16 +1291,16 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -1345,10 +1345,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -1361,7 +1361,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -1376,13 +1376,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -1400,12 +1400,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -1461,11 +1461,11 @@ exports[`TransactionDetailsScene should render 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -1509,7 +1509,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -1525,10 +1525,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -1541,7 +1541,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -1556,13 +1556,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -1580,12 +1580,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -1641,11 +1641,11 @@ exports[`TransactionDetailsScene should render 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -1789,16 +1789,16 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -1843,10 +1843,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -1859,7 +1859,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -1874,13 +1874,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -1898,12 +1898,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -1959,11 +1959,11 @@ exports[`TransactionDetailsScene should render 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -2029,16 +2029,16 @@ exports[`TransactionDetailsScene should render 1`] = `
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -2083,10 +2083,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -2099,7 +2099,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -2114,13 +2114,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -2138,12 +2138,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -2199,11 +2199,11 @@ exports[`TransactionDetailsScene should render 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -2249,7 +2249,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -2265,10 +2265,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -2281,7 +2281,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -2296,13 +2296,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -2320,12 +2320,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -2381,11 +2381,11 @@ exports[`TransactionDetailsScene should render 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -2429,7 +2429,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -2445,10 +2445,10 @@ exports[`TransactionDetailsScene should render 1`] = `
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -2461,7 +2461,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -2476,13 +2476,13 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -2500,12 +2500,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -2561,11 +2561,11 @@ exports[`TransactionDetailsScene should render 1`] = `
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -2635,9 +2635,9 @@ exports[`TransactionDetailsScene should render 1`] = `
               "flexGrow": 1,
               "flexShrink": 0,
               "justifyContent": "flex-end",
-              "margin": 11,
-              "marginBottom": 67,
-              "marginTop": 22,
+              "margin": 10,
+              "marginBottom": 59,
+              "marginTop": 20,
             }
           }
         >
@@ -2682,7 +2682,7 @@ exports[`TransactionDetailsScene should render 1`] = `
               accessible={true}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -2694,12 +2694,12 @@ exports[`TransactionDetailsScene should render 1`] = `
                 {
                   "alignItems": "center",
                   "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "height": 67,
+                  "borderRadius": 29,
+                  "height": 59,
                   "justifyContent": "center",
                   "opacity": 1,
                   "overflow": "visible",
-                  "paddingHorizontal": 34,
+                  "paddingHorizontal": 29,
                   "paddingVertical": 0,
                   "position": "relative",
                 }
@@ -2727,7 +2727,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                 }
                 style={
                   {
-                    "borderRadius": 34,
+                    "borderRadius": 29,
                     "bottom": 0,
                     "left": 0,
                     "position": "absolute",
@@ -2755,7 +2755,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       [
@@ -2765,7 +2765,7 @@ exports[`TransactionDetailsScene should render 1`] = `
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Medium",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ],
@@ -2808,9 +2808,9 @@ exports[`TransactionDetailsScene should render 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -2821,9 +2821,9 @@ exports[`TransactionDetailsScene should render 1`] = `
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {
@@ -3031,7 +3031,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
           "width": 750,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -3057,7 +3057,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
           "maxHeight": 1334,
         },
         {
-          "padding": 11,
+          "padding": 10,
         },
       ]
     }
@@ -3110,16 +3110,16 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -3150,10 +3150,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                   "flexShrink": 1,
                 },
                 {
-                  "marginBottom": 11,
-                  "marginLeft": 11,
-                  "marginRight": 11,
-                  "marginTop": 11,
+                  "marginBottom": 10,
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                  "marginTop": 10,
                 },
               ]
             }
@@ -3165,10 +3165,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "overflow": "hidden",
                   },
                   {
-                    "borderRadius": 22,
-                    "height": 45,
-                    "marginRight": 11,
-                    "width": 45,
+                    "borderRadius": 20,
+                    "height": 39,
+                    "marginRight": 10,
+                    "width": 39,
                   },
                 ]
               }
@@ -3200,7 +3200,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginRight": 34,
+                    "marginRight": 29,
                   },
                 ]
               }
@@ -3215,13 +3215,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     {
                       "color": "#3dd9f4",
-                      "fontSize": 17,
-                      "paddingRight": 22,
+                      "fontSize": 15,
+                      "paddingRight": 20,
                     },
                     null,
                   ]
@@ -3238,7 +3238,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     {
                       "color": "#FFFFFF",
                       "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
+                      "fontSize": 20,
                       "includeFontPadding": false,
                     },
                     undefined,
@@ -3296,11 +3296,11 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                   [
                     {
                       "color": undefined,
-                      "fontSize": 22,
+                      "fontSize": 20,
                     },
                     {
                       "color": "#00f1a2",
-                      "marginLeft": 11,
+                      "marginLeft": 10,
                       "textAlign": "center",
                     },
                     {
@@ -3365,16 +3365,16 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -3419,10 +3419,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -3450,13 +3450,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -3474,12 +3474,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -3517,7 +3517,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -3533,10 +3533,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -3549,7 +3549,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -3564,13 +3564,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -3595,7 +3595,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -3614,7 +3614,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -3673,11 +3673,11 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -3721,7 +3721,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -3737,10 +3737,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -3768,13 +3768,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -3799,7 +3799,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -3818,7 +3818,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         undefined,
@@ -3837,7 +3837,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Regular",
-                          "fontSize": 22,
+                          "fontSize": 20,
                           "includeFontPadding": false,
                         },
                         {
@@ -3880,7 +3880,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -3896,10 +3896,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -3927,13 +3927,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -3951,12 +3951,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -3994,7 +3994,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -4010,10 +4010,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -4041,13 +4041,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -4065,12 +4065,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -4130,16 +4130,16 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -4184,10 +4184,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -4200,7 +4200,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -4215,13 +4215,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -4239,12 +4239,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -4300,11 +4300,11 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -4348,7 +4348,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -4364,10 +4364,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -4380,7 +4380,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -4395,13 +4395,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -4419,12 +4419,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -4480,11 +4480,11 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -4628,16 +4628,16 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -4682,10 +4682,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -4698,7 +4698,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -4713,13 +4713,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -4737,12 +4737,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -4798,11 +4798,11 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -4868,16 +4868,16 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 "borderRadius": 16,
               },
               {
-                "marginBottom": 11,
-                "marginLeft": 11,
-                "marginRight": 11,
-                "marginTop": 11,
+                "marginBottom": 10,
+                "marginLeft": 10,
+                "marginRight": 10,
+                "marginTop": 10,
               },
               {
-                "paddingBottom": 11,
-                "paddingLeft": 11,
-                "paddingRight": 11,
-                "paddingTop": 11,
+                "paddingBottom": 10,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
               },
               undefined,
             ]
@@ -4922,10 +4922,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -4938,7 +4938,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -4953,13 +4953,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -4977,12 +4977,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -5038,11 +5038,11 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -5088,7 +5088,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -5104,10 +5104,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -5120,7 +5120,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -5135,13 +5135,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -5159,12 +5159,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -5220,11 +5220,11 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -5268,7 +5268,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "height": 1,
                   },
                   {
-                    "margin": 11,
+                    "margin": 10,
                   },
                 ]
               }
@@ -5284,10 +5284,10 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     "flexShrink": 1,
                   },
                   {
-                    "marginBottom": 11,
-                    "marginLeft": 11,
-                    "marginRight": 11,
-                    "marginTop": 11,
+                    "marginBottom": 10,
+                    "marginLeft": 10,
+                    "marginRight": 10,
+                    "marginTop": 10,
                   },
                 ]
               }
@@ -5300,7 +5300,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       "flexShrink": 1,
                     },
                     {
-                      "marginRight": 34,
+                      "marginRight": 29,
                     },
                   ]
                 }
@@ -5315,13 +5315,13 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#3dd9f4",
-                        "fontSize": 17,
-                        "paddingRight": 22,
+                        "fontSize": 15,
+                        "paddingRight": 20,
                       },
                       null,
                     ]
@@ -5339,12 +5339,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       {
                         "color": "#FFFFFF",
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       null,
                     ]
@@ -5400,11 +5400,11 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                     [
                       {
                         "color": undefined,
-                        "fontSize": 22,
+                        "fontSize": 20,
                       },
                       {
                         "color": "#00f1a2",
-                        "marginLeft": 11,
+                        "marginLeft": 10,
                         "textAlign": "center",
                       },
                       {
@@ -5474,9 +5474,9 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               "flexGrow": 1,
               "flexShrink": 0,
               "justifyContent": "flex-end",
-              "margin": 11,
-              "marginBottom": 67,
-              "marginTop": 22,
+              "margin": 10,
+              "marginBottom": 59,
+              "marginTop": 20,
             }
           }
         >
@@ -5521,7 +5521,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
               accessible={true}
               collapsable={false}
               focusable={true}
-              hitSlop={11}
+              hitSlop={10}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -5533,12 +5533,12 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 {
                   "alignItems": "center",
                   "alignSelf": "stretch",
-                  "borderRadius": 34,
-                  "height": 67,
+                  "borderRadius": 29,
+                  "height": 59,
                   "justifyContent": "center",
                   "opacity": 1,
                   "overflow": "visible",
-                  "paddingHorizontal": 34,
+                  "paddingHorizontal": 29,
                   "paddingVertical": 0,
                   "position": "relative",
                 }
@@ -5566,7 +5566,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                 }
                 style={
                   {
-                    "borderRadius": 34,
+                    "borderRadius": 29,
                     "bottom": 0,
                     "left": 0,
                     "position": "absolute",
@@ -5594,7 +5594,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                       {
                         "color": "#FFFFFF",
                         "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
+                        "fontSize": 20,
                         "includeFontPadding": false,
                       },
                       [
@@ -5604,7 +5604,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
                         {
                           "color": "#FFFFFF",
                           "fontFamily": "Quicksand-Medium",
-                          "fontSize": 22,
+                          "fontSize": 20,
                         },
                         null,
                       ],
@@ -5647,9 +5647,9 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
       ]
@@ -5660,9 +5660,9 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
       [
         {
           "alignSelf": "center",
-          "bottom": 11,
+          "bottom": 10,
           "justifyContent": "flex-end",
-          "paddingHorizontal": 11,
+          "paddingHorizontal": 10,
           "position": "absolute",
         },
         {

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ import NetInfo from '@react-native-community/netinfo'
 import * as Sentry from '@sentry/react-native'
 import { Buffer } from 'buffer'
 import { asObject, asString } from 'cleaners'
-import { LogBox, Text, TextInput } from 'react-native'
+import { LogBox } from 'react-native'
 import { getVersion } from 'react-native-device-info'
 import RNFS from 'react-native-fs'
 
@@ -111,23 +111,6 @@ console.log('***********************')
 
 // @ts-expect-error
 global.clog = console.log
-
-// Disable the font scaling
-// @ts-expect-error
-if (!Text.defaultProps) {
-  // @ts-expect-error
-  Text.defaultProps = {}
-}
-// @ts-expect-error
-Text.defaultProps.allowFontScaling = false
-
-// @ts-expect-error
-if (!TextInput.defaultProps) {
-  // @ts-expect-error
-  TextInput.defaultProps = {}
-}
-// @ts-expect-error
-TextInput.defaultProps.allowFontScaling = false
 
 if (!__DEV__) {
   console.log = log

--- a/src/theme/variables/edgeDark.ts
+++ b/src/theme/variables/edgeDark.ts
@@ -121,7 +121,7 @@ const deviceWidth = Dimensions.get('window').width
 
 export const edgeDark: Theme = {
   rem(size: number): number {
-    return Math.round(scale(16) * size)
+    return Math.round(scale(14) * size)
   },
   isDark: true,
   preferPrimaryButton: true,

--- a/src/theme/variables/edgeLight.ts
+++ b/src/theme/variables/edgeLight.ts
@@ -110,7 +110,7 @@ const deviceWidth = Dimensions.get('window').width
 
 export const edgeLight: Theme = {
   rem(size: number): number {
-    return Math.round(scale(16) * size)
+    return Math.round(scale(14) * size)
   },
   isDark: false,
   preferPrimaryButton: false,

--- a/src/theme/variables/testDark.ts
+++ b/src/theme/variables/testDark.ts
@@ -117,7 +117,7 @@ const deviceWidth = Dimensions.get('window').width
 
 export const testDark: Theme = {
   rem(size: number): number {
-    return Math.round(scale(16) * size)
+    return Math.round(scale(14) * size)
   },
   isDark: true,
   preferPrimaryButton: true,

--- a/src/theme/variables/testLight.ts
+++ b/src/theme/variables/testLight.ts
@@ -110,7 +110,7 @@ const deviceWidth = Dimensions.get('window').width
 
 export const testLight: Theme = {
   rem(size: number): number {
-    return Math.round(scale(16) * size)
+    return Math.round(scale(14) * size)
   },
   isDark: false,
   preferPrimaryButton: false,


### PR DESCRIPTION
Now that React Native respects the device font scaling, text is a bit larger on many phones. So, we decrease the base size to fudge around this. The 16 base size was always a little too big to begin with.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211026079011275