### PR TITLE
Warn on raw react-native-vector-icons imports, prefer theme reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 - **Files**: `.tsx` for React components, `.ts` for utilities/hooks
 - **Error Handling**: Use proper error boundaries, avoid throwing in render
 - **Text Components**: Use `EdgeText`, `Paragraph`, `SmallText`, `WarningText` instead of raw text
+- **Component Reuse**: Strongly prefer reusing existing shared components over building new ones or dropping to raw library primitives. Before adding UI, look for a component that already covers the need (e.g. text via `EdgeText`), and keep color, sizing, and styling driven by `useTheme()` rather than hard-coded per call site. When nothing suitable exists, add a reusable, themed definition instead of a one-off
 - **Hooks**: Custom hooks in `src/hooks/`, follow `use*` naming convention
 - **Testing**: Jest with React Native Testing Library, tests in `__tests__/` directories
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,7 +53,38 @@ export default [
           message:
             'Avoid using styled() - prefer regular components with useTheme() and cacheStyles()'
         }
+      ],
+
+      // Warn on raw react-native-vector-icons imports to encourage migration
+      // toward shared, theme-driven icon components:
+      'no-restricted-imports': [
+        'warn',
+        {
+          patterns: [
+            {
+              group: [
+                'react-native-vector-icons',
+                'react-native-vector-icons/*'
+              ],
+              message:
+                'Avoid importing react-native-vector-icons directly. Use a shared icon from src/components/icons/ThemedIcons or the VectorIcon component so color and size stay theme-driven, and add a new definition there if one is missing.'
+            }
+          ]
+        }
       ]
+    }
+  },
+
+  // Allow the shared icon wrappers to import react-native-vector-icons
+  // directly, since they are the components that re-export it:
+  {
+    files: [
+      'src/assets/vector/index.ts',
+      'src/components/icons/ThemedIcons.tsx',
+      'src/components/themed/VectorIcon.tsx'
+    ],
+    rules: {
+      'no-restricted-imports': 'off'
     }
   },
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

Tooling and contributor-docs only. No runtime or user-facing change.

### Dependencies

none

### Requirements

No visual changes to the GUI (ESLint config and AGENTS.md only), so the device-testing checklist does not apply:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Steer icon usage toward the shared, theme-driven icon components instead of importing `react-native-vector-icons` directly.

- Add a `no-restricted-imports` ESLint rule (level `warn`) flagging any `react-native-vector-icons` / `react-native-vector-icons/*` import, pointing contributors at the `ThemedIcons` exports and the `VectorIcon` component so icon color and size stay driven by `useTheme()` rather than hard-coded per call site.
- Exempt the three wrapper files that must import the library directly: `src/components/icons/ThemedIcons.tsx`, `src/components/themed/VectorIcon.tsx`, and `src/assets/vector/index.ts`.
- Document the broader component + theme reuse preference in `AGENTS.md`.

`warn` (not `error`) is intentional: 65 source files import the library directly today, and `npm run lint` has no `--max-warnings`, so this breaks neither CI nor commits. It matches the existing `styled()` migration rule's approach. The path to `error` later is to migrate those 65 files, then raise the level.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ESLint and contributor docs only; no runtime or user-facing behavior changes.
> 
> **Overview**
> **Tooling-only** changes that nudge contributors toward shared, theme-driven UI instead of one-off primitives.
> 
> Adds a **`warn`** `no-restricted-imports` rule for direct `react-native-vector-icons` imports, with guidance to use `ThemedIcons` / `VectorIcon`; the three icon wrapper modules are exempt. Documents the same **component reuse + `useTheme()`** preference in `AGENTS.md`.
> 
> Introduces custom **`edge/no-color-literal-props`** (also **`warn`**) to flag hardcoded color string literals on JSX props whose names end in `color`, complementing `react-native/no-color-literals` for styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3137e39156f529158790f29d41d300bfc43bd8d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->