### PR TITLE
test: add testIDs for send flow UI automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- changed: Add testIDs to the send address tile buttons and the confirm slider to support UI test automation.
+
 ## 4.49.0 (staging)
 
 - added: Monero wallet import support

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -341,7 +341,6 @@ export default [
 
       'src/components/themed/SceneHeader.tsx',
 
-      'src/components/themed/SearchFooter.tsx',
       'src/components/themed/SelectableRow.tsx',
 
       'src/components/themed/ShareButtons.tsx',

--- a/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
@@ -619,6 +619,7 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -425,6 +425,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
               },
             ]
           }
+          testID="createWalletSearch"
         >
           <View
             collapsable={false}
@@ -541,7 +542,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 "opacity": 1,
               }
             }
-            testID="undefined.doneButton"
+            testID="createWalletSearch.doneButton"
           >
             <View
               collapsable={false}
@@ -687,7 +688,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
               ]
             }
             submitBehavior="submit"
-            testID="undefined.textInput"
+            testID="createWalletSearch.textInput"
             textAlignVertical="top"
           />
           <View
@@ -724,7 +725,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                 "opacity": 1,
               }
             }
-            testID="undefined.clearIcon"
+            testID="createWalletSearch.clearIcon"
           >
             <View
               collapsable={false}
@@ -968,6 +969,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "paddingHorizontal": 11,
                 }
               }
+              testID="createRow.create-wallet:ethereum-ethereum"
             >
               <View
                 style={
@@ -1169,6 +1171,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "paddingHorizontal": 11,
                 }
               }
+              testID="createRow.create-ethereum-1985365e9f78359a9b6ad760e32412f4a445e862"
             >
               <View
                 style={
@@ -1406,6 +1409,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "paddingHorizontal": 11,
                 }
               }
+              testID="createRow.create-ethereum-221657776846890989a759ba2973e427dff5c9bb"
             >
               <View
                 style={
@@ -1643,6 +1647,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "paddingHorizontal": 11,
                 }
               }
+              testID="createRow.create-ethereum-2e91e3e54c5788e9fdd6a181497fdcea1de1bcc1"
             >
               <View
                 style={
@@ -1880,6 +1885,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
                   "paddingHorizontal": 11,
                 }
               }
+              testID="createRow.create-ethereum-6b175474e89094c44da98b954eedeac495271d0f"
             >
               <View
                 style={

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -1705,6 +1705,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -3714,6 +3715,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -5723,6 +5725,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -7313,6 +7316,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -8883,6 +8887,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -10220,6 +10225,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -11970,6 +11976,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -13671,6 +13678,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -15299,6 +15307,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -16078,6 +16087,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                         "opacity": 1,
                       }
                     }
+                    testID="sendAddressEnter"
                   >
                     <Text
                       allowFontScaling={false}
@@ -16164,6 +16174,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                         "opacity": 1,
                       }
                     }
+                    testID="sendAddressScan"
                   >
                     <Text
                       allowFontScaling={false}
