### PR TITLE
Auto-assign BitcoinDepot referral on wallet detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: Auto-assign the `bitcoindepot` referral ID to accounts containing BitcoinDepot whitelabel wallets
 - added: Logbox disable option to env.json
 - added: Reverse-resolve recipient addresses to ENS / Unstoppable Domains / ZNS names in the send flow, address modal, and transaction history.
 

--- a/src/__tests__/util/bitcoinDepotUtils.test.ts
+++ b/src/__tests__/util/bitcoinDepotUtils.test.ts
@@ -1,0 +1,56 @@
+import type { EdgeAccount, EdgeWalletInfoFull } from 'edge-core-js'
+
+import { hasBitcoinDepotWallets } from '../../util/bitcoinDepotUtils'
+
+const makeWalletInfo = (
+  appIds: string[],
+  deleted: boolean = false
+): EdgeWalletInfoFull => ({
+  id: 'wallet-id',
+  type: 'wallet:bitcoin',
+  keys: {},
+  appIds,
+  archived: false,
+  deleted,
+  hidden: false,
+  sortIndex: 0
+})
+
+const makeAccount = (allKeys: EdgeWalletInfoFull[]): EdgeAccount =>
+  // Partial mock; only `allKeys` is examined by the detection helper.
+  ({ allKeys } as unknown as EdgeAccount)
+
+describe('hasBitcoinDepotWallets', () => {
+  it('detects a wallet created under a BitcoinDepot appId', () => {
+    const account = makeAccount([
+      makeWalletInfo(['']),
+      makeWalletInfo(['com.bitcoindepot.wallet'])
+    ])
+    expect(hasBitcoinDepotWallets(account)).toBe(true)
+  })
+
+  it('matches appIds case-insensitively', () => {
+    const account = makeAccount([makeWalletInfo(['com.BitcoinDepot.wallet'])])
+    expect(hasBitcoinDepotWallets(account)).toBe(true)
+  })
+
+  it('ignores deleted wallets', () => {
+    const account = makeAccount([
+      makeWalletInfo(['com.bitcoindepot.wallet'], true)
+    ])
+    expect(hasBitcoinDepotWallets(account)).toBe(false)
+  })
+
+  it('returns false for ordinary Edge wallets', () => {
+    const account = makeAccount([
+      makeWalletInfo(['']),
+      makeWalletInfo(['app.coinhubatm.wallet'])
+    ])
+    expect(hasBitcoinDepotWallets(account)).toBe(false)
+  })
+
+  it('returns false for an account with no wallets', () => {
+    const account = makeAccount([])
+    expect(hasBitcoinDepotWallets(account)).toBe(false)
+  })
+})

--- a/src/actions/AccountReferralActions.ts
+++ b/src/actions/AccountReferralActions.ts
@@ -22,6 +22,10 @@ import {
   asMessageTweak,
   asPluginTweak
 } from '../types/TweakTypes'
+import {
+  BITCOIN_DEPOT_INSTALLER_ID,
+  hasBitcoinDepotWallets
+} from '../util/bitcoinDepotUtils'
 import { getActivePromoIds } from '../util/infoUtils'
 import { fetchReferral } from '../util/network'
 import { lockStartDates, type TweakSource } from '../util/ReferralHelpers'
@@ -52,6 +56,14 @@ export function loadAccountReferral(
       const cache = asDiskReferralCache(JSON.parse(cacheText))
       const referral = unpackAccountReferral(JSON.parse(referralText))
 
+      // Auto-affiliate BitcoinDepot whitelabel users who have no
+      // existing affiliation:
+      const isBitcoinDepot =
+        referral.installerId == null && hasBitcoinDepotWallets(account)
+      if (isBitcoinDepot) {
+        referral.installerId = BITCOIN_DEPOT_INSTALLER_ID
+      }
+
       // Reference info server promo data to see if:
       // 1. Any of these `activePromotions` are no longer valid (e.g. a
       //    promotion expired)
@@ -65,6 +77,14 @@ export function loadAccountReferral(
 
       dispatch({ type: 'ACCOUNT_REFERRAL_LOADED', data: { cache, referral } })
       await saveAccountReferral(getState())
+
+      // Also try activating the matching promotion (with silent errors):
+      if (isBitcoinDepot) {
+        await activatePromotion(BITCOIN_DEPOT_INSTALLER_ID)(
+          dispatch,
+          getState
+        ).catch(() => undefined)
+      }
       return
     } catch (error: any) {}
 
@@ -76,18 +96,32 @@ export function loadAccountReferral(
       } catch (error: any) {}
     }
 
