### PR TITLE
Remove support ticket option from help modal

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -184,7 +184,7 @@ export default [
 
       'src/components/modals/FundAccountModal.tsx',
       'src/components/modals/GradientFadeout.tsx',
-      'src/components/modals/HelpModal.tsx',
+
       'src/components/modals/InsufficientFeesModal.tsx',
       'src/components/modals/ListModal.tsx',
       'src/components/modals/LoanWelcomeModal.tsx',

--- a/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/HelpModal.test.tsx.snap
@@ -572,15 +572,22 @@ exports[`HelpModal should render with loading props 1`] = `
               }
             >
               <Text
+                adjustsFontSizeToFit={true}
                 allowFontScaling={false}
                 selectable={false}
                 style={
                   [
                     {
-                      "color": "#00f1a2",
-                      "fontSize": 34,
+                      "color": undefined,
+                      "fontSize": 12,
                     },
-                    undefined,
+                    [
+                      {
+                        "color": "#00f1a2",
+                        "fontSize": 34,
+                      },
+                      undefined,
+                    ],
                     {
                       "fontFamily": "Ionicons",
                       "fontStyle": "normal",
@@ -646,160 +653,6 @@ exports[`HelpModal should render with loading props 1`] = `
                 }
               >
                 Quick help from a live agent
