### PR TITLE
iOS deploy: auto-renew expired signing certs, switch to xcbeautify, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The included `deploy.ts` is a script to automate building, signing, and deployin
 - Set the `bundleToolPath` in `deploy-config.json` to the path to the bundle tool `.jar` file
 - Put any Android keystore files into `edge-react-gui/keystores/`
 - If using Firebase, put your account's `google-services.json` and `GoogleService-Info.plist` into `edge-react-gui/`
+- Install CocoaPods `brew install cocoapods` (use Homebrew, not `gem install`, so it survives Ruby upgrades)
 - Install xcbeautify `brew install xcbeautify`
 
 Run deploy
@@ -143,20 +144,38 @@ yarn deploy edge android master
 
 ## Fastlane support
 
-This repo supports utilizing Fastlane to automate updates to iOS Provisioning
-Profiles. To use Fastlane, set the following environment variables and run
-`yarn deploy` as mentioned above
+This repo uses Fastlane to automate iOS code signing. The deploy script uses
+`fastlane match` to install the signing certificates and provisioning profiles,
+and to renew them automatically when they expire (see Certificate renewal
+below).
+
+Fastlane must be version 2.235.0 or newer (install or upgrade with
+`brew install fastlane`). Older versions ignore `--skip_confirmation` during
+`match nuke`, which blocks the automatic certificate renewal on an interactive
+prompt.
+
+Authentication uses an App Store Connect API key, not an Apple ID. Place the key
+JSON at `fastlane.json` in the repo root (see the
+[App Store Connect API docs](https://docs.fastlane.tools/app-store-connect-api/)).
+Then set the following environment variables and run `yarn deploy` as mentioned
+above
 
     BUILD_REPO_URL          // Git repo used to store encrypted provisioning
                             // keys.
                             // Will be shared with the gitVersionFile.ts script
-    FASTLANE_USER           // Apple ID email
-    FASTLANE_PASSWORD       // Apple ID password
     GITHUB_SSH_KEY          // (Optional) SSH Key file to use when accessing
                             // BUILD_REPO_URL
     MATCH_KEYCHAIN_PASSWORD // Password to unlock the current users keychain
     MATCH_PASSWORD          // Password used to encrypt profile information
                             // before being saved to the BUILD_REPO_URL
+
+### Certificate renewal
+
+Apple signing certificates expire once a year. When `fastlane match` fails
+because a certificate is no longer valid, the deploy script automatically nukes
+that certificate type (revoking it on the Apple Developer Portal and wiping it
+from `BUILD_REPO_URL`) and re-runs match to generate a fresh certificate and
+provisioning profiles.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The included `deploy.ts` is a script to automate building, signing, and deployin
 - Set the `bundleToolPath` in `deploy-config.json` to the path to the bundle tool `.jar` file
 - Put any Android keystore files into `edge-react-gui/keystores/`
 - If using Firebase, put your account's `google-services.json` and `GoogleService-Info.plist` into `edge-react-gui/`
-- Install xcpretty `sudo gem install xcpretty`
+- Install xcbeautify `brew install xcbeautify`
 
 Run deploy
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -316,7 +316,8 @@ function buildIos(buildObj: BuildObj): void {
   // Note: We archive with AdHoc profile since that's what we export with
   // AdHoc profiles require "Apple Distribution" certificate (not "Apple Development")
   cmdStr = `xcodebuild -workspace ${buildObj.xcodeWorkspace} -scheme ${buildObj.xcodeScheme} -destination 'generic/platform=iOS' CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="Apple Distribution" PROVISIONING_PROFILE_SPECIFIER="match AdHoc ${buildObj.bundleId}" archive`
-  if (process.env.DISABLE_XCPRETTY === 'false') cmdStr = cmdStr + ' | xcpretty'
+  if (process.env.DISABLE_XCPRETTY === 'false')
+    cmdStr = cmdStr + ' | xcbeautify'
   cmdStr = cmdStr + ' && exit ${PIPE' + 'STATUS[0]}'
   call(cmdStr)
 
@@ -425,7 +426,8 @@ function buildIosMaestro(buildObj: BuildObj): void {
 
   let cmdStr
   cmdStr = `xcodebuild -workspace ${xcodeWorkspace} -scheme ${xcodeScheme} -sdk iphonesimulator -configuration Release -derivedDataPath ${buildDir}`
-  if (process.env.DISABLE_XCPRETTY === 'false') cmdStr = cmdStr + ' | xcpretty'
+  if (process.env.DISABLE_XCPRETTY === 'false')
+    cmdStr = cmdStr + ' | xcbeautify'
   cmdStr = cmdStr + ' && exit ${PIPE' + 'STATUS[0]}'
   call(cmdStr)
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -239,16 +239,28 @@ function buildIos(buildObj: BuildObj): void {
     call(`ln -sfn ${escapePath(profileDirNew)} ${escapePath(profileDirOld)}`)
 
     // Use fastlane match directly - it installs profiles to the system location
-    // The symlink ensures they land in Xcode 16's new location
-    call(
-      `GIT_SSH_COMMAND="ssh -i ${githubSshKey}" fastlane match adhoc --git_branch="${buildObj.appleDeveloperTeamName}" --app_identifier="${buildObj.bundleId}" --team_id="${buildObj.appleDeveloperTeamId}" --api_key_path="fastlane.json" --force_for_new_devices`
-    )
-    call(
-      `GIT_SSH_COMMAND="ssh -i ${githubSshKey}" fastlane match development --git_branch="${buildObj.appleDeveloperTeamName}" --app_identifier="${buildObj.bundleId}" --team_id="${buildObj.appleDeveloperTeamId}" --api_key_path="fastlane.json" --force_for_new_devices`
-    )
-    call(
-      `GIT_SSH_COMMAND="ssh -i ${githubSshKey}" fastlane match appstore --git_branch="${buildObj.appleDeveloperTeamName}" --app_identifier="${buildObj.bundleId}" --team_id="${buildObj.appleDeveloperTeamId}" --api_key_path="fastlane.json"`
-    )
+    // The symlink ensures they land in Xcode 16's new location.
+    // Each match call self-heals expired certificates: if match fails because
+    // its certificate is no longer valid, nuke that certificate type and retry
+    // so match regenerates a fresh certificate and provisioning profiles.
+    // The `distribution` type backs both `adhoc` and `appstore` profiles, so a
+    // single nuke of it covers both. A given type is only nuked once per build.
+    const nukedTypes = new Set<string>()
+    runMatchWithRenew(buildObj, nukedTypes, {
+      matchType: 'adhoc',
+      nukeType: 'distribution',
+      extraFlags: ' --force_for_new_devices'
+    })
+    runMatchWithRenew(buildObj, nukedTypes, {
+      matchType: 'development',
+      nukeType: 'development',
+      extraFlags: ' --force_for_new_devices'
+    })
+    runMatchWithRenew(buildObj, nukedTypes, {
+      matchType: 'appstore',
+      nukeType: 'distribution',
+      extraFlags: ''
+    })
   } else {
     mylog('Missing or incomplete Fastlane params. Not using Fastlane')
   }
@@ -721,4 +733,90 @@ function getPatchDir(buildObj: BuildObj): string {
 
 function escapePath(path: string): string {
   return path.replace(/(\s+)/g, '\\$1')
+}
+
+interface MatchRunOptions {
+  matchType: string // 'adhoc' | 'development' | 'appstore'
+  nukeType: string // 'distribution' | 'development'
+  extraFlags: string
+}
+
+/**
+ * Runs `fastlane match` for one profile type and self-heals expired
+ * certificates. Apple signing certificates are valid for one year. When the
+ * certificate stored in the match git repo / Apple Developer portal expires,
+ * `match` refuses to use it ("Your certificate ... is not valid, please check
+ * end date and renew it if necessary") instead of regenerating it. When that
+ * happens we `nuke` the certificate type (revoking it on the portal and wiping
+ * it from the match repo) and retry, which forces match to generate a fresh
+ * certificate and provisioning profiles.
+ *
+ * `match` is the authority on certificate validity here, not the local
+ * keychain: the build signs against a dedicated match keychain and the source
+ * of truth is the match repo / portal, so we let match's own failure drive the
+ * renewal rather than inspecting installed certificates.
+ *
+ * NOTE: `match nuke` only honors `--skip_confirmation` on fastlane >= 2.235.0.
+ * The build machine's fastlane must be at least that version or the nuke will
+ * block on an interactive prompt.
+ */
+function runMatchWithRenew(
+  buildObj: BuildObj,
+  nukedTypes: Set<string>,
+  options: MatchRunOptions
+): void {
+  const { matchType, nukeType, extraFlags } = options
+  const matchCmd = `GIT_SSH_COMMAND="ssh -i ${githubSshKey}" fastlane match ${matchType} --git_branch="${buildObj.appleDeveloperTeamName}" --app_identifier="${buildObj.bundleId}" --team_id="${buildObj.appleDeveloperTeamId}" --api_key_path="fastlane.json"${extraFlags}`
+
+  const result = callAllowFail(matchCmd)
+  if (result.ok) return
+
+  // Only treat an expired/invalid certificate as recoverable. Any other match
+  // failure is a real error and must surface. Match the full sentence from
+  // match/runner.rb: fragments like "is not valid" alone also appear in
+  // harmless output (skipped provisioning profiles, expired sessions), and a
+  // false positive here revokes the team's certificates.
+  const isExpiredCert =
+    /is not valid, please check end date and renew it/i.test(result.output)
+  if (!isExpiredCert) {
+    throw new Error(`fastlane match ${matchType} failed`)
+  }
+
+  if (!nukedTypes.has(nukeType)) {
+    mylog(
+      `match ${matchType} failed on an expired certificate. Nuking "${nukeType}" certificates and regenerating...`
+    )
+    call(
+      `MATCH_SKIP_CONFIRMATION=true GIT_SSH_COMMAND="ssh -i ${githubSshKey}" fastlane match nuke ${nukeType} --git_branch="${buildObj.appleDeveloperTeamName}" --app_identifier="${buildObj.bundleId}" --team_id="${buildObj.appleDeveloperTeamId}" --api_key_path="fastlane.json" --skip_confirmation true`
+    )
+    nukedTypes.add(nukeType)
+  }
+
+  // Retry now that the dead certificate is gone. A second failure is fatal.
+  call(matchCmd)
+}
+
+/**
+ * Like `call`, but captures combined stdout/stderr and returns whether the
+ * command succeeded instead of throwing. Used so a recoverable `fastlane match`
+ * failure can be inspected rather than aborting the build.
+ */
+function callAllowFail(cmdstring: string): { ok: boolean; output: string } {
+  console.log('callAllowFail: ' + cmdstring)
+  try {
+    const output = childProcess.execSync(`${cmdstring} 2>&1`, {
+      encoding: 'utf8',
+      timeout: 3600000,
+      cwd: _currentPath,
+      killSignal: 'SIGKILL',
+      maxBuffer: 100 * 1024 * 1024
+    })
+    console.log(output)
+    return { ok: true, output }
+  } catch (error: unknown) {
+    const execError = error as { stdout?: string; stderr?: string }
+    const output = (execError.stdout ?? '') + (execError.stderr ?? '')
+    console.log(output)
+    return { ok: false, output }
+  }
 }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Build/CI changes to the iOS deploy script only. No app or runtime code is touched (no visual changes, so the GUI testing checkboxes above are N/A).

**Auto-renew expired iOS signing certificates.** Apple signing certs expire yearly. When `fastlane match` fails because its certificate is no longer valid, `deploy.ts` now nukes that certificate type (revoking it on the Apple Developer Portal and wiping it from the match repo) and re-runs match to regenerate a fresh certificate and provisioning profiles. The nuke fires only on an unambiguous "certificate is not valid" failure; any other match error still aborts the build. The `distribution` type is nuked at most once per build since it backs both adhoc and appstore. Requires fastlane >= 2.235.0 for `match nuke --skip_confirmation`.

**Use xcbeautify instead of xcpretty** for xcodebuild output. xcpretty is a Ruby gem with no Homebrew formula and breaks whenever the build agent's Ruby is upgraded and the gem is orphaned; xcbeautify is a Homebrew formula and immune to that churn. The `DISABLE_XCPRETTY` toggle is unchanged.

**Docs.** Updated the README Fastlane section to require fastlane >= 2.235.0, document App Store Connect API key (`fastlane.json`) auth in place of the unused `FASTLANE_USER`/`FASTLANE_PASSWORD`, describe the automatic certificate renewal, and add CocoaPods + xcbeautify install steps.

Note: the build agents also need one-time setup that is not in this branch (it is environment, not repo state): `brew install cocoapods xcbeautify`, fastlane >= 2.235.0, and `/opt/homebrew/bin` ahead of any gem shim dir on PATH.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Certificate renewal can revoke and regenerate team signing assets on Apple’s portal and the match repo, though only on a narrowly matched expired-cert error; scope is CI/deploy scripts only.
> 
> **Overview**
> **iOS deploy** now **self-heals expired Apple signing certificates** during `fastlane match`. `deploy.ts` runs adhoc, development, and appstore match through `runMatchWithRenew`: on the specific “certificate is not valid, please check end date” failure it **nuke**s the matching cert type once per build (`distribution` shared for adhoc + appstore), then retries match; other match errors still fail the build. Adds `callAllowFail` to inspect match output without aborting.
> 
> **xcodebuild** log formatting switches from **xcpretty** to **xcbeautify** for release archive and Maestro simulator builds (still gated by `DISABLE_XCPRETTY`).
> 
> **README** documents Homebrew **CocoaPods** and **xcbeautify**, requires **fastlane ≥ 2.235.0** for non-interactive `match nuke`, describes **App Store Connect API key** (`fastlane.json`) instead of Apple ID env vars, and adds a **certificate renewal** section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054797c0b41f9ef9fc9b4d327627351bbc4cbb2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215646433913982