### PR TITLE
Add PocketChange UI for Monero wallet

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -107,7 +107,7 @@ export default [
       'src/actions/TransactionExportActions.tsx',
       'src/actions/WalletActions.tsx',
       'src/actions/WalletListActions.tsx',
-      'src/actions/WalletListMenuActions.tsx',
+
       'src/app.ts',
       'src/components/buttons/ButtonsView.tsx',
       'src/components/buttons/EdgeSwitch.tsx',
@@ -202,7 +202,6 @@ export default [
       'src/components/modals/SwapVerifyTermsModal.tsx',
       'src/components/modals/TextInputModal.tsx',
       'src/components/modals/TransferModal.tsx',
-      'src/components/modals/WalletListMenuModal.tsx',
 
       'src/components/modals/WalletListSortModal.tsx',
       'src/components/modals/WcSmartContractModal.tsx',

--- a/src/actions/WalletListMenuActions.tsx
+++ b/src/actions/WalletListMenuActions.tsx
@@ -31,6 +31,7 @@ import { toggleUserPausedWallet } from './SettingsActions'
 
 export type WalletListMenuKey =
   | 'settings'
+  | 'pocketChange'
   | 'rename'
   | 'delete'
   | 'resync'
@@ -65,6 +66,11 @@ export function walletListMenuAction(
         })
       }
     }
