### PR TITLE
Show Nym mixnet warning in stake/unstake/claim scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - added: Show swap KYC/terms modal for NExchange
+- added: Nym mixnet warning in Stake, Unstake, and Claim Rewards scenes
 - changed: Migrate Thorchain Savers and Thorchain Yield endpoints off NineRealms to gateway.liquify.com.
 
 ## 4.48.0 (staging)

--- a/src/components/scenes/Staking/StakeModifyScene.tsx
+++ b/src/components/scenes/Staking/StakeModifyScene.tsx
@@ -69,7 +69,7 @@ interface Props extends EdgeAppSceneProps<'stakeModify'> {
   wallet: EdgeCurrencyWallet
 }
 
-const StakeModifySceneComponent = (props: Props): React.ReactElement => {
+const StakeModifySceneComponent: React.FC<Props> = props => {
   const { navigation, route, wallet } = props
   const { modification, title, stakePlugin, stakePolicy } = route.params
   const dispatch = useDispatch()

--- a/src/components/scenes/Staking/StakeModifyScene.tsx
+++ b/src/components/scenes/Staking/StakeModifyScene.tsx
@@ -1,4 +1,5 @@
 import { div, eq, gt, toFixed } from 'biggystring'
+import { asMaybe } from 'cleaners'
 import {
   DustSpendError,
   type EdgeCurrencyWallet,
@@ -12,6 +13,7 @@ import { sprintf } from 'sprintf-js'
 import { updateStakingPosition } from '../../../actions/scene/StakingActions'
 import { useAsyncEffect } from '../../../hooks/useAsyncEffect'
 import { useDisplayDenom } from '../../../hooks/useDisplayDenom'
+import { useWatch } from '../../../hooks/useWatch'
 import { lstrings } from '../../../locales/strings'
 import {
   type ChangeQuote,
@@ -35,8 +37,10 @@ import {
   getPositionAllocations
 } from '../../../util/stakeUtils'
 import { zeroString } from '../../../util/utils'
+import { AlertCardUi4 } from '../../cards/AlertCard'
 import { EdgeCard } from '../../cards/EdgeCard'
 import { WarningCard } from '../../cards/WarningCard'
+import { EdgeAnim } from '../../common/EdgeAnim'
 import { SceneWrapper } from '../../common/SceneWrapper'
 import { withWallet } from '../../hoc/withWallet'
 import { SceneContainer } from '../../layout/SceneContainer'
@@ -52,6 +56,7 @@ import { Airship, showError } from '../../services/AirshipInstance'
 import { cacheStyles, type Theme, useTheme } from '../../services/ThemeContext'
 import { Alert } from '../../themed/Alert'
 import { EdgeText } from '../../themed/EdgeText'
+import { asPrivateNetworkingSetting } from '../../themed/MaybePrivateNetworkingSetting'
 import { SafeSlider } from '../../themed/SafeSlider'
 import { CryptoFiatAmountTile } from '../../tiles/CryptoFiatAmountTile'
 import { EditableAmountTile } from '../../tiles/EditableAmountTile'
@@ -93,6 +98,10 @@ const StakeModifySceneComponent: React.FC<Props> = props => {
   // Hooks
   const guiExchangeRates = useSelector(state => state.exchangeRates)
   const nativeAssetDenomination = useDisplayDenom(wallet.currencyConfig, null)
+
+  const userSettings = useWatch(wallet.currencyConfig, 'userSettings')
+  const isNymActive =
+    asMaybe(asPrivateNetworkingSetting)(userSettings)?.networkPrivacy === 'nym'
 
   // ChangeQuote that gets rendered in the rows
   const [changeQuote, setChangeQuote] = React.useState<ChangeQuote | null>(null)
@@ -627,12 +636,30 @@ const StakeModifySceneComponent: React.FC<Props> = props => {
     return warningMessage == null ? null : (
       <Alert
         key="warning"
-        marginRem={[0, 1, 1, 1]}
+        marginRem={[0, 1, 0, 1]}
         title={lstrings.wc_smartcontract_warning_title}
         message={warningMessage}
         numberOfLines={0}
         type="warning"
       />
+    )
+  }
+
+  const renderNymWarning = (): React.ReactElement | null => {
+    if (!isNymActive) return null
+
+    return (
+      <EdgeAnim
+        enter={{ type: 'fadeInUp', distance: 60 }}
+        exit={{ type: 'fadeOutDown' }}
+      >
+        <AlertCardUi4
+          type="warning"
+          title={lstrings.settings_nym_mixnet_warning_title}
+          body={lstrings.settings_nym_mixnet_warning_body}
+          marginRem={[0, 0.5, 0, 0.5]}
+        />
+      </EdgeAnim>
     )
   }
 
@@ -741,6 +768,7 @@ const StakeModifySceneComponent: React.FC<Props> = props => {
       <SceneContainer headerTitle={title} headerTitleChildren={icon}>
         {renderChangeQuoteAmountTiles(modification)}
         {renderWarning()}
+        {renderNymWarning()}
         <View style={styles.footer}>
           <SafeSlider
             onSlidingComplete={handleSlideComplete}
@@ -775,6 +803,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
     marginTop: theme.rem(0.5)
   },
   footer: {
+    marginTop: theme.rem(1),
     marginBottom: theme.rem(2)
   }
 }))


### PR DESCRIPTION

<img width="488" height="1062" alt="image" src="https://github.com/user-attachments/assets/f70e7286-89c4-49e7-9523-311b2edba7cf" />


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

[Asana task](https://app.asana.com/0/0/1213732304136630/f)

Asana: [Earn - Nym Mixnet warning](https://app.asana.com/1/9976422036640/project/1213880789473005/task/1213732304136630)

Adds the existing Nym mixnet warning (already used in the Send scene) to the Stake, Unstake, and Claim Rewards scenes so users are informed that staking transactions may take longer to broadcast when Nym mixnet is active.

- Gates the warning on `isNymActive` derived from `wallet.currencyConfig.userSettings` (same pattern as `SendScene2`).
- Reuses `lstrings.settings_nym_mixnet_warning_title` / `settings_nym_mixnet_warning_body` via `AlertCardUi4` wrapped in `EdgeAnim`.
- Warning renders above the slider, matching the Send scene placement.
- `StakeModifyScene` handles `stake`, `unstake`, and `claim` modes via `route.params.modification`, so a single insertion covers all three scenes.
- Also converts `StakeModifySceneComponent` to `React.FC<Props>` to clear a pre-existing lint warning in the same file (separate commit).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that conditionally renders an additional warning card based on `userSettings.networkPrivacy`; no transaction construction or staking logic changes.
> 
> **Overview**
> Adds a conditional **Nym Mixnet warning** to `StakeModifyScene` so users see a delay notice when performing *stake*, *unstake*, or *claim rewards* while Nym network privacy is enabled.
> 
> Implements `isNymActive` by watching `wallet.currencyConfig.userSettings` and renders the existing localized warning copy via `AlertCardUi4` (animated with `EdgeAnim`) above the confirmation slider, with minor spacing tweaks. Updates `CHANGELOG.md` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b21d0a9b1e95b726615759c16814edf8515793b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->