### PR TITLE
test: add testIDs to wallet options menu for maestro selectors

### DIFF
--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -337,6 +337,7 @@ export function WalletListMenuModal(props: Props): React.JSX.Element {
         return (
           <EdgeTouchableOpacity
             key={option.value}
+            testID={`walletListMenu_${option.value}`}
             onPress={async () => {
               await optionAction(option.value)
             }}


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Test infrastructure only — no behavior or visual change.

Add `testID={`walletListMenu_${option.value}`}` to the `WalletListMenuModal` rows so automated UI tests can drive the wallet options menu (Resync, Wallet Settings, Export Transactions, etc.). The row labels render through `UnscaledText`, which does not expose matchable accessibility text, so these rows had no stable selector and could not be tapped by maestro. Surfaced while writing an iOS resync test for the eCash node fix.

Asana: https://app.asana.com/0/1215088146871429/1213046875952149

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only selector attributes on touchables; no logic, navigation, or visual changes.
> 
> **Overview**
> Adds **`testID={`walletListMenu_${option.value}`}`** on each **`WalletListMenuModal`** menu row so Maestro (and similar UI automation) can tap actions like Resync, Wallet Settings, and Export Transactions by stable id instead of label text.
> 
> No user-facing or behavioral change—labels still render through **`UnscaledText`**, which does not give matchable accessibility text for those rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05d23e69346fba42384bb862c30eba353cf441a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->