### PR TITLE
Update "Recent Wallets"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - changed: Smoothly animate `NotificationCard` reflow
 - changed: `NotificationCard` auto-dismiss in 5s
 - changed: `NotificationCard` X button replaced with swipe-to-dismiss gesture
+- changed: "Recent Wallets" no longer appear in "All Wallets." "All Wallets" renamed to "Other Wallets"
 - fixed: Font scaling for displaying long addresses in `RequestScene` and `AddressTile2`
 - fixed: Mirroring in logic between `accountReferral`'s `installerId` and `accountAppleAdsAttribution`
 - fixed: Currency mapping for `simplexProvider`

--- a/src/components/themed/WalletList.tsx
+++ b/src/components/themed/WalletList.tsx
@@ -4,6 +4,7 @@ import type { ViewStyle } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 
 import { selectWalletToken } from '../../actions/WalletActions'
+import { useHandler } from '../../hooks/useHandler'
 import { lstrings } from '../../locales/strings'
 import {
   filterWalletCreateItemListBySearchText,
@@ -14,7 +15,6 @@ import { useDispatch, useSelector } from '../../types/reactRedux'
 import type { NavigationBase } from '../../types/routerTypes'
 import type { EdgeAsset, FlatListItem, WalletListItem } from '../../types/types'
 import { checkAssetFilter } from '../../util/CurrencyInfoHelpers'
-import { showError } from '../services/AirshipInstance'
 import { searchWalletList } from '../services/SortedWalletList'
 import { useTheme } from '../services/ThemeContext'
 import { ModalFooter } from './ModalParts'
@@ -40,14 +40,14 @@ interface Props {
   parentWalletId?: string
 
   // Callbacks:
-  onPress?: (walletId: string, tokenId: EdgeTokenId) => Promise<void>
+  onPress?: (walletId: string, tokenId: EdgeTokenId) => Promise<void> | void
 }
 
 /**
  * This list is used inside the wallet list modal,
  * and *only* the wallet list modal.
  */
-export function WalletList(props: Props) {
+export const WalletList: React.FC<Props> = (props: Props) => {
   const dispatch = useDispatch()
   const {
     navigation,
@@ -78,22 +78,19 @@ export function WalletList(props: Props) {
   )
   const sortedWalletList = useSelector(state => state.sortedWalletList)
 
-  const handlePress = React.useMemo(
-    () =>
-      onPress ??
-      ((walletId: string, tokenId: EdgeTokenId): void => {
-        dispatch(selectWalletToken({ navigation, walletId, tokenId })).catch(
-          (error: unknown) => {
-            showError(error)
-          }
-        )
-      }),
-    [dispatch, navigation, onPress]
+  const handlePress = useHandler(
+    async (walletId: string, tokenId: EdgeTokenId) => {
+      if (onPress != null) {
+        await onPress(walletId, tokenId)
+      } else {
+        await dispatch(selectWalletToken({ navigation, walletId, tokenId }))
+      }
+    }
   )
 
   // Filter the common wallet list:
   const filteredWalletList = React.useMemo(() => {
-    const excludeWalletSet = new Set<string>(excludeWalletIds)
+    const excludeWalletSet = new Set<string>(excludeWalletIds ?? [])
     const allowedWalletSet = new Set<string>(allowedWalletIds ?? [])
 
     return sortedWalletList.filter(item => {
@@ -153,7 +150,7 @@ export function WalletList(props: Props) {
   const recentWalletList = React.useMemo(() => {
     const out: WalletListItem[] = []
 
-    function pickLength() {
+    const pickLength = (): number => {
       if (filteredWalletList.length > 10) return 3
       if (filteredWalletList.length > 4) return 2
       return 0
@@ -204,18 +201,31 @@ export function WalletList(props: Props) {
   const walletList = React.useMemo<
     Array<WalletListItem | WalletCreateItem | string>
   >(() => {
-    const walletList: Array<WalletListItem | WalletCreateItem> = [
+    const walletItems: Array<WalletListItem | WalletCreateItem> = [
       // Search the wallet list:
       ...searchWalletList(filteredWalletList, searchText)
     ]
 
     // Show the create-wallet list, filtered by the search term:
-    walletList.push(...createWalletList)
+    walletItems.push(...createWalletList)
 
     // Show a flat list if we are searching, or have no recent wallets:
     if (searchText.length > 0 || recentWalletList.length === 0) {
-      return walletList
+      return walletItems
     }
+
+    const recentAssetKeySet = new Set(
+      recentWalletList.flatMap(item => {
+        if (item.type !== 'asset') return []
+        return [`${item.wallet.id}::${item.tokenId ?? ''}`]
+      })
+    )
+
+    const nonRecentWalletItems = walletItems.filter(item => {
+      if (item.type !== 'asset') return true
+      const key = `${item.wallet.id}::${item.tokenId ?? ''}`
+      return !recentAssetKeySet.has(key)
+    })
 
     return [
       // Parent section and wallet, if defined
@@ -223,8 +233,8 @@ export function WalletList(props: Props) {
       // Show a sectioned list with sectioned recent/all wallets:
       lstrings.wallet_list_modal_header_mru,
       ...recentWalletList,
-      lstrings.wallet_list_modal_header_all,
-      ...walletList
+      lstrings.wallet_list_modal_header_other,
+      ...nonRecentWalletItems
     ]
   }, [
     createWalletList,
@@ -258,9 +268,7 @@ export function WalletList(props: Props) {
             <WalletListCreateRow
               createItem={item.item}
               createWalletId={createWalletId}
-              onPress={async (walletId: string, tokenId: EdgeTokenId) => {
-                handlePress(walletId, tokenId)
-              }}
+              onPress={handlePress}
             />
           )
         case 'loading':

--- a/src/components/themed/WalletListCurrencyRow.tsx
+++ b/src/components/themed/WalletListCurrencyRow.tsx
@@ -26,10 +26,12 @@ interface Props {
     walletId: string,
     tokenId: EdgeTokenId,
     customAsset?: CustomAsset
-  ) => void
+  ) => Promise<void> | void
 }
 
-const WalletListCurrencyRowComponent = (props: Props) => {
+const WalletListCurrencyRowComponent = (
+  props: Props
+): React.ReactElement | null => {
   const {
     customAsset,
     token,
@@ -58,9 +60,9 @@ const WalletListCurrencyRowComponent = (props: Props) => {
   //
   // Handlers
   //
-  const handlePress = useHandler(() => {
+  const handlePress = useHandler(async () => {
     triggerHaptic('impactLight')
-    if (onPress != null) onPress(wallet.id, tokenId, customAsset)
+    if (onPress != null) await onPress(wallet.id, tokenId, customAsset)
   })
 
   const handleLongPress = useHandler(() => {

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -1141,7 +1141,7 @@ const strings = {
   exchange_slow: 'Locating a swap is taking longer than usual.\nPlease wait...',
   wallet_list_modal_header_parent: 'Parent Wallet',
   wallet_list_modal_header_mru: 'Most Recent Wallets',
-  wallet_list_modal_header_all: 'All Wallets',
+  wallet_list_modal_header_other: 'Other Wallets',
   wallet_list_modal_creating_wallet: 'Creating Wallet. Please Wait',
   wallet_list_modal_enabling_token: 'Enabling Token. Please Wait',
   wallet_list_modal_confirm_s_bank_withdrawal:

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -905,7 +905,7 @@
   "exchange_slow": "Locating a swap is taking longer than usual.\nPlease wait...",
   "wallet_list_modal_header_parent": "Parent Wallet",
   "wallet_list_modal_header_mru": "Most Recent Wallets",
-  "wallet_list_modal_header_all": "All Wallets",
+  "wallet_list_modal_header_other": "Other Wallets",
   "wallet_list_modal_creating_wallet": "Creating Wallet. Please Wait",
   "wallet_list_modal_enabling_token": "Enabling Token. Please Wait",
   "wallet_list_modal_confirm_s_bank_withdrawal": "Borrowing funds for deposit directly into a bank account requires a linked bank account with an %1$s exchange partner. Tap Continue to proceed to link a bank account. (For US users only)",


### PR DESCRIPTION
<img width="382" height="674" alt="image" src="https://github.com/user-attachments/assets/8bf65479-65fd-4262-b576-3b618a40e8fd" />

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208654467278105

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates recent wallets from the rest in the wallet picker and renames the "All Wallets" section to "Other Wallets", with handler/type refactors.
> 
> - **Wallet Picker UX**:
>   - Exclude "Most Recent Wallets" from the main list; show as separate section above "Other Wallets".
>   - Rename section header from `wallet_list_modal_header_all` ("All Wallets") to `wallet_list_modal_header_other` ("Other Wallets").
> - **Logic/Refactor**:
>   - Use `useHandler` and async `handlePress`; `onPress` now supports `Promise<void> | void` across rows.
>   - Avoid `excludeWalletIds` null issues; minor memo/var cleanups and deduping of recent assets from the rest list.
>   - Convert `WalletList` to `React.FC` and simplify row press wiring.
> - **Localization**:
>   - Update EN strings/keys to reflect "Other Wallets".
> - **Changelog**:
>   - Note UI change: recent wallets no longer appear under other wallets; section renamed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b849799a418366f1648b3ec42e719fc7400ce8c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->