### PR TITLE
Allow clearing of memo values when submitting empty input in `SendScene2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - changed: Smoothly animate `NotificationCard` reflow
 - changed: `NotificationCard` auto-dismiss in 5s
 - changed: `NotificationCard` X button replaced with swipe-to-dismiss gesture
+- changed: Allow clearing of memo values when submitting empty input in `SendScene2`
 - changed: Moonpay Faster Payments now supported
 - changed: Banxa ACH sell enabled
 - changed: "Recent Wallets" no longer appear in "All Wallets." "All Wallets" renamed to "Other Wallets"


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Submitting an empty memo now clears the selected memo (and legacy unique identifier) in SendScene2.
> 
> - **SendScene2**:
>   - Allow empty memo submission to clear the corresponding `spendInfo.memos` entry; if legacy, also clear `spendTarget.memo` and `spendTarget.uniqueIdentifier`.
>   - Update memo validation to accept empty input (skips error check) and refine types/handlers.
> - **Changelog**: Add entry noting the ability to clear memo values via empty input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c92e28c21d1137b7a482d42b325e7abd8ad360e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211540855775072