### PR TITLE
Add more robust error handling to `SwipeChart`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: More robust error handling in `SwipeChart` to handle rate limits
 - added: New Banxa payment methods
 
 ## 4.45.0 (staging)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -138,7 +138,6 @@ export default [
       'src/components/cards/VisaCardCard.tsx',
       'src/components/cards/WalletRestoreCard.tsx',
       'src/components/cards/WarningCard.tsx',
-      'src/components/charts/SwipeChart.tsx',
 
       'src/components/common/AnimatedNumber.tsx',
       'src/components/common/BlurBackground.tsx',

--- a/src/components/charts/SwipeChart.tsx
+++ b/src/components/charts/SwipeChart.tsx
@@ -286,49 +286,76 @@ export const SwipeChart: React.FC<Props> = props => {
       )
       // Start with the free base URL
       let fetchUrl = `${COINGECKO_URL}${fetchPath}`
-      do {
-        try {
-          // Construct the dataset query
-          const response = await fetch(fetchUrl)
-          const result = await response.json()
-          const apiError = asMaybe(asCoinGeckoError)(result)
-          if (apiError != null) {
-            if (apiError.status.error_code === 429) {
-              // Rate limit error, use our API key as a fallback
-              if (
-                !fetchUrl.includes('x_cg_pro_api_key') &&
-                ENV.COINGECKO_API_KEY !== ''
-              ) {
-                fetchUrl = `${COINGECKO_URL_PRO}${fetchPath}&x_cg_pro_api_key=${ENV.COINGECKO_API_KEY}`
+      try {
+        do {
+          try {
+            const response = await fetch(fetchUrl)
+
+            // Handle non-OK responses before parsing JSON
+            if (!response.ok) {
+              if (response.status === 429) {
+                if (
+                  !fetchUrl.includes('x_cg_pro_api_key') &&
+                  ENV.COINGECKO_API_KEY !== ''
+                ) {
+                  fetchUrl = `${COINGECKO_URL_PRO}${fetchPath}&x_cg_pro_api_key=${ENV.COINGECKO_API_KEY}`
+                }
+                // Wait 2 seconds before retrying. It typically takes 1 minute
+                // before rate limiting is relieved, so even 2 seconds is hasty.
+                await snooze(2000)
+                continue
               }
-              // Wait 2 second before retrying. It typically takes 1 minute
-              // before rate limiting is relieved, so even 2 seconds is hasty.
-              await snooze(2000)
-              continue
+              throw new Error(`HTTP ${response.status}: ${response.statusText}`)
             }
-            throw new Error(
-              `Failed to fetch market data: ${apiError.status.error_code} ${apiError.status.error_message}`
-            )
+
+            // Parse JSON safely - use text() first to catch parse errors locally
+            const text = await response.text()
+            let result: unknown
+            try {
+              result = JSON.parse(text)
+            } catch {
+              throw new Error(`Invalid JSON response: ${text.slice(0, 100)}...`)
+            }
+
+            const apiError = asMaybe(asCoinGeckoError)(result)
+            if (apiError != null) {
+              if (apiError.status.error_code === 429) {
+                if (
+                  !fetchUrl.includes('x_cg_pro_api_key') &&
+                  ENV.COINGECKO_API_KEY !== ''
+                ) {
+                  fetchUrl = `${COINGECKO_URL_PRO}${fetchPath}&x_cg_pro_api_key=${ENV.COINGECKO_API_KEY}`
+                }
+                // Wait 2 seconds before retrying. It typically takes 1 minute
+                // before rate limiting is relieved, so even 2 seconds is hasty.
+                await snooze(2000)
+                continue
+              }
+              throw new Error(
+                `Failed to fetch market data: ${apiError.status.error_code} ${apiError.status.error_message}`
+              )
+            }
+
+            const marketChartRange = asCoinGeckoMarketChartRange(result)
+            const rawChartData = marketChartRange.prices.map(pair => ({
+              x: new Date(pair[0]),
+              y: pair[1]
+            }))
+            const reduced = reduceChartData(rawChartData, selectedTimespan)
+
+            setChartData(reduced)
+            cachedTimespanChartData.set(selectedTimespan, reduced)
+            setCachedChartData(cachedTimespanChartData)
+          } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e)
+            console.error('SwipeChart fetch error:', message)
+            setErrorMessage(lstrings.error_data_unavailable)
           }
-
-          const marketChartRange = asCoinGeckoMarketChartRange(result)
-          const rawChartData = marketChartRange.prices.map(pair => ({
-            x: new Date(pair[0]),
-            y: pair[1]
-          }))
-          const reduced = reduceChartData(rawChartData, selectedTimespan)
-
-          setChartData(reduced)
-          cachedTimespanChartData.set(selectedTimespan, reduced)
-          setCachedChartData(cachedTimespanChartData)
-        } catch (e: unknown) {
-          console.error(JSON.stringify(e))
-          setErrorMessage(lstrings.error_data_unavailable)
-        } finally {
-          setIsFetching(false)
-        }
-        break
-      } while (true)
+          break
+        } while (true)
+      } finally {
+        setIsFetching(false)
+      }
     },
     [selectedTimespan, isConnected, fetchAssetId, coingeckoFiat],
     'swipeChart'


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

#### Context

The `SwipeChart` component fetches market data from CoinGecko API and has insufficient error handling for network failures and rate-limiting scenarios. When rate limits or HTTP errors occur, the error handling is ambiguous and can fail silently, making debugging difficult.

#### Changes

- **Added HTTP status validation**: Check `response.ok` before parsing JSON to catch non-2xx status codes early
- **Improved JSON parsing**: Added try-catch around JSON parsing with fallback to raw text for error messages
- **Better rate-limit handling**: Explicit HTTP 429 detection before JSON parsing phase
- **Enhanced error messages**: More descriptive error text for HTTP errors and JSON parsing failures
- **Restructured error handling**: Wrapped the retry loop in a try-catch to ensure `setIsFetching(false)` is always called via finally block

These changes make the component more resilient to API failures and easier to debug when issues occur.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI data-fetch error-handling and lint config tweak; minimal behavioral risk beyond how chart errors/retries are surfaced.
> 
> **Overview**
> Improves `SwipeChart` market-data fetching resilience by validating `response.ok`, explicitly handling HTTP 429 rate limits (including retry + pro-key fallback), and safely parsing JSON via `text()` with clearer error messages.
> 
> Ensures `setIsFetching(false)` always runs via a `finally`, and updates lint config to stop excluding `SwipeChart.tsx` from linting; adds a matching CHANGELOG entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b79cde0684e402a8399e8cc9361ded65d1dcb72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->