### PR TITLE
Add remote enable/disable of gift card providers via info server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- added: Remote enable/disable of gift card providers via the info server's giftCardInfo config, supporting whole-provider disabling for Phaze and Bitrefill and per-brand disabling for Phaze.
+
 ## 4.49.0 (staging)
 
 - added: Monero wallet import support

--- a/src/__tests__/GiftCardInfoActions.test.ts
+++ b/src/__tests__/GiftCardInfoActions.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from '@jest/globals'
+
+import type { NestedDisableMap } from '../actions/ExchangeInfoActions'
+import {
+  asGiftCardInfo,
+  isGiftCardBrandDisabled,
+  isGiftCardProviderDisabled
+} from '../actions/GiftCardInfoActions'
+
+describe('asGiftCardInfo cleaner', () => {
+  test('defaults to an empty disable map when disablePlugins is missing', () => {
+    expect(asGiftCardInfo({})).toEqual({ disablePlugins: {} })
+  })
+
+  test('parses whole-provider and per-brand disable maps', () => {
+    const parsed = asGiftCardInfo({
+      disablePlugins: {
+        bitrefill: true,
+        phaze: { '12345': true }
+      }
+    })
+    expect(parsed.disablePlugins).toEqual({
+      bitrefill: true,
+      phaze: { '12345': true }
+    })
+  })
+})
+
+describe('isGiftCardProviderDisabled', () => {
+  test('true only when the provider is disabled as a whole', () => {
+    expect(isGiftCardProviderDisabled({ bitrefill: true }, 'bitrefill')).toBe(
+      true
+    )
+    expect(isGiftCardProviderDisabled({}, 'bitrefill')).toBe(false)
+    // A per-brand map disables brands, not the whole provider
+    expect(isGiftCardProviderDisabled({ phaze: { '1': true } }, 'phaze')).toBe(
+      false
+    )
+  })
+})
+
+describe('isGiftCardBrandDisabled', () => {
+  test('true when the whole provider is disabled', () => {
+    expect(isGiftCardBrandDisabled({ phaze: true }, 'phaze', '12345')).toBe(
+      true
+    )
+  })
+
+  test('true only for the specific disabled brand', () => {
+    const disablePlugins: NestedDisableMap = { phaze: { '12345': true } }
+    expect(isGiftCardBrandDisabled(disablePlugins, 'phaze', '12345')).toBe(true)
+    expect(isGiftCardBrandDisabled(disablePlugins, 'phaze', '99999')).toBe(
+      false
+    )
+  })
+
+  test('false when the provider is absent from the map', () => {
+    expect(isGiftCardBrandDisabled({}, 'phaze', '12345')).toBe(false)
+  })
+})

