### PR TITLE
Prevent swap KYC terms modal from stacking and dismiss abuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed: Swap quote timeout error interrupting user after cancelling a slow swap search
 - fixed: Disable "Migrate Wallets" button when no assets are available to migrate
 - fixed: Contacts permission prompt no longer appears on first receive and only shows from transaction-list or payee edit flows
+- fixed: Swap KYC terms modal stacking on auto-refresh and accidental dismissal disabling providers
 
 ## 4.45.0 (2026-03-10)
 

--- a/src/components/modals/SwapVerifyTermsModal.tsx
+++ b/src/components/modals/SwapVerifyTermsModal.tsx
@@ -111,9 +111,6 @@ const SwapVerifyTermsModal: React.FC<Props> = props => {
           <ModalTitle>{displayName}</ModalTitle>
         </View>
       }
-      onCancel={() => {
-        bridge.resolve(false)
-      }}
     >
       <Paragraph>{lstrings.swap_terms_statement}</Paragraph>
       <ModalButtons

--- a/src/components/scenes/SwapConfirmationScene.tsx
+++ b/src/components/scenes/SwapConfirmationScene.tsx
@@ -98,6 +98,9 @@ export const SwapConfirmationScene: React.FC<Props> = (props: Props) => {
 
   const isFocused = useIsFocused()
 
+  const termsCheckPending = React.useRef(false)
+  const timerExpiredDuringTerms = React.useRef(false)
+
   const pickBestQuoteWithPreference = (
     allQuotes: EdgeSwapQuote[]
   ): EdgeSwapQuote => {
@@ -206,6 +209,10 @@ export const SwapConfirmationScene: React.FC<Props> = (props: Props) => {
 
   const handleExchangeTimerExpired = useHandler(() => {
     if (!isFocused) return
+    if (termsCheckPending.current) {
+      timerExpiredDuringTerms.current = true
+      return
+    }
 
     navigation.replace('swapProcessing', {
       swapRequest: selectedQuote.request,
@@ -227,12 +234,20 @@ export const SwapConfirmationScene: React.FC<Props> = (props: Props) => {
     const swapConfig = account.swapConfig[pluginId]
 
     dispatch(logEvent('Exchange_Shift_Quote'))
+    termsCheckPending.current = true
     swapVerifyTerms(swapConfig)
       .then(async result => {
-        if (!result) handleExchangeTimerExpired()
+        termsCheckPending.current = false
+        if (!result || timerExpiredDuringTerms.current) {
+          handleExchangeTimerExpired()
+        }
       })
       .catch((err: unknown) => {
+        termsCheckPending.current = false
         showError(err)
+        if (timerExpiredDuringTerms.current) {
+          handleExchangeTimerExpired()
+        }
       })
   })
 


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1213613256799799/f)

Fixes two bugs with the swap KYC terms verification modal:

1. **Stacking modals**: When the quote auto-refresh timer expires while the terms modal is open, the scene replaces itself via `SwapProcessingScene`, remounts, and calls `swapVerifyTerms` again — stacking a duplicate modal on the still-open first one. Fixed by deferring the timer: if it fires while the terms modal is pending, the expiry is recorded and replayed after the modal resolves.

2. **Destructive dismissal**: Backdrop tap, swipe-down, X button, and hardware back all resolved `false`, triggering `changeEnabled(false)` on the swap provider — silently removing it from exchange settings without clear user intent. Fixed by removing `onCancel` from the `EdgeModal`, making the modal non-dismissable. The user must now explicitly tap Accept or Reject.

Closes: https://app.asana.com/1/9976422036640/project/1200972350208303/task/1213613256799799

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap confirmation navigation timing and makes the terms modal non-dismissible, which can affect swap quote refresh/timeout behavior and provider enablement in edge cases.
> 
> **Overview**
> Fixes swap KYC/terms verification UX by making `SwapVerifyTermsModal` non-cancelable (users must explicitly Accept/Reject) to prevent accidental rejection from backdrop/back actions.
> 
> Updates `SwapConfirmationScene` to defer the auto-refresh/expiry timer while the terms check is open and replay expiration after the modal resolves, preventing duplicate stacked terms modals during quote refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a104576dc72faffa157fd1eef08b74b1af57a77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->