### PR TITLE
Jon/fix/text autoselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed: Mirroring in logic between `accountReferral`'s `installerId` and `accountAppleAdsAttribution`
 - fixed: Currency mapping for `simplexProvider`
 - fixed: `IconButton` `superscriptLabel` styling
+- fixed: Broken `autoselect` prop in `FilledTextInput`
 
 ## 4.35.2 (2025-09-25)
 

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -259,6 +259,10 @@ export const FilledTextInput = React.forwardRef<
   function setNativeProps(nativeProps: object): void {
     if (inputRef.current != null) inputRef.current.setNativeProps(nativeProps)
   }
+  function selectAll(): void {
+    if (inputRef.current != null)
+      inputRef.current.setSelection(0, sharedDisplayValue.value.length)
+  }
   React.useImperativeHandle(ref, () => ({
     blur,
     clear,
@@ -341,9 +345,9 @@ export const FilledTextInput = React.forwardRef<
     focusAnimation.value = withTiming(1, { duration: baseDuration })
     if (autoSelect) {
       setNativeProps({
-        selection: { start: 0, end: sharedDisplayValue.value.length },
         selectTextOnFocus: true
       })
+      selectAll()
     }
     if (onFocus != null) onFocus()
   })


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `autoSelect` in `FilledTextInput` by selecting all text on focus and notes the change in the changelog.
> 
> - **UI**:
>   - **`FilledTextInput`**: Fix `autoSelect` by adding `selectAll()` (uses `setSelection`) and invoking it on focus instead of setting selection via `setNativeProps`.
> - **Docs**:
>   - Update `CHANGELOG.md` with "fixed: Broken `autoselect` prop in `FilledTextInput`".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d1d6262488afd2c2adcc8e208c514a796911580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211501068778534