--- a/src/__tests__/reducers/__snapshots__/RootReducer.test.ts.snap
+++ b/src/__tests__/reducers/__snapshots__/RootReducer.test.ts.snap
@@ -92,6 +92,9 @@ exports[`initialState 1`] = `
       "fioAddressesLoading": false,
       "fioDomains": [],
     },
+    "giftCardInfo": {
+      "disablePlugins": {},
+    },
     "notificationHeight": 0,
     "passwordReminder": {
       "lastLoginDate": -Infinity,

--- a/src/actions/ExchangeInfoActions.ts
+++ b/src/actions/ExchangeInfoActions.ts
@@ -28,7 +28,7 @@ export type DisablePluginMap = ReturnType<typeof asDisablePluginsMap>
 export interface NestedDisableMap {
   [pluginId: string]: true | NestedDisableMap
 }
-const asNestedDisableMap: Cleaner<NestedDisableMap> = asObject(
+export const asNestedDisableMap: Cleaner<NestedDisableMap> = asObject(
   asEither(asTrue, raw => asNestedDisableMap(raw))
 )
 

--- a/src/actions/GiftCardInfoActions.ts
+++ b/src/actions/GiftCardInfoActions.ts
@@ -1,0 +1,60 @@
+import { asMaybe, asObject } from 'cleaners'
+
+import type { ThunkAction } from '../types/reduxTypes'
+import { infoServerData } from '../util/network'
+import {
+  asNestedDisableMap,
+  type NestedDisableMap
+} from './ExchangeInfoActions'
+
+// Remote enable/disable config for gift card providers, served by the info
+// server as `giftCardInfo`. `disablePlugins` is a generic NestedDisableMap
+// keyed by providerId, so it works for any present or future provider:
+//   { phaze: true }              // disable the entire provider
+//   { phaze: { '12345': true } } // disable a single brand by productId
+//   { bitrefill: true }          // webview provider: whole-provider only
+export const asGiftCardInfo = asObject({
+  disablePlugins: asMaybe(asNestedDisableMap, () => ({}))
+})
+
+export type GiftCardInfo = ReturnType<typeof asGiftCardInfo>
+
+export function updateGiftCardInfo(): ThunkAction<Promise<void>> {
+  return async dispatch => {
+    try {
+      // `giftCardInfo` is a forward-compatible read: the field arrives once the
+      // edge-info-server dependency that defines it is published and bumped.
+      // Until then the rollup omits it and we fall back to an empty config.
+      const rollup = infoServerData.rollup as
+        | { giftCardInfo?: unknown }
+        | undefined
+      const data = asGiftCardInfo(rollup?.giftCardInfo ?? {})
+      dispatch({ type: 'UPDATE_GIFT_CARD_INFO', data })
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e)
+      console.warn(`Failed to get info server giftCardInfo: ${message}`)
+    }
+  }
+}
+
+/** True when the entire provider is remotely disabled. */
+export const isGiftCardProviderDisabled = (
+  disablePlugins: NestedDisableMap,
+  pluginId: string
+): boolean => disablePlugins[pluginId] === true
+
+/**
+ * True when a specific brand within a provider is remotely disabled — either
+ * because the whole provider is disabled, or because the brand is listed
+ * individually.
+ */
+export const isGiftCardBrandDisabled = (
+  disablePlugins: NestedDisableMap,
+  pluginId: string,
+  brandId: string
+): boolean => {
+  const providerNode = disablePlugins[pluginId]
+  if (providerNode === true) return true
+  if (providerNode == null) return false
+  return providerNode[brandId] === true
+}

--- a/src/components/scenes/GiftCardMarketScene.tsx
+++ b/src/components/scenes/GiftCardMarketScene.tsx
@@ -6,6 +6,10 @@ import LinearGradient from 'react-native-linear-gradient'
 import Animated from 'react-native-reanimated'
 
 import { showCountrySelectionModal } from '../../actions/CountryListActions'
+import {
+  isGiftCardBrandDisabled,
+  isGiftCardProviderDisabled
+} from '../../actions/GiftCardInfoActions'
 import { readSyncedSettings } from '../../actions/SettingsActions'
 import { EDGE_CONTENT_SERVER_URI } from '../../constants/CdnConstants'
 import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
@@ -42,6 +46,12 @@ type ViewMode = 'grid' | 'list'
 
 // Internal constant for "All" category comparison - display uses lstrings.string_all
 const CATEGORY_ALL = 'All'
+
+// Provider IDs used as keys in the info-server giftCardInfo.disablePlugins map.
+// Phaze supports per-brand granularity (keyed by productId); Bitrefill is a
+// webview, so only whole-provider disabling applies.
+const PHAZE_PLUGIN_ID = 'phaze'
+const BITREFILL_PLUGIN_ID = 'bitrefill'
 
 /**
  * Formats a normalized category for display:
@@ -110,6 +120,11 @@ export const GiftCardMarketScene: React.FC<Props> = props => {
   const account = useSelector(state => state.core.account)
   const isConnected = useSelector(state => state.network.isConnected)
 
+  // Info-server remote enable/disable config for gift card providers
+  const giftCardDisablePlugins = useSelector(
+    state => state.ui.giftCardInfo.disablePlugins
+  )
+
   // Provider (requires API key configured)
   const phazeConfig = ENV.PLUGIN_API_KEYS?.phaze
   const { provider, isReady } = useGiftCardProvider({
@@ -135,19 +150,6 @@ export const GiftCardMarketScene: React.FC<Props> = props => {
       }))
     }
     return null
-  })
-  const [allCategories, setAllCategories] = React.useState<string[]>(() => {
-    const cached = getCachedBrandsSync(countryCode)
-    if (cached != null) {
-      const categorySet = new Set<string>()
-      for (const brand of cached) {
-        for (const category of brand.categories) {
-          categorySet.add(normalizeCategory(category))
-        }
-      }
-      return Array.from(categorySet).sort()
-    }
-    return []
   })
 
   // Search state
@@ -199,27 +201,12 @@ export const GiftCardMarketScene: React.FC<Props> = props => {
     []
   )
 
-  // Extract unique normalized categories from brands
-  const extractCategories = React.useCallback(
-    (brands: PhazeGiftCardBrand[]): string[] => {
-      const categorySet = new Set<string>()
-      for (const brand of brands) {
-        for (const category of brand.categories) {
-          categorySet.add(normalizeCategory(category))
-        }
-      }
-      return Array.from(categorySet).sort()
-    },
-    []
-  )
-
   // Helper to update UI state from brands
   const updateFromBrands = React.useCallback(
     (brands: PhazeGiftCardBrand[]): void => {
       setItems(mapBrandsToItems(brands))
-      setAllCategories(extractCategories(brands))
     },
-    [extractCategories, mapBrandsToItems]
+    [mapBrandsToItems]
   )
 
   // If the user changes country while on this scene, clear the current list so
@@ -232,7 +219,6 @@ export const GiftCardMarketScene: React.FC<Props> = props => {
       prevCountryCodeRef.current !== countryCode
     ) {
       setItems(null)
-      setAllCategories([])
       setSelectedCategory(CATEGORY_ALL)
       setSearchText('')
       setIsSearching(false)
@@ -296,20 +282,52 @@ export const GiftCardMarketScene: React.FC<Props> = props => {
     }
   }, [apiBrands, updateFromBrands])
 
-  // Build category list with "All" first, then alphabetized categories
+  // Remove phaze brands disabled by the info server, either because the whole
+  // phaze provider is disabled or because the brand's productId is listed.
+  const enabledItems = React.useMemo(() => {
+    if (items == null) return null
+    return items.filter(
+      item =>
+        !isGiftCardBrandDisabled(
+          giftCardDisablePlugins,
+          PHAZE_PLUGIN_ID,
+          String(item.productId)
+        )
+    )
+  }, [items, giftCardDisablePlugins])
+
+  // Build the category list from the enabled items only, so a category whose
+  // brands are all disabled by the info server does not show a chip that leads
+  // to an empty grid. "All" comes first, then the categories alphabetized.
   const categoryList = React.useMemo(() => {
     const normalizedSet = new Set<string>()
-    for (const cat of allCategories) {
-      normalizedSet.add(normalizeCategory(cat))
+    if (enabledItems != null) {
+      for (const item of enabledItems) {
+        for (const category of item.categories) {
+          normalizedSet.add(normalizeCategory(category))
+        }
+      }
     }
     return [CATEGORY_ALL, ...Array.from(normalizedSet).sort()]
-  }, [allCategories])
+  }, [enabledItems])
+
+  // If the selected category is no longer available (e.g. all of its brands
+  // became disabled by the info server on a later refresh), fall back to "All"
+  // so the grid is not left stuck on an empty selection.
+  React.useEffect(() => {
+    if (
+      selectedCategory !== CATEGORY_ALL &&
+      !categoryList.includes(selectedCategory)
+    ) {
+      setSelectedCategory(CATEGORY_ALL)
+    }
+  }, [categoryList, selectedCategory])
 
   // Filter items by search text and category
   const filteredItems = React.useMemo(() => {
-    if (items == null) return null
+    if (enabledItems == null) return null
 
-    let filtered = items
+    let filtered = enabledItems
 
     // Filter by category (unless "All" is selected, which shows all)
     if (selectedCategory !== CATEGORY_ALL) {
@@ -327,7 +345,7 @@ export const GiftCardMarketScene: React.FC<Props> = props => {
     }
 
     return filtered
-  }, [items, searchText, selectedCategory])
+  }, [enabledItems, searchText, selectedCategory])
 
   const handleItemPress = useHandler((item: MarketItem) => {
     if (provider == null) return
@@ -476,10 +494,17 @@ export const GiftCardMarketScene: React.FC<Props> = props => {
     ]
   )
 
-  // Build list data: filtered items + Bitrefill option at end
+  // Build list data: filtered items + Bitrefill option at end (unless the
+  // Bitrefill provider is remotely disabled)
   const listData = React.useMemo(() => {
-    return [...(filteredItems ?? []), BITREFILL_ITEM]
-  }, [filteredItems])
+    const base = filteredItems ?? []
+    if (
+      isGiftCardProviderDisabled(giftCardDisablePlugins, BITREFILL_PLUGIN_ID)
+    ) {
+      return base
+    }
+    return [...base, BITREFILL_ITEM]
+  }, [filteredItems, giftCardDisablePlugins])
 
   return (
     <SceneWrapper

--- a/src/components/services/Services.tsx
+++ b/src/components/services/Services.tsx
@@ -9,6 +9,7 @@ import { usePowerState } from 'react-native-device-info'
 import { updateExchangeInfo } from '../../actions/ExchangeInfoActions'
 import { refreshConnectedWallets } from '../../actions/FioActions'
 import { refreshAllFioAddresses } from '../../actions/FioAddressActions'
+import { updateGiftCardInfo } from '../../actions/GiftCardInfoActions'
 import { registerNotificationsV2 } from '../../actions/NotificationActions'
 import { trackAppUsageAfterUpgrade } from '../../actions/RequestReviewActions'
 import { checkCompromisedKeys } from '../../actions/WalletActions'
@@ -143,6 +144,9 @@ export const Services: React.FC<Props> = props => {
   useRefresher(
     async () => {
       dispatch(updateExchangeInfo()).catch((error: unknown) => {
+        console.warn(error)
+      })
+      dispatch(updateGiftCardInfo()).catch((error: unknown) => {
         console.warn(error)
       })
     },

--- a/src/reducers/GiftCardInfoReducer.ts
+++ b/src/reducers/GiftCardInfoReducer.ts
@@ -1,0 +1,22 @@
+import type { GiftCardInfo } from '../actions/GiftCardInfoActions'
+import type { Action } from '../types/reduxTypes'
+
+export const initialState: GiftCardInfo = {
+  disablePlugins: {}
+}
+
+export const giftCardInfo = (
+  state: GiftCardInfo = initialState,
+  action: Action
+): GiftCardInfo => {
+  switch (action.type) {
+    case 'UPDATE_GIFT_CARD_INFO': {
+      return {
+        ...state,
+        ...action.data
+      }
+    }
+    default:
+      return state
+  }
+}

--- a/src/reducers/uiReducer.ts
+++ b/src/reducers/uiReducer.ts
@@ -1,9 +1,11 @@
 import { combineReducers, type Reducer } from 'redux'
 
 import type { ExchangeInfo } from '../actions/ExchangeInfoActions'
+import type { GiftCardInfo } from '../actions/GiftCardInfoActions'
 import type { Action } from '../types/reduxTypes'
 import { exchangeInfo } from './ExchangeInfoReducer'
 import { fio, type FioState } from './FioReducer'
+import { giftCardInfo } from './GiftCardInfoReducer'
 import {
   passwordReminder,
   type PasswordReminderState
@@ -16,6 +18,7 @@ import { settings, type SettingsState } from './scenes/SettingsReducer'
 
 export interface UiState {
   readonly exchangeInfo: ExchangeInfo
+  readonly giftCardInfo: GiftCardInfo
   readonly fio: FioState
   readonly fioAddress: FioAddressSceneState
   readonly passwordReminder: PasswordReminderState
@@ -27,6 +30,7 @@ export interface UiState {
 
 const uiInner = combineReducers<UiState, Action>({
   exchangeInfo,
+  giftCardInfo,
   fio,
   fioAddress,
   passwordReminder,

--- a/src/types/reduxActions.ts
+++ b/src/types/reduxActions.ts
@@ -8,6 +8,7 @@ import type {
 
 import type { ExchangeInfo } from '../actions/ExchangeInfoActions'
 import type { GuiExchangeRates } from '../actions/ExchangeRateActions'
+import type { GiftCardInfo } from '../actions/GiftCardInfoActions'
 import type { NotificationSettings } from '../actions/NotificationActions'
 import type {
   PasswordReminderTime,
@@ -158,6 +159,7 @@ export type Action =
       data: { wallets: EdgeCurrencyWallet[] }
     }
   | { type: 'UPDATE_EXCHANGE_INFO'; data: ExchangeInfo }
+  | { type: 'UPDATE_GIFT_CARD_INFO'; data: GiftCardInfo }
   | { type: 'UPDATE_SORTED_WALLET_LIST'; data: WalletListItem[] }
   | {
       type: 'UPDATE_SHOW_PASSWORD_RECOVERY_REMINDER_MODAL'


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Requires edge-info-server to publish the new `giftCardInfo` rollup field (edge-info-server#154). This GUI PR reads `giftCardInfo` forward-compatibly, so it is backward compatible and inert against the currently published info server: with no `giftCardInfo` in the rollup, nothing is disabled. The feature activates once edge-info-server publishes the field and the `edge-info-server` dependency is bumped.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

[Asana task](https://app.asana.com/0/0/1215731967028387/f)

Adds remote enable/disable of gift card providers, mirroring the existing exchange-plugins (`exchangeInfo`) pattern.

A new `giftCardInfo` config is read from the info server rollup and cached in redux (`state.ui.giftCardInfo`). It carries a generic `disablePlugins` `NestedDisableMap` keyed by providerId, so it works for any present or future gift card provider:

- `{ phaze: true }` disables the entire Phaze provider.
- `{ phaze: { "<productId>": true } }` disables individual Phaze brands by `productId`.
- `{ bitrefill: true }` disables Bitrefill (a webview, so whole-provider only).

The Gift Card Marketplace scene filters disabled Phaze brands out of the grid and gates the Bitrefill option, via `isGiftCardBrandDisabled` / `isGiftCardProviderDisabled` helpers. The `NestedDisableMap` cleaner is reused from `ExchangeInfoActions`.

Changes:
- `GiftCardInfoActions.ts`: `asGiftCardInfo` cleaner, `updateGiftCardInfo()` thunk, and gating helpers.
- `GiftCardInfoReducer.ts` wired into `uiReducer` (`state.ui.giftCardInfo`); `UPDATE_GIFT_CARD_INFO` action.
- `Services.tsx`: dispatch `updateGiftCardInfo()` in the existing info-server refresher.
- `GiftCardMarketScene.tsx`: apply per-brand and per-provider gating.
- Unit tests for the cleaner and gating helpers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating driven by remote config with safe empty defaults; no auth, payments, or wallet logic changes.
> 
> **Overview**
> Adds **remote kill switches** for gift card providers from the info server `giftCardInfo` rollup, following the same `disablePlugins` / `NestedDisableMap` pattern as `exchangeInfo`.
> 
> New Redux state (`state.ui.giftCardInfo`) is refreshed on the existing info-server poll in `Services.tsx`. **Phaze** brands can be hidden per `productId` or by disabling the whole provider; **Bitrefill** is gated only at the provider level. The marketplace scene filters the grid and category chips from enabled items only, resets the category when it becomes empty, and omits Bitrefill when disabled. Missing rollup data defaults to no disables (forward-compatible until the server ships the field).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee34009f1d1311d58e9bd91fc9b9becc831cb5d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->