### PR TITLE
Honor af affiliate parameter on deep.edge.app links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 4.49.0 (staging)
 
+- added: Honor `af` affiliate parameter on `deep.edge.app` deep links, activating the promotion alongside any inner payload (e.g. private-key import).
 - added: Show swap KYC/terms modal for NExchange
 - added: Nym mixnet warning in Stake, Unstake, and Claim Rewards scenes
 - changed: Migrate Thorchain Savers and Thorchain Yield endpoints off NineRealms to gateway.liquify.com.

--- a/src/__tests__/DeepLink.test.ts
+++ b/src/__tests__/DeepLink.test.ts
@@ -321,7 +321,50 @@ describe('parseDeepLink', function () {
       'https://dl.edge.app': {
         type: 'promotion',
         installerId: ''
+      },
+      'https://deep.edge.app/?af=bob': {
+        type: 'promotion',
+        installerId: 'bob'
+      },
+      'https://deep.edge.app/promotion/bob?af=bob': {
+        type: 'promotion',
+        installerId: 'bob'
       }
+    })
+  })
+
+  describe('affiliate', function () {
+    makeLinkTests({
+      'https://deep.edge.app/pay/bitcoincash/abc123?af=zano-telegram': {
+        type: 'affiliate',
+        installerId: 'zano-telegram',
+        link: {
+          type: 'other',
+          protocol: 'bitcoincash',
+          uri: 'bitcoincash:abc123'
+        }
+      },
+      'https://deep.edge.app/plugin/simplex/rabbit/hole?af=bob&param=alice': {
+        type: 'affiliate',
+        installerId: 'bob',
+        link: {
+          type: 'plugin',
+          pluginId: 'simplex',
+          path: '/rabbit/hole',
+          query: { param: 'alice' }
+        }
+      }
+    })
+
+    // Lookalike hosts must NOT be treated as deep.edge.app:
+    it('https://deep.edge.appsomething.com/?af=evil', () => {
+      expect(
+        parseDeepLink('https://deep.edge.appsomething.com/?af=evil')
+      ).toEqual({
+        type: 'other',
+        protocol: 'https',
+        uri: 'https://deep.edge.appsomething.com/?af=evil'
+      })
     })
   })
 

