### PR TITLE
Route maestro builds to dedicated Zealot channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- changed: Route maestro test builds to a dedicated Zealot channel so they no longer appear in the production release list.
+
 ## 4.49.0 (staging)
 
 - added: Monero wallet import support

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -45,6 +45,7 @@ interface BuildConfigFile {
   zealotUrl?: string
   zealotApiToken?: string
   zealotChannelKey?: string
+  zealotMaestroChannelKey?: string
   hockeyAppId: string
   hockeyAppTags: string
   hockeyAppToken: string
@@ -521,7 +522,13 @@ function buildAndroid(buildObj: BuildObj): void {
 }
 
 function buildCommonPost(buildObj: BuildObj): void {
-  const { maestroBuild, zealotApiToken, zealotChannelKey, zealotUrl } = buildObj
+  const {
+    maestroBuild,
+    zealotApiToken,
+    zealotChannelKey,
+    zealotMaestroChannelKey,
+    zealotUrl
+  } = buildObj
   let curl
   const notes = `${buildObj.productName} ${buildObj.version} (${buildObj.buildNum}) branch: ${buildObj.repoBranch} #${buildObj.guiHash}`
 
@@ -557,12 +564,12 @@ function buildCommonPost(buildObj: BuildObj): void {
     mylog('\nUploaded to HockeyApp')
   }
 
-  if (
-    zealotApiToken != null &&
-    zealotUrl != null &&
-    zealotChannelKey != null &&
-    !maestroBuild
-  ) {
+  // Maestro test builds upload to their own channel so they do not pollute the
+  // production channel's release list. Production builds use zealotChannelKey.
+  // A maestro build with no zealotMaestroChannelKey configured skips Zealot.
+  const channelKey = maestroBuild ? zealotMaestroChannelKey : zealotChannelKey
+
+  if (zealotApiToken != null && zealotUrl != null && channelKey != null) {
     const branch = encodeURIComponent(buildObj.repoBranch)
     const gitCommit = encodeURIComponent(buildObj.guiHash)
     chdir(buildObj.guiDir)
@@ -576,7 +583,7 @@ function buildCommonPost(buildObj: BuildObj): void {
     )
 
     call(
-      `curl -X POST "${zealotUrl}/api/apps/upload?token=${zealotApiToken}&channel_key=${zealotChannelKey}&branch=${branch}&git_commit=${gitCommit}&changelog=${changelog}" -F "file=@${buildObj.ipaFile}"`
+      `curl -X POST "${zealotUrl}/api/apps/upload?token=${zealotApiToken}&channel_key=${channelKey}&branch=${branch}&git_commit=${gitCommit}&changelog=${changelog}" -F "file=@${buildObj.ipaFile}"`
     )
     mylog('\n*** Upload to Zealot Complete ***')
   }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Build/CI change to the deploy script only. No app or runtime code is touched, so the GUI testing checkboxes above are N/A.

Maestro builds were excluded from Zealot uploads by the `!maestroBuild` guard in `deploy.ts` and only went to rsync plus the git test repo. This adds an optional `zealotMaestroChannelKey` to the build config and selects it for maestro builds so they upload to their own Zealot channel:

- Production builds still use `zealotChannelKey` and are unchanged.
- A maestro build with no `zealotMaestroChannelKey` configured continues to skip Zealot, so this is safe to merge before the Zealot channels and `deploy-config.json` entries exist.
- The upload still records the source branch via the `branch=` query param, so per-branch maestro channels stay distinguishable inside Zealot.

Follow-up (environment, not repo state, so not in this PR): create the maestro Zealot channels and add `zealotMaestroChannelKey` to `deploy-config.json` on the `ios-build-sim` and `android-build` agents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-script-only change with no app runtime impact; maestro builds without the new key continue to skip Zealot as before.
> 
> **Overview**
> **Maestro CI builds can upload to Zealot again**, but on a separate channel so they do not show up in the production release list.
> 
> `scripts/deploy.ts` adds optional **`zealotMaestroChannelKey`** to the build config. **`buildCommonPost`** picks **`zealotMaestroChannelKey`** for maestro builds and **`zealotChannelKey`** for production; the old **`!maestroBuild`** guard on Zealot uploads is removed. If a maestro run has no maestro channel key configured, Zealot upload is still skipped (safe before agents get the new config). Upload still passes **`branch`** (and existing metadata) so builds stay identifiable in Zealot.
> 
> CHANGELOG notes the routing change for unreleased develop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b22478a95c8ddfd54bd725ddc2fc798d1580d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216177723920843