### PR TITLE
Rename deposit button label to Receive

### DIFF
--- a/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
@@ -1646,7 +1646,7 @@ exports[`BalanceCard should render with loading props 1`] = `
               ]
             }
           >
-            Deposit
+            Receive
           </Text>
         </View>
       </View>

--- a/src/components/cards/BalanceCard.tsx
+++ b/src/components/cards/BalanceCard.tsx
@@ -227,7 +227,7 @@ export const BalanceCard = (props: Props) => {
         layout="row"
         secondary={{
           onPress: handleDeposit,
-          label: lstrings.loan_fragment_deposit
+          label: lstrings.fragment_request_subtitle
         }}
         secondary2={{
           onPress: handleSend,


### PR DESCRIPTION
## Summary
- Rename the balance card secondary action label from "Deposit" to "Receive".
- Scope is limited to balance card UI text and related snapshot updates.
- Planning document: `/Users/eddy/git/edge-plans/2026-02/rename-deposit-button-to-receive.md`.

## Test plan
- [ ] yarn lint
- [ ] yarn test