+    case 'pocketChange': {
+      return async () => {
+        // Handled directly in WalletListMenuModal via Airship
+      }
+    }
     case 'manageTokens': {
       return async (dispatch, getState) => {
         navigation.navigate('manageTokens', {
@@ -79,7 +85,7 @@ export function walletListMenuAction(
         const { account } = state.core
         account
           .changeWalletStates({ [walletId]: { deleted: true } })
-          .catch(error => {
+          .catch((error: unknown) => {
             showError(error)
           })
       }
@@ -118,8 +124,8 @@ export function walletListMenuAction(
             try {
               const fioAddresses =
                 await engine.otherMethods.getFioAddressNames()
-              fioAddress = fioAddresses.length ? fioAddresses[0] : ''
-            } catch (e: any) {
+              fioAddress = fioAddresses.length > 0 ? fioAddresses[0] : ''
+            } catch (e: unknown) {
               fioAddress = ''
             }
           }
@@ -129,7 +135,7 @@ export function walletListMenuAction(
         let additionalMsg: string | undefined
         let tokenCurrencyCode: string | undefined
         if (tokenId == null) {
-          if (fioAddress) {
+          if (fioAddress !== '') {
             additionalMsg =
               lstrings.fragmet_wallets_delete_fio_extra_message_mobile
           } else if (Object.keys(wallet.currencyConfig.allTokens).length > 0) {
@@ -155,7 +161,7 @@ export function walletListMenuAction(
                   )} ${wallet.type} ${wallet.id}`
                 )
               })
-              .catch(error => {
+              .catch((error: unknown) => {
                 showError(error)
               })
 
@@ -176,7 +182,7 @@ export function walletListMenuAction(
                   } ${tokenId}`
                 )
               })
-              .catch(error => {
+              .catch((error: unknown) => {
                 showError(error)
               })
           }
@@ -297,8 +303,8 @@ export function walletListMenuAction(
           )
           // Add a copy button only for development
           let devButtons = {}
-          // @ts-expect-error
-          if (global.__DEV__)
+          // @ts-expect-error - __DEV__ is a RN global not in TS types
+          if (global.__DEV__ === true)
             devButtons = {
               copy: { label: lstrings.fragment_wallets_copy_seed }
             }
@@ -313,8 +319,8 @@ export function walletListMenuAction(
               buttons={{ ok: { label: lstrings.string_ok_cap }, ...devButtons }}
             />
           )).then(buttonPressed => {
-            // @ts-expect-error
-            if (global.__DEV__ && buttonPressed === 'copy') {
+            // @ts-expect-error - __DEV__ is a RN global not in TS types
+            if (global.__DEV__ === true && buttonPressed === 'copy') {
               Clipboard.setString(privateKey)
               showToast(lstrings.fragment_wallets_copied_seed)
             }

--- a/src/components/modals/PocketChangeModal.tsx
+++ b/src/components/modals/PocketChangeModal.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react'
+import { View } from 'react-native'
+import type { AirshipBridge } from 'react-native-airship'
+
+import { useHandler } from '../../hooks/useHandler'
+import { lstrings } from '../../locales/strings'
+import { EdgeButton } from '../buttons/EdgeButton'
+import { cacheStyles, type Theme, useTheme } from '../services/ThemeContext'
+import { SettingsHeaderRow } from '../settings/SettingsHeaderRow'
+import { SettingsSwitchRow } from '../settings/SettingsSwitchRow'
+import { EdgeText, Paragraph } from '../themed/EdgeText'
+import { EdgeModal } from './EdgeModal'
+
+const POCKET_AMOUNTS_XMR = [0.1, 0.2, 0.3, 0.5, 0.8, 1.3]
+
+export interface PocketChangeConfig {
+  enabled: boolean
+  amountIndex: number
+}
+
+interface Props {
+  bridge: AirshipBridge<PocketChangeConfig | undefined>
+  initialConfig: PocketChangeConfig
+}
+
+export const PocketChangeModal: React.FC<Props> = props => {
+  const { bridge, initialConfig } = props
+  const theme = useTheme()
+  const styles = getStyles(theme)
+  const [enabled, setEnabled] = React.useState(initialConfig.enabled)
+  const [amountIndex, setAmountIndex] = React.useState(
+    initialConfig.amountIndex
+  )
+
+  const handleCancel = useHandler((): void => {
+    bridge.resolve(undefined)
+  })
+
+  const handleSave = useHandler((): void => {
+    bridge.resolve({ enabled, amountIndex })
+  })
+
+  const handleToggle = useHandler((): void => {
+    setEnabled(prev => !prev)
+  })
+
+  const handleDecrease = useHandler((): void => {
+    setAmountIndex(prev => Math.max(0, prev - 1))
+  })
+
+  const handleIncrease = useHandler((): void => {
+    setAmountIndex(prev => Math.min(POCKET_AMOUNTS_XMR.length - 1, prev + 1))
+  })
+
+  return (
+    <EdgeModal
+      bridge={bridge}
+      onCancel={handleCancel}
+      title={lstrings.pocketchange_title}
+    >
+      <View style={styles.container}>
+        <Paragraph>{lstrings.pocketchange_description}</Paragraph>
+
+        <SettingsSwitchRow
+          label={lstrings.pocketchange_enable}
+          value={enabled}
+          onPress={handleToggle}
+        />
+
+        {enabled ? (
+          <>
+            <SettingsHeaderRow label={lstrings.pocketchange_amount_header} />
+
+            <View style={styles.stepperRow}>
+              <EdgeButton
+                label="−"
+                type="secondary"
+                mini
+                onPress={handleDecrease}
+                disabled={amountIndex <= 0}
+              />
+              <EdgeText style={styles.amountText}>
+                {POCKET_AMOUNTS_XMR[amountIndex]} XMR{' '}
+                {lstrings.pocketchange_per_pocket}
+              </EdgeText>
+              <EdgeButton
+                label="+"
+                type="secondary"
+                mini
+                onPress={handleIncrease}
+                disabled={amountIndex >= POCKET_AMOUNTS_XMR.length - 1}
+              />
+            </View>
+
+            <Paragraph>{lstrings.pocketchange_explainer}</Paragraph>
+          </>
+        ) : null}
+
+        <View style={styles.saveButton}>
+          <EdgeButton label={lstrings.pocketchange_save} onPress={handleSave} />
+        </View>
+      </View>
+    </EdgeModal>
+  )
+}
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  container: {
+    paddingHorizontal: theme.rem(0.5)
+  },
+  stepperRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: theme.rem(0.5)
+  },
+  amountText: {
+    fontSize: theme.rem(1.1),
+    marginHorizontal: theme.rem(1)
+  },
+  saveButton: {
+    marginTop: theme.rem(1),
+    marginBottom: theme.rem(0.5)
+  }
+}))

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -26,11 +26,12 @@ import {
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { CryptoIcon } from '../icons/CryptoIcon'
-import { showError } from '../services/AirshipInstance'
+import { Airship, showError } from '../services/AirshipInstance'
 import { cacheStyles, type Theme, useTheme } from '../services/ThemeContext'
 import { UnscaledText } from '../text/UnscaledText'
 import { ModalTitle } from '../themed/ModalParts'
 import { EdgeModal } from './EdgeModal'
+import { type PocketChangeConfig, PocketChangeModal } from './PocketChangeModal'
 
 interface Option {
   value: WalletListMenuKey
@@ -53,6 +54,7 @@ const icons: Record<string, string> = {
   getSeed: 'key',
   goToParent: 'upcircleo',
   manageTokens: 'plus',
+  pocketChange: 'wallet',
   rawDelete: 'warning',
   rename: 'edit',
   resync: 'sync',
@@ -74,6 +76,11 @@ export const WALLET_LIST_MENU: Array<{
   {
     label: lstrings.settings_asset_settings,
     value: 'settings'
+  },
+  {
+    pluginIds: ['monero'],
+    label: lstrings.pocketchange_menu_item,
+    value: 'pocketChange'
   },
   {
     label: lstrings.string_rename,
@@ -142,7 +149,7 @@ export const WALLET_LIST_MENU: Array<{
   }
 ]
 
-export function WalletListMenuModal(props: Props) {
+export function WalletListMenuModal(props: Props): React.ReactElement {
   const { bridge, tokenId, navigation, walletId } = props
 
   const [options, setOptions] = React.useState<Option[]>([])
@@ -161,12 +168,40 @@ export function WalletListMenuModal(props: Props) {
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const handleCancel = () => {
+  const handleCancel = (): void => {
     props.bridge.resolve()
   }
 
   const optionAction = useHandler(async (option: WalletListMenuKey) => {
     if (loadingOption != null) return // Prevent multiple actions
+
+    if (option === 'pocketChange' && wallet != null) {
+      setLoadingOption(option)
+      try {
+        let initialConfig: PocketChangeConfig = {
+          enabled: false,
+          amountIndex: 2
+        }
+        if (wallet.otherMethods?.getPocketChangeSetting != null) {
+          const saved = await wallet.otherMethods.getPocketChangeSetting()
+          if (saved != null) initialConfig = saved
+        }
+        const result = await Airship.show<PocketChangeConfig | undefined>(b => (
+          <PocketChangeModal bridge={b} initialConfig={initialConfig} />
+        ))
+        if (
+          result != null &&
+          wallet.otherMethods?.setPocketChangeSetting != null
+        ) {
+          await wallet.otherMethods.setPocketChangeSetting(result)
+        }
+        bridge.resolve()
+      } catch (error) {
+        setLoadingOption(null)
+        showError(error)
+      }
+      return
+    }
 
     setLoadingOption(option)
     try {

--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -260,6 +260,10 @@ const SendComponent = (props: Props): React.ReactElement => {
   // -1 = no max spend, otherwise equal to the index the spendTarget that requested the max spend.
   const [maxSpendSetter, setMaxSpendSetter] = useState<number>(-1)
 
+  const [pocketChangeTargets, setPocketChangeTargets] = useState<
+    EdgeSpendTarget[]
+  >([])
+
   const countryCode = useSelector(state => state.ui.countryCode)
   const account = useSelector<EdgeAccount>(state => state.core.account)
   const exchangeRates = useSelector<GuiExchangeRates>(
@@ -1110,6 +1114,29 @@ const SendComponent = (props: Props): React.ReactElement => {
     )
   }
 
+  const renderPocketChange = (): React.ReactElement | null => {
+    if (pocketChangeTargets.length === 0) return null
+
+    return (
+      <>
+        {pocketChangeTargets.map((target, i) => {
+          const displayAmount = div(
+            target.nativeAmount ?? '0',
+            cryptoDisplayDenomination.multiplier,
+            DECIMAL_PRECISION
+          )
+          return (
+            <EdgeRow
+              key={`pocket-${i}`}
+              title={lstrings.pocketchange_line_item}
+              body={`${displayAmount} ${cryptoDisplayDenomination.name}`}
+            />
+          )
+        })}
+      </>
+    )
+  }
+
   const renderScamWarning = (): React.ReactElement | null => {
     const { publicAddress } = spendInfo.spendTargets[0]
 
@@ -1581,9 +1608,32 @@ const SendComponent = (props: Props): React.ReactElement => {
           }
         }
 
+        // Expand spend targets with pocket change outputs if supported
+        let finalSpendInfo = spendInfo
+        if (coreWallet.otherMethods?.getPocketChangeTargetsForSpend != null) {
+          try {
+            const expanded =
+              await coreWallet.otherMethods.getPocketChangeTargetsForSpend(
+                spendInfo.spendTargets
+              )
+            const pockets = expanded.filter(
+              (t: EdgeSpendTarget) => t.otherParams?.isPocketChange === true
+            )
+            setPocketChangeTargets(pockets)
+            if (expanded.length > spendInfo.spendTargets.length) {
+              finalSpendInfo = { ...spendInfo, spendTargets: expanded }
+            }
+          } catch (e: unknown) {
+            console.log('Pocket change expansion skipped:', e)
+            setPocketChangeTargets([])
+          }
+        } else {
+          setPocketChangeTargets([])
+        }
+
         makeSpendCounter.current++
         const localMakeSpendCounter = makeSpendCounter.current
-        const edgeTx = await coreWallet.makeSpend(spendInfo)
+        const edgeTx = await coreWallet.makeSpend(finalSpendInfo)
         if (localMakeSpendCounter < makeSpendCounter.current) {
           // This makeSpend result is out of date. Throw it away since a newer one is in flight.
           // This is not REALLY needed since useAsyncEffect seems to serialize calls into the effect
@@ -1770,6 +1820,7 @@ const SendComponent = (props: Props): React.ReactElement => {
             <EdgeAnim enter={{ type: 'fadeInDown', distance: 40 }}>
               <EdgeCard sections>
                 {renderFees()}
+                {renderPocketChange()}
                 {renderMetadataNotes()}
                 {renderMemoOptions()}
                 {renderInfoTiles()}

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -2497,7 +2497,22 @@ const strings = {
     'Please ensure all details are correct before making the transfer.',
   // #endregion
 
-  unknown_error_message: 'An unknown error occurred.'
+  unknown_error_message: 'An unknown error occurred.',
+
+  // #region Pocket Change
+  pocketchange_title: 'Pocket Change',
+  pocketchange_description:
+    'Pocket Change pre-splits your balance into smaller outputs for faster spending. Each "pocket" can be spent independently without waiting for change.',
+  pocketchange_enable: 'Enable Pocket Change',
+  pocketchange_amount_header: 'Pocket Size',
+  pocketchange_amount_label: 'Amount per pocket',
+  pocketchange_per_pocket: 'per pocket',
+  pocketchange_explainer:
+    'When enabled, received funds will automatically be split into pockets of the selected size.',
+  pocketchange_menu_item: 'Pocket Change',
+  pocketchange_line_item: 'Pocket Change',
+  pocketchange_save: 'Save'
+  // #endregion
 } as const
 
 export default strings

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -1947,5 +1947,15 @@
   "ramp_account_number_label": "Account Number",
   "ramp_routing_number_label": "Routing Number",
   "ramp_bank_routing_warning": "Please ensure all details are correct before making the transfer.",
-  "unknown_error_message": "An unknown error occurred."
+  "unknown_error_message": "An unknown error occurred.",
+  "pocketchange_title": "Pocket Change",
+  "pocketchange_description": "Pocket Change pre-splits your balance into smaller outputs for faster spending. Each \"pocket\" can be spent independently without waiting for change.",
+  "pocketchange_enable": "Enable Pocket Change",
+  "pocketchange_amount_header": "Pocket Size",
+  "pocketchange_amount_label": "Amount per pocket",
+  "pocketchange_per_pocket": "per pocket",
+  "pocketchange_explainer": "When enabled, received funds will automatically be split into pockets of the selected size.",
+  "pocketchange_menu_item": "Pocket Change",
+  "pocketchange_line_item": "Pocket Change",
+  "pocketchange_save": "Save"
 }


### PR DESCRIPTION
## Overview

Adds UI components and localization for PocketChange feature. This PR provides the user-facing interface for configuring PocketChange settings. **Requires**: edge-currency-monero PR #101 for core functionality.

## Changes

### New Components

**`src/components/modals/PocketChangeModal.tsx`:**
- Settings modal with toggle to enable/disable PocketChange
- Slider to select pocket amount (0.1, 0.2, 0.3, 0.5, 0.8, 1.3 XMR)
- Integrates with Airship modal system
- TypeScript types: `PocketChangeConfig` interface

**`src/locales/strings/enUS.json`:**
- Added 11 localization strings:
  - Modal title, description, labels
  - Send confirmation breakdown text
  - Menu item labels

## Integration Requirements (Not Yet Implemented)

This PR provides the UI scaffolding. The following integration work is still needed:

### 1. Add Settings Menu Trigger

**Option A: Wallet List Menu** (Recommended)

Edit: `src/components/modals/WalletListMenuModal.tsx`

Add menu item for Monero wallets:
```typescript
{
  pluginIds: ['monero'],
  label: lstrings.pocketchange_menu_item,
  value: 'pocketChangeSettings'
}
```

Add action in `src/actions/WalletListMenuActions.ts`:
```typescript
case 'pocketChangeSettings':
  const wallet = await account.waitForCurrencyWallet(walletId)
  
  // Load current setting
  const currentSetting = wallet.walletLocalData.pocketChangeSetting ?? {
    enabled: false,
    amountPiconero: '100000000000'
  }
  
  // Convert piconero to index
  const POCKET_AMOUNTS_XMR = [0.1, 0.2, 0.3, 0.5, 0.8, 1.3]
  const amountXMR = Number(currentSetting.amountPiconero) / 1e12
  const amountIndex = POCKET_AMOUNTS_XMR.findIndex(a => Math.abs(a - amountXMR) < 0.01)
  
  // Show modal
  const result = await Airship.show<PocketChangeConfig | undefined>(bridge => (
    <PocketChangeModal
      bridge={bridge}
      initialConfig={{
        enabled: currentSetting.enabled,
        amountIndex: amountIndex >= 0 ? amountIndex : 0
      }}
    />
  ))
  
  // Save result
  if (result != null) {
    const newAmountPiconero = String(POCKET_AMOUNTS_XMR[result.amountIndex] * 1e12)
    await wallet.changeWalletLocalData({
      pocketChangeSetting: {
        enabled: result.enabled,
        amountPiconero: newAmountPiconero
      }
    })
  }
  break
```

### 2. Integrate into Send Flow

Edit: `src/components/scenes/SendScene.tsx` or `SendScene2.tsx`

Before creating the spend:
```typescript
// Get user's intended targets
const baseTargets = [{
  publicAddress: recipientAddress,
  nativeAmount: sendAmount
}]

// Apply PocketChange if enabled (Monero only)
let finalTargets = baseTargets
if (wallet.currencyInfo.pluginId === 'monero' && wallet.otherMethods?.getPocketChangeTargetsForSpend) {
  try {
    finalTargets = await wallet.otherMethods.getPocketChangeTargetsForSpend(baseTargets)
  } catch (error) {
    console.warn('PocketChange not available:', error)
  }
}

// Separate for display
const paymentTargets = finalTargets.filter(t => !t.otherParams?.isPocketChange)
const pocketTargets = finalTargets.filter(t => t.otherParams?.isPocketChange)

// Create spend with all targets
const edgeTransaction = await wallet.makeSpend({
  spendTargets: finalTargets,
  ...otherSpendInfo
})
```

### 3. Update Send Confirmation UI

Edit: `src/components/scenes/SendConfirmationScene.tsx`

Show pocket breakdown:
```typescript
{pocketTargets.length > 0 && (
  <View>
    <Text>{lstrings.pocketchange_send_breakdown_title}</Text>
    <Text>{sprintf(lstrings.pocketchange_send_pocket_count, pocketTargets.length)}</Text>
    <Text>
      {sprintf(
        lstrings.pocketchange_send_total,
        formatCurrencyAmount(sumAmounts(pocketTargets))
      )}
    </Text>
  </View>
)}
```

## Testing

After integration is complete:

1. **Enable PocketChange:**
   - Open Monero wallet
   - Access PocketChange settings (via wallet menu)
   - Toggle ON, select 0.1 XMR
   - Save

2. **Send Transaction:**
   - Create a send (any amount)
   - Verify confirmation shows pocket breakdown (e.g., "6 pockets, 0.6 XMR total")
   - Confirm transaction

3. **Verify Immediate Spend:**
   - Immediately send again (before 20 min)
   - Should succeed using unlocked pocket funds

## Related

- Core PR: EdgeApp/edge-currency-monero#101
- Asana task: (will be added)

## Files Modified

- `src/components/modals/PocketChangeModal.tsx` - NEW (103 lines)
- `src/locales/strings/enUS.json` - 11 new strings

## Files Requiring Integration (TODO)

- `src/components/modals/WalletListMenuModal.tsx` OR `src/components/scenes/CurrencySettingsScene.tsx`
- `src/actions/WalletListMenuActions.ts`
- `src/components/scenes/SendScene.tsx` (or `SendScene2.tsx`)
- `src/components/scenes/SendConfirmationScene.tsx`

## Notes

This PR is intentionally minimal (UI components only) to keep the review scope manageable. Integration work can be done as a follow-up or included before merge depending on preference.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213259130316641

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Monero-specific settings and modifies `SendScene2` to optionally expand spend targets via wallet `otherMethods`, which can affect transaction construction and displayed fee/amount breakdowns if the underlying plugin implementation is incorrect.
> 
> **Overview**
> Adds a new **Pocket Change** configuration modal (toggle + pocket-size stepper) and wires it into the Monero wallet list menu via a new `pocketChange` option that loads/saves settings through wallet `otherMethods`.
> 
> Updates `SendScene2` to optionally expand `spendTargets` using `otherMethods.getPocketChangeTargetsForSpend`, pass the expanded targets into `makeSpend`, and display any pocket-change outputs as additional line items in the fees/details card. Also includes supporting en-US localization strings and small TypeScript/strictness cleanups in `WalletListMenuActions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef1d4c5f2d211e33b9ea162d83af5d873d95a6ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->