### PR TITLE
test: add confirmSliderThumb testID for maestro selectors

### DIFF
--- a/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AccelerateTxModal.test.tsx.snap
@@ -619,6 +619,7 @@ exports[`AccelerateTxModalComponent should render with loading props 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -1705,6 +1705,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -3714,6 +3715,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -5723,6 +5725,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -7313,6 +7316,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -8883,6 +8887,7 @@ exports[`SendScene2 2 spendTargets hide tiles 2`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -10220,6 +10225,7 @@ exports[`SendScene2 2 spendTargets hide tiles 3`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -11970,6 +11976,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -13671,6 +13678,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}
@@ -15299,6 +15307,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                 },
               ]
             }
+            testID="confirmSliderThumb"
           >
             <Text
               adjustsFontSizeToFit={true}

--- a/src/__tests__/scenes/__snapshots__/SwapConfirmationScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SwapConfirmationScene.test.tsx.snap
@@ -2033,6 +2033,7 @@ exports[`SwapConfirmationScene should render with loading props 1`] = `
                     },
                   ]
                 }
+                testID="confirmSliderThumb"
               >
                 <Text
                   adjustsFontSizeToFit={true}

--- a/src/components/themed/SafeSlider.tsx
+++ b/src/components/themed/SafeSlider.tsx
@@ -120,6 +120,7 @@ export const SafeSlider: React.FC<Props> = props => {
 
         <GestureDetector gesture={gesture}>
           <Animated.View
+            testID="confirmSliderThumb"
             style={[
               styles.thumb,
               sliderDisabled ? styles.disabledThumb : null,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Adds a stable `testID="confirmSliderThumb"` to the `SafeSlider` thumb so automated UI flows (maestro) can drive the confirm slider by id instead of brittle coordinate swipes. Test-infra only: no behavior or visual change. Snapshot files that render `SafeSlider` are updated to include the new prop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only accessibility hook with no logic, styling, or transaction-flow changes.
> 
> **Overview**
> Adds **`testID="confirmSliderThumb"`** on the `SafeSlider` thumb `Animated.View` in `SafeSlider.tsx` so Maestro (and similar automation) can target the slide-to-confirm control by id instead of coordinate swipes.
> 
> Jest snapshots for screens/modals that render `SafeSlider` are refreshed to include the new prop. **No user-visible or runtime behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922c344f87b69fe9149dd662e43b09239e133a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->