### PR TITLE
Jon/fix/chart gesture hack

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1072,6 +1072,7 @@ const EdgeAppStack: React.FC = () => {
 const EdgeApp: React.FC = () => {
   return (
     <Drawer.Navigator
+      id="edgeDrawer"
       drawerContent={({ navigation }) => <SideMenu navigation={navigation} />}
       initialRouteName="edgeAppStack"
       screenOptions={{

--- a/src/components/charts/SwipeChart.tsx
+++ b/src/components/charts/SwipeChart.tsx
@@ -233,13 +233,18 @@ export const SwipeChart: React.FC<Props> = props => {
   // chart. These two gestures fight with each other on Android only...
   React.useEffect(() => {
     if (Platform.OS !== 'android') return
-    const parent = navigation?.getParent?.()
-    if (parent == null) return
-    parent.setOptions({ swipeEnabled: !isCursorActive })
+    const parent = navigation?.getParent?.('edgeDrawer')
+
+    if (parent == null) {
+      console.error('SwipeChart: no parent for Android swipe detection.')
+      return
+    }
+    parent.setOptions({ swipeEnabled: false })
+
     return () => {
       parent.setOptions({ swipeEnabled: true })
     }
-  }, [navigation, isCursorActive])
+  }, [navigation])
 
   // While pointer active, also disable SceneWrapper scrolling so gestures don't
   // conflict.


### PR DESCRIPTION
`WalletDetailsScene` manages its own scroll, so it needed the explicit binding to disable the scene-level scrolling while the chart gesture was active.

Unable to find a workaround to reliably dynamically resolve the chart vs drawer gesture conflict, most noticeable in `WalletDetailsScene` but also still possible under some rapid interactions in `CoinRankingDetailsScene` so the drawer gesture was simply disabled for all chart scenes. Newer androids already have a built-in gesture conflict anyway with the drawer since the swipe from right gesture is reserved for "Back" in most modern Androids, so we're not missing much by going with this approach.

iOS was left without modifications to drawer gesture functionality since it's such an "edge" case (literally). There's only a tiny area of chart pointer activation where the conflict would occur.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
