### PR TITLE
Feat: Changelly integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: Changelly swap provider
 - added: NYM swap provider (`nymswap`)
 - added: Optional Bridgeless swap referral id via the `BRIDGELESS_INIT` env config, passed through to the swap plugin.
 - changed: Route maestro test builds to a dedicated Zealot channel so they no longer appear in the production release list.

--- a/scripts/obfuscateString.ts
+++ b/scripts/obfuscateString.ts
@@ -1,0 +1,16 @@
+// Generates the obfuscated char-code array to paste into env.json for
+// fields cleaned by asObfuscatedString.
+//
+// Usage:
+//   node -r sucrase/register scripts/obfuscateString.ts <plaintext...>
+
+import { wasObfuscatedString } from '../src/util/cleaners/asObfuscatedString'
+
+const plaintext = process.argv.slice(2).join(' ')
+
+if (plaintext === '') {
+  console.error('Usage: obfuscateString.ts <plaintext>')
+  process.exit(1)
+}
+
+console.log(JSON.stringify(wasObfuscatedString(plaintext)))

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -712,6 +712,7 @@ export const pluginIdIcons: Record<string, string> = {
   bridgeless: EDGE_CONTENT_SERVER_URI + '/bridgeless.png',
   changenow: EDGE_CONTENT_SERVER_URI + '/changenow.png',
   changehero: EDGE_CONTENT_SERVER_URI + '/changehero.png',
+  changelly: EDGE_CONTENT_SERVER_URI + '/changelly.png',
   cosmosibc: EDGE_CONTENT_SERVER_URI + '/cosmosibc.png',
   exolix: EDGE_CONTENT_SERVER_URI + '/exolix-logo.png',
   fantomsonicupgrade: EDGE_CONTENT_SERVER_URI + '/fantomsonicupgrade.png',

--- a/src/components/modals/SwapVerifyTermsModal.tsx
+++ b/src/components/modals/SwapVerifyTermsModal.tsx
@@ -31,6 +31,11 @@ const pluginData: Record<string, TermsUri> = {
     privacyUri: 'https://changenow.io/privacy-policy',
     kycUri: 'https://changenow.io/faq/kyc'
   },
+  changelly: {
+    termsUri: 'https://changelly.com/terms-of-use',
+    privacyUri: 'https://changelly.com/privacy-policy',
+    kycUri: 'https://changelly.com/aml-kyc'
+  },
   exolix: {
     termsUri: 'https://exolix.com/terms',
     privacyUri: 'https://exolix.com/privacy',

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -19,6 +19,7 @@ import { asInitOptions as asPaybisInitOptions } from './plugins/ramps/paybis/pay
 import { asInitOptions as asRevolutInitOptions } from './plugins/ramps/revolut/revolutRampTypes'
 import { asInitOptions as asSimplexInitOptions } from './plugins/ramps/simplex/simplexRampTypes'
 import { asBase16 } from './util/cleaners/asHex'
+import { asObfuscatedString } from './util/cleaners/asObfuscatedString'
 
 function asNullable<T>(cleaner: Cleaner<T>): Cleaner<T | null> {
   return function asNullable(raw) {
@@ -272,6 +273,16 @@ export const asEnvConfig = asObject({
   CHANGEHERO_INIT: asCorePluginInit(
     asObject({
       apiKey: asOptional(asString, '')
+    }).withRest
+  ),
+  CHANGELLY_INIT: asCorePluginInit(
+    asObject({
+      // Arrays of XOR-masked char codes; see asObfuscatedString.
+      // No fallback values: the plugin itself refuses to load when either
+      // member is missing, so a partial entry disables Changelly instead of
+      // supplying placeholder credentials.
+      apiKey: asOptional(asObfuscatedString),
+      partnerId: asOptional(asString)
     }).withRest
   ),
   COREUM_INIT: asCorePluginInit(asBoolean),

--- a/src/util/cleaners/asObfuscatedString.ts
+++ b/src/util/cleaners/asObfuscatedString.ts
@@ -1,0 +1,19 @@
+import { asArray, asCodec, asNumber, uncleaner } from 'cleaners'
+
+// XOR mask applied to each char code. Not a secret.
+const MASK = 0x5a
+
+/**
+ * Decodes a string stored as an array of XOR-masked char codes,
+ * e.g. "hi" <-> [0x32, 0x33]. Use `wasObfuscatedString` or
+ * scripts/obfuscateString.ts to generate the array.
+ */
+export const asObfuscatedString = asCodec<string>(
+  raw =>
+    asArray(asNumber)(raw)
+      .map(code => String.fromCharCode(code ^ MASK))
+      .join(''),
+  clean => clean.split('').map(ch => ch.charCodeAt(0) ^ MASK)
+)
+
+export const wasObfuscatedString = uncleaner(asObfuscatedString)

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -92,6 +92,7 @@ export const swapPlugins = {
   // Centralized Swaps
   changehero: ENV.CHANGEHERO_INIT,
   changenow: ENV.CHANGE_NOW_INIT,
+  changelly: ENV.CHANGELLY_INIT,
   exolix: ENV.EXOLIX_INIT,
   godex: ENV.GODEX_INIT,
   lifi: ENV.LIFI_INIT,


### PR DESCRIPTION
Replaces #5988, reordered so the obfuscation utility lands first:

1. **Add asObfuscatedString cleaner** — a codec that decodes strings stored as arrays of XOR-masked char codes, plus `scripts/obfuscateString.ts` to generate the arrays.
2. **Feat: Changelly integration** — enables the changelly swap plugin with `CHANGELLY_INIT`: an apiKey stored XOR-obfuscated in env.json plus a plaintext `partnerId` (`edge-app`), both required with no defaults, passed to the plugin via initOptions (see EdgeApp/edge-exchange-plugins#471).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New third-party swap integration and env credential handling; impact is limited to swap quoting/execution when config is present, not core auth or funds custody.
> 
> **Overview**
> Adds **Changelly** as a centralized swap provider, gated by new `CHANGELLY_INIT` in env config (`apiKey` via XOR-masked char arrays, plaintext `partnerId`; both optional with no defaults so incomplete config disables the plugin). The provider is registered in `swapPlugins` and gets the usual UI wiring (CDN icon, KYC/terms links in `SwapVerifyTermsModal`).
> 
> Introduces **`asObfuscatedString`** (cleaner + `scripts/obfuscateString.ts`) so sensitive env fields can be stored as obfuscated arrays instead of plain strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c377f4eab60465e6942b365330410082407fc2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213981191982797