### PR TITLE
Move import options into CreateWalletImportScene

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -238,6 +238,7 @@ export default [
       'src/components/scenes/ConfirmScene.tsx',
       'src/components/scenes/CreateWalletAccountSelectScene.tsx',
       'src/components/scenes/CreateWalletAccountSetupScene.tsx',
+      'src/components/scenes/CreateWalletCompletionScene.tsx',
 
       'src/components/scenes/CurrencyNotificationScene.tsx',
       'src/components/scenes/DefaultFiatSettingScene.tsx',

--- a/src/components/scenes/CreateWalletImportScene.tsx
+++ b/src/components/scenes/CreateWalletImportScene.tsx
@@ -1,6 +1,6 @@
 import type { JsonObject } from 'edge-core-js'
 import * as React from 'react'
-import { Platform, View } from 'react-native'
+import { Linking, Platform, View } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { sprintf } from 'sprintf-js'
 
@@ -19,8 +19,10 @@ import {
 import { useSelector } from '../../types/reactRedux'
 import type { EdgeAppSceneProps } from '../../types/routerTypes'
 import { SceneButtons } from '../buttons/SceneButtons'
+import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { CryptoIcon } from '../icons/CryptoIcon'
+import { InformationCircleIcon } from '../icons/ThemedIcons'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { Airship, showError } from '../services/AirshipInstance'
 import { cacheStyles, type Theme, useTheme } from '../services/ThemeContext'
@@ -299,27 +301,52 @@ const CreateWalletImportComponent = (props: Props): React.JSX.Element => {
                 if (item == null) return null
 
                 const { value, error } = item
+                const { knowledgeBaseUri } = opt.displayDescription ?? {}
+
+                const returnKeyType =
+                  opt.inputType === 'number-pad' && Platform.OS === 'ios'
+                    ? undefined
+                    : 'done'
 
                 return (
-                  <FilledTextInput
-                    key={key}
-                    aroundRem={0.5}
-                    placeholder={`${opt.displayName}${
-                      opt.required ? ` (${lstrings.fragment_required})` : ''
-                    }`}
-                    value={value}
-                    error={
-                      error ? lstrings.create_wallet_invalid_input : undefined
-                    }
-                    keyboardType={opt.inputType}
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                    autoComplete="off"
-                    onChangeText={(text: string) => {
-                      handleOptionChange(text, pluginId, opt)
-                    }}
-                    returnKeyType="done"
-                  />
+                  <View key={key} style={styles.optionRow}>
+                    <FilledTextInput
+                      aroundRem={0.5}
+                      expand
+                      placeholder={`${opt.displayName}${
+                        opt.required ? ` (${lstrings.fragment_required})` : ''
+                      }`}
+                      value={value}
+                      error={
+                        error ? lstrings.create_wallet_invalid_input : undefined
+                      }
+                      keyboardType={opt.inputType}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      autoComplete="off"
+                      onChangeText={(text: string) => {
+                        handleOptionChange(text, pluginId, opt)
+                      }}
+                      returnKeyType={returnKeyType}
+                    />
+                    {knowledgeBaseUri != null ? (
+                      <EdgeTouchableOpacity
+                        style={styles.infoButton}
+                        onPress={() => {
+                          Linking.openURL(knowledgeBaseUri).catch(
+                            (err: unknown) => {
+                              showError(err)
+                            }
+                          )
+                        }}
+                      >
+                        <InformationCircleIcon
+                          size={theme.rem(1.25)}
+                          color={theme.iconTappable}
+                        />
+                      </EdgeTouchableOpacity>
+                    ) : null}
+                  </View>
                 )
               })}
             </View>
@@ -365,6 +392,13 @@ const getStyles = cacheStyles((theme: Theme) => ({
   pluginIdText: {
     fontSize: theme.rem(1),
     marginLeft: theme.rem(0.5)
+  },
+  optionRow: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  infoButton: {
+    padding: theme.rem(0.5)
   }
 }))
 

--- a/src/components/scenes/CreateWalletImportScene.tsx
+++ b/src/components/scenes/CreateWalletImportScene.tsx
@@ -1,8 +1,7 @@
 import type { JsonObject } from 'edge-core-js'
 import * as React from 'react'
-import { Linking, Platform, View } from 'react-native'
+import { Platform, View } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
-import Ionicon from 'react-native-vector-icons/Ionicons'
 import { sprintf } from 'sprintf-js'
 
 import { PLACEHOLDER_WALLET_ID } from '../../actions/CreateWalletActions'
@@ -20,12 +19,9 @@ import {
 import { useSelector } from '../../types/reactRedux'
 import type { EdgeAppSceneProps } from '../../types/routerTypes'
 import { SceneButtons } from '../buttons/SceneButtons'
-import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { CryptoIcon } from '../icons/CryptoIcon'
 import { ButtonsModal } from '../modals/ButtonsModal'
-import { TextInputModal } from '../modals/TextInputModal'
-import { EdgeRow } from '../rows/EdgeRow'
 import { Airship, showError } from '../services/AirshipInstance'
 import { cacheStyles, type Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText, Paragraph } from '../themed/EdgeText'
@@ -117,62 +113,6 @@ const CreateWalletImportComponent = (props: Props): React.JSX.Element => {
           map => new Map(map.set(key, { value: input, error: true }))
         )
       }
