### PR TITLE
gui: Migrate Thorchain Savers and Yield endpoints off NineRealms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - added: Show swap KYC/terms modal for NExchange
+- changed: Migrate Thorchain Savers and Thorchain Yield endpoints off NineRealms to gateway.liquify.com.
 
 ## 4.48.0 (staging)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -453,8 +453,7 @@ export default [
       'src/plugins/stake-plugins/generic/util/tarotUtils.ts',
       'src/plugins/stake-plugins/metadataCache.ts',
       'src/plugins/stake-plugins/stakePlugins.ts',
-      'src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.tsx',
-      'src/plugins/stake-plugins/thorchainSavers/tcSaversPluginSegwit.tsx',
+
       'src/plugins/stake-plugins/uniswapV2/Ecosystem.ts',
 
       'src/plugins/stake-plugins/uniswapV2/policies/VelodromeV2StakePolicy.ts',

--- a/src/plugins/stake-plugins/generic/pluginInfo/thorchainYield.ts
+++ b/src/plugins/stake-plugins/generic/pluginInfo/thorchainYield.ts
@@ -21,7 +21,7 @@ const thorchainYieldPolicyConfig: Array<
         ENV.THORCHAIN_INIT !== false
           ? ENV.THORCHAIN_INIT.ninerealmsClientId
           : undefined,
-      thornodeServers: ['https://thornode.ninerealms.com']
+      thornodeServers: ['https://gateway.liquify.com/chain/thorchain_api']
     },
 
     hideClaimAction: true,

--- a/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.tsx
+++ b/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.tsx
@@ -62,10 +62,12 @@ import { getEvmApprovalData, getEvmDepositWithExpiryData } from './defiUtils'
 const EXCHANGE_INFO_UPDATE_FREQ_MS = 10 * 60 * 1000 // 2 min
 const INBOUND_ADDRESSES_UPDATE_FREQ_MS = 10 * 60 * 1000 // 2 min
 const MIDGARD_SERVERS_DEFAULT = [
-  'https://midgard.ninerealms.com',
+  'https://gateway.liquify.com/chain/thorchain_midgard',
   'https://midgard.thorchain.info'
 ]
-const THORNODE_SERVERS_DEFAULT = ['https://thornode.ninerealms.com']
+const THORNODE_SERVERS_DEFAULT = [
+  'https://gateway.liquify.com/chain/thorchain_api'
+]
 const EVM_WITHDRAWAL_MIN_AMOUNT = '1000000000000'
 
 // When withdrawing from a vault, this represents a withdrawal of 100% of the staked amount.

--- a/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.tsx
+++ b/src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.tsx
@@ -598,7 +598,7 @@ async function fetchClaimableTcy(
   return json.tcy_claimer[0].amount
 }
 
