### PR TITLE
Jon/fix/zec name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## 4.48.1 (2026-04-28)
 
-- added: Resolve and display ZcashNames (.zcash) in the Zcash send flow and transaction history.
+- added: Resolve and display ZNS names (.zcash/.zec) in the Zcash send flow and transaction history.
 - changed: Remove free FIO handle creation flows.
 - changed: Migrate Thorchain Savers and Thorchain Yield endpoints off NineRealms to gateway.liquify.com.
 

--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -1415,6 +1415,27 @@ const SendComponent = (props: Props): React.ReactElement => {
 
         await coreWallet.saveTx(broadcastedTx)
 
+        // edge-core-js's saveTx silently drops tx.metadata when the engine
+        // has already registered the txid in walletState before we get here
+        // (race against the engine's onTransactionsChanged callback, which
+        // calls setupNewTxMetadata with no metadata for the engine's view of
+        // the tx). Re-apply via saveTxMetadata so payeeName and fio notes
+        // survive a reload from disk.
+        if (payeeName != null) {
+          await coreWallet
+            .saveTxMetadata({
+              txid: broadcastedTx.txid,
+              tokenId: broadcastedTx.tokenId,
+              metadata: {
+                name: broadcastedTx.metadata.name,
+                notes: broadcastedTx.metadata.notes
+              }
+            })
+            .catch((error: unknown) => {
+              showError(error)
+            })
+        }
+
         for (const target of spendInfo.spendTargets) {
           // Write FIO OBT per spendTarget
           await recordFioObtData(

--- a/src/util/zns.ts
+++ b/src/util/zns.ts
@@ -1,6 +1,12 @@
 import { ZNS } from 'zcashname-sdk'
 
+// Canonical suffix used when rendering a name resolved from an address.
 export const ZNS_SUFFIX = '.zcash'
+
+// All suffixes accepted as ZNS input. Order matters for `stripZnsSuffix`:
+// longer suffixes must be checked first so that e.g. ".zcash" is preferred
+// over a hypothetical ".z" prefix-match.
+const ZNS_INPUT_SUFFIXES = ['.zcash', '.zec'] as const
 
 // The SDK's `network` option only selects the registry address; its `url`
 // always falls back to the testnet indexer unless overridden explicitly.
@@ -17,14 +23,18 @@ export const resetZnsClient = (): void => {
   znsClient = null
 }
 
-export const isZnsName = (input: string): boolean =>
-  input.toLowerCase().endsWith(ZNS_SUFFIX)
+export const isZnsName = (input: string): boolean => {
+  const lower = input.toLowerCase()
+  return ZNS_INPUT_SUFFIXES.some(suffix => lower.endsWith(suffix))
+}
 
 export const stripZnsSuffix = (input: string): string => {
   const lower = input.toLowerCase()
-  return lower.endsWith(ZNS_SUFFIX)
-    ? lower.slice(0, lower.length - ZNS_SUFFIX.length)
-    : lower
+  for (const suffix of ZNS_INPUT_SUFFIXES) {
+    if (lower.endsWith(suffix))
+      return lower.slice(0, lower.length - suffix.length)
+  }
+  return lower
 }
 
 export const resolveZnsName = async (input: string): Promise<string | null> => {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the transaction send/save path by adding a secondary `saveTxMetadata` write to work around a core race, which could affect how send metadata persists across reloads. Also expands ZNS name parsing to accept multiple suffixes, potentially impacting Zcash address resolution behavior.
> 
> **Overview**
> Improves Zcash name support by treating both `.zcash` and `.zec` as valid ZNS inputs while continuing to render resolved names with the canonical `.zcash` suffix.
> 
> Fixes a send-flow persistence issue where `saveTx` can lose `tx.metadata` in a race with engine transaction registration by re-applying `name`/`notes` via `saveTxMetadata` after broadcast, ensuring payee names and FIO notes survive disk reloads.
> 
> Updates the changelog to reflect ZNS suffix support expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8261d3a4e02fcd9fb67d3a0b7f724d8037eab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214337881808283