-              </Text>
-            </View>
-          </View>
-        </View>
-        <View
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": false,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={false}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            {
-              "alignSelf": "stretch",
-              "borderRadius": 16,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
-              "opacity": 1,
-              "paddingBottom": 11,
-              "paddingLeft": 11,
-              "paddingRight": 11,
-              "paddingTop": 11,
-            }
-          }
-        >
-          <View
-            style={
-              {
-                "backgroundColor": "rgba(255, 255, 255, .1)",
-                "borderRadius": 16,
-                "bottom": 0,
-                "left": 0,
-                "overflow": "hidden",
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              }
-            }
-          />
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "space-between",
-                "width": "100%",
-              }
-            }
-          >
-            <View
-              style={
-                {
-                  "margin": 11,
-                }
-              }
-            >
-              <Text
-                allowFontScaling={false}
-                selectable={false}
-                style={
-                  [
-                    {
-                      "color": "#00f1a2",
-                      "fontSize": 34,
-                    },
-                    undefined,
-                    {
-                      "fontFamily": "custom",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    {},
-                  ]
-                }
-              >
-                
-              </Text>
-            </View>
-            <View
-              style={
-                {
-                  "alignItems": "flex-start",
-                  "flex": 1,
-                  "flexDirection": "column",
-                  "margin": 11,
-                }
-              }
-            >
-              <Text
-                adjustsFontSizeToFit={true}
-                allowFontScaling={false}
-                minimumFontScale={0.65}
-                numberOfLines={1}
-                style={
-                  [
-                    {
-                      "color": "#FFFFFF",
-                      "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
-                      "includeFontPadding": false,
-                    },
-                    undefined,
-                    null,
-                  ]
-                }
-              >
-                Submit a Support Ticket
-              </Text>
-              <Text
-                adjustsFontSizeToFit={true}
-                allowFontScaling={false}
-                minimumFontScale={0.65}
-                numberOfLines={2}
-                style={
-                  [
-                    {
-                      "color": "#FFFFFF",
-                      "fontFamily": "Quicksand-Regular",
-                      "fontSize": 22,
-                      "includeFontPadding": false,
-                    },
-                    {
-                      "color": "#3dd9f4",
-                      "fontSize": 17,
-                      "marginTop": 6,
-                    },
-                    null,
-                  ]
-                }
-              >
-                Troubleshooting and technical support
               </Text>
             </View>
           </View>

--- a/src/components/icons/ThemedIcons.tsx
+++ b/src/components/icons/ThemedIcons.tsx
@@ -173,3 +173,5 @@ export const ArrowRightIcon = makeFontIcon(AntDesignIcon, 'arrowright')
 export const EditIcon = makeFontIcon(FontAwesome, 'edit')
 export const DeleteIcon = makeFontIcon(FontAwesome, 'times')
 export const QuestionIcon = makeFontIcon(SimpleLineIcons, 'question')
+
+export const ChatBubblesIcon = makeFontIcon(Ionicons, 'chatbubbles-outline')

--- a/src/components/modals/HelpModal.tsx
+++ b/src/components/modals/HelpModal.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { Image, Keyboard, Linking, View } from 'react-native'
 import type { AirshipBridge } from 'react-native-airship'
 import { getBuildNumber, getVersion } from 'react-native-device-info'
-import Ionicons from 'react-native-vector-icons/Ionicons'
 import { sprintf } from 'sprintf-js'
 
 import { Fontello } from '../../assets/vector'
@@ -13,6 +12,7 @@ import { config } from '../../theme/appConfig'
 import { useSelector } from '../../types/reactRedux'
 import type { NavigationBase } from '../../types/routerTypes'
 import { openBrowserUri } from '../../util/WebUtils'
+import { ChatBubblesIcon } from '../icons/ThemedIcons'
 import { Airship } from '../services/AirshipInstance'
 import { cacheStyles, type Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
@@ -105,11 +105,7 @@ export const HelpModal: React.FC<Props> = (props: Props) => {
       {config.supportChatSite == null ? null : (
         <SelectableRow
           icon={
-            <Ionicons
-              name="chatbubbles-outline"
-              color={theme.iconTappable}
-              size={theme.rem(1.5)}
-            />
+            <ChatBubblesIcon color={theme.iconTappable} size={theme.rem(1.5)} />
           }
           title={lstrings.help_live_chat}
           subTitle={lstrings.help_live_chat_text}
@@ -119,21 +115,6 @@ export const HelpModal: React.FC<Props> = (props: Props) => {
           }}
         />
       )}
-
-      <SelectableRow
-        icon={
-          <Fontello
-            name="help_headset"
-            color={theme.iconTappable}
-            size={theme.rem(1.5)}
-          />
-        }
-        title={lstrings.help_support}
-        subTitle={lstrings.help_support_text}
-        onPress={async () => {
-          await handleSitePress(lstrings.help_support, config.supportSite)
-        }}
-      />
 
       <SelectableRow
         icon={

--- a/src/components/modals/WebViewModal.tsx
+++ b/src/components/modals/WebViewModal.tsx
@@ -8,15 +8,6 @@ import { Airship } from '../services/AirshipInstance'
 import { cacheStyles, type Theme, useTheme } from '../services/ThemeContext'
 import { EdgeModal } from './EdgeModal'
 
-export async function showWebViewModal(
-  title: string,
-  uri: string
-): Promise<void> {
-  await Airship.show(bridge => (
-    <WebViewModal bridge={bridge} title={title} uri={uri} />
-  ))
-}
-
 /** Show a modal with HTML content rendered in a WebView */
 export async function showHtmlModal(
   title: string,

--- a/src/components/scenes/RequestScene.tsx
+++ b/src/components/scenes/RequestScene.tsx
@@ -15,7 +15,6 @@ import { sprintf } from 'sprintf-js'
 import { refreshAllFioAddresses } from '../../actions/FioAddressActions'
 import { toggleAccountBalanceVisibility } from '../../actions/LocalSettingsActions'
 import { selectWalletToken } from '../../actions/WalletActions'
-import { Fontello } from '../../assets/vector'
 import {
   getSpecialCurrencyInfo,
   SPECIAL_CURRENCY_INFO
@@ -43,8 +42,11 @@ import {
   truncateDecimals,
   zeroString
 } from '../../util/utils'
+import { openBrowserUri } from '../../util/WebUtils'
 import { ButtonsView } from '../buttons/ButtonsView'
+import { EdgeButton } from '../buttons/EdgeButton'
 import { EdgeCard } from '../cards/EdgeCard'
+import { DividerLineUi4 } from '../common/DividerLineUi4'
 import type { AccentColors } from '../common/DotsBackground'
 import {
   EdgeAnim,
@@ -57,14 +59,13 @@ import {
 import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { withWallet } from '../hoc/withWallet'
-import { ChevronRightIcon } from '../icons/ThemedIcons'
+import { ChatBubblesIcon, ChevronRightIcon } from '../icons/ThemedIcons'
 import { AddressModal } from '../modals/AddressModal'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import {
   WalletListModal,
   type WalletListResult
 } from '../modals/WalletListModal'
-import { showWebViewModal } from '../modals/WebViewModal'
 import { Airship, showError, showToast } from '../services/AirshipInstance'
 import {
   cacheStyles,
@@ -81,7 +82,6 @@ import {
   type ExchangedFlipInputAmounts,
   type ExchangedFlipInputRef
 } from '../themed/ExchangedFlipInput2'
-import { MainButton } from '../themed/MainButton'
 import { QrCarousel } from '../themed/QrCarousel'
 import { SceneHeader } from '../themed/SceneHeader'
 import { ShareButtons } from '../themed/ShareButtons'
@@ -361,39 +361,40 @@ export class RequestSceneComponent extends React.Component<
   }
 
   handleKeysOnlyModePress = async (): Promise<void> => {
-    await showWebViewModal(lstrings.help_support, config.supportSite)
+    await openBrowserUri(config.supportSite)
   }
 
   renderKeysOnlyMode = (): React.ReactNode => {
     const styles = getStyles(this.props.theme)
     return (
       <SceneWrapper>
-        <SceneHeader
-          title={sprintf(
-            lstrings.request_deprecated_header,
-            this.props.wallet?.currencyInfo.displayName
-          )}
-          underline
-          withTopMargin
-        />
+        <View style={styles.keysOnlyModeHeader}>
+          <EdgeText style={styles.keysOnlyModeHeaderText}>
+            {sprintf(
+              lstrings.request_deprecated_header,
+              this.props.wallet?.currencyInfo.displayName
+            )}
+          </EdgeText>
+        </View>
+        <DividerLineUi4 extendRight />
         <UnscaledText style={styles.keysOnlyModeText}>
           {sprintf(
             lstrings.request_deprecated_currency_code,
             this.props.currencyCode
           )}
         </UnscaledText>
-        <MainButton
-          onPress={this.handleKeysOnlyModePress}
-          label={lstrings.help_support}
-          marginRem={[4, 0, 2]}
-          type="secondary"
-        >
-          <Fontello
-            name="help_headset"
-            color={this.props.theme.iconTappable}
-            size={this.props.theme.rem(1.5)}
-          />
-        </MainButton>
+        <View style={styles.keysOnlyModeButtonContainer}>
+          <EdgeButton
+            onPress={this.handleKeysOnlyModePress}
+            label={lstrings.button_support}
+            type="secondary"
+          >
+            <ChatBubblesIcon
+              color={this.props.theme.iconTappable}
+              size={this.props.theme.rem(1.5)}
+            />
+          </EdgeButton>
+        </View>
       </SceneWrapper>
     )
   }
@@ -758,12 +759,25 @@ export class RequestSceneComponent extends React.Component<
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
+  keysOnlyModeHeader: {
+    marginHorizontal: theme.rem(1),
+    marginBottom: theme.rem(1),
+    marginTop: theme.rem(1.5)
+  },
+  keysOnlyModeHeaderText: {
+    fontFamily: theme.fontFaceMedium,
+    fontSize: theme.rem(1.2)
+  },
   keysOnlyModeText: {
     color: theme.primaryText,
     fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(1),
     padding: theme.rem(1),
     paddingTop: theme.rem(0.5)
+  },
+  keysOnlyModeButtonContainer: {
+    marginTop: theme.rem(3.5),
+    marginBottom: theme.rem(2)
   },
   container: {
     flex: 1,

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -435,8 +435,6 @@ const strings = {
   help_faq_text: 'Commonly asked questions',
   help_live_chat: 'Live Chat',
   help_live_chat_text: 'Quick help from a live agent',
-  help_support: 'Submit a Support Ticket',
-  help_support_text: 'Troubleshooting and technical support',
   help_call_agent: 'Call for Assistance',
   help_call_agent_text: 'Our agents are also available by phone',
   help_official_site: 'Visit Official Site',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -299,8 +299,6 @@
   "help_faq_text": "Commonly asked questions",
   "help_live_chat": "Live Chat",
   "help_live_chat_text": "Quick help from a live agent",
-  "help_support": "Submit a Support Ticket",
-  "help_support_text": "Troubleshooting and technical support",
   "help_call_agent": "Call for Assistance",
   "help_call_agent_text": "Our agents are also available by phone",
   "help_official_site": "Visit Official Site",


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX changes that remove a help option and adjust how support links open; main risk is users losing the in-app support-ticket path or a regression in external link navigation.
> 
> **Overview**
> Removes the **“Submit a Support Ticket”** row from `HelpModal` and deletes the associated localized strings.
> 
> Standardizes the live-chat icon by adding `ChatBubblesIcon` to `ThemedIcons` and switching `HelpModal` to use it (instead of a direct `Ionicons` import), updating snapshots accordingly.
> 
> Simplifies support navigation by removing `showWebViewModal` from `WebViewModal` and updating `RequestScene` “keys-only mode” support to open `config.supportSite` in the external browser (plus minor layout/button styling changes there).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01478f42b1e455f58edac6e29a464a9c1481c289. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213657986059786