### PR TITLE
Add Zcash ZIP-321 payment-request deeplink support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -85,6 +85,7 @@
         <data android:scheme="ethereum" />
         <data android:scheme="dash" />
         <data android:scheme="litecoin" />
+        <data android:scheme="zcash" />
       </intent-filter>
       <intent-filter android:label="Wallet Connect">
         <action android:name="android.intent.action.VIEW" />

--- a/ios/edge/Info.plist
+++ b/ios/edge/Info.plist
@@ -51,6 +51,7 @@
 				<string>ethereum</string>
 				<string>bitcoincash</string>
 				<string>bitcoin</string>
+				<string>zcash</string>
 				<string>reqaddr</string>
 			</array>
 		</dict>
@@ -71,6 +72,7 @@
 		<string>ethereum</string>
 		<string>bitcoincash</string>
 		<string>bitcoin</string>
+		<string>zcash</string>
 		<string>reqaddr</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>

--- a/src/__tests__/DeepLink.test.ts
+++ b/src/__tests__/DeepLink.test.ts
@@ -402,4 +402,64 @@ describe('parseDeepLink', function () {
         }
     })
   })
+
+  describe('zcash ZIP-321', () => {
+    // Transparent-only address: the GUI routes this to the zcash wallet's
+    // parseUri, which extracts the address and amount.
+    const tAddress = 'tmKZ8RrXqfPwhDxN7d8r4wQ3iyc3LwhTSpf'
+    const sAddress =
+      'zs1z7rejlpsa98s2rrrfkwmaxu53e4ue0ulcrw0h4x5g8jl04tak0d3mm47vdtahatqrlkngh9sly'
+    const uAddress =
+      'u1l8xunezsvhq8fgzfl7404m450nwnd76zshscn6nfys7vyz2ywyh4cc5daaq0c7q2su5lqfh23sp7jpe57qa6jukhvz5skp7y34zwlexc'
+
+    makeLinkTests({
+      [`zcash:${tAddress}?amount=0.001`]: {
+        type: 'other',
+        protocol: 'zcash',
+        uri: `zcash:${tAddress}?amount=0.001`
+      },
+      [`zcash:${sAddress}?amount=0.05&memo=dGVzdA&label=lunch&message=hello`]: {
+        type: 'other',
+        protocol: 'zcash',
+        uri: `zcash:${sAddress}?amount=0.05&memo=dGVzdA&label=lunch&message=hello`
+      },
+      [`zcash:${uAddress}?amount=0.001&memo=dGVzdA`]: {
+        type: 'other',
+        protocol: 'zcash',
+        uri: `zcash:${uAddress}?amount=0.001&memo=dGVzdA`
+      },
+      // Unknown query params without the `req-` prefix are ignored per spec.
+      [`zcash:${tAddress}?amount=0.001&future=anything`]: {
+        type: 'other',
+        protocol: 'zcash',
+        uri: `zcash:${tAddress}?amount=0.001&future=anything`
+      }
+    })
+
+    it('rejects unknown req- params', () => {
+      expect(() =>
+        parseDeepLink(`zcash:${tAddress}?amount=0.001&req-future=1`)
+      ).toThrow(/Unrecognized required ZIP-321 parameter/)
+    })
+
+    it('rejects indexed req- params', () => {
+      expect(() =>
+        parseDeepLink(`zcash:${tAddress}?amount=0.001&req-future.1=1`)
+      ).toThrow(/Unrecognized required ZIP-321 parameter: req-future/)
+    })
+
+    it('rejects multi-recipient indexed form', () => {
+      expect(() =>
+        parseDeepLink(
+          `zcash:?address=${tAddress}&amount=0.1&address.1=${sAddress}&amount.1=0.2`
+        )
+      ).toThrow(/Multi-recipient ZIP-321/)
+    })
+
+    it('rejects a single recipient encoded as top-level address param', () => {
+      expect(() =>
+        parseDeepLink(`zcash:?address=${tAddress}&amount=0.001`)
+      ).toThrow(/Multi-recipient ZIP-321/)
+    })
+  })
 })

--- a/src/util/DeepLinkParser.ts
+++ b/src/util/DeepLinkParser.ts
@@ -114,10 +114,56 @@ export function parseDeepLink(
     }
   }
 
+  // Validate ZIP-321 (`zcash:`) URIs before falling through to the generic
+  // coin-link path. The plugin's parseUri handles single-recipient extraction,
+  // but the spec also mandates rejecting unknown `req-*` params and we don't
+  // yet implement the multi-recipient form.
+  if (url.protocol === 'zcash:') {
+    validateZip321Uri(betterUrl)
+  }
+
   // Assume anything else is a coin link of some kind (with the exception of
   // deprecated currencies):
   const protocol = url.protocol.replace(/:$/, '')
   return { type: 'other', protocol, uri }
