### PR TITLE
Deprecate Botanix to keys-only mode on July 9, 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - added: Reverse-resolve recipient addresses to ENS / Unstoppable Domains / ZNS names in the send flow, address modal, and transaction history.
 - changed: Migrate Monero to the react-native-monero implementation, replacing edge-currency-monero
 - changed: Migrate package manager from yarn to npm.
+- changed: Deprecate Botanix by switching it to keys-only mode on July 9, 2026.
 - fixed: Android build failure from the home screen long-press shortcuts feature, caused by an expo-quick-actions Kotlin compile error under Kotlin 2.3.
 
 ## 4.48.2 (2026-06-03)

--- a/src/__tests__/constants/WalletAndCurrencyConstants.test.ts
+++ b/src/__tests__/constants/WalletAndCurrencyConstants.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, jest, test } from '@jest/globals'
+
+import {
+  isKeysOnlyModeDate,
+  SPECIAL_CURRENCY_INFO
+} from '../../constants/WalletAndCurrencyConstants'
+
+const DEPRECATION_MS = new Date('2026-07-09T00:00:00.000Z').getTime()
+
+describe('isKeysOnlyModeDate', function () {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const date = new Date('2026-07-09T00:00:00.000Z')
+
+  test('returns false before the date', function () {
+    jest.spyOn(Date, 'now').mockReturnValue(DEPRECATION_MS - 1)
+    expect(isKeysOnlyModeDate(date)).toBe(false)
+  })
+
+  test('returns true exactly on the date', function () {
+    jest.spyOn(Date, 'now').mockReturnValue(DEPRECATION_MS)
+    expect(isKeysOnlyModeDate(date)).toBe(true)
+  })
+
+  test('returns true after the date', function () {
+    jest.spyOn(Date, 'now').mockReturnValue(DEPRECATION_MS + 86400000)
+    expect(isKeysOnlyModeDate(date)).toBe(true)
+  })
+})
+
+describe('botanix keysOnlyMode', function () {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // The flag is a getter so it re-evaluates the date on each read, rather than
+  // freezing the value at module load.
+  test('re-evaluates the date on each read', function () {
+    const nowSpy = jest.spyOn(Date, 'now')
+
+    nowSpy.mockReturnValue(DEPRECATION_MS - 1)
+    expect(SPECIAL_CURRENCY_INFO.botanix.keysOnlyMode).toBe(false)
+
+    nowSpy.mockReturnValue(DEPRECATION_MS)
+    expect(SPECIAL_CURRENCY_INFO.botanix.keysOnlyMode).toBe(true)
+  })
+})

--- a/src/components/modals/WalletListModal.tsx
+++ b/src/components/modals/WalletListModal.tsx
@@ -86,13 +86,6 @@ interface Props {
   parentWalletId?: string
 }
 