@@ -16252,6 +16263,7 @@ exports[`SendScene2 Render SendScene 1`] = `
                         "opacity": 1,
                       }
                     }
+                    testID="sendAddressPaste"
                   >
                     <Text
                       allowFontScaling={false}

--- a/src/__tests__/scenes/__snapshots__/SwapConfirmationScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SwapConfirmationScene.test.tsx.snap
@@ -2033,6 +2033,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     },
                   ]
                 }
+                testID="confirmSliderThumb"
               >
                 <Text
                   adjustsFontSizeToFit={true}

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -393,6 +393,7 @@ const CreateWalletSelectCryptoComponent: React.FC<Props> = (props: Props) => {
           pluginId={pluginId}
           tokenId={tokenId}
           walletName={displayName}
+          testID={`createRow.${key}`}
           onPress={async () => {
             await handleCreateWalletToggle(key)
           }}
@@ -445,6 +446,7 @@ const CreateWalletSelectCryptoComponent: React.FC<Props> = (props: Props) => {
             withTopMargin
           />
           <SimpleTextInput
+            testID="createWalletSearch"
             verticalRem={0.5}
             horizontalRem={1}
             autoCorrect={false}

--- a/src/components/scenes/WalletListScene.tsx
+++ b/src/components/scenes/WalletListScene.tsx
@@ -222,6 +222,7 @@ export const WalletListScene: React.FC<Props> = props => {
       ) : (
         <SearchFooter
           name={key}
+          testID="walletListSearch"
           placeholder={lstrings.wallet_list_wallet_search}
           isSearching={isSearching}
           searchText={searchText}

--- a/src/components/themed/CreateWalletSelectCryptoRow.tsx
+++ b/src/components/themed/CreateWalletSelectCryptoRow.tsx
@@ -15,6 +15,7 @@ interface Props {
   rightSide?: React.ReactNode
   settingsSummary?: string
   walletName: string
+  testID?: string
 
   // Icon currency:
   pluginId: string
@@ -29,6 +30,7 @@ export const CreateWalletSelectCryptoRowComponent: React.FC<Props> = props => {
     rightSide,
     settingsSummary,
     walletName,
+    testID,
 
     // Icon currency:
     pluginId,
@@ -62,6 +64,7 @@ export const CreateWalletSelectCryptoRowComponent: React.FC<Props> = props => {
       style={styles.container}
       disabled={onPress == null}
       onPress={handlePress}
+      testID={testID}
     >
       <CryptoIcon
         marginRem={0.5}

--- a/src/components/themed/SafeSlider.tsx
+++ b/src/components/themed/SafeSlider.tsx
@@ -120,6 +120,7 @@ export const SafeSlider: React.FC<Props> = props => {
 
         <GestureDetector gesture={gesture}>
           <Animated.View
+            testID="confirmSliderThumb"
             style={[
               styles.thumb,
               sliderDisabled ? styles.disabledThumb : null,

--- a/src/components/themed/SearchFooter.tsx
+++ b/src/components/themed/SearchFooter.tsx
@@ -19,6 +19,7 @@ interface SearchFooterProps {
 
   noBackground?: boolean
   sceneWrapperInfo?: SceneWrapperInfo
+  testID?: string
 
   onChangeText: (value: string) => void
   onCancel: () => void
@@ -34,6 +35,7 @@ export const SearchFooter: React.FC<SearchFooterProps> = props => {
     searchText,
     noBackground,
     sceneWrapperInfo,
+    testID,
 
     onChangeText,
     onCancel,
@@ -90,6 +92,7 @@ export const SearchFooter: React.FC<SearchFooterProps> = props => {
       onLayoutHeight={handleFooterLayoutHeight}
     >
       <SimpleTextInput
+        testID={testID}
         returnKeyType="search"
         placeholder={placeholder}
         onChangeText={handleChangeText}

--- a/src/components/themed/WalletListCurrencyRow.tsx
+++ b/src/components/themed/WalletListCurrencyRow.tsx
@@ -190,6 +190,7 @@ const WalletListCurrencyRowComponent = (
       }
       onLongPress={handleLongPress}
       onPress={handlePress}
+      testID={`walletRow.${wallet.id}${tokenId == null ? '' : `.${tokenId}`}`}
       paddingRem={0.5}
       gradientBackground={{
         colors: [primaryColor, '#00000000'],

--- a/src/components/tiles/AddressTile2.tsx
+++ b/src/components/tiles/AddressTile2.tsx
@@ -517,6 +517,7 @@ export const AddressTile2 = React.forwardRef(
           >
             <EdgeTouchableOpacity
               style={styles.buttonContainer}
+              testID="sendAddressEnter"
               onPress={handleChangeAddress}
             >
               <FontAwesome
@@ -531,6 +532,7 @@ export const AddressTile2 = React.forwardRef(
             {canSelfTransfer ? (
               <EdgeTouchableOpacity
                 style={styles.buttonContainer}
+                testID="sendAddressMyself"
                 onPress={handleSelfTransfer}
               >
                 <AntDesign
@@ -545,6 +547,7 @@ export const AddressTile2 = React.forwardRef(
             ) : null}
             <EdgeTouchableOpacity
               style={styles.buttonContainer}
+              testID="sendAddressScan"
               onPress={handleScan}
             >
               <FontAwesome5
@@ -558,6 +561,7 @@ export const AddressTile2 = React.forwardRef(
             </EdgeTouchableOpacity>
             <EdgeTouchableOpacity
               style={styles.buttonContainer}
+              testID="sendAddressPaste"
               onPress={handlePasteFromClipboard}
             >
               <FontAwesome5


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Test-infrastructure only. No behavior or visual changes.

Adds stable `testID` props so UI automation can drive the send flow by selector instead of brittle text or coordinate matching:

- `AddressTile2`: `sendAddressEnter`, `sendAddressMyself`, `sendAddressScan`, `sendAddressPaste`.
- `SafeSlider`: `confirmSliderThumb` on the draggable thumb (the id the shared maestro confirm-slider flow already expects).

These were added while verifying the TON duplicate-transaction fix ([edge-currency-accountbased#1059](https://github.com/EdgeApp/edge-currency-accountbased/pull/1059)); the send flow had no stable selectors. Snapshot files updated to reflect the new props. Related to [Asana task](https://app.asana.com/0/1215088146871429/1208857053925054).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only accessibility identifiers with no logic, styling, or runtime behavior changes.
> 
> **Overview**
> Adds stable **`testID`** props across key wallet and send UI so Maestro/automation can target controls without text or coordinates. **No user-visible or behavioral changes**—snapshots and CHANGELOG only reflect the new identifiers.
> 
> **Send flow:** `AddressTile2` buttons (`sendAddressEnter`, `sendAddressMyself`, `sendAddressScan`, `sendAddressPaste`). **`SafeSlider`** thumb gets `confirmSliderThumb` for the shared confirm-slider automation pattern.
> 
> **Wallet / create flows:** `WalletListCurrencyRow` uses `walletRow.{walletId}[.{tokenId}]`; create-wallet search and rows use `createWalletSearch` and `createRow.{key}`; wallet list search footer uses `walletListSearch` via an optional `testID` on **`SearchFooter`** (and **`CreateWalletSelectCryptoRow`**).
> 
> `SearchFooter` is removed from an ESLint allowlist entry (file no longer needs that exemption).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 305c4ff9bea65adc7fd9475a73c8df2ed44591bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->