### PR TITLE
Label USDC.e Tarot/Velodrome pools correctly on Optimism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added: Logbox disable option to env.json
 - added: Reverse-resolve recipient addresses to ENS / Unstoppable Domains / ZNS names in the send flow, address modal, and transaction history.
+- fixed: Label Optimism Tarot/Velodrome pools that use USDC.e as USDC.e instead of USDC, so staking shows the correct required asset.
 
 ## 4.49.0 (staging)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - changed: Standardize wallet list automation test IDs to use period separators.
+- fixed: USDC.e shown as USDC in the Optimism Tarot staking pools
 
 ## 4.51.0 (staging)
 
@@ -26,12 +27,12 @@
 - changed: Add maestro test selectors (testIDs) to the swap scene's from and to wallet pills.
 - changed: The balance card title now reads "Unhide Balance" while balances are hidden, and hiding balances shows a toast explaining how to bring them back.
 - changed: Deep links now wait only for the account state they actually use, so a link that just opens a scene, such as the buy/sell entry, follows immediately after login instead of waiting for every wallet to finish loading.
-- fixed: Wallet list rows now announce as a button to screen readers, instead of as an inert group that reads out but does not present itself as something to activate.
-- fixed: The buy/sell amount field no longer reads "Amount undefined" while the app is still working out which wallet to use.
-- fixed: Show the Monero Transaction Key of a send whose key never reached the transaction's saved metadata, by falling back to the key the wallet engine mirrors into `otherParams`. Covers sends made on 4.49.0 and later while the send path reported no key, on devices that still hold the original wallet cache.
 - changed: Add maestro test selectors (testIDs) to Manage Tokens rows.
 - changed: Add maestro test selectors (testIDs) to the Wallet Settings name input and Done button.
 - changed: Add a maestro test selector (testID) to the split-wallet confirmation button.
