### PR TITLE
Fix Android build failure from long-press shortcuts feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added: Logbox disable option to env.json
 - added: Reverse-resolve recipient addresses to ENS / Unstoppable Domains / ZNS names in the send flow, address modal, and transaction history.
 - changed: Migrate package manager from yarn to npm.
+- fixed: Android build failure from the home screen long-press shortcuts feature, caused by an expo-quick-actions Kotlin compile error under Kotlin 2.3.
 
 ## 4.49.0 (staging)
 

--- a/patches/expo-quick-actions+5.0.0.patch
+++ b/patches/expo-quick-actions+5.0.0.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoAppIconModule.kt b/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoAppIconModule.kt
+index 4db980e..53bb319 100644
+--- a/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoAppIconModule.kt
++++ b/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoAppIconModule.kt
+@@ -44,7 +44,7 @@ class ExpoAppIconModule : Module() {
+         return@Function iconName
+       }
+       } catch (e: Exception) {
+-      return@Function false
++      return@Function null
+       }
+     }
+ 
 diff --git a/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift b/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift
 index 252da49..12a29e4 100644
 --- a/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

No visual changes. This is an Android-native build fix only.

### Description

[Asana task](https://app.asana.com/0/0/1215776835822945/f)

Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1215776835822945

PR #6001 ("add home screen long-press shortcuts via expo-quick-actions") builds on iOS but broke the Android build.

Root cause: `expo-quick-actions@5.0.0`'s bundled `ExpoAppIconModule.setIcon` returns mixed types: `null`, the icon name (`String?`), and `false` (`Boolean`) in its catch block. Expo's `inline fun <reified R> Function(...)` then infers `R` as the intersection `Comparable<...> & Serializable`. Kotlin `2.3.20` (pinned in `android/build.gradle` for `zcash-android-sdk`) promotes "reified type parameter inferred to intersection type" from a warning to a hard error, so `:expo-quick-actions:compileDebugKotlin` fails. The package was written against an older Kotlin where this was only a warning.

Fix: extend the existing `expo-quick-actions` patch to unify the error-path return to `null`, so every branch of `setIcon` returns `String?` (a single reifiable type). Edge does not use the app-icon API (only the shortcuts API via `QuickActions.setItems` / `useQuickActionCallback`), so this is behavior-neutral for the app, and the long-press shortcuts feature is unchanged.

GitHub CI does not build Android (`pr-checks.yml` only blocks WIP PRs), so this regression was not caught there.

### Testing

Verified locally with a full Android build (Android SDK + NDK 27.1.12297006, Kotlin 2.3.20):

- Before: `./gradlew :app:assembleDebug` fails at `:expo-quick-actions:compileDebugKotlin`.
- After: `./gradlew :app:assembleDebug` reaches `BUILD SUCCESSFUL` and produces `app-debug.apk`.

`verify-repo.sh` (install, prepare, jest) passes. iOS is unaffected (the iOS hunk of the patch is unchanged by this PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only node_modules patch with no app code changes; shortcuts behavior is unchanged because the app does not use the app-icon API.
> 
> **Overview**
> **Fixes the Android build** broken after home screen long-press shortcuts (`expo-quick-actions`) by extending the existing `patch-package` patch for `expo-quick-actions@5.0.0`.
> 
> On Android, `ExpoAppIconModule.setIcon` previously returned **`false` on error** while other paths returned `String?` / `null`, which made Expo’s reified `Function` infer an intersection type. **Kotlin 2.3** (pinned for Zcash) treats that as a **compile error**, so `:expo-quick-actions:compileDebugKotlin` failed. The patch changes the catch branch to **`return null`**, unifying the return type. Edge only uses the shortcuts API (`QuickActions.setItems` / `useQuickActionCallback`), not app-icon switching, so behavior for the app is unchanged.
> 
> Adds an **Unreleased CHANGELOG** entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549aba30b84867fc9578cbd3d18ea65b9c23ec77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->