-    // Otherwise, just use default values:
+    // Otherwise, just use default values, auto-affiliating BitcoinDepot
+    // whitelabel users detected by their wallets:
+    const isBitcoinDepot = hasBitcoinDepotWallets(account)
     const referral: AccountReferral = {
       promotions: [],
       ignoreAccountSwap: false,
       hiddenAccountMessages: {},
       activePromotions: []
     }
+    if (isBitcoinDepot) {
+      referral.installerId = BITCOIN_DEPOT_INSTALLER_ID
+    }
     const cache: ReferralCache = {
       accountMessages: [],
       accountPlugins: []
     }
     dispatch({ type: 'ACCOUNT_REFERRAL_LOADED', data: { cache, referral } })
+    if (isBitcoinDepot) {
+      // Persist the affiliation, then try activating the matching
+      // promotion (with silent errors):
+      await saveAccountReferral(getState())
+      await activatePromotion(BITCOIN_DEPOT_INSTALLER_ID)(
+        dispatch,
+        getState
+      ).catch(() => undefined)
+    }
   }
 }
 

--- a/src/util/bitcoinDepotUtils.ts
+++ b/src/util/bitcoinDepotUtils.ts
@@ -1,0 +1,29 @@
+import type { EdgeAccount } from 'edge-core-js'
+
+/**
+ * The referral/affiliate ID auto-assigned to detected BitcoinDepot
+ * whitelabel users.
+ */
+export const BITCOIN_DEPOT_INSTALLER_ID = 'bitcoindepot'
+
+/**
+ * Wallets created by the BitcoinDepot whitelabel app carry its login
+ * appId in their `appIds` list. Match by substring so minor appId
+ * variations (e.g. nested appIds) still detect.
+ */
+const BITCOIN_DEPOT_APP_ID_MATCH = 'bitcoindepot'
+
+/**
+ * Detects BitcoinDepot whitelabel users by examining the account's wallets.
+ * Returns true if any non-deleted wallet was created under the BitcoinDepot
+ * login appId.
+ */
+export function hasBitcoinDepotWallets(account: EdgeAccount): boolean {
+  return account.allKeys.some(
+    walletInfo =>
+      !walletInfo.deleted &&
+      walletInfo.appIds.some(appId =>
+        appId.toLowerCase().includes(BITCOIN_DEPOT_APP_ID_MATCH)
+      )
+  )
+}


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana task: https://app.asana.com/0/1215088146871429/1214990791228138

Detect BitcoinDepot whitelabel users at login by examining the account's wallets and auto-assign them the `bitcoindepot` referral/affiliate ID.

- Adds `hasBitcoinDepotWallets(account)` (`src/util/bitcoinDepotUtils.ts`): true when any non-deleted wallet's `appIds` contains a BitcoinDepot appId (case-insensitive substring match, single updatable constant).
- `loadAccountReferral` assigns `installerId: 'bitcoindepot'` to unaffiliated accounts on both load paths (existing referral file without `installerId`, and the no-referral default path), persists it via the existing `saveAccountReferral` flow, and attempts `activatePromotion('bitcoindepot')` with silent errors.
- Existing affiliations (`installerId` already set) are never overwritten.
- No visual changes; unit tests cover the detection helper.

Note: the exact BitcoinDepot login appId is not present in this repo; the substring match constant should be confirmed/adjusted once the whitelabel appId is verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes login-time referral and promotion activation for a subset of users; mis-detection from the substring `appIds` match could affiliate wrong accounts, though existing `installerId` values are preserved.
> 
> **Overview**
> Adds **automatic BitcoinDepot whitelabel affiliation** at login when wallet history indicates the user came from that app and the account has no `installerId` yet.
> 
> A new `hasBitcoinDepotWallets` helper scans non-deleted wallets for a case-insensitive `bitcoindepot` substring in `appIds`. **`loadAccountReferral`** sets `installerId` to `bitcoindepot`, persists via the existing save flow, and calls `activatePromotion('bitcoindepot')` with errors ignored. The same logic applies on the existing-referral path (only when `installerId` is unset) and on the no-referral-file default path. **Existing affiliations are never overwritten.** Unit tests cover the detector; CHANGELOG is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a478e0157a99c444d09df06c687e8a183e4a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->