### PR TITLE
Add drpc and subscan keys to envConfig

### DIFF
--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -366,7 +366,14 @@ export const asEnvConfig = asObject({
     })
   ),
   PULSECHAIN_INIT: asCorePluginInit(asEvmApiKeys),
-  POLKADOT_INIT: asOptional(asBoolean, true),
+  POLKADOT_INIT: asEither(
+    asOptional(asBoolean, true), // Defaults to true if missing.
+    asCorePluginInit(
+      asObject({
+        subscanApiKey: asOptional(asString, '')
+      })
+    )
+  ),
   POLYGON_INIT: asCorePluginInit(asEvmApiKeys),
   RANGO_INIT: asCorePluginInit(
     asObject({
@@ -450,6 +457,7 @@ export const asEnvConfig = asObject({
   ),
   TON_INIT: asCorePluginInit(
     asObject({
+      drpcApiKey: asOptional(asString, ''),
       tonCenterApiKeys: asOptional(asArray(asString), () => [])
     }).withRest
   ),


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `POLKADOT_INIT` env schema from a boolean to a boolean-or-object, which could affect existing deployments if they rely on strict typing/serialization of env values. Otherwise it is additive configuration for API keys with default empty strings.
> 
> **Overview**
> Adds support for additional provider keys in `asEnvConfig`.
> 
> `POLKADOT_INIT` now accepts either the legacy boolean flag (defaulting to `true`) *or* a core-plugin init object containing a `subscanApiKey`. `TON_INIT` now also reads an optional `drpcApiKey` alongside existing TON Center keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ab3bb75410f4387cec27f63e4dc6b49c120277. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213983679796223