+}
+
+/**
+ * Enforce the parts of ZIP-321 (https://zips.z.cash/zip-0321) that the zcash
+ * plugin's parseUri does not enforce on its own:
+ *
+ * 1. Any query param starting with `req-` is required; unknown required params
+ *    must cause the URI to be rejected.
+ * 2. The multi-recipient form (`zcash:?address=...&address.1=...`) is not yet
+ *    routed through the GUI's single-recipient send flow, so we reject it
+ *    with a clear error instead of silently mis-parsing it.
+ */
+function validateZip321Uri(url: URL<Record<string, string | undefined>>): void {
+  const query = url.query
+
+  for (const key of Object.keys(query)) {
+    // The spec only defines req-* as a marker for required params. Since no
+    // req-* params are recognized today, the presence of any such key means
+    // the URI must be rejected. Index suffixes (`req-foo.1`) are stripped for
+    // a cleaner error message.
+    if (key.startsWith('req-')) {
+      throw new SyntaxError(
+        `Unrecognized required ZIP-321 parameter: ${key.replace(/\.\d+$/, '')}`
+      )
+    }
+  }
+
+  // Multi-recipient form: either an indexed `address.N` param or a top-level
+  // `address` param when no address is present in the path.
+  const hasIndexedAddress = Object.keys(query).some(key =>
+    /^address\.\d+$/.test(key)
+  )
+  const hasTopLevelAddress = query.address != null
+  if (hasIndexedAddress || hasTopLevelAddress) {
+    throw new SyntaxError(
+      'Multi-recipient ZIP-321 payment requests are not supported'
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds end-to-end Zcash [ZIP-321](https://zips.z.cash/zip-0321) payment-request URI support so that tapping (or pasting) a `zcash:` URI lands the user on the send scene with the address, amount, and memo prefilled.

- **iOS scheme registration:** `zcash` added to `CFBundleURLTypes` and `LSApplicationQueriesSchemes` so the OS routes `zcash:` URIs to the app.
- **ZIP-321 spec enforcement** in `parseDeepLink` for the parts the zcash plugin's `parseUri` does not enforce on its own:
  - Reject any `req-*` query parameter (unknown required params must cause rejection per the spec).
  - Reject the multi-recipient form (`address.N` indexed params or top-level `address=` without a host) with a clear error.
- The single-recipient prefill path already works once the scheme is recognized, because the zcash plugin in `edge-currency-accountbased` already handles address, amount, base64url-decoded memo, label, and message via `ZcashTools.parseUri` and threads the memo through `uniqueIdentifier` / `spendTarget.memo`.

## Out of scope

- **Full multi-recipient routing.** BIP21 multi-output URIs are not currently routed through the GUI's single-recipient send flow either, so we keep ZIP-321 consistent and reject the multi-recipient form. Implementing it would require fanning out the multi-recipient query into a `spendInfo.spendTargets[]` array and is a separate piece of work.
- **Higher-fidelity `proposeFulfillingPaymentURI` path.** The zcash plugin engine supports `otherParams.zip321Uri` for proposal-level fidelity, but the existing address/amount/memo prefill is sufficient for the prefill UX described in the task.

## Test URIs

These map to the new `describe('zcash ZIP-321')` block in `src/__tests__/DeepLink.test.ts`:

- Transparent only: `zcash:tmKZ8RrXqfPwhDxN7d8r4wQ3iyc3LwhTSpf?amount=0.001`
- Shielded with memo / label / message: `zcash:zs1z7rejlpsa98s2rrrfkwmaxu53e4ue0ulcrw0h4x5g8jl04tak0d3mm47vdtahatqrlkngh9sly?amount=0.05&memo=dGVzdA&label=lunch&message=hello`
- Unified: `zcash:u1l8xunezsvhq8fgzfl7404m450nwnd76zshscn6nfys7vyz2ywyh4cc5daaq0c7q2su5lqfh23sp7jpe57qa6jukhvz5skp7y34zwlexc?amount=0.001&memo=dGVzdA`
- Reject (unknown `req-*`): `zcash:tmKZ8RrXqfPwhDxN7d8r4wQ3iyc3LwhTSpf?amount=0.001&req-future=1`
- Reject (multi-recipient): `zcash:?address=tmKZ8RrXqfPwhDxN7d8r4wQ3iyc3LwhTSpf&amount=0.1&address.1=zs1...&amount.1=0.2`

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npx jest DeepLink.test.ts` passes (56 tests, including 8 new zcash cases)
- [x] Manual: `xcrun simctl openurl <udid> 'zcash:tmKZ8R...?amount=0.001&memo=dGVzdA'` opens the send scene with address, amount, and memo "test" prefilled.

## Asana

https://app.asana.com/0/1215088146871429/1215201512214395

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped deeplink and URI validation changes with explicit rejection of unsupported ZIP-321 forms; no auth or core payment execution changes in this diff.
> 
> **Overview**
> Registers the **`zcash`** URL scheme on **Android** and **iOS** alongside other coin payment links so the OS can open `zcash:` URIs in Edge.
> 
> In **`parseDeepLink`**, **`zcash:`** links now run **ZIP-321** checks before the generic coin-link path: any unknown **`req-*`** query parameter throws, and **multi-recipient** forms (indexed `address.N` or top-level `address=` without a path address) are rejected with explicit errors. Valid single-recipient URIs still surface as **`type: 'other'`** with **`protocol: 'zcash'`** for the existing wallet **`parseUri`** / send prefill flow.
> 
> **`DeepLink.test.ts`** adds coverage for transparent, shielded, and unified addresses plus the rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f757c03108ef146ba61bc25c22eba63330f34474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- gk-ai-analysis-start:f757c03108ef146ba61bc25c22eba63330f34474 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiQWRkcyBaY2FzaCBaSVAtMzIxIGRlZXBsaW5rIHN1cHBvcnQgYnkgcmVnaXN0ZXJpbmcgdGhlICd6Y2FzaCcgc2NoZW1lIGFuZCB2YWxpZGF0aW5nIFVSSXMgZm9yIHVuc3VwcG9ydGVkIG11bHRpLXJlY2lwaWVudCBvciByZXF1aXJlZCBwYXJhbWV0ZXJzLiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IlpjYXNoIHNjaGVtZSByZWdpc3RyYXRpb24iLCJkZXNjcmlwdGlvbiI6IlJlZ2lzdGVycyB0aGUgJ3pjYXNoJyBVUkwgc2NoZW1lIGluIGJvdGggQW5kcm9pZCAoYEFuZHJvaWRNYW5pZmVzdC54bWxgKSBhbmQgaU9TIChgSW5mby5wbGlzdGApIHRvIGFsbG93IHRoZSBPUyB0byByb3V0ZSB0aGVzZSBsaW5rcyB0byB0aGUgRWRnZSBhcHAuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6ImFuZHJvaWQvYXBwL3NyYy9tYWluL0FuZHJvaWRNYW5pZmVzdC54bWwiLCJsaW5lU3RhcnQiOjg4fSx7InRpdGxlIjoiWklQLTMyMSB2YWxpZGF0aW9uIiwiZGVzY3JpcHRpb24iOiJBZGRlZCB2YWxpZGF0aW9uIGZvciBgemNhc2g6YCBVUklzIGluIGBwYXJzZURlZXBMaW5rYC4gSXQgZXhwbGljaXRseSByZWplY3RzIGFueSBxdWVyeSBwYXJhbWV0ZXJzIHByZWZpeGVkIHdpdGggYHJlcS1gIChhcyB1bmtub3duIHJlcXVpcmVkIHBhcmFtZXRlcnMpIGFuZCByZWplY3RzIG11bHRpLXJlY2lwaWVudCBmb3JtcyAoYGFkZHJlc3MuTmAgb3IgdG9wLWxldmVsIGBhZGRyZXNzYCBwYXJhbWV0ZXJzKS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic3JjL3V0aWwvRGVlcExpbmtQYXJzZXIudHMiLCJsaW5lU3RhcnQiOjExN31dLCJpc3N1ZXMiOltdLCJzdWdnZXN0aW9ucyI6W3sidGl0bGUiOiJDaGVjayBwYXRoIGFkZHJlc3MgZm9yIHRvcC1sZXZlbCBhZGRyZXNzIHJlamVjdGlvbiIsImRlc2NyaXB0aW9uIjoiVGhlIGNvbW1lbnQgbWVudGlvbnMgcmVqZWN0aW5nIGEgdG9wLWxldmVsIGBhZGRyZXNzYCBwYXJhbWV0ZXIgJ3doZW4gbm8gYWRkcmVzcyBpcyBwcmVzZW50IGluIHRoZSBwYXRoJy4gSG93ZXZlciwgdGhlIGxvZ2ljIGBjb25zdCBoYXNUb3BMZXZlbEFkZHJlc3MgPSBxdWVyeS5hZGRyZXNzICE9IG51bGxgIHJlamVjdHMgaXQgcmVnYXJkbGVzcyBvZiB3aGV0aGVyIGFuIGFkZHJlc3MgaXMgcHJlc2VudCBpbiB0aGUgcGF0aC4gSWYgWklQLTMyMSBhbGxvd3MgYW4gZW1wdHkgcGF0aCB3aXRoIGBhZGRyZXNzPWAgZm9yIGEgc2luZ2xlIHJlY2lwaWVudCwgdGhpcyBtaWdodCB1bmludGVudGlvbmFsbHkgcmVqZWN0IHZhbGlkIHNpbmdsZS1yZWNpcGllbnQgVVJJcy4gQ29uc2lkZXIgY2hlY2tpbmcgdGhlIHBhdGggaWYgdGhhdCBpcyBpbnRlbmRlZC4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoic3JjL3V0aWwvRGVlcExpbmtQYXJzZXIudHMiLCJsaW5lU3RhcnQiOjE1OH1dLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:f757c03108ef146ba61bc25c22eba63330f34474 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/EdgeApp/edge-react-gui/pull/6018?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->