### PR TITLE
Fiat Providers Region Expansion

### DIFF
--- a/.cursor/rules/component-export.mdc
+++ b/.cursor/rules/component-export.mdc
@@ -1,4 +1,4 @@
 ---
-description: Component exports for any modified files should follow the form: `export const Component: React.FC<Props> = (props: Props) => {`
+description: Component exports for any modified files should follow the form: `export const Component: React.FC<Props> = props => {`
 alwaysApply: false
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - changed: Smoothly animate `NotificationCard` reflow
 - changed: `NotificationCard` auto-dismiss in 5s
 - changed: `NotificationCard` X button replaced with swipe-to-dismiss gesture
+- changed: Moonpay Faster Payments now supported
+- changed: Banxa ACH sell enabled
 - changed: "Recent Wallets" no longer appear in "All Wallets." "All Wallets" renamed to "Other Wallets"
 - fixed: Font scaling for displaying long addresses in `RequestScene` and `AddressTile2`
 - fixed: Mirroring in logic between `accountReferral`'s `installerId` and `accountAppleAdsAttribution`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -448,14 +448,14 @@ export default [
       'src/plugins/gui/components/GuiFormField.tsx',
       'src/plugins/gui/fiatPlugin.tsx',
       'src/plugins/gui/pluginUtils.ts',
-      'src/plugins/gui/providers/banxaProvider.ts',
+
       'src/plugins/gui/providers/bityProvider.ts',
       'src/plugins/gui/providers/ioniaProvider.ts',
       'src/plugins/gui/providers/kadoOtcProvider.ts',
       'src/plugins/gui/providers/kadoProvider.ts',
       'src/plugins/gui/providers/moonpayProvider.ts',
       'src/plugins/gui/providers/mtpelerinProvider.ts',
-      'src/plugins/gui/providers/paybisProvider.ts',
+
       'src/plugins/gui/providers/revolutProvider.ts',
       'src/plugins/gui/providers/simplexProvider.ts',
       'src/plugins/gui/RewardsCardPlugin.tsx',

--- a/src/constants/plugins/sellPluginList.json
+++ b/src/constants/plugins/sellPluginList.json
@@ -147,8 +147,7 @@
     ],
     "description": "Fee: ~1.5%\nSettlement: 1 hour - 24 hours",
     "title": "Faster Payments",
-    "forCountries": [
-    ],
+    "forCountries": ["GB"],
     "cryptoCodes": [],
     "paymentTypeLogoKey": "bank"
   },

--- a/src/plugins/gui/providers/banxaProvider.ts
+++ b/src/plugins/gui/providers/banxaProvider.ts
@@ -71,6 +71,7 @@ const allowedPaymentTypes: AllowedPaymentTypes = {
     turkishbank: true
   },
   sell: {
+    ach: true,
     directtobank: true,
     fasterpayments: true,
     interac: true,
@@ -133,7 +134,8 @@ const asBanxaPaymentType = asValue(
   'MONOOVAPAYID',
   'PRIMERAP',
   'PRIMERCC',
-  'WORLDPAYGOOGLE'
+  'WORLDPAYGOOGLE',
+  'ZHACHSELL'
 )
 
 const asBanxaStatus = asValue('ACTIVE', 'INACTIVE')
@@ -1092,7 +1094,8 @@ const typeMap: Record<BanxaPaymentType, FiatPaymentType> = {
   MONOOVAPAYID: 'payid',
   PRIMERAP: 'applepay',
   PRIMERCC: 'credit',
-  WORLDPAYGOOGLE: 'googlepay'
+  WORLDPAYGOOGLE: 'googlepay',
+  ZHACHSELL: 'ach'
 }
 
 // While this could use Array.find(), this is an inner loop routine used hundreds of times interating over

--- a/src/plugins/gui/providers/moonpayProvider.ts
+++ b/src/plugins/gui/providers/moonpayProvider.ts
@@ -70,7 +70,8 @@ const allowedCurrencyCodes: Record<
     ach: { providerId, fiat: {}, crypto: {} },
     credit: { providerId, fiat: {}, crypto: {} },
     paypal: { providerId, fiat: {}, crypto: {} },
-    venmo: { providerId, fiat: {}, crypto: {} }
+    venmo: { providerId, fiat: {}, crypto: {} },
+    fasterpayments: { providerId, fiat: {}, crypto: {} }
   }
 }
 const allowedCountryCodes: Record<FiatDirection, FiatProviderExactRegions> = {
@@ -152,6 +153,7 @@ type MoonpayPaymentMethod =
   | 'credit_debit_card'
   | 'paypal'
   | 'venmo'
+  | 'gbp_bank_transfer'
 
 interface MoonpayWidgetQueryParams {
   apiKey: string
@@ -200,7 +202,8 @@ const MOONPAY_PAYMENT_TYPE_MAP: Partial<
   googlepay: 'credit_debit_card',
   ach: 'ach_bank_transfer',
   paypal: 'paypal',
-  venmo: 'venmo'
+  venmo: 'venmo',
+  fasterpayments: 'gbp_bank_transfer'
 }
 
 const NETWORK_CODE_PLUGINID_MAP: StringMap = {

--- a/src/plugins/gui/providers/paybisProvider.ts
+++ b/src/plugins/gui/providers/paybisProvider.ts
@@ -466,12 +466,7 @@ export const paybisProvider: FiatProviderFactory = {
         regionCode
       }): Promise<FiatProviderAssetMap> => {
         // Do not allow sell to debit in US, disable all UK
-        if (
-          regionCode.countryCode === 'GB' ||
-          (direction === 'sell' &&
-            paymentTypes.includes('credit') &&
-            regionCode.countryCode === 'US')
-        ) {
+        if (regionCode.countryCode === 'GB') {
           throw new FiatProviderError({
             providerId,
             errorType: 'paymentUnsupported'
@@ -762,11 +757,11 @@ export const paybisProvider: FiatProviderFactory = {
             const addresses = await coreWallet.getAddresses({ tokenId: null })
             const [defaultAddress] = addresses
             assert(defaultAddress != null, 'Paybis: Missing receive address')
-            const segwitAddresses = addresses.find(
+            const segwitAddress = addresses.find(
               row => row.addressType === 'segwitAddress'
             )
             const receivePublicAddress =
-              segwitAddresses?.publicAddress ?? defaultAddress.publicAddress
+              segwitAddress?.publicAddress ?? defaultAddress.publicAddress
 
             let bodyParams
             if (direction === 'buy') {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211378716912712
  - https://app.asana.com/0/0/1211339212811158

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Banxa ACH sell support and Moonpay Faster Payments (UK), with provider address handling and webview/deeplink flow refinements.
> 
> - **Fiat Providers**:
>   - **Banxa (`banxaProvider.ts`)**: Enable `sell.ach`; add Banxa payment type→`ach` mapping; switch polling to `setInterval`; prefer segwit receive addresses; tighten types and error handling.
>   - **Moonpay (`moonpayProvider.ts`)**: Add Faster Payments (`gbp_bank_transfer`) mapping and support (sell); improve deeplink/webview handlers and validation; minor fetch/US support checks refined.
>   - **Paybis (`paybisProvider.ts`)**: Prefer segwit receive addresses; harden deeplink/onUrlChange handlers and logging.
> - **Config**:
>   - `src/constants/plugins/sellPluginList.json`: Restrict `fasterpayments` to `GB`.
> - **CHANGELOG**: Note Moonpay Faster Payments support and Banxa ACH sell enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0e10aede9dcb7039b3102d6fe55828c617de75b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->