### PR TITLE
Fix `IconButton` `superscriptLabel` styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed: Font scaling for displaying long addresses in `RequestScene` and `AddressTile2`
 - fixed: Mirroring in logic between `accountReferral`'s `installerId` and `accountAppleAdsAttribution`
 - fixed: Currency mapping for `simplexProvider`
+- fixed: `IconButton` `superscriptLabel` styling
 
 ## 4.35.2 (2025-09-25)
 

--- a/src/components/buttons/IconButton.tsx
+++ b/src/components/buttons/IconButton.tsx
@@ -31,7 +31,7 @@ export interface Props {
  * Renders the superScriptLabel in the top right in a primary button style
  * container, if given.
  */
-export const IconButton = (props: Props) => {
+export const IconButton: React.FC<Props> = props => {
   const {
     children,
     disabled,
@@ -79,6 +79,7 @@ export const IconButton = (props: Props) => {
                 Platform.OS === 'android' ? styles.androidAdjust : null
               ]}
               disableFontScaling
+              numberOfLines={1}
             >
               {superscriptLabel}
             </EdgeText>
@@ -119,15 +120,15 @@ const getStyles = cacheStyles((theme: Theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     paddingVertical: 0,
-    transform: [{ translateX: theme.rem(1) }],
-    paddingLeft: theme.rem(0.5),
-    paddingRight: theme.rem(0.5) - 2
+    transform: [{ translateX: theme.rem(1) }]
   },
   label: {
     textAlign: 'center'
   },
   superscriptLabel: {
-    fontSize: theme.rem(0.75)
+    fontSize: theme.rem(0.75),
+    marginLeft: theme.rem(0.5),
+    marginRight: theme.rem(0.5) - 2
   },
   androidAdjust: {
     marginTop: 1


### PR DESCRIPTION
<img width="847" height="291" alt="image" src="https://github.com/user-attachments/assets/d599476b-3258-4863-9df9-93fd7fb44761" />

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes IconButton superscriptLabel spacing and ensures it truncates to a single line; updates CHANGELOG.
> 
> - **UI**:
>   - **`src/components/buttons/IconButton.tsx`**:
>     - Type: export as `React.FC<Props>`.
>     - Superscript: add `numberOfLines={1}` to prevent wrapping.
>     - Styles: shift padding from `superScriptContainer` to `superscriptLabel` margins; remove container left/right padding to correct spacing.
> - **Docs**:
>   - Update `CHANGELOG.md` with fix entry for `IconButton` `superscriptLabel` styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ba3930d7348c01f6ca386d954b00b9c159d7de5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211501068778527