+- fixed: Wallet list rows now announce as a button to screen readers, instead of as an inert group that reads out but does not present itself as something to activate.
+- fixed: The buy/sell amount field no longer reads "Amount undefined" while the app is still working out which wallet to use.
+- fixed: Show the Monero Transaction Key of a send whose key never reached the transaction's saved metadata, by falling back to the key the wallet engine mirrors into `otherParams`. Covers sends made on 4.49.0 and later while the send path reported no key, on devices that still hold the original wallet cache.
 - fixed: Force `NODE_ENV=test` in the Jest script so UI tests keep working when npm is invoked via Socket (Socket otherwise sets `NODE_ENV=development`, which makes react-native-gesture-handler treat Jest as a non-test env).
 - fixed: Bitwave CSV exports now use ISO 8601 UTC timestamps, leave the fee columns blank so Bitwave does not double-count fees, and copy the description into the second custom metadata column.
 - fixed: Bitwave account ids are no longer capitalized by the keyboard or padded with whitespace when entered, so exports import without hand-editing the account id.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -437,7 +437,7 @@ export default [
       'src/plugins/gui/util/fetchRevolut.ts',
       'src/plugins/gui/util/initializeProviders.ts',
       'src/plugins/stake-plugins/currency/tronStakePlugin.ts',
-      'src/plugins/stake-plugins/generic/pluginInfo/optimismTarotPool.ts',
+
       'src/plugins/stake-plugins/generic/policyAdapters/CardanoKilnAdaptor.ts',
       'src/plugins/stake-plugins/generic/policyAdapters/EthereumKilnAdaptor.ts',
       'src/plugins/stake-plugins/generic/policyAdapters/GlifInfinityPoolAdapter.ts',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -453,7 +453,6 @@ export default [
       'src/plugins/gui/util/fetchRevolut.ts',
       'src/plugins/gui/util/initializeProviders.ts',
 
-      'src/plugins/stake-plugins/generic/pluginInfo/optimismTarotPool.ts',
       'src/plugins/stake-plugins/generic/policyAdapters/CardanoKilnAdaptor.ts',
       'src/plugins/stake-plugins/generic/policyAdapters/EthereumKilnAdaptor.ts',
       'src/plugins/stake-plugins/generic/policyAdapters/GlifInfinityPoolAdapter.ts',

--- a/src/plugins/stake-plugins/generic/pluginInfo/optimismTarotPool.ts
+++ b/src/plugins/stake-plugins/generic/pluginInfo/optimismTarotPool.ts
@@ -87,7 +87,7 @@ const adaptors: TarotPoolAdapterConfig[] = [
     },
     token1: {
       contractAddress: '0x7F5c764cBc14f9669B88837ca1490cCa17c31607',
-      symbol: 'USDC',
+      symbol: 'USDC.e',
       decimals: 6,
       tokenId: '7f5c764cbc14f9669b88837ca1490cca17c31607'
     },
@@ -110,7 +110,7 @@ const adaptors: TarotPoolAdapterConfig[] = [
     poolContractAddress: '0x5B0dce514B4AEd993751D2CF7379B75df9860312',
     token0: {
       contractAddress: '0x7F5c764cBc14f9669B88837ca1490cCa17c31607',
-      symbol: 'USDC',
+      symbol: 'USDC.e',
       decimals: 6,
       tokenId: '7f5c764cbc14f9669b88837ca1490cca17c31607'
     },
@@ -165,7 +165,9 @@ const adaptors: TarotPoolAdapterConfig[] = [
   }
 ]
 
-const makePolicyConfig = (adapterConfig: TarotPoolAdapterConfig) => {
+const makePolicyConfig = (
+  adapterConfig: TarotPoolAdapterConfig
+): StakePolicyConfig<TarotPoolAdapterConfig> => {
   return {
     stakePolicyId: `optimism_tarot_${adapterConfig.token0.tokenId}_${adapterConfig.token1.tokenId}_${adapterConfig.leverage}x`,
     stakeProviderInfo: {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Fixes the Velodrome/Tarot staking pools on Optimism that displayed **USDC.e** as **USDC**.

Two Tarot pools use the USDC.e contract (`0x7F5c764cBc14f9669B88837ca1490cCa17c31607`) but their token `symbol` was set to `USDC`:

- **TAROT/USDC** pool `0x3CD9F7912B6b04b702232FBb3f12F94145B8A0E4` (the reported case)
- **USDC/VELO** pool `0x5B0dce514B4AEd993751D2CF7379B75df9860312` (same mislabel)

Per `edge-currency-accountbased/.../optimismInfo.ts`, that contract is `USDC.e`, while native `USDC` is `0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85`. Because both pools showed "USDC", a user holding native USDC (but no USDC.e) believed they could stake in both but could only stake in one. The staking logic correctly requires USDC.e (keyed by `tokenId`); only the label was wrong.

This relabels the two USDC.e token entries in `optimismTarotPool.ts` from `USDC` to `USDC.e`. Only the display `symbol` changes; `tokenId`, contract addresses, and the derived `stakePolicyId` are untouched, so on-chain behavior and existing staking positions are unaffected. The native-USDC pool keeps its `USDC` label. Also added the previously-missing return type on `makePolicyConfig` (flagged by lint on the touched file).

**Verification:** `tsc --noEmit` clean, full jest suite (511 tests) passes, and the value flow was traced end-to-end (`symbol` flows to `stakeAssets[].currencyCode` and the `TarotPoolAdaptor` token match, both staying consistent). In-app verification on iOS sim (this follow-up run): the Optimism Earn scene now renders both pools with the corrected label, "Stake: TAROT + USDC.e" and "Stake: USDC.e + VELO" (previously "USDC"). Tapping the corrected TAROT + USDC.e pool opens the Optimism wallet selector as expected. Proof screenshots attached in a comment below. The deeper StakeOptions detail was not reached: edge-funds' Optimism wallets are unfunded and the slot's Optimism RPC returns "could not detect network", so no live position renders; a native SIGSEGV in the debug build also interrupts the wallet-modal drill-down. Neither affects the label, which comes from static plugin config.

The CHANGELOG entry was rewritten to the current entry-shape rules (one clause, outcome only). The diff also moves three `changed` entries above the `fixed` block in the 4.51.0 (staging) section: that section arrived out of type order on develop and failed the CHANGELOG order check, which blocks every land. The move edits no entry text.

Asana: https://app.asana.com/0/1215088146871429/1210469020492774

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static display metadata only; no changes to contracts, token IDs, or staking logic.
> 
> **Overview**
> Corrects **misleading stake labels** on two Optimism Tarot/Velodrome pools that use the bridged USDC.e contract (`0x7F5c…1607`) but were shown as **USDC**, which could make users think native Optimism USDC would work when staking actually requires USDC.e.
> 
> Updates `optimismTarotPool.ts` so **TAROT/USDC** and **USDC/VELO** token configs use `symbol: 'USDC.e'`. Contract addresses, `tokenId`, and `stakePolicyId` are unchanged, so matching and on-chain behavior stay the same. Also adds an explicit return type on `makePolicyConfig` and a CHANGELOG entry; `optimismTarotPool.ts` is dropped from an ESLint override list now that the file passes lint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e0241e6ccbd957363c863bd6ac3a93515e77d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