--- a/src/actions/DeepLinkingActions.tsx
+++ b/src/actions/DeepLinkingActions.tsx
@@ -182,6 +182,11 @@ async function handleLink(
       await dispatch(activatePromotion(link.installerId ?? ''))
       break
 
+    case 'affiliate':
+      await dispatch(activatePromotion(link.installerId))
+      await handleLink(navigation, dispatch, state, link.link)
+      break
+
     case 'requestAddress':
       await doRequestAddress(navigation, state.core.account, dispatch, link)
       break

--- a/src/types/DeepLinkTypes.ts
+++ b/src/types/DeepLinkTypes.ts
@@ -23,6 +23,11 @@
  *   - https://dl.edge.app/... = edge://promotion/...
  *   - https://dl.edge.app/?af=... = edge://promotion/...
  *
+ * `deep.edge.app` URLs may also carry an `?af=<installerId>` query parameter.
+ * When present alongside another payload (e.g. a `pay` private-key URI), the
+ * deep link resolves to an `affiliate` wrapper that activates the promotion
+ * and then delegates to the inner link.
+ *
  * We also support some legacy prefixes (but don't use these):
  *
  *   - edge-ret://plugins/simplex/... = edge://plugin/simplex/...
@@ -147,7 +152,14 @@ export interface ModalLink {
   modalName: ModalNames
 }
 
+export interface AffiliateLink {
+  type: 'affiliate'
+  installerId: string
+  link: DeepLink
+}
+
 export type DeepLink =
+  | AffiliateLink
   | AztecoLink
   | SceneLink
   | EdgeLoginLink

--- a/src/util/DeepLinkParser.ts
+++ b/src/util/DeepLinkParser.ts
@@ -26,6 +26,19 @@ export function parseDeepLink(
 ): DeepLink {
   const { aztecoApiKey = ENV.AZTECO_API_KEY } = opts
 
+  // Extract an `af` affiliate installer id from `deep.edge.app` URLs before
+  // the prefix normalization below strips the host. Matches the `dl.edge.app`
+  // behavior and adds a wrapper when there is also an inner payload:
+  const affiliateSplit = splitAffiliateLink(uri)
+  if (affiliateSplit != null) {
+    const { installerId, remainingUri } = affiliateSplit
+    const inner = parseDeepLink(remainingUri, opts)
+    if (inner.type === 'promotion' || inner.type === 'noop') {
+      return { type: 'promotion', installerId }
+    }
+    return { type: 'affiliate', installerId, link: inner }
+  }
+
   // Normalize some legacy cases:
   for (const prefix of prefixes) {
     const [from, to] = prefix
@@ -351,3 +364,31 @@ const prefixes: Array<[string, string]> = [
   ['airbitz://', 'edge://'],
   ['reqaddr://', 'edge://reqaddr']
 ]
+
+/**
+ * Detect an `af` affiliate installer id on a `deep.edge.app` URL and return
+ * the extracted id plus the original URL with `af` stripped from the query.
+ * Returns `null` for every other input.
+ */
+function splitAffiliateLink(
+  uri: string
+): { installerId: string; remainingUri: string } | null {
+  if (!uri.startsWith('https://')) return null
+
+  const url = new URL(uri)
+  if (url.host !== 'deep.edge.app') return null
+  const query = parseQuery(url.query)
+  const { af } = query
+  if (af == null || af === '') return null
+
+  const remainingQuery: typeof query = {}
+  for (const key of Object.keys(query)) {
+    if (key !== 'af') remainingQuery[key] = query[key]
+  }
+  const queryString =
+    Object.keys(remainingQuery).length === 0
+      ? ''
+      : stringifyQuery(remainingQuery)
+  const remainingUri = `${url.protocol}//${url.host}${url.pathname}${queryString}${url.hash}`
+  return { installerId: af, remainingUri }
+}


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1214156446908729/f)

Extend deep link parsing so `https://deep.edge.app/...` URLs can carry an `af` affiliate parameter the same way `dl.edge.app` already does. When `af` appears on a URL that also has a payload (e.g. a `pay` private-key import), the deep link now resolves to a new `AffiliateLink` wrapper that activates the promotion and then delegates to the inner link. When `af` is the only meaningful content (empty path or explicit `/promotion/...` path), the result collapses to a plain `PromotionLink` — matching the `dl.edge.app` behavior.

Unlocks the BCHx gift-card use case: a single scanned QR can both import the BCH private key and activate the `af=<installerId>` referral that surfaces an in-app Telegram-group card.

**Asana:** [BCHx Cards – Add referral parameter to deep.edge.app links](https://app.asana.com/1/9976422036640/project/1213880789473005/task/1214156446908729)

**Files touched**
- `src/util/DeepLinkParser.ts` — pre-pass that extracts `af` from `deep.edge.app` URLs and wraps or unwraps the result.
- `src/types/DeepLinkTypes.ts` — new `AffiliateLink` type in the `DeepLink` union + updated header comment.
- `src/actions/DeepLinkingActions.tsx` — handle `affiliate` type: `activatePromotion` + recurse into inner link.
- `src/__tests__/DeepLink.test.ts` — new cases for bare-af, promotion+af (no double wrap), pay+af, plugin+af.
- `CHANGELOG.md`.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

No visual changes — deep-link parser + action-layer only. Verified via `yarn test` (all related suites pass).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deep-link parsing and execution flow to auto-activate promotions from `deep.edge.app` URLs and then continue handling an inner payload, which could alter how some inbound links route or trigger promotions.
> 
> **Overview**
> Adds support for an `?af=<installerId>` affiliate parameter on `https://deep.edge.app/...` URLs. When present, the parser either collapses to a normal `promotion` link (if there is no meaningful payload) or returns a new `affiliate` wrapper that activates the promotion and then delegates to the parsed inner deep link.
> 
> Updates link handling to process `affiliate` by dispatching `activatePromotion` and then recursively handling the wrapped link, and expands unit tests and the changelog to cover the new `deep.edge.app` affiliate behaviors (including rejecting lookalike hosts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b724830500f40357259aa518faef9e3e61ede79a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->