### PR TITLE
Remove SideShift privateKey from env config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - changed: Route maestro test builds to a dedicated Zealot channel so they no longer appear in the production release list.
 - changed: Hide the wallet "Get Raw Keys" option behind Developer Mode, while still showing it for wallets that fail to load.
+- removed: SideShift `privateKey` from env config; the swap integration no longer sends the affiliate secret header.
 
 ## 4.49.0 (staging)
 

--- a/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
@@ -619,6 +619,7 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -1705,6 +1705,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -3714,6 +3715,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -5723,6 +5725,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -7313,6 +7316,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -8883,6 +8887,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -10220,6 +10225,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -11970,6 +11976,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -13671,6 +13678,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -15299,6 +15307,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}

--- a/src/__tests__/scenes/__snapshots__/SwapConfirmationScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SwapConfirmationScene.test.tsx.snap
@@ -2033,6 +2033,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     },
                   ]
                 }
+                testID="confirmSliderThumb"
               >
                 <Text
                   adjustsFontSizeToFit={true}

--- a/src/components/themed/SafeSlider.tsx
+++ b/src/components/themed/SafeSlider.tsx
@@ -26,6 +26,7 @@ interface Props {
   width?: number
   confirmText?: string
   disabledText?: string
+  testID?: string
 
   onSlidingComplete: (reset: () => void) => Promise<void> | void
 }
@@ -36,7 +37,8 @@ export const SafeSlider: React.FC<Props> = props => {
     disabledText,
     disabled = false,
     onSlidingComplete,
-    parentStyle
+    parentStyle,
+    testID = 'confirmSliderThumb'
   } = props
 
   const theme = useTheme()
@@ -120,6 +122,7 @@ export const SafeSlider: React.FC<Props> = props => {
 
         <GestureDetector gesture={gesture}>
           <Animated.View
+            testID={testID}
             style={[
               styles.thumb,
               sliderDisabled ? styles.disabledThumb : null,

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -385,9 +385,8 @@ export const asEnvConfig = asObject({
   SEPOLIA_INIT: asCorePluginInit(asEvmApiKeys),
   SIDESHIFT_INIT: asCorePluginInit(
     asObject({
-      affiliateId: asOptional(asString, ''),
-      privateKey: asOptional(asString)
-    }).withRest
+      affiliateId: asOptional(asString, '')
+    })
   ),
   SOLANA_INIT: asCorePluginInit(
     asObject({


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

SideShift hack followup. The SideShift affiliate account was compromised, so we
stop sending the affiliate secret. This removes the `privateKey` field that was
added to `SIDESHIFT_INIT` in env config by #5369. The SideShift swap plugin
sends that value as the `x-sideshift-secret` header; with the field gone the
header is omitted. SideShift confirmed the integration works identically without
it (the `affiliateId` query param is what tracks affiliate commission). Rotating
to a new affiliate account/`affiliateId` and removing the secret from the
production env are handled operationally, outside this repo.

Asana: https://app.asana.com/0/1215088146871429/1214800712844381

**Verification.**
- `tsc --noEmit` and `verify-repo` (eslint + jest) pass.
- Executed a real end-to-end SideShift swap in the iOS simulator (edge-funds account, SideShift forced as the only swap provider via a local, uncommitted corePlugins edit): BTC `My Bitcoin` 0.00023481 (USD 14.99) to SOL `My Solana` 0.20594, "Powered by SideShift.ai". Slid to confirm and reached the "Congratulations! Your exchange is being processed!" success scene; the BTC spend is recorded as an `Exchange: To SOL` transaction. The plugin issued the shift-creation request with no `x-sideshift-secret` header and the swap still created and broadcast, confirming the integration works without the `privateKey`. See the attached screenshots (quote, success scene, transaction details).
- The prior geo-block (SideShift denies US egress) was cleared by re-testing from a non-US VPN exit, where createShift is permitted; the shift created successfully.
- A `confirmSliderThumb` testID was added to the shared confirm slider so the maestro swap flow can drive it (test infrastructure, separate commit).

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live SideShift swap configuration and removes a credential from env parsing; behavior change is intentional and low blast radius if affiliateId-only integration is verified, but swap partner traffic is user-facing.
> 
> **Overview**
> After a compromised SideShift affiliate account, this PR **stops configuring an affiliate secret** in the app. `SIDESHIFT_INIT` in `envConfig` no longer accepts `privateKey` (and drops `.withRest`), so the swap plugin will not send the `x-sideshift-secret` header; affiliate tracking continues via `affiliateId` only.
> 
> Separately, **`SafeSlider`** gains an optional `testID` prop (default `confirmSliderThumb`) on the confirm thumb so Maestro can drive send/swap confirm flows; snapshot tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6014df16f9042b125d81057253b35b2fabf8c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