-const keysOnlyModeAssets: EdgeAsset[] = Object.keys(SPECIAL_CURRENCY_INFO)
-  .filter(pluginId => isKeysOnlyPlugin(pluginId))
-  .map(pluginId => ({
-    pluginId,
-    tokenId: null
-  }))
-
 export const WalletListModal: React.FC<Props> = props => {
   const {
     bridge,
@@ -140,10 +133,16 @@ export const WalletListModal: React.FC<Props> = props => {
 
   // #region Init
 
-  // Prevent plugins that are "watch only" from being used unless it's explicitly allowed
+  // Prevent plugins that are "watch only" from being used unless it's explicitly allowed.
+  // Computed per render (not once at import) so date-gated keysOnlyMode plugins are
+  // honored mid-session without an app restart.
   const walletListExcludeAssets = React.useMemo(() => {
     const result = excludeAssets
-    return allowKeysOnlyMode ? result : keysOnlyModeAssets.concat(result ?? [])
+    if (allowKeysOnlyMode) return result
+    const keysOnlyModeAssets: EdgeAsset[] = Object.keys(SPECIAL_CURRENCY_INFO)
+      .filter(pluginId => isKeysOnlyPlugin(pluginId))
+      .map(pluginId => ({ pluginId, tokenId: null }))
+    return keysOnlyModeAssets.concat(result ?? [])
   }, [allowKeysOnlyMode, excludeAssets])
 
   // #endregion Init

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -609,6 +609,12 @@ export const SPECIAL_CURRENCY_INFO: Record<string, SpecialCurrencyInfo> = {
     showChainIcon: true,
     dummyPublicAddress: '0x0d73358506663d484945ba85d0cd435ad610b0a0',
     isImportKeySupported: true,
+    // Getter, not a fixed boolean: this is read on each access (e.g. via
+    // isKeysOnlyPlugin) so the date gate re-evaluates during a running session
+    // and takes effect at the cutover without requiring an app restart.
+    get keysOnlyMode(): boolean {
+      return isKeysOnlyModeDate(new Date('2026-07-09T00:00:00.000Z'))
+    },
     walletConnectV2ChainId: {
       namespace: 'eip155',
       reference: '3637'
@@ -1092,6 +1098,25 @@ function isZecBroken(): boolean {
     return Platform.constants.Version < 28
   }
   return false
+}
+
+/**
+ * Generic time-gate for deprecating an asset into keysOnlyMode (watch-only) on
+ * a specific date. Returns true once the current time is on or after `date`. On
+ * and after the date the asset becomes keys-only: existing wallets remain
+ * accessible (keys-only) but no new wallets can be created.
+ *
+ * Not specific to any single plugin. Call it from a `keysOnlyMode` getter so
+ * the gate re-evaluates on each read and takes effect at the cutover without an
+ * app restart:
+ *   get keysOnlyMode(): boolean { return isKeysOnlyModeDate(new Date('YYYY-MM-DD')) }
+ *
+ * Declared as a hoisted function (not a `const`) because `SPECIAL_CURRENCY_INFO`
+ * references it during module initialization, before a later `const` would be
+ * assigned (temporal dead zone).
+ */
+export function isKeysOnlyModeDate(date: Date): boolean {
+  return Date.now() >= date.getTime()
 }
 
 export const USD_FIAT = 'iso:USD'


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1215599238343239

Deprecate the Botanix asset by making it keys-only, date-gated to take effect on July 9, 2026. On and after that date `keysOnlyMode` becomes true for `botanix`: existing Botanix wallets remain accessible (keys-only, view/export) but new Botanix wallets can no longer be created. Before the date the asset is unaffected.

The mechanism is generic, not Botanix-specific. A reusable `isKeysOnlyModeDate(date)` helper returns true once the current time reaches the given date. `botanix.keysOnlyMode` is a getter that calls it, so the flag re-evaluates on each read and flips at the cutover without an app restart (the same dynamic-`keysOnlyMode` pattern as `zcash` and `piratechain`). Any future asset can be deprecated on a date by giving its entry the same getter. The helper is a hoisted function rather than a module-level `const` because `SPECIAL_CURRENCY_INFO` reads it during module initialization.

`WalletListModal` builds its keys-only exclude list per render inside `useMemo` instead of once at import, so the date-gated flag is honored mid-session.

Changes:
- Generic `isKeysOnlyModeDate(date)` helper next to `isZecBroken()`.
- `botanix.keysOnlyMode` getter calling `isKeysOnlyModeDate(new Date('2026-07-09'))`.
- `WalletListModal` computes the keys-only exclude list per render.
- Unit tests for the date helper (before, on, after the date) and the getter re-evaluation.

Once active, the flag flows through the existing create-wallet filter (`isKeysOnlyPlugin` removes keys-only assets from the create-wallet list).

### Testing

- `tsc --noEmit`: clean.
- `verify-repo.sh` full suite and jest: passed (399 tests).
- Unit tests: `isKeysOnlyModeDate` is false before 2026-07-09 and true on/after; the `botanix.keysOnlyMode` getter re-evaluates per read. Passing.
- iOS simulator (proxy): built, installed, and ran the app. Botanix's plugin is disabled by default (`BOTANIX_INIT: false`) and enabling it crashes the debug build, and the gate is not active until 2026-07-09, so Botanix itself is not runnable in the sim today. Verified the identical keys-only create-wallet exclusion the gate feeds via the `bitcoinsv` proxy (hardcoded-enabled and `keysOnlyMode: true`): searching "Bitcoin SV" in "Choose Wallets to Add" yields no creatable result, while "Bitcoin" returns creatable BTC/BCH variants. Screenshots attached. The date logic itself is covered by the unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scheduled wallet-creation restriction for one chain using existing keys-only plumbing; no auth or funds-handling changes.
> 
> **Overview**
> Schedules **Botanix** to enter **keys-only (watch-only) mode** on **July 9, 2026**: existing wallets stay usable for view/export, but **new Botanix wallets** are blocked from the create-wallet flow once the cutover hits.
> 
> Introduces reusable **`isKeysOnlyModeDate(date)`** and wires **`botanix.keysOnlyMode`** as a **getter** (not a fixed boolean) so the flag **re-evaluates on each read** and flips at the deadline **without an app restart**. **`WalletListModal`** now builds the keys-only exclude list **inside `useMemo` per render** instead of once at import, so mid-session cutovers apply to wallet-picker filtering. **CHANGELOG** and **unit tests** cover the date helper and getter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839214df76f3a910351c4534762b4e74c7e001a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

