### PR TITLE
Upgrade Zcash to NU6.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 35
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.3.20" // Required by zcash-android-sdk >= 2.4.8 (Kotlin 2.3 metadata)
     }
     repositories {
         google()
@@ -19,7 +19,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
 
         // Edge additions:
         classpath 'com.google.gms:google-services:4.3.14'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1774,7 +1774,7 @@ PODS:
   - react-native-zano (0.2.8):
     - OpenSSL-Universal
     - React-Core
-  - react-native-zcash (0.10.7):
+  - react-native-zcash (0.11.0):
     - gRPC-Swift (~> 1.8)
     - MnemonicSwift (~> 2.2)
     - React-Core
@@ -3416,7 +3416,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 83e0ac3d023997de1c2e035af907cc4dc05f718c
   react-native-webview: 69c118d283fccfbc4fca0cd680e036ff3bf188fa
   react-native-zano: 55542cc969fbe349608b3f877575b9f3ce62c303
-  react-native-zcash: 76620c76bc6f6fb86e151900c56a34ef0f7244f3
+  react-native-zcash: 75730d2bd433a354f441103724b0811f537fbe35
   React-NativeModulesApple: df8e5bc59e78ca3040ffbf41336889f3bd0fad68
   React-oscompat: ef5df1c734f19b8003e149317d041b8ce1f7d29c
   React-perflogger: 9a151e0b4c933c9205fd648c246506a83f31395d

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "react-native-wheel-picker-android": "^2.0.6",
     "react-native-worklets": "^0.6.1",
     "react-native-zano": "^0.2.8",
-    "react-native-zcash": "^0.10.7",
+    "react-native-zcash": "^0.11.0",
     "react-redux": "^8.1.1",
     "redux": "^4.2.1",
     "redux-thunk": "^2.3.0",

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -876,6 +876,7 @@ export const SPECIAL_CURRENCY_INFO: Record<string, SpecialCurrencyInfo> = {
     noChangeMiningFee: true,
     isImportKeySupported: true,
     keysOnlyMode: isZecBroken(),
+    highPrecisionSyncRatioDisplay: true,
     importKeyOptions: [
       {
         optionName: 'birthdayHeight',

--- a/yarn.lock
+++ b/yarn.lock
@@ -15789,10 +15789,10 @@ react-native-zano@^0.2.8:
   dependencies:
     cleaners "^0.3.17"
 
-react-native-zcash@^0.10.7:
-  version "0.10.7"
-  resolved "https://registry.yarnpkg.com/react-native-zcash/-/react-native-zcash-0.10.7.tgz#ca93f7b5dd1d729f4ca1adae9baefb656eadb8c3"
-  integrity sha512-HS2OE+xH1bOBHynVWwGEU7XtbqtiOB2nDVSngl5On3rSb8mn6A6JqY+/Em91CRrmCYQHWXR05nfqhqp/RAMBtA==
+react-native-zcash@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-zcash/-/react-native-zcash-0.11.0.tgz#a992f5f697b8774518962fc67f0d11f78f5db86b"
+  integrity sha512-cvbaA9Kqh0woKy/mKeNswvrw3dRKR8zr5mWlLoYoCJNh00yWoucvx2mn3Yj9r6Yt7d1osRwP8i9jnAcERtX57w==
   dependencies:
     biggystring "^4.2.3"
     rfc4648 "^1.3.0"


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Updates the native Zcash wallet stack and Android Kotlin toolchain; incorrect NU6.2 or SDK behavior could affect sync, balances, or transactions for ZEC users.
> 
> **Overview**
> Upgrades **`react-native-zcash`** from **0.10.7** to **0.11.0** (with matching **`yarn.lock`** / **`Podfile.lock`**) to pick up Zcash **NU6.2** support in the native bridge.
> 
> On **Android**, bumps **`kotlinVersion`** from **2.0.21** to **2.3.20** and pins the Kotlin Gradle plugin to that version so the build matches **zcash-android-sdk** (Kotlin 2.3 metadata).
> 
> In app config, sets **`highPrecisionSyncRatioDisplay: true`** on the **`zcash`** entry in **`WalletAndCurrencyConstants`** so sync progress can show finer-grained ratios during long shielded syncs (same pattern as Pirate Chain).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c234d73fcf51a7e1fb4e0a2be78bb5c83fdefd16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215407017692418