### PR TITLE
Update Infinite ONRAMP for new headless transfer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased (develop)
 
+- changed: Update Infinite ONRAMP to the new headless transfer API: ACH push payment to a per-customer virtual bank account, with the deposit beneficiary surfaced on the bank routing scene.
+- fixed: Always reset the Infinite confirmation slider once `onConfirm` settles so a successful transfer with missing deposit instructions no longer leaves the slider spinning.
+- fixed: Pop the Infinite ramp stack to the top after the user dismisses the bank routing details scene, instead of stepping back through the confirmation scene.
+- fixed: Allow the Infinite bank routing instructions and warning text to wrap and stop them from shrinking under large system fonts.
+
 ## 4.49.0 (staging)
 
 - added: Honor `af` affiliate parameter on `deep.edge.app` deep links, activating the promotion alongside any inner payload (e.g. private-key import).

--- a/src/components/scenes/RampBankRoutingDetailsScene.tsx
+++ b/src/components/scenes/RampBankRoutingDetailsScene.tsx
@@ -16,7 +16,7 @@ import { SceneContainer } from '../layout/SceneContainer'
 import { EdgeRow } from '../rows/EdgeRow'
 import { showToast } from '../services/AirshipInstance'
 import { cacheStyles, type Theme, useTheme } from '../services/ThemeContext'
