### PR TITLE
Enable NYM swap provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: NYM swap provider (`nymswap`)
 - changed: Route maestro test builds to a dedicated Zealot channel so they no longer appear in the production release list.
 - changed: Hide the wallet "Get Raw Keys" option behind Developer Mode, while still showing it for wallets that fail to load.
 - removed: SideShift `privateKey` from env config; the swap integration no longer sends the affiliate secret header.

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -355,6 +355,11 @@ export const asEnvConfig = asObject({
     }).withRest
   ),
   NYM_INIT: asCorePluginInit(asBoolean),
+  NYM_SWAP_INIT: asCorePluginInit(
+    asObject({
+      apiKey: asOptional(asString, '')
+    }).withRest
+  ),
   OPBNB_INIT: asCorePluginInit(asEvmApiKeys),
   OPTIMISM_INIT: asCorePluginInit(asEvmApiKeys),
   OSMOSIS_INIT: asCorePluginInit(asEvmApiKeys),

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -100,6 +100,7 @@ export const swapPlugins = {
   sideshift: ENV.SIDESHIFT_INIT,
   swapuz: ENV.SWAPUZ_INIT,
   xgram: ENV.XGRAM_INIT,
+  nymswap: ENV.NYM_SWAP_INIT,
 
   // Defi Swaps
   bridgeless: true,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

EdgeApp/edge-exchange-plugins#457

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Enable the NYM swap provider (added in edge-exchange-plugins#457).

- `src/util/corePlugins.ts`: register `nymswap: ENV.NYM_SWAP_INIT` in `swapPlugins`. The swap plugin id is `nymswap`, intentionally distinct from the `nym` *currency* plugin id (edge-core-js keys all plugins in one namespace; reusing `nym` silently drops the swap plugin).
- `src/envConfig.ts`: add `NYM_SWAP_INIT` (`{ apiKey }`, sent as the `x-api-key` header).

Configure the key in `env.json`:

```json
"NYM_SWAP_INIT": { "apiKey": "<key>" }
```

NYM swaps run on NYM's livenet (production) backend; the endpoints live in edge-exchange-plugins#457. GUI wiring is endpoint-agnostic, so this PR is unchanged by the testnet → livenet migration.

**Verified end-to-end in the iOS simulator**: ran a real mainnet swap My Ether 4 (USDT on Ethereum) → My Nym (native NYM on Nyx). The quote resolved "Powered by NYM" (6.006 USDT → 326.99 NYM) and slide-to-confirm broadcast the on-chain payin (max network fee 0.0002709 ETH), with the order entering processing ("Congratulations! Your exchange is being processed", tx category `Exchange: To NYM`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Standard swap-plugin registration and optional API key config only; no changes to auth, payments, or wallet key handling.
> 
> **Overview**
> Enables the **NYM** centralized swap provider in the app by wiring the existing `nymswap` exchange plugin into core plugin registration and environment config.
> 
> **`src/util/corePlugins.ts`** adds `nymswap: ENV.NYM_SWAP_INIT` alongside other CEX swap plugins. The id is **`nymswap`**, separate from the **`nym`** wallet/currency plugin, so both can load in the shared plugin namespace.
> 
> **`src/envConfig.ts`** introduces **`NYM_SWAP_INIT`** with an optional **`apiKey`** (for the `x-api-key` header on NYM’s API). Operators enable it via `env.json`, e.g. `"NYM_SWAP_INIT": { "apiKey": "<key>" }`.
> 
> CHANGELOG notes the new provider. Swap routing/quote UI behavior follows the same pattern as other env-gated swap plugins; the NYM backend lives in **edge-exchange-plugins**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9db3df554a9b37f8921429a07e4bbe9750f7f9f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

