### PR TITLE
feat: add home screen long-press shortcuts via expo-quick-actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: Home screen long-press shortcuts for "⚠️ Save 2FA First!" warning and "Contact Support".
 - added: Logbox disable option to env.json
 - added: Reverse-resolve recipient addresses to ENS / Unstoppable Domains / ZNS names in the send flow, address modal, and transaction history.
 

--- a/android/app/src/main/java/co/edgesecure/app/MainActivity.kt
+++ b/android/app/src/main/java/co/edgesecure/app/MainActivity.kt
@@ -8,6 +8,7 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 import com.zoontek.rnbootsplash.RNBootSplash
+import expo.modules.ReactActivityDelegateWrapper
 
 class MainActivity : ReactActivity() {
   /**
@@ -18,10 +19,16 @@ class MainActivity : ReactActivity() {
 
   /**
    * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
-   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled].
+   * The Expo wrapper forwards activity lifecycle events (onCreate intent capture, onNewIntent)
+   * to expo modules; expo-quick-actions needs it to deliver shortcut taps on cold start.
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate =
-    DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+    ReactActivityDelegateWrapper(
+      this,
+      BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
+      DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+    )
 
   // Edge addition
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/app/src/main/res/drawable/message.xml
+++ b/android/app/src/main/res/drawable/message.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Home screen quick action icon, referenced by name from QuickActionsManager.tsx -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF616161"
+      android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM18,14L6,14v-2h12v2zM18,11L6,11L6,9h12v2zM18,8L6,8L6,6h12v2z"/>
+</vector>

--- a/android/app/src/main/res/drawable/prohibit.xml
+++ b/android/app/src/main/res/drawable/prohibit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Home screen quick action icon, referenced by name from QuickActionsManager.tsx -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF616161"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM4,12c0,-4.42 3.58,-8 8,-8 1.85,0 3.55,0.63 4.9,1.69L5.69,16.9C4.63,15.55 4,13.85 4,12zM12,20c-1.85,0 -3.55,-0.63 -4.9,-1.69L18.31,7.1C19.37,8.45 20,10.15 20,12c0,4.42 -3.58,8 -8,8z"/>
+</vector>

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,9 @@
+// This side-effect import must come before expo-quick-actions is evaluated:
+// expo-quick-actions reads globalThis.expo.modules.ExpoQuickActions at module
+// evaluation time, and that global is installed lazily by expo-modules-core.
+// Without it, every expo-quick-actions call (including setItems) silently
+// no-ops and the home screen shortcuts never appear.
+import 'expo-modules-core'
 import 'react-native-gesture-handler'
 import './src/app'
 import './src/perf'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -87,6 +87,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - ExpoQuickActions (5.0.0):
+    - ExpoModulesCore
   - fast_float (6.1.4)
   - FBLazyVector (0.79.2)
   - Firebase/CoreOnly (10.29.0):
@@ -2889,6 +2891,7 @@ DEPENDENCIES:
   - ExpoFont (from `../node_modules/expo-font/ios`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core`)
+  - ExpoQuickActions (from `../node_modules/expo-quick-actions/ios`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
@@ -3089,6 +3092,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-keep-awake/ios"
   ExpoModulesCore:
     :path: "../node_modules/expo-modules-core"
+  ExpoQuickActions:
+    :path: "../node_modules/expo-quick-actions/ios"
   fast_float:
     :podspec: "../node_modules/react-native/third-party-podspecs/fast_float.podspec"
   FBLazyVector:
@@ -3347,6 +3352,7 @@ SPEC CHECKSUMS:
   ExpoFont: cf508bc2e6b70871e05386d71cab927c8524cc8e
   ExpoKeepAwake: bf0811570c8da182bfb879169437d4de298376e7
   ExpoModulesCore: 471ae18809dc8a5c9a623193a317eef6048a4f8a
+  ExpoQuickActions: fdbda7f5874aed3dd2b1d891ec00ab3300dc7541
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 84b955f7b4da8b895faf5946f73748267347c975
   Firebase: cec914dab6fd7b1bd8ab56ea07ce4e03dd251c2d

--- a/ios/edge/AppDelegate.swift
+++ b/ios/edge/AppDelegate.swift
@@ -1,3 +1,4 @@
+import ExpoQuickActions
 import Firebase
 import FirebaseMessaging
 import RNBootSplash
@@ -56,6 +57,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Client-side background fetch interval:
     application.setMinimumBackgroundFetchInterval(60 * 60 * 12)
 
+    // Capture a home-screen quick action on a cold launch so
+    // expo-quick-actions can report it as the initial action once JS loads.
+    // This delegate is not an ExpoAppDelegate, so the library's own
+    // subscriber never runs. Edge addition.
+    if let shortcutItem = launchOptions?[.shortcutItem] as? UIApplicationShortcutItem {
+      ExpoQuickActions.initialAction = shortcutItem
+    }
+
     // React Native template code:
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)
@@ -73,6 +82,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     )
 
     return true
+  }
+
+  /**
+   * Handles home-screen quick action taps while the app is running.
+   * Mirrors ExpoQuickActionsAppDelegate, which never runs because this
+   * delegate is not an ExpoAppDelegate. Edge addition.
+   */
+  func application(
+    _ application: UIApplication,
+    performActionFor shortcutItem: UIApplicationShortcutItem,
+    completionHandler: @escaping (Bool) -> Void
+  ) {
+    NotificationCenter.default.post(
+      name: Notification.Name("onQuickAction"), object: shortcutItem)
+    completionHandler(true)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "edge-login-ui-rn": "^3.35.8",
     "ethers": "^5.7.2",
     "expo": "^53.0.0",
+    "expo-quick-actions": "^5.0.0",
     "jsrsasign": "^11.1.0",
     "marked": "^15.0.9",
     "p-debounce": "^4.0.0",

--- a/patches/expo-quick-actions+5.0.0.patch
+++ b/patches/expo-quick-actions+5.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift b/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift
+index 252da49..12a29e4 100644
+--- a/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift
++++ b/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift
+@@ -71,7 +71,7 @@ func toActionObject(item: UIApplicationShortcutItem?) -> ActionObject? {
+     )
+ }
+ 
+-var initialAction: UIApplicationShortcutItem?
++public var initialAction: UIApplicationShortcutItem?
+ 
+ public class ExpoQuickActionsModule: Module {
+     

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,6 +10,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { useHandler } from '../hooks/useHandler'
 import { CrashScene } from './scenes/CrashScene'
 import { EdgeCoreManager } from './services/EdgeCoreManager'
+import { QuickActionsManager } from './services/QuickActionsManager'
 import { StatusBarManager } from './services/StatusBarManager'
 import { ThemeProvider } from './services/ThemeContext'
 
@@ -38,6 +39,7 @@ const MainApp: React.FC = () => {
               fallback={<CrashScene />}
             >
               <StatusBarManager />
+              <QuickActionsManager />
               <EdgeCoreManager />
             </ErrorBoundary>
           </GestureHandlerRootView>

--- a/src/components/services/QuickActionsManager.tsx
+++ b/src/components/services/QuickActionsManager.tsx
@@ -1,0 +1,61 @@
+import * as QuickActions from 'expo-quick-actions'
+import { useQuickActionCallback } from 'expo-quick-actions/hooks'
+import type * as React from 'react'
+import { Linking, Platform } from 'react-native'
+
+import { useAsyncEffect } from '../../hooks/useAsyncEffect'
+import { useHandler } from '../../hooks/useHandler'
+import { lstrings } from '../../locales/strings'
+import { config } from '../../theme/appConfig'
+import { showError } from './AirshipInstance'
+
+export const QuickActionsManager: React.FC = () => {
+  useAsyncEffect(
+    async () => {
+      const { quickActions } = config
+      if (quickActions == null) return
+      try {
+        await QuickActions.setItems([
+          {
+            id: 'do_not_uninstall',
+            title: lstrings.shortcut_do_not_uninstall_title,
+            subtitle: lstrings.shortcut_do_not_uninstall_subtitle,
+            icon: Platform.select({
+              ios: 'symbol:nosign',
+              default: 'prohibit'
+            }),
+            params: { url: quickActions.uninstallWarningUrl }
+          },
+          {
+            id: 'contact_support',
+            title: lstrings.shortcut_contact_support_title,
+            subtitle: lstrings.shortcut_contact_support_subtitle,
+            icon: Platform.select({
+              ios: 'symbol:message.fill',
+              default: 'message'
+            }),
+            params: { url: quickActions.contactSupportUrl }
+          }
+        ])
+      } catch (error: unknown) {
+        showError(error)
+      }
+    },
+    [],
+    'QuickActionsManager'
+  )
+
+  const handleQuickAction = useHandler(async (action: QuickActions.Action) => {
+    const url = action.params?.url
+    if (typeof url !== 'string') return
+    try {
+      await Linking.openURL(url)
+    } catch (error: unknown) {
+      showError(error)
+    }
+  })
+
+  useQuickActionCallback(handleQuickAction)
+
+  return null
+}

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -2552,6 +2552,12 @@ const strings = {
     'Please ensure all details are correct before making the transfer.',
   // #endregion
 
+  // Home screen long-press shortcuts (expo-quick-actions)
+  shortcut_do_not_uninstall_title: '⚠️ Save 2FA First!',
+  shortcut_do_not_uninstall_subtitle: 'Login requires 2FA & credentials!',
+  shortcut_contact_support_title: 'Contact Support',
+  shortcut_contact_support_subtitle: 'Get help from our support team',
+
   unknown_error_message: 'An unknown error occurred.'
 } as const
 

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -1991,5 +1991,9 @@
   "ramp_account_number_label": "Account Number",
   "ramp_routing_number_label": "Routing Number",
   "ramp_bank_routing_warning": "Please ensure all details are correct before making the transfer.",
+  "shortcut_do_not_uninstall_title": "⚠️ Save 2FA First!",
+  "shortcut_do_not_uninstall_subtitle": "Login requires 2FA & credentials!",
+  "shortcut_contact_support_title": "Contact Support",
+  "shortcut_contact_support_subtitle": "Get help from our support team",
   "unknown_error_message": "An unknown error occurred."
 }

--- a/src/theme/edgeConfig.ts
+++ b/src/theme/edgeConfig.ts
@@ -37,5 +37,11 @@ export const edgeConfig: AppConfig = {
   supportSite: 'https://help.edge.app/support/tickets/new',
   termsOfServiceSite: 'https://edge.app/tos/',
   website: 'https://edge.app',
-  supportChatSite: 'https://support.edge.app/hc/en-us?chat=open'
+  supportChatSite: 'https://support.edge.app/hc/en-us?chat=open',
+  quickActions: {
+    uninstallWarningUrl:
+      'https://support.edge.app/en/articles/14439418-warning-don-t-uninstall-edge-without-your-login-credentials',
+    contactSupportUrl:
+      'https://support.edge.app/en/articles/14054649-need-help-reach-out-via-our-chat-bubble?chat=open'
+  }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -382,6 +382,14 @@ export interface AppConfig {
    * Support article for pending transactions "Learn more" link.
    */
   pendingTxLearnMoreUrl?: string
+  /**
+   * Home screen long-press quick action shortcuts.
+   * Omit to disable the shortcuts for a build.
+   */
+  quickActions?: {
+    uninstallWarningUrl: string
+    contactSupportUrl: string
+  }
   extraTab?: {
     webviewUrl: string
     tabType: 'edgeProvider' | 'webview'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,20 +1063,7 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.0.tgz#518aa113359b062042379e333db18380b537e34b"
-  integrity sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==
-  dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@babel/generator" "^7.28.0"
-    "@babel/helper-globals" "^7.28.0"
-    "@babel/parser" "^7.28.0"
-    "@babel/template" "^7.27.2"
-    "@babel/types" "^7.28.0"
-    debug "^4.3.1"
-
-"@babel/traverse@^7.25.3", "@babel/traverse@^7.27.1", "@babel/traverse@^7.27.3", "@babel/traverse@^7.28.0", "@babel/traverse@^7.7.0":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.27.1", "@babel/traverse@^7.27.3", "@babel/traverse@^7.28.0", "@babel/traverse@^7.7.0":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.0.tgz#518aa113359b062042379e333db18380b537e34b"
   integrity sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==
@@ -1973,7 +1960,7 @@
     resolve-from "^5.0.0"
     semver "^7.6.0"
 
-"@expo/image-utils@^0.7.6":
+"@expo/image-utils@^0.7.6", "@expo/image-utils@~0.7.4":
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.7.6.tgz#b8442bef770e1c7b39997d57f666bffeeced0a7a"
   integrity sha512-GKnMqC79+mo/1AFrmAcUcGfbsXXTRqOMNS1umebuevl3aaw+ztsYEFEiuNhHZW7PQ3Xs3URNT513ZxKhznDscw==
@@ -6776,7 +6763,7 @@ ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv-keywords@^5.0.0:
+ajv-keywords@^5.0.0, ajv-keywords@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
   integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
@@ -6797,6 +6784,16 @@ ajv@^8.0.0, ajv@^8.8.0:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
+ajv@^8.9.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"
@@ -10625,6 +10622,15 @@ expo-modules-core@2.5.0:
   integrity sha512-aIbQxZE2vdCKsolQUl6Q9Farlf8tjh/ROR4hfN1qT7QBGPl1XrJGnaOKkcgYaGrlzCPg/7IBe0Np67GzKMZKKQ==
   dependencies:
     invariant "^2.2.4"
+
+expo-quick-actions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/expo-quick-actions/-/expo-quick-actions-5.0.0.tgz#6b3c5c21190607f779be1588ebaf119577a3c120"
+  integrity sha512-NSsDhfbal11gXsHkJbvYVw7x0QUCKrEth2kBBKZUv03dX4J7ZPADSV89LyEpOVYXCkrw6LuanlEtKavg/BFaRA==
+  dependencies:
+    "@expo/image-utils" "~0.7.4"
+    schema-utils "^4.2.0"
+    sf-symbols-typescript "^2.1.0"
 
 expo@^53.0.0:
   version "53.0.20"
@@ -16419,6 +16425,16 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
 
+schema-utils@^4.2.0:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.3.tgz#5b1850912fa31df90716963d45d9121fdfc09f46"
+  integrity sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.9.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.1.0"
+
 scrypt-js@3.0.1, scrypt-js@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
@@ -16662,6 +16678,11 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+sf-symbols-typescript@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/sf-symbols-typescript/-/sf-symbols-typescript-2.2.0.tgz#926d6e0715e3d8784cadf7658431e36581254208"
+  integrity sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==
 
 sha.js@^2.3.6, sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.12, sha.js@^2.4.8:
   version "2.4.12"
@@ -17143,16 +17164,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17261,7 +17273,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -17274,13 +17286,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.0, strip-ansi@^7.0.1:
   version "7.1.0"
@@ -18669,7 +18674,7 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18682,15 +18687,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Help users about to uninstall Edge recover their accounts: add a warning shortcut linking to the "save 2FA & credentials before uninstalling" support article, and a direct "Contact Support" link.

Use expo-quick-actions so titles/subtitles flow through lstrings and Crowdin instead of duplicating translations across 12 locales of InfoPlist.strings and values-*/strings.xml. Shortcuts are registered dynamically in JS, which means they only appear after the first app launch post-install — acceptable since the audience is established users considering uninstall, not fresh installs.

The `import 'expo-modules-core'` side effect in index.ts is non- obvious but required: expo-quick-actions reads
globalThis.expo.modules.ExpoQuickActions at module-evaluation time, and that global is installed lazily by expo-modules-core's NativeModule/SharedObject/EventEmitter module imports. Without one of those evaluating first the global stays empty and every expo-quick-actions call silently no-ops, including setItems, so the shortcuts never appear.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new native module dependency (`expo-quick-actions`) and iOS pod changes, plus startup-side-effect initialization in `index.ts` that could impact app boot if misconfigured.
> 
> **Overview**
> Adds home screen long-press quick actions via `expo-quick-actions`, registering two shortcuts ("⚠️ Save 2FA First!" and "Contact Support") that open Edge support URLs.
> 
> Wires a new `QuickActionsManager` into `App` to set items on startup and handle shortcut activation, and adds an `expo-modules-core` side-effect import in `index.ts` to ensure the module registry is initialized.
> 
> Updates iOS pods (`ExpoQuickActions`), `package.json`, lockfiles, localized strings, and the `CHANGELOG` entry to reflect the new shortcuts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bec8ad020e658fdbed7ea4dc34867b3c73fdb93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211843114452190