-import { EdgeText, Paragraph } from '../themed/EdgeText'
+import { EdgeText } from '../themed/EdgeText'
 
 export interface BankInfo {
   name: string
@@ -57,9 +57,9 @@ export const RampBankRoutingDetailsScene: React.FC<Props> = props => {
             size={theme.rem(2.5)}
             color={theme.primaryText}
           />
-          <Paragraph style={styles.instructionText}>
+          <EdgeText numberOfLines={0} style={styles.instructionText}>
             {lstrings.ramp_bank_routing_instructions}
-          </Paragraph>
+          </EdgeText>
         </View>
 
         <EdgeCard>
@@ -100,7 +100,11 @@ export const RampBankRoutingDetailsScene: React.FC<Props> = props => {
         </EdgeCard>
 
         <View style={styles.warningTextContainer}>
-          <EdgeText style={styles.warningText}>
+          <EdgeText
+            style={styles.warningText}
+            disableFontScaling
+            numberOfLines={0}
+          >
             {lstrings.ramp_bank_routing_warning}
           </EdgeText>
         </View>
@@ -127,7 +131,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     color: theme.iconTappable
   },
   instructionText: {
-    flexShrink: 1
+    flexShrink: 1,
+    marginLeft: theme.rem(0.5)
   },
   cardContent: {
     padding: theme.rem(0.5)

--- a/src/components/scenes/RampBankRoutingDetailsScene.tsx
+++ b/src/components/scenes/RampBankRoutingDetailsScene.tsx
@@ -22,6 +22,7 @@ export interface BankInfo {
   name: string
   accountNumber: string
   routingNumber: string
+  beneficiaryName?: string
 }
 
 export interface RampBankRoutingDetailsParams {
@@ -82,6 +83,13 @@ export const RampBankRoutingDetailsScene: React.FC<Props> = props => {
 
         <SectionHeader leftTitle={lstrings.ramp_bank_details_section_title} />
         <EdgeCard sections>
+          {bank.beneficiaryName != null && bank.beneficiaryName !== '' ? (
+            <EdgeRow
+              title={lstrings.ramp_bank_beneficiary_name_label}
+              body={bank.beneficiaryName}
+              rightButtonType="copy"
+            />
+          ) : null}
           <EdgeRow
             title={lstrings.ramp_bank_name_label}
             body={bank.name}

--- a/src/components/scenes/RampConfirmationScene.tsx
+++ b/src/components/scenes/RampConfirmationScene.tsx
@@ -48,10 +48,10 @@ export const RampConfirmationScene: React.FC<Props> = props => {
     setIsConfirming(true)
     try {
       await onConfirm()
-    } catch (err) {
+    } catch (err: unknown) {
       setError(err)
-      reset() // Reset the slider on error
     } finally {
+      reset()
       setIsConfirming(false)
     }
   })

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -2545,6 +2545,7 @@ const strings = {
     'Please send the exact amount shown below to the following bank account.',
   ramp_send_amount_label: 'Amount to Send',
   ramp_bank_details_section_title: 'Bank Details',
+  ramp_bank_beneficiary_name_label: 'Beneficiary Name',
   ramp_bank_name_label: 'Bank Name',
   ramp_account_number_label: 'Account Number',
   ramp_routing_number_label: 'Routing Number',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -1987,6 +1987,7 @@
   "ramp_bank_routing_instructions": "Please send the exact amount shown below to the following bank account.",
   "ramp_send_amount_label": "Amount to Send",
   "ramp_bank_details_section_title": "Bank Details",
+  "ramp_bank_beneficiary_name_label": "Beneficiary Name",
   "ramp_bank_name_label": "Bank Name",
   "ramp_account_number_label": "Account Number",
   "ramp_routing_number_label": "Routing Number",

--- a/src/plugins/ramps/infinite/infiniteApi.ts
+++ b/src/plugins/ramps/infinite/infiniteApi.ts
@@ -52,6 +52,7 @@ const USE_DUMMY_DATA: Record<keyof InfiniteApi, boolean> = {
   createQuote: false,
   createTransfer: false,
   getTransferStatus: false,
+  getDepositAddress: false,
   createCustomer: false,
   verifyOtp: false,
   getKycStatus: false,
@@ -335,28 +336,35 @@ export const makeInfiniteApi = (config: InfiniteApiConfig): InfiniteApi => {
         return asInfiniteTransferResponse(data)
       }
 
-      // Dummy response - New format
-      const dummyResponse: InfiniteTransferResponse = {
-        id: `transfer_${params.type.toLowerCase()}_${Date.now()}`,
-        sourceDepositInstructions:
-          params.type === 'ONRAMP'
-            ? {
+      // Dummy response - New format. ONRAMP returns null id + depositAddressId.
+      const dummyResponse: InfiniteTransferResponse =
+        params.type === 'ONRAMP'
+          ? {
+              id: null,
+              depositAddressId: `vba_${Date.now().toString(16)}`,
+              sourceDepositInstructions: {
                 amount: params.amount,
                 bankAccountNumber: '8312008517',
                 bankRoutingNumber: '021000021',
                 bankName: 'JPMorgan Chase Bank',
+                bankBeneficiaryName: 'Edge Wallet, Inc.',
                 toAddress: null
               }
-            : {
+            }
+          : {
+              id: `tfr_${Date.now().toString(16)}`,
+              depositAddressId: undefined,
+              sourceDepositInstructions: {
                 amount: params.amount,
                 bankAccountNumber: null,
                 bankRoutingNumber: null,
                 bankName: null,
+                bankBeneficiaryName: null,
                 toAddress: `0xdeadbeef2${params.source.currency}${
                   params.source.network
                 }${Date.now().toString(16)}`
               }
-      }
+            }
 
       return dummyResponse
     },
@@ -382,7 +390,44 @@ export const makeInfiniteApi = (config: InfiniteApiConfig): InfiniteApi => {
       // Dummy response - simulate a completed transfer
       const dummyResponse: InfiniteTransferResponse = {
         id: transferId,
+        depositAddressId: undefined,
         sourceDepositInstructions: undefined
+      }
+
+      return dummyResponse
+    },
+
+    getDepositAddress: async (depositAddressId: string) => {
+      // Reload deposit instructions for an existing ONRAMP virtual bank
+      // account. Auth required; only onboarded wallets get a 200 here.
+      if (authState.token == null || isTokenExpired()) {
+        throw new Error('Authentication required')
+      }
+
+      if (!USE_DUMMY_DATA.getDepositAddress) {
+        const response = await fetchInfinite(
+          `/v1/headless/transfers/deposit-address/${depositAddressId}`,
+          {
+            headers: makeHeaders({ includeAuth: true })
+          }
+        )
+
+        const data = await response.text()
+        return asInfiniteTransferResponse(data)
+      }
+
+      // Dummy response - same shape as ONRAMP create
+      const dummyResponse: InfiniteTransferResponse = {
+        id: null,
+        depositAddressId,
+        sourceDepositInstructions: {
+          amount: 0,
+          bankAccountNumber: '8312008517',
+          bankRoutingNumber: '021000021',
+          bankName: 'JPMorgan Chase Bank',
+          bankBeneficiaryName: 'Edge Wallet, Inc.',
+          toAddress: null
+        }
       }
 
       return dummyResponse

--- a/src/plugins/ramps/infinite/infiniteApiTypes.ts
+++ b/src/plugins/ramps/infinite/infiniteApiTypes.ts
@@ -75,21 +75,24 @@ export const asInfiniteQuoteResponse = asJSON(
 )
 
 // Transfer response - New format for headless API
+// ONRAMP create returns id: null and a depositAddressId (vba_…). OFFRAMP and
+// follow-up GETs against /transfers/:transferId return id as a string.
 export const asInfiniteTransferResponse = asJSON(
   asObject({
-    id: asString,
+    id: asEither(asString, asNull),
+    depositAddressId: asOptional(asString),
     sourceDepositInstructions: asOptional(
       asObject({
         amount: asNumber,
         bankAccountNumber: asOptional(asString, null),
         bankRoutingNumber: asOptional(asString, null),
         bankName: asOptional(asString, null),
+        bankBeneficiaryName: asOptional(asString, null),
         toAddress: asOptional(asString, null)
         // UNUSED fields:
         // network: asString,
         // currency: asString,
         // depositMessage: asOptional(asString, null),
-        // bankBeneficiaryName: asOptional(asString, null),
         // fromAddress: asOptional(asString, null)
       })
     )
@@ -111,10 +114,56 @@ export const asInfiniteTransferResponse = asJSON(
     //   accountId: asOptional(asString, null),
     //   toAddress: asOptional(asString, null)
     // }),
+    // fees: asObject({
+    //   infiniteFee: asNumber,
+    //   partnerFee: asNumber,
+    //   total: asNumber,
+    //   currency: asString
+    // }),
     // createdAt: asString,
     // updatedAt: asString
   })
 )
+
+// Transfer request - discriminated by direction. ONRAMP no longer accepts an
+// account id; Infinite provisions a virtual bank account and returns deposit
+// instructions in the create response.
+export interface InfiniteOnrampTransferRequest {
+  type: 'ONRAMP'
+  amount: number
+  source: {
+    currency: string
+    network: string
+  }
+  destination: {
+    currency: string
+    network: string
+    toAddress: string
+  }
+  clientReferenceId?: string
+  developerFee?: string
+}
+
+export interface InfiniteOfframpTransferRequest {
+  type: 'OFFRAMP'
+  amount: number
+  source: {
+    currency: string
+    network: string
+    fromAddress: string
+  }
+  destination: {
+    currency: string
+    network: string
+    accountId: string
+  }
+  clientReferenceId?: string
+  developerFee?: string
+}
+
+export type InfiniteTransferRequest =
+  | InfiniteOnrampTransferRequest
+  | InfiniteOfframpTransferRequest
 
 // Customer types
 export const asInfiniteCustomerType = asValue('individual', 'business')
@@ -443,26 +492,15 @@ export interface InfiniteApi {
   }) => Promise<InfiniteQuoteResponse>
 
   // Transfer methods
-  createTransfer: (params: {
-    type: InfiniteQuoteFlow
-    amount: number
-    source: {
-      currency: string
-      network: string
-      accountId?: string
-      fromAddress?: string
-    }
-    destination: {
-      currency: string
-      network: string
-      accountId?: string
-      toAddress?: string
-    }
-    clientReferenceId?: string
-    developerFee?: string
-  }) => Promise<InfiniteTransferResponse>
+  createTransfer: (
+    params: InfiniteTransferRequest
+  ) => Promise<InfiniteTransferResponse>
 
   getTransferStatus: (transferId: string) => Promise<InfiniteTransferResponse>
+
+  getDepositAddress: (
+    depositAddressId: string
+  ) => Promise<InfiniteTransferResponse>
 
   // Customer methods
   createCustomer: (

--- a/src/plugins/ramps/infinite/infiniteRampPlugin.ts
+++ b/src/plugins/ramps/infinite/infiniteRampPlugin.ts
@@ -703,7 +703,6 @@ export const infiniteRampPlugin: RampPluginFactory = (
                 freshQuote,
                 coreWallet,
                 bankAccountId: bankAccountResult.bankAccountId,
-                flow,
                 infiniteNetwork,
                 cleanFiatCode
               }
@@ -712,6 +711,11 @@ export const infiniteRampPlugin: RampPluginFactory = (
             if (!result.confirmed || result.transfer == null) {
               return
             }
+
+            // ONRAMP create returns id: null and a depositAddressId; OFFRAMP
+            // returns a tfr_… id. Fall back through both for analytics.
+            const orderId =
+              result.transfer.id ?? result.transfer.depositAddressId ?? ''
 
             // Log the success event based on direction
             if (request.direction === 'buy') {
@@ -726,7 +730,7 @@ export const infiniteRampPlugin: RampPluginFactory = (
                     exchangeAmount: freshQuote.target.amount.toString()
                   }),
                   fiatProviderId: pluginId,
-                  orderId: result.transfer.id
+                  orderId
                 }
               })
             } else {
@@ -741,7 +745,7 @@ export const infiniteRampPlugin: RampPluginFactory = (
                     exchangeAmount: freshQuote.source.amount.toString()
                   }),
                   fiatProviderId: pluginId,
-                  orderId: result.transfer.id
+                  orderId
                 }
               })
             }

--- a/src/plugins/ramps/infinite/infiniteRampPlugin.ts
+++ b/src/plugins/ramps/infinite/infiniteRampPlugin.ts
@@ -45,8 +45,8 @@ import { kycWorkflow } from './workflows/kycWorkflow'
 const pluginId = 'infinite'
 const partnerIcon = `${EDGE_CONTENT_SERVER_URI}/infinite.png`
 const pluginDisplayName = 'Infinite'
-// Extend as more become supported:
-const DEFAULT_PAYMENT_TYPE: FiatPaymentType = 'wire'
+// ACH push payment is the only supported buy rail today.
+const BUY_PAYMENT_TYPE: FiatPaymentType = 'ach'
 
 // Storage keys
 const INFINITE_PRIVATE_KEY = 'infinite_auth_private_key'
@@ -196,7 +196,7 @@ export const infiniteRampPlugin: RampPluginFactory = (
         }
 
         // Global constraints pre-check
-        const paymentTypes: FiatPaymentType[] = [DEFAULT_PAYMENT_TYPE]
+        const paymentTypes: FiatPaymentType[] = [BUY_PAYMENT_TYPE]
         const constraintOk = validateRampCheckSupportRequest(
           pluginId,
           request,
@@ -303,7 +303,7 @@ export const infiniteRampPlugin: RampPluginFactory = (
       const quoteConstraintOk = validateRampQuoteRequest(
         pluginId,
         request,
-        DEFAULT_PAYMENT_TYPE
+        BUY_PAYMENT_TYPE
       )
       if (!quoteConstraintOk) return []
 
@@ -625,7 +625,7 @@ export const infiniteRampPlugin: RampPluginFactory = (
         fiatAmount: (responseFiatAmount ?? 0).toString(),
         direction: request.direction,
         regionCode: request.regionCode,
-        paymentType: 'wire', // Infinite uses wire bank transfers
+        paymentType: BUY_PAYMENT_TYPE,
         expirationDate:
           quoteResponse.expiresAt != null
             ? new Date(quoteResponse.expiresAt)
@@ -667,13 +667,20 @@ export const infiniteRampPlugin: RampPluginFactory = (
               vault
             })
 
-            // Ensure we have a bank account
-            const bankAccountResult = await bankAccountWorkflow({
-              countryCode: request.regionCode.countryCode,
-              infiniteApi,
-              navigationFlow,
-              vault
-            })
+            // ONRAMP is push-payment: Infinite provisions a virtual bank
+            // account and the user pushes funds to it, so we don't collect
+            // their bank account details. OFFRAMP still requires a destination
+            // bank account on file with Infinite.
+            let bankAccountId: string | undefined
+            if (request.direction === 'sell') {
+              const bankAccountResult = await bankAccountWorkflow({
+                countryCode: request.regionCode.countryCode,
+                infiniteApi,
+                navigationFlow,
+                vault
+              })
+              bankAccountId = bankAccountResult.bankAccountId
+            }
 
             // Get fresh quote before confirmation using existing params
             const freshQuote = await infiniteApi.createQuote(quoteParams)
@@ -702,7 +709,7 @@ export const infiniteRampPlugin: RampPluginFactory = (
                 request,
                 freshQuote,
                 coreWallet,
-                bankAccountId: bankAccountResult.bankAccountId,
+                bankAccountId,
                 infiniteNetwork,
                 cleanFiatCode
               }

--- a/src/plugins/ramps/infinite/utils/navigationFlow.ts
+++ b/src/plugins/ramps/infinite/utils/navigationFlow.ts
@@ -3,6 +3,7 @@ import type { NavigationBase } from '../../../../types/routerTypes'
 export interface NavigationFlow {
   navigate: NavigationBase['navigate']
   goBack: () => void
+  popToTop: () => void
 }
 
 export const makeNavigationFlow = (
@@ -26,5 +27,10 @@ export const makeNavigationFlow = (
     hasNavigated = false
   }
 
-  return { navigate, goBack }
+  const popToTop = (): void => {
+    navigation.popToTop()
+    hasNavigated = false
+  }
+
+  return { navigate, goBack, popToTop }
 }

--- a/src/plugins/ramps/infinite/workflows/confirmationWorkflow.ts
+++ b/src/plugins/ramps/infinite/workflows/confirmationWorkflow.ts
@@ -101,7 +101,8 @@ export const confirmationWorkflow = async (
             bank: {
               name: instructions.bankName,
               accountNumber: instructions.bankAccountNumber ?? '',
-              routingNumber: instructions.bankRoutingNumber ?? ''
+              routingNumber: instructions.bankRoutingNumber ?? '',
+              beneficiaryName: instructions.bankBeneficiaryName ?? undefined
             },
             fiatCurrencyCode: cleanFiatCode,
             fiatAmount: instructions.amount.toString(),

--- a/src/plugins/ramps/infinite/workflows/confirmationWorkflow.ts
+++ b/src/plugins/ramps/infinite/workflows/confirmationWorkflow.ts
@@ -4,7 +4,8 @@ import { showToast } from '../../../../components/services/AirshipInstance'
 import type { RampQuoteRequest } from '../../rampPluginTypes'
 import type {
   InfiniteApi,
-  InfiniteQuoteFlow,
+  InfiniteOfframpTransferRequest,
+  InfiniteOnrampTransferRequest,
   InfiniteQuoteResponse,
   InfiniteTransferResponse
 } from '../infiniteApiTypes'
@@ -28,8 +29,8 @@ export interface ConfirmationParams {
   // New parameters for transfer creation
   freshQuote: InfiniteQuoteResponse
   coreWallet: EdgeCurrencyWallet
-  bankAccountId: string
-  flow: InfiniteQuoteFlow
+  /** Required for OFFRAMP; unused for ONRAMP push-payment flow. */
+  bankAccountId?: string
   infiniteNetwork: string
   cleanFiatCode: string
 }
@@ -51,7 +52,6 @@ export const confirmationWorkflow = async (
     freshQuote,
     coreWallet,
     bankAccountId,
-    flow,
     infiniteNetwork,
     cleanFiatCode
   } = confirmationParams
@@ -64,21 +64,22 @@ export const confirmationWorkflow = async (
       onConfirm: async () => {
         // Create the transfer here - let errors bubble up
         if (request.direction === 'buy') {
-          // For buy (onramp), source is bank account
+          // ONRAMP is push-payment: Infinite provisions a virtual bank account
+          // and returns the deposit instructions in the create response. The
+          // user's own bank account is not part of the request.
           const [receiveAddress] = await coreWallet.getAddresses({
             tokenId: request.tokenId
           })
 
-          const transferParams = {
-            type: flow,
+          const transferParams: InfiniteOnrampTransferRequest = {
+            type: 'ONRAMP',
             amount: freshQuote.source.amount,
             source: {
-              currency: cleanFiatCode.toLowerCase(),
-              network: 'wire', // Default to wire for bank transfers
-              accountId: bankAccountId
+              currency: cleanFiatCode.toUpperCase(),
+              network: 'ACH'
             },
             destination: {
-              currency: request.displayCurrencyCode.toLowerCase(),
+              currency: request.displayCurrencyCode.toUpperCase(),
               network: infiniteNetwork,
               toAddress: receiveAddress.publicAddress
             },
@@ -108,21 +109,27 @@ export const confirmationWorkflow = async (
         } else {
           // TODO: This whole else block is a WIP implementation!
 
+          if (bankAccountId == null) {
+            throw new Error(
+              'Infinite OFFRAMP requires a destination bank account id'
+            )
+          }
+
           // For sell (offramp), destination is bank account
           const [receiveAddress] = await coreWallet.getAddresses({
             tokenId: request.tokenId
           })
 
-          const transferParams = {
-            type: flow,
+          const transferParams: InfiniteOfframpTransferRequest = {
+            type: 'OFFRAMP',
             amount: freshQuote.source.amount,
             source: {
-              currency: request.displayCurrencyCode.toLowerCase(),
+              currency: request.displayCurrencyCode.toUpperCase(),
               network: infiniteNetwork,
               fromAddress: receiveAddress.publicAddress
             },
             destination: {
-              currency: cleanFiatCode.toLowerCase(),
+              currency: cleanFiatCode.toUpperCase(),
               network: 'ach', // Default to ACH for bank transfers
               accountId: bankAccountId
             },

--- a/src/plugins/ramps/infinite/workflows/confirmationWorkflow.ts
+++ b/src/plugins/ramps/infinite/workflows/confirmationWorkflow.ts
@@ -88,22 +88,27 @@ export const confirmationWorkflow = async (
 
           const transfer = await infiniteApi.createTransfer(transferParams)
 
-          // Show deposit instructions for bank transfer with replace
           const instructions = transfer.sourceDepositInstructions
-          if (instructions?.bankName != null && instructions.amount != null) {
-            navigationFlow.navigate('rampBankRoutingDetails', {
-              bank: {
-                name: instructions.bankName,
-                accountNumber: instructions.bankAccountNumber ?? '',
-                routingNumber: instructions.bankRoutingNumber ?? ''
-              },
-              fiatCurrencyCode: cleanFiatCode,
-              fiatAmount: instructions.amount.toString(),
-              onDone: () => {
-                navigationFlow.goBack()
-              }
-            })
+          if (instructions?.bankName == null || instructions.amount == null) {
+            throw new Error(
+              `Transfer ${
+                transfer.id ?? transfer.depositAddressId ?? ''
+              } created but deposit instructions are missing`
+            )
           }
+
+          navigationFlow.navigate('rampBankRoutingDetails', {
+            bank: {
+              name: instructions.bankName,
+              accountNumber: instructions.bankAccountNumber ?? '',
+              routingNumber: instructions.bankRoutingNumber ?? ''
+            },
+            fiatCurrencyCode: cleanFiatCode,
+            fiatAmount: instructions.amount.toString(),
+            onDone: () => {
+              navigationFlow.goBack()
+            }
+          })
 
           resolve({ confirmed: true, transfer })
         } else {

--- a/src/plugins/ramps/infinite/workflows/confirmationWorkflow.ts
+++ b/src/plugins/ramps/infinite/workflows/confirmationWorkflow.ts
@@ -106,7 +106,7 @@ export const confirmationWorkflow = async (
             fiatCurrencyCode: cleanFiatCode,
             fiatAmount: instructions.amount.toString(),
             onDone: () => {
-              navigationFlow.goBack()
+              navigationFlow.popToTop()
             }
           })
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/1/9976422036640/project/1200972350208303/task/1213511119302370?focus=true)

Replaces #5976 (closed in favor of this branch).

#### Context

Infinite updated their headless transfer API to fix the deposit-matching problem the original PR set out to solve. Each ONRAMP create now provisions a per-customer Virtual Bank Account (VBA), so funds match a transfer record by destination instead of by memo. The new shape is:

- `POST /v1/headless/transfers` with `"type": "ONRAMP"` returns `id: null` plus a stable `depositAddressId` (e.g. `vba_…`); the `tfr_…` is created later, when funds arrive.
- Source is now `{ currency: "USD", network: "ACH" }`. The user's own bank account is no longer part of the request — they push funds to the VBA we get back.
- New `GET /v1/headless/transfers/deposit-address/:depositAddressId` re-fetches the same response shape for an existing VBA.
- OFFRAMP semantics are unchanged.

#### Changes

- Update `infiniteApiTypes` for the new response shape: nullable `id`, optional `depositAddressId`, optional `bankBeneficiaryName` on `sourceDepositInstructions`. Rebuild `InfiniteOnrampTransferRequest` to match the new `{ source, destination }` payload and add `getDepositAddress` to the `InfiniteApi` surface.
- Switch the Infinite buy quote to ACH push payment (`paymentType: 'ach'`) and skip `bankAccountWorkflow` on ONRAMP since Edge no longer collects the user's bank.
- Always reset the confirmation slider once `onConfirm` settles. Throw an explicit error from the ONRAMP create flow when deposit instructions are missing so the slider error path triggers instead of the slider hanging.
- Pop the Infinite ramp stack to the top after the user dismisses the bank routing details scene (replaces the old `goBack()`-by-one).
- Make the bank routing instructions and warning text wrap and stop them from shrinking under large system fonts.
- Surface the `bankBeneficiaryName` from the create response as a copy-able row above the bank name on the routing details scene.

#### Notes

The bank-info-fields commit from the prior PR (`287928f079`, address lines / deposit-message / split instruction strings) is intentionally not pulled — those fields aren't in the spec Infinite shared and need product confirmation before adding.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

[Asana task](https://app.asana.com/0/0/1213511119302370/f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the buy transfer request/response contract and navigation flow for the Infinite ramp, which can affect transfer creation and user completion paths.
> 
> **Overview**
> Updates Infinite ONRAMP to the new headless transfers API: buy now uses **ACH push** and no longer sends/collects the user’s bank account; `createTransfer` returns `id: null` with a `depositAddressId` and optional `bankBeneficiaryName`, and the API surface adds `getDepositAddress`.
> 
> Improves ramp UX robustness: the confirmation slider now always resets after `onConfirm` completes (including missing-instructions errors), bank routing details can show a copyable *Beneficiary Name*, wraps instruction/warning text for large fonts, and dismissing routing details now `popToTop()` instead of stepping back through confirmation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43403f0ef32df7f6dd3c73f77b740d9e724c598e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->