### PR TITLE
Make LogBox configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- added: Logbox disable option to env.json
+
 ## 4.49.0 (staging)
 
 - added: Honor `af` affiliate parameter on `deep.edge.app` deep links, activating the promotion alongside any inner payload (e.g. private-key import).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -107,7 +107,7 @@ export default [
 
       'src/actions/WalletListActions.tsx',
       'src/actions/WalletListMenuActions.tsx',
-      'src/app.ts',
+
       'src/components/buttons/ButtonsView.tsx',
       'src/components/buttons/EdgeSwitch.tsx',
       'src/components/buttons/IconButton.tsx',

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,12 +57,15 @@ if (ENV.SENTRY_ORGANIZATION_SLUG.includes('SENTRY_ORGANIZATION')) {
   })
 }
 
-// Uncomment the next line to remove popup warning/error boxes.
-// LogBox.ignoreAllLogs()
-LogBox.ignoreLogs([
-  'Require cycle:',
-  'Attempted to end a Span which has already ended.'
-])
+// Set ENV.LOGBOX_DISABLE to remove popup warning/error boxes.
+if (ENV.LOGBOX_DISABLE) {
+  LogBox.ignoreAllLogs()
+} else {
+  LogBox.ignoreLogs([
+    'Require cycle:',
+    'Attempted to end a Span which has already ended.'
+  ])
+}
 
 // Mute specific console output types.
 // Useful for debugging using console output, i.e. mute everything but `debug`

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -558,5 +558,6 @@ export const asEnvConfig = asObject({
       overrideThemeFile: '/Users/username/Documents/overrideTheme.json'
     }
   ),
-  EXPERIMENT_CONFIG_OVERRIDE: asOptional(asObject(asString), {})
+  EXPERIMENT_CONFIG_OVERRIDE: asOptional(asObject(asString), {}),
+  LOGBOX_DISABLE: asOptional(asBoolean, false)
 }).withRest


### PR DESCRIPTION
In preparation for making it easier for agents to control the sim

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new env flag that only affects developer-facing LogBox warning/error popups and slightly tightens linting coverage for `src/app.ts`.
> 
> **Overview**
> Makes React Native LogBox behavior configurable via a new `ENV.LOGBOX_DISABLE` flag (wired through `envConfig.ts`), allowing environments to fully suppress LogBox popups when desired.
> 
> Updates app startup to either `ignoreAllLogs()` when disabled or continue ignoring only a small set of known noisy warnings, and records the new option in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08e0bd9d05c7aaf936b6c12ad8a1a8ec01fc785e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214447474338292