### PR TITLE
fix: preserve imported token migrations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -287,8 +287,6 @@ export default [
 
       'src/components/scenes/SwapSettingsScene.tsx',
       'src/components/scenes/SwapSuccessScene.tsx',
-      'src/components/scenes/SweepPrivateKeyCalculateFeeScene.tsx',
-      'src/components/scenes/SweepPrivateKeyCompletionScene.tsx',
 
       'src/components/scenes/TransactionDetailsScene.tsx',
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -238,7 +238,6 @@ export default [
       'src/components/scenes/ConfirmScene.tsx',
       'src/components/scenes/CreateWalletAccountSelectScene.tsx',
       'src/components/scenes/CreateWalletAccountSetupScene.tsx',
-      'src/components/scenes/CreateWalletCompletionScene.tsx',
 
       'src/components/scenes/CurrencyNotificationScene.tsx',
       'src/components/scenes/DefaultFiatSettingScene.tsx',

--- a/src/components/scenes/CreateWalletCompletionScene.tsx
+++ b/src/components/scenes/CreateWalletCompletionScene.tsx
@@ -252,23 +252,44 @@ const CreateWalletCompletionComponent: React.FC<Props> = props => {
   })
 
   const handleMigrate = useHandler(() => {
-    // Transform filtered items into the structure expected by the migration component
-    const migrateWalletList: MigrateWalletItem[] = newWalletItems.map(
-      createWallet => {
-        const { key, pluginId } = createWallet
-        const wallet = wallets.find(
-          wallet => wallet.currencyInfo.pluginId === pluginId
-        )
-
-        return {
-          ...createWallet,
-          createWalletId: wallet == null ? '' : wallet.id,
-          displayName: walletNames[key],
-          key,
-          type: 'create'
-        }
-      }
+    // Build migrate items from successfully created parent wallets, then attach
+    // selected tokens for the same plugin to that same wallet id.
+    const successfulNewWalletItems = newWalletItems.filter(
+      item => itemStatus[item.key] === 'complete'
     )
+    const addedTokenKeys = new Set<string>()
+    const migrateWalletList: MigrateWalletItem[] = []
+
+    for (const createWallet of successfulNewWalletItems) {
+      const { key, pluginId, walletType } = createWallet
+      const wallet = wallets.find(
+        wallet => wallet.currencyInfo.pluginId === pluginId
+      )
+      const createWalletId = wallet?.id ?? ''
+      const displayName = walletNames[key]
+
+      migrateWalletList.push({
+        ...createWallet,
+        createWalletId,
+        displayName,
+        key,
+        type: 'create'
+      })
+
+      for (const tokenItem of newTokenItems) {
+        if (tokenItem.pluginId !== pluginId) continue
+        if (addedTokenKeys.has(tokenItem.key)) continue
+        addedTokenKeys.add(tokenItem.key)
+
+        migrateWalletList.push({
+          ...tokenItem,
+          createWalletId,
+          displayName,
+          walletType,
+          type: 'create'
+        })
+      }
+    }
 
     // Navigate to the migration screen with the prepared list
     if (migrateWalletList.length > 0) {

--- a/src/components/scenes/MigrateWalletCalculateFeeScene.tsx
+++ b/src/components/scenes/MigrateWalletCalculateFeeScene.tsx
@@ -39,7 +39,11 @@ export interface MigrateWalletCalculateFeeParams {
 
 type Props = EdgeAppSceneProps<'migrateWalletCalculateFee'>
 
-type AssetRowState = string | Error
+type AssetRowState = string | Error | 'included'
+type MakeMaxSpendMethod = (params: {
+  tokenIds?: Array<string | null>
+  spendTargets: Array<{ publicAddress: string }>
+}) => Promise<EdgeTransaction>
 
 const MigrateWalletCalculateFeeComponent: React.FC<Props> = props => {
   const { navigation, route } = props
@@ -117,6 +121,14 @@ const MigrateWalletCalculateFeeComponent: React.FC<Props> = props => {
             />
           )
         }
+      } else if (fee === 'included') {
+        rightSide = (
+          <EdgeText
+            style={{ color: theme.secondaryText, fontSize: theme.rem(0.75) }}
+          >
+            {lstrings.string_included}
+          </EdgeText>
+        )
       } else {
         const fakeEdgeTransaction: EdgeTransaction = {
           blockHeight: 0,
@@ -222,73 +234,125 @@ const MigrateWalletCalculateFeeComponent: React.FC<Props> = props => {
         }, [])
 
       let successCount = 0
-      const walletPromises = []
+      const walletRoutines = []
       for (const bundle of bundledWalletAssets) {
         const wallet = currencyWallets[bundle[bundle.length - 1].createWalletId]
         const {
           currencyInfo: { pluginId }
         } = wallet
-
         let feeTotal = '0'
         const bundlesFeeTotals = new Map<string, AssetRowState>(
           bundle.map(item => [item.key, '0'])
         )
 
-        const assetPromises = bundle.map((asset, i) => {
-          return async () => {
-            const publicAddress =
-              SPECIAL_CURRENCY_INFO[pluginId].dummyPublicAddress ??
-              (await wallet.getReceiveAddress({ tokenId: null })).publicAddress
-            const spendInfo: EdgeSpendInfo = {
-              tokenId: asset.tokenId,
-              spendTargets: [{ publicAddress }],
-              networkFeeOption: 'standard'
-            }
+        let assetSpendRoutines: Array<() => Promise<void>>
+        if (
+          (wallet.otherMethods.makeMaxSpend as
+            | MakeMaxSpendMethod
+            | undefined) != null
+        ) {
+          assetSpendRoutines = [
+            async () => {
+              const publicAddress =
+                SPECIAL_CURRENCY_INFO[pluginId].dummyPublicAddress ??
+                (await wallet.getReceiveAddress({ tokenId: null }))
+                  .publicAddress
 
-            try {
-              const maxAmount = await wallet.getMaxSpendable(spendInfo)
-              if (maxAmount === '0') {
-                throw new InsufficientFundsError({ tokenId: asset.tokenId })
-              }
-              const maxSpendInfo = {
-                ...spendInfo,
-                spendTargets: [{ publicAddress, nativeAmount: maxAmount }]
-              }
-              const edgeTransaction = await wallet.makeSpend(maxSpendInfo)
-              const txFee =
-                edgeTransaction.parentNetworkFee ?? edgeTransaction.networkFee
-              bundlesFeeTotals.set(asset.key, txFee)
-              feeTotal = add(feeTotal, txFee)
-
-              // While imperfect, sanity check that the total fee spent so far to send tokens + fee to send mainnet currency is under the total mainnet balance
-              if (
-                i === bundle.length - 1 &&
-                lt(wallet.balanceMap.get(null) ?? '0', feeTotal)
-              ) {
-                throw new InsufficientFundsError({
-                  tokenId: null,
-                  networkFee: feeTotal
+              try {
+                const tokenIds = bundle.map(item => item.tokenId)
+                const edgeTransaction = await (
+                  wallet.otherMethods.makeMaxSpend as MakeMaxSpendMethod
+                )({
+                  tokenIds,
+                  spendTargets: [{ publicAddress }]
                 })
-              }
-            } catch (e: any) {
-              for (const key of bundlesFeeTotals.keys()) {
-                const insufficientFundsError = asMaybeInsufficientFundsError(e)
-                if (insufficientFundsError != null) {
-                  bundlesFeeTotals.set(key, e)
-                } else {
+                const txFee =
+                  edgeTransaction.parentNetworkFee ?? edgeTransaction.networkFee
+                for (const item of bundle) {
                   bundlesFeeTotals.set(
-                    key,
-                    Error(lstrings.migrate_unknown_error_fragment)
+                    item.key,
+                    item.tokenId == null ? txFee : 'included'
                   )
+                }
+
+                successCount++
+              } catch (e: any) {
+                for (const key of bundlesFeeTotals.keys()) {
+                  const insufficientFundsError =
+                    asMaybeInsufficientFundsError(e)
+                  if (insufficientFundsError != null) {
+                    bundlesFeeTotals.set(key, e)
+                  } else {
+                    bundlesFeeTotals.set(
+                      key,
+                      Error(lstrings.migrate_unknown_error_fragment)
+                    )
+                  }
                 }
               }
             }
-          }
-        })
+          ]
+        } else {
+          // Create an array of async functions to call that will spend each
+          // asset in the bundle.
+          assetSpendRoutines = bundle.map((asset, i) => {
+            return async () => {
+              const publicAddress =
+                SPECIAL_CURRENCY_INFO[pluginId].dummyPublicAddress ??
+                (await wallet.getReceiveAddress({ tokenId: null }))
+                  .publicAddress
+              const spendInfo: EdgeSpendInfo = {
+                tokenId: asset.tokenId,
+                spendTargets: [{ publicAddress }],
+                networkFeeOption: 'standard'
+              }
 
-        walletPromises.push(async () => {
-          for (const promise of assetPromises) {
-            await promise()
+              try {
+                const maxAmount = await wallet.getMaxSpendable(spendInfo)
+                if (maxAmount === '0') {
+                  throw new InsufficientFundsError({ tokenId: asset.tokenId })
+                }
+                const maxSpendInfo = {
+                  ...spendInfo,
+                  spendTargets: [{ publicAddress, nativeAmount: maxAmount }]
+                }
+                const edgeTransaction = await wallet.makeSpend(maxSpendInfo)
+                const txFee =
+                  edgeTransaction.parentNetworkFee ?? edgeTransaction.networkFee
+                bundlesFeeTotals.set(asset.key, txFee)
+                feeTotal = add(feeTotal, txFee)
+
+                // While imperfect, sanity check that the total fee spent so far to send tokens + fee to send mainnet currency is under the total mainnet balance
+                if (
+                  i === bundle.length - 1 &&
+                  lt(wallet.balanceMap.get(null) ?? '0', feeTotal)
+                ) {
+                  throw new InsufficientFundsError({
+                    tokenId: null,
+                    networkFee: feeTotal
+                  })
+                }
+              } catch (e: any) {
+                for (const key of bundlesFeeTotals.keys()) {
+                  const insufficientFundsError =
+                    asMaybeInsufficientFundsError(e)
+                  if (insufficientFundsError != null) {
+                    bundlesFeeTotals.set(key, e)
+                  } else {
+                    bundlesFeeTotals.set(
+                      key,
+                      Error(lstrings.migrate_unknown_error_fragment)
+                    )
+                  }
+                }
+              }
+            }
+          })
+        }
+
+        walletRoutines.push(async () => {
+          for (const spendRoutine of assetSpendRoutines) {
+            await spendRoutine()
           }
 
           const success = [...bundlesFeeTotals.values()].some(
@@ -305,8 +369,8 @@ const MigrateWalletCalculateFeeComponent: React.FC<Props> = props => {
       }
 
       await Promise.all(
-        walletPromises.map(async promise => {
-          await promise()
+        walletRoutines.map(async routine => {
+          await routine()
         })
       )
 

--- a/src/components/scenes/MigrateWalletCalculateFeeScene.tsx
+++ b/src/components/scenes/MigrateWalletCalculateFeeScene.tsx
@@ -274,8 +274,6 @@ const MigrateWalletCalculateFeeComponent: React.FC<Props> = props => {
                     item.tokenId == null ? txFee : 'included'
                   )
                 }
-
-                successCount++
               } catch (e: any) {
                 for (const key of bundlesFeeTotals.keys()) {
                   const insufficientFundsError =

--- a/src/components/scenes/MigrateWalletCompletionScene.tsx
+++ b/src/components/scenes/MigrateWalletCompletionScene.tsx
@@ -41,6 +41,11 @@ interface Props extends EdgeAppSceneProps<'migrateWalletCompletion'> {}
 interface MigrateWalletTokenItem extends MigrateWalletItem {
   tokenId: string
 }
+type MakeMaxSpendMethod = (params: {
+  tokenIds?: Array<string | null>
+  spendTargets: Array<{ publicAddress: string }>
+  metadata?: EdgeSpendInfo['metadata']
+}) => Promise<EdgeTransaction>
 
 const MigrateWalletCompletionComponent: React.FC<Props> = props => {
   const { navigation, route } = props
@@ -180,6 +185,57 @@ const MigrateWalletCompletionComponent: React.FC<Props> = props => {
             ])
           ]
           await newWallet.changeEnabledTokenIds(tokenIdsToEnable)
+
+          if (
+            (oldWallet.otherMethods.makeMaxSpend as
+              | MakeMaxSpendMethod
+              | undefined) != null
+          ) {
+            try {
+              const tokenIds = bundle.map(item => item.tokenId)
+              const unsignedTx = await (
+                oldWallet.otherMethods.makeMaxSpend as MakeMaxSpendMethod
+              )({
+                tokenIds,
+                spendTargets: [{ publicAddress: newPublicAddress }],
+                metadata: {
+                  category: 'Transfer',
+                  name: newWalletName,
+                  notes: sprintf(
+                    lstrings.migrate_wallet_tx_notes,
+                    newWalletName
+                  )
+                }
+              })
+              const signedTx = await oldWallet.signTx(unsignedTx)
+              const broadcastedTx = await oldWallet.broadcastTx(signedTx)
+              await oldWallet.saveTx(broadcastedTx)
+
+              for (const item of bundle) {
+                handleItemStatus(item, 'complete')
+              }
+              const successfullyTransferredTokenIds = tokenIds.filter(
+                (id): id is string => id != null
+              )
+              await oldWallet.changeEnabledTokenIds(
+                tokenIdsToEnable.filter(
+                  tokenId => !successfullyTransferredTokenIds.includes(tokenId)
+                )
+              )
+
+              const { modalShown } = securityCheckedWallets[oldWalletId]
+              securityCheckedWallets[oldWalletId] = {
+                checked: true,
+                modalShown
+              }
+            } catch (e) {
+              showError(e)
+              for (const item of bundle) {
+                handleItemStatus(item, 'error')
+              }
+            }
+            return
+          }
 
           // Send tokens
           let feeTotal = '0'

--- a/src/components/scenes/SweepPrivateKeyCalculateFeeScene.tsx
+++ b/src/components/scenes/SweepPrivateKeyCalculateFeeScene.tsx
@@ -4,6 +4,7 @@ import {
   type EdgeCurrencyWallet,
   type EdgeMemoryWallet,
   type EdgeSpendInfo,
+  type EdgeTokenId,
   type EdgeTransaction,
   InsufficientFundsError
 } from 'edge-core-js'
@@ -29,6 +30,7 @@ import { CreateWalletSelectCryptoRow } from '../themed/CreateWalletSelectCryptoR
 import { EdgeText } from '../themed/EdgeText'
 import { SafeSlider } from '../themed/SafeSlider'
 import { SceneHeader } from '../themed/SceneHeader'
+import type { SweepPrivateKeyCompletionParams } from './SweepPrivateKeyCompletionScene'
 import type { SweepPrivateKeyItem } from './SweepPrivateKeyProcessingScene'
 
 export interface SweepPrivateKeyCalculateFeeParams {
@@ -38,8 +40,13 @@ export interface SweepPrivateKeyCalculateFeeParams {
 }
 
 type Props = EdgeAppSceneProps<'sweepPrivateKeyCalculateFee'>
+type AssetTxState = EdgeTransaction | Error | 'included'
+type MakeMaxSpendMethod = (params: {
+  tokenIds?: EdgeTokenId[]
+  spendTargets: Array<{ publicAddress: string }>
+}) => Promise<EdgeTransaction>
 
-const SweepPrivateKeyCalculateFeeComponent = (props: Props) => {
+const SweepPrivateKeyCalculateFeeComponent: React.FC<Props> = props => {
   const { navigation, route } = props
   const { memoryWallet, receivingWallet, sweepPrivateKeyList } = route.params
 
@@ -66,7 +73,7 @@ const SweepPrivateKeyCalculateFeeComponent = (props: Props) => {
   const mounted = React.useRef<boolean>(true)
 
   const [transactionState, setTransactionState] = React.useState<
-    Map<string, EdgeTransaction | Error>
+    Map<string, AssetTxState>
   >(new Map())
   const [sliderDisabled, setSliderDisabled] = React.useState(true)
 
@@ -111,6 +118,14 @@ const SweepPrivateKeyCalculateFeeComponent = (props: Props) => {
             />
           )
         }
+      } else if (tx === 'included') {
+        rightSide = (
+          <EdgeText
+            style={{ color: theme.secondaryText, fontSize: theme.rem(0.75) }}
+          >
+            {lstrings.string_included}
+          </EdgeText>
+        )
       } else {
         const exchangeDenom = getExchangeDenom(
           receivingWallet.currencyConfig,
@@ -170,22 +185,26 @@ const SweepPrivateKeyCalculateFeeComponent = (props: Props) => {
     const unsignedEdgeTransactions: EdgeTransaction[] = []
     for (const item of sweepPrivateKeyList) {
       const tx = transactionState.get(item.key)
-      if (tx == null || tx instanceof Error) continue
+      if (tx == null || tx instanceof Error || tx === 'included') continue
       unsignedEdgeTransactions.push(tx)
     }
-    navigation.push('sweepPrivateKeyCompletion', {
+    const hasIncludedAssets = sweepPrivateKeyList.some(
+      item => transactionState.get(item.key) === 'included'
+    )
+    const completionParams: SweepPrivateKeyCompletionParams = {
       memoryWallet,
       receivingWallet,
-      unsignedEdgeTransactions
-    })
+      sweepPrivateKeyList,
+      unsignedEdgeTransactions,
+      hasIncludedAssets
+    }
+    navigation.push('sweepPrivateKeyCompletion', completionParams)
   })
 
   // Create getMaxSpendable/makeSpend promises for each selected asset. We'll group them by wallet first and then execute all of them while keeping
   // track of which makeSpends are successful so we can enable the slider. A single failure from any of a wallet's assets will cast them all as failures.
   useAsyncEffect(
     async () => {
-      let feeTotal = '0'
-
       const tokenItems = [...sweepPrivateKeyList]
       const mainnetItem = tokenItems.splice(
         sweepPrivateKeyList.length - 1,
@@ -195,90 +214,124 @@ const SweepPrivateKeyCalculateFeeComponent = (props: Props) => {
         await receivingWallet.getReceiveAddress({ tokenId: null })
       ).publicAddress
       let enableSlider = false
-
-      const getMax = async (
-        asset: SweepPrivateKeyItem,
-        numPendingTxs: number
-      ) => {
-        const fakeEdgeTransaction: EdgeTransaction = {
-          blockHeight: 0,
-          currencyCode: '',
-          date: 0,
-          memos: [],
-          isSend: true,
-          nativeAmount: '0',
-          networkFee: '0',
-          networkFees: [],
-          ourReceiveAddresses: [],
-          signedTx: '',
-          tokenId: null,
-          txid: '',
-          walletId: ''
-        }
-
-        const spendInfo: EdgeSpendInfo = {
-          tokenId: asset.tokenId,
-          spendTargets: [{ publicAddress }],
-          networkFeeOption: 'standard',
-          pendingTxs: Array.from(
-            { length: numPendingTxs },
-            () => fakeEdgeTransaction
-          )
-        }
-
+      if (
+        ((memoryWallet as any).otherMethods?.makeMaxSpend as
+          | MakeMaxSpendMethod
+          | undefined) != null
+      ) {
         try {
-          const maxAmount = await memoryWallet.getMaxSpendable(spendInfo)
-          if (maxAmount === '0') {
-            throw new InsufficientFundsError({ tokenId: asset.tokenId })
-          }
-          let nativeAmount = maxAmount
-          if (asset.tokenId === null) {
-            nativeAmount = sub(nativeAmount, feeTotal)
-          }
-          const maxSpendInfo = {
-            ...spendInfo,
-            spendTargets: [{ publicAddress, nativeAmount }]
-          }
-          const edgeTransaction = await memoryWallet.makeSpend(maxSpendInfo)
-          const txFee =
-            edgeTransaction.parentNetworkFee ?? edgeTransaction.networkFee
+          const tokenIds = sweepPrivateKeyList.map(item => item.tokenId)
+          const edgeTransaction = await (
+            (memoryWallet as any).otherMethods
+              .makeMaxSpend as MakeMaxSpendMethod
+          )({
+            tokenIds,
+            spendTargets: [{ publicAddress }]
+          })
           setTransactionState(
-            prevState => new Map([...prevState, [asset.key, edgeTransaction]])
+            new Map(
+              sweepPrivateKeyList.map(item => [
+                item.key,
+                item.tokenId == null ? edgeTransaction : 'included'
+              ])
+            )
           )
-          feeTotal = add(feeTotal, txFee)
-          // While imperfect, sanity check that the total fee spent so far to send tokens + fee to send mainnet currency is under the total mainnet balance
-          if (lt(memoryWallet.balanceMap.get(null) ?? '0', feeTotal)) {
-            throw new InsufficientFundsError({
-              tokenId: null,
-              networkFee: feeTotal
-            })
-          }
           enableSlider = true
         } catch (e) {
           const insufficientFundsError = asMaybeInsufficientFundsError(e)
-          if (insufficientFundsError != null) {
-            setTransactionState(
-              prevState =>
-                new Map([...prevState, [asset.key, insufficientFundsError]])
-            )
-          } else {
-            setTransactionState(
-              prevState =>
-                new Map([
-                  ...prevState,
-                  [asset.key, Error(lstrings.migrate_unknown_error_fragment)]
-                ])
+          const error =
+            insufficientFundsError ??
+            Error(lstrings.migrate_unknown_error_fragment)
+          setTransactionState(
+            new Map(sweepPrivateKeyList.map(item => [item.key, error]))
+          )
+        }
+      } else {
+        let feeTotal = '0'
+        const getMax = async (
+          asset: SweepPrivateKeyItem,
+          numPendingTxs: number
+        ): Promise<void> => {
+          const fakeEdgeTransaction: EdgeTransaction = {
+            blockHeight: 0,
+            currencyCode: '',
+            date: 0,
+            memos: [],
+            isSend: true,
+            nativeAmount: '0',
+            networkFee: '0',
+            networkFees: [],
+            ourReceiveAddresses: [],
+            signedTx: '',
+            tokenId: null,
+            txid: '',
+            walletId: ''
+          }
+
+          const spendInfo: EdgeSpendInfo = {
+            tokenId: asset.tokenId,
+            spendTargets: [{ publicAddress }],
+            networkFeeOption: 'standard',
+            pendingTxs: Array.from(
+              { length: numPendingTxs },
+              () => fakeEdgeTransaction
             )
           }
-        }
-      }
 
-      await Promise.all(
-        tokenItems.map(async (item, index) => {
-          await getMax(item, index)
-        })
-      )
-      await getMax(mainnetItem, tokenItems.length)
+          try {
+            const maxAmount = await memoryWallet.getMaxSpendable(spendInfo)
+            if (maxAmount === '0') {
+              throw new InsufficientFundsError({ tokenId: asset.tokenId })
+            }
+            let nativeAmount = maxAmount
+            if (asset.tokenId === null) {
+              nativeAmount = sub(nativeAmount, feeTotal)
+            }
+            const maxSpendInfo = {
+              ...spendInfo,
+              spendTargets: [{ publicAddress, nativeAmount }]
+            }
+            const edgeTransaction = await memoryWallet.makeSpend(maxSpendInfo)
+            const txFee =
+              edgeTransaction.parentNetworkFee ?? edgeTransaction.networkFee
+            setTransactionState(
+              prevState => new Map([...prevState, [asset.key, edgeTransaction]])
+            )
+            feeTotal = add(feeTotal, txFee)
+            // While imperfect, sanity check that the total fee spent so far to send tokens + fee to send mainnet currency is under the total mainnet balance
+            if (lt(memoryWallet.balanceMap.get(null) ?? '0', feeTotal)) {
+              throw new InsufficientFundsError({
+                tokenId: null,
+                networkFee: feeTotal
+              })
+            }
+            enableSlider = true
+          } catch (e) {
+            const insufficientFundsError = asMaybeInsufficientFundsError(e)
+            if (insufficientFundsError != null) {
+              setTransactionState(
+                prevState =>
+                  new Map([...prevState, [asset.key, insufficientFundsError]])
+              )
+            } else {
+              setTransactionState(
+                prevState =>
+                  new Map([
+                    ...prevState,
+                    [asset.key, Error(lstrings.migrate_unknown_error_fragment)]
+                  ])
+              )
+            }
+          }
+        }
+
+        await Promise.all(
+          tokenItems.map(async (item, index) => {
+            await getMax(item, index)
+          })
+        )
+        await getMax(mainnetItem, tokenItems.length)
+      }
 
       if (enableSlider && mounted.current) {
         setSliderDisabled(false)

--- a/src/components/scenes/SweepPrivateKeyCompletionScene.tsx
+++ b/src/components/scenes/SweepPrivateKeyCompletionScene.tsx
@@ -22,19 +22,41 @@ import { cacheStyles, type Theme, useTheme } from '../services/ThemeContext'
 import { CreateWalletSelectCryptoRow } from '../themed/CreateWalletSelectCryptoRow'
 import { MainButton } from '../themed/MainButton'
 import { SceneHeader } from '../themed/SceneHeader'
+import type { SweepPrivateKeyItem } from './SweepPrivateKeyProcessingScene'
 
 export interface SweepPrivateKeyCompletionParams {
+  /** Temporary source wallet created from the swept private key(s). */
   memoryWallet: EdgeMemoryWallet
+  /**
+   * Destination wallet that receives swept funds and enables
+   * successfully transferred tokens.
+   */
   receivingWallet: EdgeCurrencyWallet
+  /**
+   * Original asset selection order from processing, with token
+   * and mainnet metadata.
+   */
+  sweepPrivateKeyList: SweepPrivateKeyItem[]
+  /** Unsent transactions prepared in fee calculation. */
   unsignedEdgeTransactions: EdgeTransaction[]
+  /**
+   * True when fee calculation marked token rows as included in
+   * a bundled max-spend transaction.
+   */
+  hasIncludedAssets: boolean
 }
 
 interface Props extends EdgeAppSceneProps<'sweepPrivateKeyCompletion'> {}
 
-const SweepPrivateKeyCompletionComponent = (props: Props) => {
+const SweepPrivateKeyCompletionComponent: React.FC<Props> = props => {
   const { navigation, route } = props
-  const { memoryWallet, receivingWallet, unsignedEdgeTransactions } =
-    route.params
+  const {
+    memoryWallet,
+    receivingWallet,
+    sweepPrivateKeyList,
+    unsignedEdgeTransactions,
+    hasIncludedAssets
+  } = route.params
 
   const theme = useTheme()
   const styles = getStyles(theme)
@@ -58,7 +80,7 @@ const SweepPrivateKeyCompletionComponent = (props: Props) => {
   const handleTxStatus = (
     tx: EdgeTransaction,
     status: 'complete' | 'error'
-  ) => {
+  ): void => {
     setItemStatus(currentState => {
       const newState = new Map(currentState)
       newState.set(tx.tokenId, status)
@@ -108,6 +130,12 @@ const SweepPrivateKeyCompletionComponent = (props: Props) => {
             mainnetTransaction
           )
           handleTxStatus(tx, 'complete')
+          if (hasIncludedAssets) {
+            for (const item of sweepPrivateKeyList) {
+              if (item.tokenId == null) continue
+              successfullyTransferredTokenIds.push(item.tokenId)
+            }
+          }
         } catch (e) {
           showError(e)
           handleTxStatus(mainnetTransaction, 'error')

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -690,6 +690,7 @@ const strings = {
   gasPrice: 'Gas Price (Gwei)',
   string_disable: 'Disabled',
   string_done_cap: 'Done',
+  string_included: 'Included',
   string_first_amoy_wallet_name: 'My Amoy',
   string_first_ethereum_wallet_name: 'My Ether',
   string_first_ethereum_classic_wallet_name: 'My Ethereum Classic',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -523,6 +523,7 @@
   "gasPrice": "Gas Price (Gwei)",
   "string_disable": "Disabled",
   "string_done_cap": "Done",
+  "string_included": "Included",
   "string_first_amoy_wallet_name": "My Amoy",
   "string_first_ethereum_wallet_name": "My Ether",
   "string_first_ethereum_classic_wallet_name": "My Ethereum Classic",


### PR DESCRIPTION
Imported token migrations were losing their parent wallet context between wallet creation and the migration flow, which made token migrations disappear or crash before users could review them.

Track the created wallet ids during import completion and carry the parent wallet metadata into the migration payload so imported tokens reach the migration scenes as first-class assets.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes transaction-building and broadcast paths for wallet migration and private-key sweep flows, including new bundled `makeMaxSpend` handling; mistakes could impact fee calculation, asset selection, or token enable/disable behavior during fund transfers.
> 
> **Overview**
> Ensures imported token migrations retain their parent wallet context by building `migrateWalletList` from *successfully created* wallets and attaching matching tokens with the correct `createWalletId` in `CreateWalletCompletionScene`.
> 
> Updates migration and sweep fee calculation to use wallet-provided `otherMethods.makeMaxSpend` when available, marking token rows as **"Included"** (new `string_included`) and treating bundled tokens differently from the mainnet fee row.
> 
> Adjusts completion flows to handle bundled max-spend behavior (including passing sweep selection metadata and enabling tokens when token transfers are implicitly included in the mainnet transaction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bfced13cc7056210def5c43d70c510ba9bb82b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213831335736726
  - https://app.asana.com/0/0/1213968564434715