-const updatePolicyApys = (infoServerResponse: InfoServerResponse) => {
+const updatePolicyApys = (infoServerResponse: InfoServerResponse): void => {
   policies.forEach(policy => {
     const apy = infoServerResponse.policies[policy.stakePolicyId]
     if (apy != null) {
@@ -968,8 +968,8 @@ const stakeRequest = async (
     asset,
     parentToTokenRate,
     parentBalance
-  ).catch(e => {
-    console.error(e.message)
+  ).catch((e: unknown) => {
+    console.error(e instanceof Error ? e.message : String(e))
   })
 
   if (futureUnstakeFee != null) {

--- a/src/plugins/stake-plugins/thorchainSavers/tcSaversPluginSegwit.tsx
+++ b/src/plugins/stake-plugins/thorchainSavers/tcSaversPluginSegwit.tsx
@@ -62,10 +62,12 @@ import { getEvmApprovalData, getEvmDepositWithExpiryData } from './defiUtils'
 const EXCHANGE_INFO_UPDATE_FREQ_MS = 10 * 60 * 1000 // 2 min
 const INBOUND_ADDRESSES_UPDATE_FREQ_MS = 10 * 60 * 1000 // 2 min
 const MIDGARD_SERVERS_DEFAULT = [
-  'https://midgard.ninerealms.com',
+  'https://gateway.liquify.com/chain/thorchain_midgard',
   'https://midgard.thorchain.info'
 ]
-const THORNODE_SERVERS_DEFAULT = ['https://thornode.ninerealms.com']
+const THORNODE_SERVERS_DEFAULT = [
+  'https://gateway.liquify.com/chain/thorchain_api'
+]
 const EVM_WITHDRAWAL_MIN_AMOUNT = '1000000000000'
 
 // When withdrawing from a vault, this represents a withdrawal of 100% of the staked amount.

--- a/src/plugins/stake-plugins/thorchainSavers/tcSaversPluginSegwit.tsx
+++ b/src/plugins/stake-plugins/thorchainSavers/tcSaversPluginSegwit.tsx
@@ -593,7 +593,7 @@ async function fetchClaimableTcy(
   return json.tcy_claimer[0].amount
 }
 
-const updatePolicyApys = (infoServerResponse: InfoServerResponse) => {
+const updatePolicyApys = (infoServerResponse: InfoServerResponse): void => {
   policies.forEach(policy => {
     const apy = infoServerResponse.policies[policy.stakePolicyId]
     if (apy != null) {
@@ -963,8 +963,8 @@ const stakeRequest = async (
     asset,
     parentToTokenRate,
     parentBalance
-  ).catch(e => {
-    console.error(e.message)
+  ).catch((e: unknown) => {
+    console.error(e instanceof Error ? e.message : String(e))
   })
 
   if (futureUnstakeFee != null) {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

- https://github.com/EdgeApp/edge-exchange-plugins/pull/453
- https://github.com/EdgeApp/edge-currency-accountbased/pull/1050

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

*No visual changes — URL-only migration.*

### Description

[Asana task](https://app.asana.com/0/0/1214112326000662/f)

Migrates the Thorchain Savers and Thorchain Yield stake plugins off `*.ninerealms.com`. Those hosts are being retired on 2026-04-20 (already returning 301). Without this change Thorchain Savers + Yield stop loading positions, quoting stakes, and fetching inbound addresses.

**Migration commit** (`Migrate Thorchain Savers and Yield endpoints off NineRealms`):
- `src/plugins/stake-plugins/thorchainSavers/tcSaversPlugin.tsx`
  - `MIDGARD_SERVERS_DEFAULT[0]`: `midgard.ninerealms.com` → `gateway.liquify.com/chain/thorchain_midgard`
  - `THORNODE_SERVERS_DEFAULT[0]`: `thornode.ninerealms.com` → `gateway.liquify.com/chain/thorchain_api`
- `src/plugins/stake-plugins/thorchainSavers/tcSaversPluginSegwit.tsx` — same two line changes (file is a near-duplicate of the non-Segwit variant)
- `src/plugins/stake-plugins/generic/pluginInfo/thorchainYield.ts`
  - `thornodeServers[0]`: `thornode.ninerealms.com` → `gateway.liquify.com/chain/thorchain_api`

**Lint-fix commit** (`Fix lint warnings in tcSaversPlugin`): committing the two `tcSavers*` files removes them from the ESLint warning-suppression list. That promotes 4 rule findings to errors. Fixes in this commit:
- Added `: void` return type to `updatePolicyApys` (both files)
- Typed `.catch(e => …)` as `.catch((e: unknown) => …)` and guarded `e.message` access (both files)

Kept intact (intentional):
- `ninerealmsClientId` init option + `x-client-id` header — Liquify accepts it without issue.
- Secondary fallback `midgard.thorchain.info` — already off NineRealms.
- 21 remaining `no-deprecated` warnings (`parentNetworkFee`, `networkFee`, `getReceiveAddress`) — not in the suppressed-rule set so they stay as warnings; addressing them is architectural and out of scope for a URL migration.

Sibling PRs handle the actual swap plugin (edge-exchange-plugins) and the RUNE chain plugin (edge-currency-accountbased).

Asana parent: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1214109247963126

### Testing

Curl-verified new endpoints with existing `ninerealmsClientId`:
- `gateway.liquify.com/chain/thorchain_api/thorchain/network` → 200 OK
- `gateway.liquify.com/chain/thorchain_midgard/v2/health` → 200 OK

Reviewer should confirm on device: open Thorchain Savers (APY loads, positions show), open Thorchain Yield (TCY position loads / stake quote resolves).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches Thorchain Savers and Yield plugins to new Midgard/Thornode base URLs, which could impact staking position loading/quoting if the gateway behavior differs or has downtime. Remaining changes are lint/type-safety fixes with low functional risk.
> 
> **Overview**
> Updates Thorchain Savers (including Segwit variant) and Thorchain Yield stake plugins to stop using `*.ninerealms.com` and instead query Thorchain Midgard/Thornode via `https://gateway.liquify.com/chain/*`.
> 
> As part of committing these files, removes them from the ESLint ignore list and fixes newly-enforced lint issues by adding explicit `void` return types and safer `unknown` error handling in a `.catch` path. Also records the migration in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe5e83226d8e7895224083652c97d879ea84064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->