### PR TITLE
Guard onError behind mounted check in CancellableProcessingScene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added: Xgram swap exchange plugin support
 - added: New Banxa payment methods
 - added: Debug settings scene (Developer Mode only) with nodes/servers inspection, engine `dataDump` viewer, and log viewer
+- fixed: Swap quote timeout error interrupting user after cancelling a slow swap search
 
 ## 4.45.0 (2025-03-10)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -221,7 +221,7 @@ export default [
       'src/components/navigation/TransactionDetailsTitle.tsx',
       'src/components/notification/NotificationCenterCard.tsx',
       'src/components/progress-indicators/AccountSyncBar.tsx',
-      'src/components/progress-indicators/CancellableProcessingScene.tsx',
+
       'src/components/progress-indicators/FullScreenLoader.tsx',
       'src/components/progress-indicators/LoadingSplashScreen.tsx',
 
@@ -297,7 +297,6 @@ export default [
       'src/components/scenes/SwapSuccessScene.tsx',
       'src/components/scenes/SweepPrivateKeyCalculateFeeScene.tsx',
       'src/components/scenes/SweepPrivateKeyCompletionScene.tsx',
-      'src/components/scenes/SweepPrivateKeyProcessingScene.tsx',
 
       'src/components/scenes/TransactionDetailsScene.tsx',
 

--- a/src/components/progress-indicators/CancellableProcessingScene.tsx
+++ b/src/components/progress-indicators/CancellableProcessingScene.tsx
@@ -53,7 +53,7 @@ export const CancellableProcessingScene: React.FC<Props> = props => {
       try {
         await doWork(() => !mounted.current)
       } catch (error: unknown) {
-        await onError(error)
+        if (mounted.current) await onError(error)
       }
 
       return () => {

--- a/src/components/progress-indicators/CancellableProcessingScene.tsx
+++ b/src/components/progress-indicators/CancellableProcessingScene.tsx
@@ -3,35 +3,30 @@ import { ActivityIndicator, View } from 'react-native'
 
 import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { lstrings } from '../../locales/strings'
-import type { NavigationBase } from '../../types/routerTypes'
 import { ButtonsView } from '../buttons/ButtonsView'
 import { EdgeAnim } from '../common/EdgeAnim'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { cacheStyles, type Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 
-interface Props<T> {
+interface Props {
   animationDuration?: number
-  navigation: NavigationBase
 
-  doWork: () => Promise<T>
+  doWork: (isCancelled: () => boolean) => Promise<void>
   onCancel: () => void
-  onDone: (res: T) => void
-  onError: (navigation: NavigationBase, error: unknown) => Promise<void>
+  onError: (error: unknown) => Promise<void>
 
   processingText: string
   longProcessingText?: string
   longProcessingTime?: number
 }
 
-export function CancellableProcessingScene<T>(props: Props<T>) {
+export const CancellableProcessingScene: React.FC<Props> = props => {
   const theme = useTheme()
   const styles = getStyles(theme)
   const {
     animationDuration = 5000,
-    navigation,
     onCancel,
-    onDone,
     onError,
     doWork,
     processingText,
@@ -56,10 +51,9 @@ export function CancellableProcessingScene<T>(props: Props<T>) {
   useAsyncEffect(
     async () => {
       try {
-        const result = await doWork()
-        if (mounted.current) onDone(result)
+        await doWork(() => !mounted.current)
       } catch (error: unknown) {
-        await onError(navigation, error)
+        await onError(error)
       }
 
       return () => {

--- a/src/components/scenes/SwapProcessingScene.tsx
+++ b/src/components/scenes/SwapProcessingScene.tsx
@@ -53,18 +53,16 @@ export const SwapProcessingScene: React.FC<Props> = (props: Props) => {
     swapRequest.toTokenId
   )
 
-  const doWork = async (): Promise<EdgeSwapQuote[]> => {
+  const doWork = async (isCancelled: () => boolean): Promise<void> => {
     const quotes = await account.fetchSwapQuotes(
       swapRequest,
       swapRequestOptions
     )
-    return quotes
+    if (isCancelled()) return
+    onDone(quotes)
   }
 
-  const onError = async (
-    navigation: NavigationBase,
-    error: unknown
-  ): Promise<void> => {
+  const onError = async (error: unknown): Promise<void> => {
     // Handle same-address requirement for swap flows requiring a split:
     const addressError = asMaybeSwapAddressError(error)
     if (addressError != null && addressError.reason === 'mustMatch') {
@@ -174,7 +172,7 @@ export const SwapProcessingScene: React.FC<Props> = (props: Props) => {
       await showPendingTxModal(
         swapRequest.fromWallet,
         swapRequest.fromTokenId,
-        navigation
+        navigation as NavigationBase
       )
       return
     }
@@ -205,18 +203,16 @@ export const SwapProcessingScene: React.FC<Props> = (props: Props) => {
       await showInsufficientFeesModal({
         coreError: insufficientFunds,
         countryCode,
-        navigation,
+        navigation: navigation as NavigationBase,
         wallet: swapRequest.fromWallet
       })
     }
   }
 
   return (
-    <CancellableProcessingScene<EdgeSwapQuote[]>
-      navigation={navigation as NavigationBase}
+    <CancellableProcessingScene
       doWork={doWork}
       onCancel={onCancel}
-      onDone={onDone}
       onError={onError}
       processingText={lstrings.trying_to_find}
       longProcessingText={lstrings.exchange_slow}

--- a/src/components/scenes/SweepPrivateKeyProcessingScene.tsx
+++ b/src/components/scenes/SweepPrivateKeyProcessingScene.tsx
@@ -6,7 +6,7 @@ import type {
 import * as React from 'react'
 
 import { lstrings } from '../../locales/strings'
-import type { EdgeAppSceneProps, NavigationBase } from '../../types/routerTypes'
+import type { EdgeAppSceneProps } from '../../types/routerTypes'
 import { zeroString } from '../../util/utils'
 import { CancellableProcessingScene } from '../progress-indicators/CancellableProcessingScene'
 import { showError } from '../services/AirshipInstance'
@@ -26,14 +26,14 @@ export interface SweepPrivateKeyItem {
 
 interface Props extends EdgeAppSceneProps<'sweepPrivateKeyProcessing'> {}
 
-export function SweepPrivateKeyProcessingScene(props: Props) {
+export const SweepPrivateKeyProcessingScene: React.FC<Props> = props => {
   const { route, navigation } = props
   const { memoryWalletPromise, receivingWallet } = route.params
 
   const { displayName, pluginId } = receivingWallet.currencyInfo
   const { allTokens } = receivingWallet.currencyConfig
 
-  const promise = async (): Promise<EdgeMemoryWallet> => {
+  const doWork = async (isCancelled: () => boolean): Promise<void> => {
     const memoryWallet = await memoryWalletPromise
     await memoryWallet.startEngine()
 
@@ -42,13 +42,15 @@ export function SweepPrivateKeyProcessingScene(props: Props) {
       syncRatioResolver = resolve
     })
 
-    const syncRatioWatcher = (syncRatio: number) => {
+    const syncRatioWatcher = (syncRatio: number): void => {
       if (syncRatio >= 1) {
         syncRatioResolver(syncRatio)
       }
     }
 
-    const detectedTokenIdsWatcher = async (tokenIds: string[]) => {
+    const detectedTokenIdsWatcher = async (
+      tokenIds: string[]
+    ): Promise<void> => {
       await memoryWallet.changeEnabledTokenIds(tokenIds)
     }
 
@@ -56,19 +58,7 @@ export function SweepPrivateKeyProcessingScene(props: Props) {
     memoryWallet.watch('detectedTokenIds', detectedTokenIdsWatcher)
 
     await syncRatioPromise
-    return memoryWallet
-  }
 
-  const onCancel = () => {
-    memoryWalletPromise
-      .then(async memoryWallet => {
-        await memoryWallet.close()
-      })
-      .catch(() => {})
-    navigation.goBack()
-  }
-
-  const onDone = (memoryWallet: EdgeMemoryWallet) => {
     const sweepPrivateKeyList: SweepPrivateKeyItem[] = [
       { key: 'null', displayName, pluginId, tokenId: null }
     ]
@@ -81,6 +71,8 @@ export function SweepPrivateKeyProcessingScene(props: Props) {
         tokenId
       })
     }
+
+    if (isCancelled()) return
 
     if (sweepPrivateKeyList.length > 1) {
       navigation.replace('sweepPrivateKeySelectCrypto', {
@@ -97,6 +89,15 @@ export function SweepPrivateKeyProcessingScene(props: Props) {
     }
   }
 
+  const onCancel = (): void => {
+    memoryWalletPromise
+      .then(async (memoryWallet: EdgeMemoryWallet) => {
+        await memoryWallet.close()
+      })
+      .catch(() => {})
+    navigation.goBack()
+  }
+
   const onError = async (error: unknown): Promise<void> => {
     showError(error)
   }
@@ -104,10 +105,8 @@ export function SweepPrivateKeyProcessingScene(props: Props) {
   return (
     <CancellableProcessingScene
       animationDuration={1000}
-      navigation={navigation as NavigationBase}
-      doWork={promise}
+      doWork={doWork}
       onCancel={onCancel}
-      onDone={onDone}
       onError={onError}
       processingText={lstrings.sweep_private_key_syncing_balances}
     />


### PR DESCRIPTION
### Description

When the user taps "Cancel" during a slow swap quote search, `CancellableProcessingScene` sets `mounted.current = false` and navigates away. However, the background `fetchSwapQuotes` call continues running until its 60s `noResponseMs` timeout. The `onDone` callback was guarded by `mounted.current`, but `onError` was not — so the timeout rejection would navigate the user back to `swapCreate` with an error even after cancelling.

This adds the same `mounted.current` guard to the `catch` block.

Asana: https://app.asana.com/0/0/1211870198637149/f

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

N/A — Logic-only fix, no visual changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors `CancellableProcessingScene` to change its callback contract and add a mounted guard for `onError`, which affects async flow/cancellation behavior in swap and sweep flows. Low surface area, but mistakes could suppress real errors or trigger navigation at the wrong time.
> 
> **Overview**
> Prevents background async failures (notably swap quote timeouts) from surfacing after a user cancels out of `CancellableProcessingScene` by guarding `onError` behind the mounted check.
> 
> Refactors `CancellableProcessingScene`’s API so callers provide `doWork(isCancelled)` and handle completion themselves (removing `navigation`/`onDone` from the component), updating `SwapProcessingScene` and `SweepPrivateKeyProcessingScene` to early-exit on cancellation.
> 
> Adds a changelog entry noting the swap cancel/timeout fix and updates ESLint config file lists to reflect removed scene references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0bf3ff8180d7f228400d8452bd161b61e37d88c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->