-    }
-  )
-
-  const handleEditOption = useHandler(
-    async (
-      initialValue: string,
-      pluginId: string,
-      opt: ImportKeyOption
-    ): Promise<void> => {
-      const onSubmit = async (input: string): Promise<string | true> => {
-        if (input === '' || opt.inputValidation(input)) return true
-        return lstrings.create_wallet_invalid_input
-      }
-
-      let description: React.ReactNode | undefined
-      if (opt.displayDescription != null) {
-        const { message, knowledgeBaseUri } = opt.displayDescription
-
-        if (knowledgeBaseUri != null) {
-          const onPress = (): void => {
-            Linking.openURL(knowledgeBaseUri).catch((err: unknown) => {
-              showError(err)
-            })
-          }
-          description = (
-            <Paragraph>
-              {message}
-              <EdgeTouchableOpacity onPress={onPress}>
-                <Ionicon
-                  name="help-circle-outline"
-                  size={theme.rem(1)}
-                  color={theme.iconTappable}
-                />
-              </EdgeTouchableOpacity>
-            </Paragraph>
-          )
-        } else {
-          description = message
-        }
-      }
-
-      await Airship.show<string | undefined>(bridge => (
-        <TextInputModal
-          bridge={bridge}
-          initialValue={initialValue}
-          inputLabel={opt.displayName}
-          title={opt.displayName}
-          message={description}
-          keyboardType={opt.inputType}
-          onSubmit={onSubmit}
-        />
-      )).then((response: string | undefined) => {
-        if (response != null) {
-          handleOptionChange(response, pluginId, opt)
-        }
-      })
     }
   )
 
@@ -341,12 +281,18 @@ const CreateWalletImportComponent = (props: Props): React.JSX.Element => {
           ) : null}
           {importOptsEntries.map(([pluginId, opts]) => (
             <View key={pluginId} style={styles.optionContainer}>
-              <View style={styles.optionHeader}>
-                <CryptoIcon sizeRem={1.25} pluginId={pluginId} tokenId={null} />
-                <EdgeText style={styles.pluginIdText}>
-                  {currencyConfig[pluginId].currencyInfo.displayName}
-                </EdgeText>
-              </View>
+              {importOptsEntries.length > 1 ? (
+                <View style={styles.optionHeader}>
+                  <CryptoIcon
+                    sizeRem={1.25}
+                    pluginId={pluginId}
+                    tokenId={null}
+                  />
+                  <EdgeText style={styles.pluginIdText}>
+                    {currencyConfig[pluginId].currencyInfo.displayName}
+                  </EdgeText>
+                </View>
+              ) : null}
               {[...opts].map(opt => {
                 const key = getOptionKey(pluginId, opt)
                 const item = optionValues.get(key)
@@ -355,24 +301,25 @@ const CreateWalletImportComponent = (props: Props): React.JSX.Element => {
                 const { value, error } = item
 
                 return (
-                  <View key={key} style={styles.optionInput}>
-                    <EdgeRow
-                      rightButtonType="editable"
-                      title={opt.displayName}
-                      maximumHeight="large"
-                      onPress={async () => {
-                        await handleEditOption(value, pluginId, opt)
-                      }}
-                      error={error || (value === '' && opt.required)}
-                    >
-                      <View style={styles.optionRow}>
-                        <EdgeText>{value}</EdgeText>
-                        <EdgeText style={styles.requiredText}>
-                          {opt.required ? lstrings.fragment_required : null}
-                        </EdgeText>
-                      </View>
-                    </EdgeRow>
-                  </View>
+                  <FilledTextInput
+                    key={key}
+                    aroundRem={0.5}
+                    placeholder={`${opt.displayName}${
+                      opt.required ? ` (${lstrings.fragment_required})` : ''
+                    }`}
+                    value={value}
+                    error={
+                      error ? lstrings.create_wallet_invalid_input : undefined
+                    }
+                    keyboardType={opt.inputType}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    autoComplete="off"
+                    onChangeText={(text: string) => {
+                      handleOptionChange(text, pluginId, opt)
+                    }}
+                    returnKeyType="done"
+                  />
                 )
               })}
             </View>
@@ -403,31 +350,21 @@ const getStyles = cacheStyles((theme: Theme) => ({
   optionsHeading: {
     fontSize: theme.rem(1),
     marginTop: theme.rem(1.5),
-    marginLeft: theme.rem(0.5)
+    marginLeft: theme.rem(0.5),
+    marginBottom: theme.rem(0.5)
   },
   optionContainer: {
-    marginTop: theme.rem(1)
+    marginTop: theme.rem(0.5)
   },
   optionHeader: {
     flexDirection: 'row',
-    marginLeft: theme.rem(1)
+    alignItems: 'center',
+    marginLeft: theme.rem(0.5),
+    marginBottom: theme.rem(0.5)
   },
   pluginIdText: {
     fontSize: theme.rem(1),
     marginLeft: theme.rem(0.5)
-  },
-  optionInput: {
-    marginLeft: theme.rem(1)
-  },
-  optionRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between'
-  },
-  requiredText: {
-    marginTop: theme.rem(0.25),
-    textAlign: 'right',
-    fontSize: theme.rem(0.75),
-    color: theme.deactivatedText
   }
 }))
 


### PR DESCRIPTION
Additional change on https://github.com/EdgeApp/edge-react-gui/pull/5982. This replaces that PR

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the wallet import flow UI and validation for per-currency import options, which could block imports or mis-handle required fields if regressions occur. Changes are localized to the import scene plus lint config.
> 
> **Overview**
> **Refactors `CreateWalletImportScene` to collect import key options inline** instead of via an editable row + modal, using `FilledTextInput` fields with per-option validation/required handling.
> 
> Adds an in-row info button that opens any option `knowledgeBaseUri`, shows the currency header only when multiple plugins are present, and tweaks return-key behavior and spacing styles. Updates `eslint.config.mjs` to include `CreateWalletCompletionScene.tsx` in the TypeScript project-service linting block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df3f7aa89be90c198560710037392792c8a2da13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213807682840405