### PR TITLE
Use two rates server lists

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -550,7 +550,7 @@ export default [
       'src/util/maestro.ts',
       'src/util/memoUtils.ts',
       'src/util/middleware/perfLogger.ts',
-      'src/util/network.ts',
+
       'src/util/otpReminder.tsx',
       'src/util/scaling.ts',
       'src/util/show-confetti.ts',

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -13,11 +13,8 @@ import { runOnce } from './runOnce'
 import { asyncWaterfall, getOsVersion, shuffleArray } from './utils'
 import { checkAppVersion } from './versionCheck'
 const INFO_SERVERS = ['https://info1.edge.app', 'https://info2.edge.app']
-// const RATES_SERVERS = ['https://rates3.edge.app', 'https://rates4.edge.app']
-const RATES_SERVERS = [
-  'https://rates-wusa1.edge.app',
-  'https://rates-eusa1.edge.app'
-]
+const RATES_SERVERS = ['https://rates3.edge.app', 'https://rates4.edge.app']
+const RATES_SERVER_V2 = ['https://rates1.edge.app', 'https://rates2.edge.app']
 
 const INFO_FETCH_INTERVAL = 5 * 60 * 1000 // 5 minutes
 
@@ -95,7 +92,8 @@ export const fetchRates = async (
   timeout?: number,
   doFetch?: EdgeFetchFunction
 ): Promise<EdgeFetchResponse> => {
-  return await multiFetch(RATES_SERVERS, path, options, timeout, doFetch)
+  const servers = path.startsWith('v2') ? RATES_SERVER_V2 : RATES_SERVERS
+  return await multiFetch(servers, path, options, timeout, doFetch)
 }
 export const fetchReferral = async (
   path: string,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-rates-server/pull/115

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211309911794804