### PR TITLE
Prevent send-to-self for EVM assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added: Logbox disable option to env.json
 - added: Reverse-resolve recipient addresses to ENS / Unstoppable Domains / ZNS names in the send flow, address modal, and transaction history.
+- changed: Prevent sending to the same wallet's own address for EVM assets.
 
 ## 4.49.0 (staging)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -472,7 +472,7 @@ export default [
       'src/util/crypto.ts',
       'src/util/CryptoAmount.ts',
       'src/util/cryptoTextUtils.ts',
-      'src/util/CurrencyInfoHelpers.ts',
+
       'src/util/CurrencyWalletHelpers.ts',
 
       'src/util/exchangeRates.ts',

--- a/src/components/modals/PendingTxModal.tsx
+++ b/src/components/modals/PendingTxModal.tsx
@@ -6,11 +6,11 @@ import type {
 import * as React from 'react'
 import type { AirshipBridge } from 'react-native-airship'
 
-import { getSpecialCurrencyInfo } from '../../constants/WalletAndCurrencyConstants'
 import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { useHandler } from '../../hooks/useHandler'
 import { lstrings } from '../../locales/strings'
 import type { NavigationBase } from '../../types/routerTypes'
+import { isEvmWallet } from '../../util/CurrencyInfoHelpers'
 import { ButtonsView } from '../buttons/ButtonsView'
 import { Airship, showError, showToast } from '../services/AirshipInstance'
 import { Paragraph } from '../themed/EdgeText'
@@ -23,16 +23,6 @@ interface PendingTxModalProps {
   wallet: EdgeCurrencyWallet
   tokenId: EdgeTokenId
   navigation: NavigationBase
-}
-
-/**
- * Checks if a wallet is EVM-based by looking at its WalletConnect v2 chain ID namespace.
- * EVM chains use the 'eip155' namespace.
- */
-function isEvmWallet(wallet: EdgeCurrencyWallet): boolean {
-  const { pluginId } = wallet.currencyInfo
-  const specialInfo = getSpecialCurrencyInfo(pluginId)
-  return specialInfo.walletConnectV2ChainId?.namespace === 'eip155'
 }
 
 const PendingTxModal = (props: PendingTxModalProps): React.ReactElement => {

--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -49,7 +49,7 @@ import { useState } from '../../types/reactHooks'
 import { useDispatch, useSelector } from '../../types/reactRedux'
 import type { EdgeAppSceneProps, NavigationBase } from '../../types/routerTypes'
 import type { FioRequest } from '../../types/types'
-import { getCurrencyCode } from '../../util/CurrencyInfoHelpers'
+import { getCurrencyCode, isEvmWallet } from '../../util/CurrencyInfoHelpers'
 import { getWalletName } from '../../util/CurrencyWalletHelpers'
 import {
   addToFioAddressCache,
@@ -181,16 +181,6 @@ const ALLOW_MULTIPLE_TARGETS = true
 const MULTI_OUT_DIFF_PERCENT = '0.005'
 const PIN_MAX_LENGTH = 4
 const INFINITY_STRING = '999999999999999999999999999999999999999'
-
-/**
- * Checks if a wallet is EVM-based by looking at its WalletConnect v2 chain ID
- * namespace. EVM chains use the 'eip155' namespace.
- */
-const isEvmWallet = (wallet: EdgeCurrencyWallet): boolean => {
-  const { pluginId } = wallet.currencyInfo
-  const specialInfo = getSpecialCurrencyInfo(pluginId)
-  return specialInfo.walletConnectV2ChainId?.namespace === 'eip155'
-}
 
 const SendComponent: React.FC<Props> = props => {
   const { route, navigation } = props

--- a/src/components/tiles/AddressTile2.tsx
+++ b/src/components/tiles/AddressTile2.tsx
@@ -21,7 +21,7 @@ import { lstrings } from '../../locales/strings'
 import { PaymentProtoError } from '../../types/PaymentProtoError'
 import { useSelector } from '../../types/reactRedux'
 import type { NavigationBase } from '../../types/routerTypes'
-import { getCurrencyCode } from '../../util/CurrencyInfoHelpers'
+import { getCurrencyCode, isEvmWallet } from '../../util/CurrencyInfoHelpers'
 import { parseDeepLink } from '../../util/DeepLinkParser'
 import { checkPubAddress } from '../../util/FioAddressUtils'
 import { type NameService, reverseLookupName } from '../../util/nameServices'
@@ -308,6 +308,24 @@ export const AddressTile2 = React.forwardRef(
           ) {
             showError(lstrings.scan_invalid_address_error_title)
             return
+          }
+
+          // Prevent sending to the same wallet's own address. EVM wallets use a
+          // single static address across all EVM chains, so a self-send is
+          // always a mistake. (Cross-wallet "self transfer" to a *different*
+          // wallet via `handleSelfTransfer` is unaffected.) Compare
+          // case-insensitively since EVM addresses are checksummed hex.
+          if (isEvmWallet(coreWallet)) {
+            const ownReceiveAddress = await coreWallet.getReceiveAddress({
+              tokenId: null
+            })
+            if (
+              parsedUri.publicAddress.toLowerCase() ===
+              ownReceiveAddress.publicAddress.toLowerCase()
+            ) {
+              showError(lstrings.send_to_self_error_message)
+              return
+            }
           }
 
           // If we don't already have a resolved name from a forward-typed

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -248,6 +248,7 @@ const strings = {
   fragment_required: 'Required',
   scan_invalid_address_error_title: 'Invalid Address',
   scan_invalid_address_error_description: 'Not a valid public address',
+  send_to_self_error_message: 'You cannot send to the same wallet',
   fragment_send_subtitle: 'Send',
   fragment_send_myself: 'Myself',
   fragment_send_from_label: 'From',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -154,6 +154,7 @@
   "fragment_required": "Required",
   "scan_invalid_address_error_title": "Invalid Address",
   "scan_invalid_address_error_description": "Not a valid public address",
+  "send_to_self_error_message": "You cannot send to the same wallet",
   "fragment_send_subtitle": "Send",
   "fragment_send_myself": "Myself",
   "fragment_send_from_label": "From",

--- a/src/util/CurrencyInfoHelpers.ts
+++ b/src/util/CurrencyInfoHelpers.ts
@@ -10,7 +10,10 @@ import type {
 } from 'edge-core-js'
 
 import { showError } from '../components/services/AirshipInstance'
-import { SPECIAL_CURRENCY_INFO } from '../constants/WalletAndCurrencyConstants'
+import {
+  getSpecialCurrencyInfo,
+  SPECIAL_CURRENCY_INFO
+} from '../constants/WalletAndCurrencyConstants'
 import { ENV } from '../env'
 import type { EdgeAsset } from '../types/types'
 import { asMaybeContractLocation } from './cleaners'
@@ -22,6 +25,16 @@ import { asMaybeContractLocation } from './cleaners'
 export function isKeysOnlyPlugin(pluginId: string): boolean {
   const { keysOnlyMode = false } = SPECIAL_CURRENCY_INFO[pluginId] ?? {}
   return keysOnlyMode || ENV.KEYS_ONLY_PLUGINS[pluginId]
+}
+
+/**
+ * Checks if a wallet is EVM-based by looking at its WalletConnect v2 chain ID
+ * namespace. EVM chains use the 'eip155' namespace.
+ */
+export function isEvmWallet(wallet: EdgeCurrencyWallet): boolean {
+  const { pluginId } = wallet.currencyInfo
+  const specialInfo = getSpecialCurrencyInfo(pluginId)
+  return specialInfo.walletConnectV2ChainId?.namespace === 'eip155'
 }
 
 export type FindTokenParams =


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1213742694496279

Previously a user could paste their own wallet's receive address into the Send
flow and successfully send to themselves. For EVM assets this is always a
mistake (a single static address per wallet across all EVM chains).

This rejects an entered/pasted/scanned address in the Send flow when it matches
the sending wallet's own receive address, scoped to EVM wallets, surfacing the
error "You cannot send to the same wallet" instead of allowing the send.

- The guard lives in `AddressTile2.changeAddress`, right after the URI is parsed
  — the single choke point every entered address passes through (used only by
  `SendScene2`). It compares `parsedUri.publicAddress` against
  `getReceiveAddress({ tokenId: null })` case-insensitively (EVM addresses are
  checksummed hex).
- Cross-wallet "self transfer" to a *different* wallet of the same asset
  (`handleSelfTransfer`, which excludes the current wallet) is unaffected.
- Non-EVM assets are unaffected (UTXO change/consolidation to an own address
  stays legal).
- The duplicated `isEvmWallet` helper (previously copied in `SendScene2` and
  `PendingTxModal`) is consolidated into `CurrencyInfoHelpers`.

Verified in-app on the iOS simulator with an EVM (Fantom) wallet: entering the
wallet's own address shows the error and leaves the recipient empty, while a
different address is accepted and advances to the amount entry. See the attached
screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a scoped send-flow validation for EVM recipients only; no changes to signing, broadcast, or auth paths.
> 
> **Overview**
> Blocks users from sending EVM assets to their **same wallet’s receive address** when they paste, scan, or enter it in Send. The check runs in **`AddressTile2`** after URI parsing (the shared entry point for recipient addresses in **`SendScene2`**) and compares against **`getReceiveAddress`** case-insensitively, showing **“You cannot send to the same wallet”** instead of continuing.
> 
> The guard applies only to **EVM wallets** (via a shared **`isEvmWallet`** helper moved into **`CurrencyInfoHelpers`**, replacing duplicate copies in **`SendScene2`** and **`PendingTxModal`**). Cross-wallet “send to myself” on a **different** wallet and non-EVM sends to an own address are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d96a2a09e82160e5aa226a7e4703bf7af423c3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="1" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6026/commits/15ac90a4ecf1036e63a53a46a8623cb3ce348879"><code>15ac90a</code></a><br><sub>Prevent send-to-self for EVM assets</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6026/20260610-002732-agent-proof-1213742694496279-01-own-receive-address.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6026/20260610-002732-agent-proof-1213742694496279-01-own-receive-address.png" width="200"></a><br><sub>agent proof 1213742694496279 01 own receive address</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6026/20260610-002732-agent-proof-1213742694496279-02-send-to-self-error.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6026/20260610-002732-agent-proof-1213742694496279-02-send-to-self-error.png" width="200"></a><br><sub>agent proof 1213742694496279 02 send to self error</sub></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->