### PR TITLE
ios: Disable Liquid Glass UI for iOS 26 compatibility

### DIFF
--- a/ios/edge/Info.plist
+++ b/ios/edge/Info.plist
@@ -179,5 +179,7 @@
 	<array>
 		<string>applinks:edge.app</string>
 	</array>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Set `UIDesignRequiresCompatibility=YES` in Info.plist to opt out of Apple's new Liquid Glass design language in iOS 26. This reverts to the previous stable UI style until the app is ready to adopt the new design system.

This is a temporary compatibility flag — Apple recommends it for apps that need time to adapt to the new design. Can be removed once Edge's UI is updated for Liquid Glass.

Ref: https://github.com/facebook/react-native/issues/52823

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk plist-only change that only affects iOS UI appearance/compatibility behavior; no app logic, data, or security paths are modified.
> 
> **Overview**
> Adds `UIDesignRequiresCompatibility` set to `true` in `ios/edge/Info.plist` to force iOS compatibility UI behavior (opting out of the new Liquid Glass design) for iOS 26.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 112a0767582161349a76cec8981b4656405ea0de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->