### PR TITLE
Disable Migrate Wallets when no assets to migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added: New Banxa payment methods
 - added: Debug settings scene (Developer Mode only) with nodes/servers inspection, engine `dataDump` viewer, and log viewer
 - fixed: Swap quote timeout error interrupting user after cancelling a slow swap search
+- fixed: Disable "Migrate Wallets" button when no assets are available to migrate
 
 ## 4.45.0 (2025-03-10)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -104,7 +104,7 @@ export default [
       'src/actions/SoundActions.ts',
       'src/actions/TokenTermsActions.tsx',
       'src/actions/TransactionExportActions.tsx',
-      'src/actions/WalletActions.tsx',
+
       'src/actions/WalletListActions.tsx',
       'src/actions/WalletListMenuActions.tsx',
       'src/app.ts',
@@ -240,7 +240,6 @@ export default [
       'src/components/scenes/ConfirmScene.tsx',
       'src/components/scenes/CreateWalletAccountSelectScene.tsx',
       'src/components/scenes/CreateWalletAccountSetupScene.tsx',
-      'src/components/scenes/CreateWalletCompletionScene.tsx',
 
       'src/components/scenes/CreateWalletImportOptionsScene.tsx',
       'src/components/scenes/CreateWalletImportScene.tsx',
@@ -280,8 +279,6 @@ export default [
       'src/components/scenes/Loans/LoanStatusScene.tsx',
 
       'src/components/scenes/ManageTokensScene.tsx',
-      'src/components/scenes/MigrateWalletCalculateFeeScene.tsx',
-      'src/components/scenes/MigrateWalletCompletionScene.tsx',
 
       'src/components/scenes/NotificationCenterScene.tsx',
       'src/components/scenes/NotificationScene.tsx',

--- a/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
@@ -4540,7 +4540,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                 allowFontScaling={false}
                 style={
                   {
-                    "color": "#FFFFFF",
+                    "color": "#888888",
                     "flexGrow": 1,
                     "flexShrink": 1,
                     "fontFamily": "Quicksand-Regular",
@@ -4644,7 +4644,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
                             "fontSize": 22,
                           },
                           {
-                            "color": "#00f1a2",
+                            "color": "rgba(255, 255, 255, .75)",
                             "fontSize": 22,
                             "marginHorizontal": 11,
                           },

--- a/src/actions/WalletActions.tsx
+++ b/src/actions/WalletActions.tsx
@@ -38,6 +38,7 @@ import type { NavigationBase } from '../types/routerTypes'
 import type { MapObject } from '../types/types'
 import { getCurrencyCode, isKeysOnlyPlugin } from '../util/CurrencyInfoHelpers'
 import { getWalletName } from '../util/CurrencyWalletHelpers'
+import { getMigrateWalletItemList } from '../util/getMigrateWalletItemList'
 import { fetchInfo } from '../util/network'
 
 export interface SelectWalletTokenParams {
@@ -450,13 +451,17 @@ export function checkCompromisedKeys(
       ))
     }
 
-    // If any walletId come back true show modal to go to migration scene with affected wallets preselected
-    if (exposedWalletIds.length > 0) {
-      const walletNames = exposedWalletIds.map(walletId =>
+    const migratableItems = getMigrateWalletItemList(currencyWallets)
+    const migratableWalletIds = exposedWalletIds.filter(id =>
+      migratableItems.some(item => item.createWalletId === id)
+    )
+
+    if (migratableWalletIds.length > 0) {
+      const walletNames = migratableWalletIds.map(walletId =>
         getWalletName(currencyWallets[walletId])
       )
       const response = await MigrateWalletsModal(walletNames)
-      exposedWalletIds.forEach(walletId => {
+      migratableWalletIds.forEach(walletId => {
         const { checked, modalShown } = securityCheckedWallets[walletId]
         securityCheckedWallets[walletId] = {
           checked,
@@ -466,7 +471,7 @@ export function checkCompromisedKeys(
 
       if (response === 'yes') {
         navigation.push('migrateWalletSelectCrypto', {
-          preSelectedWalletIds: exposedWalletIds
+          preSelectedWalletIds: migratableWalletIds
         })
       }
     }

--- a/src/actions/WalletActions.tsx
+++ b/src/actions/WalletActions.tsx
@@ -68,7 +68,7 @@ export function selectWalletToken({
     // Manually un-pause the wallet, if necessary:
     const wallet: EdgeCurrencyWallet = currencyWallets[walletId]
     if (wallet.paused && !isKeysOnlyPlugin(wallet.currencyInfo.pluginId))
-      wallet.changePaused(false).catch(error => {
+      wallet.changePaused(false).catch((error: unknown) => {
         showError(error)
       })
 
@@ -93,7 +93,7 @@ export function selectWalletToken({
     const { isAccountActivationRequired } = getSpecialCurrencyInfo(
       wallet.currencyInfo.pluginId
     )
-    if (isAccountActivationRequired) {
+    if (isAccountActivationRequired === true) {
       // activation-required wallets need different path in case not activated yet
       if (alwaysActivate) {
         return await dispatch(
@@ -141,7 +141,7 @@ function selectActivationRequiredWallet(
           )}
           buttons={{ ok: { label: lstrings.string_ok } }}
         />
-      )).catch(err => {
+      )).catch((err: unknown) => {
         showError(err)
       })
       return false
@@ -172,7 +172,7 @@ export function updateMostRecentWalletsSelected(
           data: { mostRecentWallets: currentMostRecentWallets }
         })
       })
-      .catch(error => {
+      .catch((error: unknown) => {
         showError(error)
       })
   }
@@ -278,7 +278,7 @@ export function activateWalletTokens(
                 message={sprintf(msg, feeString)}
                 buttons={{ ok: { label: lstrings.string_ok } }}
               />
-            )).catch(err => {
+            )).catch((err: unknown) => {
               showError(err)
             })
             navigation.pop()
@@ -306,7 +306,7 @@ export function activateWalletTokens(
               )
               navigation.pop()
             })
-            .catch(e => {
+            .catch((e: unknown) => {
               navigation.pop()
               showError(e)
             })
@@ -413,7 +413,7 @@ export function checkCompromisedKeys(
       const keyInfo = exposedKeyInfos.find(
         info => info.pubKeyHash === pubkeyHash
       )
-      if (keyInfo?.exposed) {
+      if (keyInfo?.exposed === true) {
         exposedWalletIds.push(walletId)
       } else {
         securityCheckedWallets[walletId] = {

--- a/src/components/scenes/CreateWalletCompletionScene.tsx
+++ b/src/components/scenes/CreateWalletCompletionScene.tsx
@@ -39,7 +39,7 @@ export interface CreateWalletCompletionParams {
 
 interface Props extends EdgeAppSceneProps<'createWalletCompletion'> {}
 
-const CreateWalletCompletionComponent = (props: Props) => {
+const CreateWalletCompletionComponent: React.FC<Props> = props => {
   const { navigation, route } = props
   const {
     createWalletList,
@@ -145,7 +145,7 @@ const CreateWalletCompletionComponent = (props: Props) => {
               [tokenKey]: 'complete'
             }))
           },
-          error => {
+          (error: unknown) => {
             showError(error)
             setItemStatus(currentState => ({
               ...currentState,
@@ -255,7 +255,6 @@ const CreateWalletCompletionComponent = (props: Props) => {
     // Transform filtered items into the structure expected by the migration component
     const migrateWalletList: MigrateWalletItem[] = newWalletItems.map(
       createWallet => {
-        // Link the createWalletIds with the created wallets
         const { key, pluginId } = createWallet
         const wallet = wallets.find(
           wallet => wallet.currencyInfo.pluginId === pluginId
@@ -263,7 +262,7 @@ const CreateWalletCompletionComponent = (props: Props) => {
 
         return {
           ...createWallet,
-          createWalletIds: wallet == null ? [''] : [wallet.id],
+          createWalletId: wallet == null ? '' : wallet.id,
           displayName: walletNames[key],
           key,
           type: 'create'

--- a/src/components/scenes/MigrateWalletCalculateFeeScene.tsx
+++ b/src/components/scenes/MigrateWalletCalculateFeeScene.tsx
@@ -41,7 +41,7 @@ type Props = EdgeAppSceneProps<'migrateWalletCalculateFee'>
 
 type AssetRowState = string | Error
 
-const MigrateWalletCalculateFeeComponent = (props: Props) => {
+const MigrateWalletCalculateFeeComponent: React.FC<Props> = props => {
   const { navigation, route } = props
   const { migrateWalletList } = route.params
 
@@ -71,10 +71,14 @@ const MigrateWalletCalculateFeeComponent = (props: Props) => {
 
   const renderCurrencyRow = useHandler(
     (data: ListRenderItemInfo<MigrateWalletItem>) => {
-      const { key, pluginId, tokenId, walletType, createWalletIds } = data.item
+      const {
+        key,
+        pluginId,
+        tokenId,
+        walletType,
+        createWalletId: walletId
+      } = data.item
       if (walletType == null) return null
-
-      const walletId = createWalletIds[0]
       const wallet = currencyWallets[walletId]
       if (wallet == null) return null
       const {
@@ -198,12 +202,11 @@ const MigrateWalletCalculateFeeComponent = (props: Props) => {
       // This bundles the assets by similar walletId with the main asset (ie. ETH) at the end of each array so its makeSpend is called last
       const bundledWalletAssets: MigrateWalletItem[][] =
         migrateWalletList.reduce((bundles: MigrateWalletItem[][], asset) => {
-          const { createWalletIds } = asset
-          const walletId = createWalletIds[0]
+          const { createWalletId: walletId } = asset
 
           // Find the bundle with the main currency at the end of it
           const index = bundles.findIndex(
-            bundle => walletId === bundle[0].createWalletIds[0]
+            bundle => walletId === bundle[0].createWalletId
           )
           if (index === -1) {
             bundles.push([asset]) // create bundle for this walletId
@@ -221,8 +224,7 @@ const MigrateWalletCalculateFeeComponent = (props: Props) => {
       let successCount = 0
       const walletPromises = []
       for (const bundle of bundledWalletAssets) {
-        const wallet =
-          currencyWallets[bundle[bundle.length - 1].createWalletIds[0]]
+        const wallet = currencyWallets[bundle[bundle.length - 1].createWalletId]
         const {
           currencyInfo: { pluginId }
         } = wallet
@@ -322,11 +324,9 @@ const MigrateWalletCalculateFeeComponent = (props: Props) => {
 
   // Wait for wallets to sync
   React.useEffect(() => {
-    const migrateWalletIds = migrateWalletList.map(
-      item => item.createWalletIds[0]
-    )
+    const migrateWalletIds = migrateWalletList.map(item => item.createWalletId)
 
-    const updateProgress = () => {
+    const updateProgress = (): void => {
       const syncedWallets = migrateWalletIds.filter(walletId => {
         const wallet = currencyWallets[walletId]
 

--- a/src/components/scenes/MigrateWalletCompletionScene.tsx
+++ b/src/components/scenes/MigrateWalletCompletionScene.tsx
@@ -42,7 +42,7 @@ interface MigrateWalletTokenItem extends MigrateWalletItem {
   tokenId: string
 }
 
-const MigrateWalletCompletionComponent = (props: Props) => {
+const MigrateWalletCompletionComponent: React.FC<Props> = props => {
   const { navigation, route } = props
   const { migrateWalletList } = route.params
 
@@ -54,12 +54,11 @@ const MigrateWalletCompletionComponent = (props: Props) => {
 
   const sortedMigrateWalletListBundles = React.useMemo(() => {
     return migrateWalletList.reduce((bundles: MigrateWalletItem[][], asset) => {
-      const { createWalletIds } = asset
-      const walletId = createWalletIds[0]
+      const { createWalletId: walletId } = asset
 
       // Find the bundle with the main currency at the end of it
       const index = bundles.findIndex(
-        bundle => walletId === bundle[0].createWalletIds[0]
+        bundle => walletId === bundle[0].createWalletId
       )
 
       if (index === -1) {
@@ -98,7 +97,7 @@ const MigrateWalletCompletionComponent = (props: Props) => {
   const handleItemStatus = (
     item: MigrateWalletItem,
     status: 'complete' | 'error'
-  ) => {
+  ): void => {
     setItemStatus(currentState => ({ ...currentState, [item.key]: status }))
     const index = sortedMigrateWalletList.findIndex(
       asset => asset.key === item.key
@@ -119,8 +118,7 @@ const MigrateWalletCompletionComponent = (props: Props) => {
       const migrationPromises = []
       for (const bundle of sortedMigrateWalletListBundles) {
         const mainnetItem = bundle[bundle.length - 1]
-        const { createWalletIds } = mainnetItem
-        const oldWalletId = createWalletIds[0]
+        const { createWalletId: oldWalletId } = mainnetItem
 
         securityCheckedWallets[oldWalletId] ??= {
           checked: false,
@@ -135,7 +133,7 @@ const MigrateWalletCompletionComponent = (props: Props) => {
         const newWalletName = `${oldWalletName}${lstrings.migrate_wallet_new_fragment}`
 
         // Create new wallet
-        const createNewWalletPromise = async () => {
+        const createNewWalletPromise = async (): Promise<void> => {
           const previouslyCreatedWalletInfo = account.allKeys.find(
             keys =>
               keys.migratedFromWalletId === oldWalletId &&
@@ -342,9 +340,7 @@ const MigrateWalletCompletionComponent = (props: Props) => {
   const renderRow = useHandler(
     (data: ListRenderItemInfo<MigrateWalletItem>) => {
       const { item } = data
-      const { createWalletIds } = item
-
-      const walletId = createWalletIds[0]
+      const { createWalletId: walletId } = item
       const wallet = currencyWallets[walletId]
       if (wallet == null) return null
       return (

--- a/src/components/scenes/MigrateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/MigrateWalletSelectCryptoScene.tsx
@@ -3,19 +3,15 @@ import { type ListRenderItemInfo, Switch, View } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
-import { SPECIAL_CURRENCY_INFO } from '../../constants/WalletAndCurrencyConstants'
 import { useHandler } from '../../hooks/useHandler'
 import { useWatch } from '../../hooks/useWatch'
 import { lstrings } from '../../locales/strings'
-import type { WalletCreateItem } from '../../selectors/getCreateWalletList'
 import { useSelector } from '../../types/reactRedux'
 import type { EdgeAppSceneProps } from '../../types/routerTypes'
 import {
-  getCurrencyCode,
-  isKeysOnlyPlugin
-} from '../../util/CurrencyInfoHelpers'
-import { getWalletName } from '../../util/CurrencyWalletHelpers'
-import { zeroString } from '../../util/utils'
+  getMigrateWalletItemList,
+  type MigrateWalletItem
+} from '../../util/getMigrateWalletItemList'
 import { EdgeAnim } from '../common/EdgeAnim'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { showError } from '../services/AirshipInstance'
@@ -30,9 +26,7 @@ export interface MigrateWalletSelectCryptoParams {
 
 interface Props extends EdgeAppSceneProps<'migrateWalletSelectCrypto'> {}
 
-export interface MigrateWalletItem extends WalletCreateItem {
-  createWalletIds: [string]
-}
+export type { MigrateWalletItem }
 
 const MigrateWalletSelectCryptoComponent: React.FC<Props> = props => {
   const { navigation, route } = props
@@ -44,46 +38,15 @@ const MigrateWalletSelectCryptoComponent: React.FC<Props> = props => {
   const account = useSelector(state => state.core.account)
   const currencyWallets = useWatch(account, 'currencyWallets')
 
-  const migrateWalletList = React.useMemo(() => {
-    let list: MigrateWalletItem[] = []
-    Object.keys(currencyWallets).forEach(walletId => {
-      const wallet = currencyWallets[walletId]
-      const {
-        currencyInfo: { pluginId, walletType },
-        balanceMap,
-        enabledTokenIds
-      } = wallet
-
-      if (isKeysOnlyPlugin(pluginId)) return
-      if (SPECIAL_CURRENCY_INFO[pluginId].isAccountActivationRequired === true)
-        return // ignore activation required plugins
-      if (pluginId === 'ripple') return // ignore currencies with token approval since they can't do bulk approvals
-
-      const walletAssetList: MigrateWalletItem[] = []
-      for (const [tokenId, bal] of Array.from(balanceMap.entries())) {
-        if (zeroString(bal)) continue // ignore token
-        if (tokenId != null && !enabledTokenIds.includes(tokenId)) continue // ignore token
-        const currencyCode = getCurrencyCode(wallet, tokenId)
-        walletAssetList.push({
-          type: 'create',
-          createWalletIds: [walletId],
-          currencyCode,
-          displayName: getWalletName(wallet),
-          key: `${walletId}:${tokenId ?? 'PARENT_TOKEN'}`,
-          pluginId,
-          tokenId,
-          walletType
-        })
-      }
-      list = [...list, ...walletAssetList]
-    })
-    return list
-  }, [currencyWallets])
+  const migrateWalletList = React.useMemo(
+    () => getMigrateWalletItemList(currencyWallets),
+    [currencyWallets]
+  )
 
   const [selectedItems, setSelectedItems] = React.useState<Set<string>>(() => {
     const out = new Set<string>()
     for (const migrateWalletItem of migrateWalletList) {
-      if (preSelectedWalletIds.includes(migrateWalletItem.createWalletIds[0]))
+      if (preSelectedWalletIds.includes(migrateWalletItem.createWalletId))
         out.add(migrateWalletItem.key)
     }
     return out

--- a/src/components/scenes/SettingsScene.tsx
+++ b/src/components/scenes/SettingsScene.tsx
@@ -45,6 +45,7 @@ import { useDispatch, useSelector } from '../../types/reactRedux'
 import type { EdgeAppSceneProps, NavigationBase } from '../../types/routerTypes'
 import type { ThemeMode } from '../../types/types'
 import { secondsToDisplay } from '../../util/displayTime'
+import { getMigrateWalletItemList } from '../../util/getMigrateWalletItemList'
 import { getDisplayUsername, removeIsoPrefix } from '../../util/utils'
 import { ButtonsView } from '../buttons/ButtonsView'
 import { EdgeCard } from '../cards/EdgeCard'
@@ -118,6 +119,12 @@ export const SettingsScene: React.FC<Props> = props => {
   const hasRestoreWallets =
     allKeys != null &&
     allKeys.filter(key => key.archived || key.deleted).length > 0
+
+  const currencyWallets = useWatch(account, 'currencyWallets')
+  const hasMigrateWallets = React.useMemo(
+    () => getMigrateWalletItemList(currencyWallets).length > 0,
+    [currencyWallets]
+  )
 
   const context = useSelector(state => state.core.context)
   const logSettings = useWatch(context, 'logSettings')
@@ -697,9 +704,14 @@ export const SettingsScene: React.FC<Props> = props => {
             />
             <SettingsTappableRow
               label={lstrings.migrate_wallets_title}
-              onPress={() => {
-                navigation.push('migrateWalletSelectCrypto', {})
-              }}
+              onPress={
+                hasMigrateWallets
+                  ? () => {
+                      navigation.push('migrateWalletSelectCrypto', {})
+                    }
+                  : undefined
+              }
+              disabled={!hasMigrateWallets}
             />
             <SettingsTappableRow
               label={lstrings.title_terms_of_service}

--- a/src/util/getMigrateWalletItemList.ts
+++ b/src/util/getMigrateWalletItemList.ts
@@ -1,0 +1,54 @@
+import type { EdgeCurrencyWallet } from 'edge-core-js'
+
+import { SPECIAL_CURRENCY_INFO } from '../constants/WalletAndCurrencyConstants'
+import type { WalletCreateItem } from '../selectors/getCreateWalletList'
+import { getCurrencyCode, isKeysOnlyPlugin } from './CurrencyInfoHelpers'
+import { getWalletName } from './CurrencyWalletHelpers'
+import { zeroString } from './utils'
+
+export interface MigrateWalletItem extends WalletCreateItem {
+  createWalletId: string
+}
+
+/**
+ * Assets the user can migrate: non-zero balances on wallets that support the
+ * migrate flow (same rules as MigrateWalletSelectCryptoScene).
+ */
+export function getMigrateWalletItemList(
+  currencyWallets: Readonly<Record<string, EdgeCurrencyWallet>> | undefined
+): MigrateWalletItem[] {
+  if (currencyWallets == null) return []
+  let list: MigrateWalletItem[] = []
+  for (const walletId of Object.keys(currencyWallets)) {
+    const wallet = currencyWallets[walletId]
+    const {
+      currencyInfo: { pluginId, walletType },
+      balanceMap,
+      enabledTokenIds
+    } = wallet
+
+    if (isKeysOnlyPlugin(pluginId)) continue
+    if (SPECIAL_CURRENCY_INFO[pluginId]?.isAccountActivationRequired === true)
+      continue
+    if (pluginId === 'ripple') continue
+
+    const walletAssetList: MigrateWalletItem[] = []
+    for (const [tokenId, bal] of Array.from(balanceMap.entries())) {
+      if (zeroString(bal)) continue
+      if (tokenId != null && !enabledTokenIds.includes(tokenId)) continue
+      const currencyCode = getCurrencyCode(wallet, tokenId)
+      walletAssetList.push({
+        type: 'create',
+        createWalletId: walletId,
+        currencyCode,
+        displayName: getWalletName(wallet),
+        key: `${walletId}:${tokenId ?? 'PARENT_TOKEN'}`,
+        pluginId,
+        tokenId,
+        walletType
+      })
+    }
+    list = [...list, ...walletAssetList]
+  }
+  return list
+}


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1211114363135206/f)

Disable the "Migrate Wallets" button in Settings when there are no assets available to migrate, matching the existing "Restore Wallets" disabled pattern. Also filter compromised-key wallet IDs through the same eligibility check so the migrate modal is never shown for wallets with no migratable assets.

Extracts the migrate-wallet eligibility logic into a shared `getMigrateWalletItemList` utility to avoid duplicating the filtering rules across SettingsScene, WalletActions, and MigrateWalletSelectCryptoScene.

Closes https://app.asana.com/1/9976422036640/project/1200972350208303/task/1211114363135206

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes eligibility logic that gates the wallet migration flow and affects compromised-key handling/navigation; mistakes could incorrectly hide migration or preselect wrong wallets.
> 
> **Overview**
> Disables the Settings `Migrate Wallets` row when there are no eligible non-zero assets to migrate, matching the existing disabled behavior for `Restore Wallets`.
> 
> Extracts and centralizes migration eligibility into `getMigrateWalletItemList`, and updates migration-related scenes/actions to use a single `createWalletId` field (instead of an array) and to only show the compromised-key migration modal / preselect wallets that actually have migratable assets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18a3c1b907b86de0262665097dd2cb358b9ef86d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->