### PR TITLE
Add DFX fiat ramp provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: DFX (app.dfx.swiss) as a SEPA fiat buy/sell ramp provider.
 - added: Remote enable/disable of gift card providers via the info server's giftCardInfo config, supporting whole-provider disabling for Phaze and Bitrefill and per-brand disabling for Phaze.
 
 ## 4.49.0 (staging)

--- a/src/components/scenes/RampCreateScene.tsx
+++ b/src/components/scenes/RampCreateScene.tsx
@@ -811,7 +811,10 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
         {/* Amount Inputs */}
         {/* Top Input (Fiat) */}
         <View style={styles.inputRowView}>
-          <DropdownInputButton onPress={handleFiatDropdown}>
+          <DropdownInputButton
+            onPress={handleFiatDropdown}
+            testID="rampFiatDropdown"
+          >
             {selectedFiatFlagUri !== '' ? (
               <ShadowedView style={styles.shadowedIcon}>
                 <FastImage
@@ -861,7 +864,10 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
             />
           ) : (
             <>
-              <DropdownInputButton onPress={handleCryptDropdown}>
+              <DropdownInputButton
+                onPress={handleCryptDropdown}
+                testID="rampCryptoDropdown"
+              >
                 {isLoadingPersistedCryptoSelection ? (
                   <ActivityIndicator />
                 ) : selectedCrypto == null || selectedWallet == null ? null : (

--- a/src/constants/plugins/GuiPlugins.ts
+++ b/src/constants/plugins/GuiPlugins.ts
@@ -94,6 +94,13 @@ export const guiPlugins: Record<string, GuiPlugin> = {
     displayName: 'Bits of Gold',
     permissions: ['camera']
   },
+  dfx: {
+    pluginId: 'dfx',
+    storeId: 'dfx',
+    baseUri: 'https://app.dfx.swiss',
+    displayName: 'DFX',
+    permissions: ['camera']
+  },
   creditcard: {
     pluginId: 'amountquote',
     storeId: '',

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -12,6 +12,7 @@ import {
 
 import { asInitOptions as asBanxaInitOptions } from './plugins/ramps/banxa/banxaRampTypes'
 import { asInitOptions as asBitsofgoldInitOptions } from './plugins/ramps/bitsofgold/bitsofgoldRampTypes'
+import { asInitOptions as asDfxInitOptions } from './plugins/ramps/dfx/dfxRampTypes'
 import { asInitOptions as asInfiniteInitOptions } from './plugins/ramps/infinite/infiniteRampTypes'
 import { asInitOptions as asLibertyxInitOptions } from './plugins/ramps/libertyx/libertyxRampTypes'
 import { asInitOptions as asMoonpayInitOptions } from './plugins/ramps/moonpay/moonpayRampTypes'
@@ -186,6 +187,7 @@ export const asEnvConfig = asObject({
     asObject<Record<string, unknown>>({
       banxa: asOptional(asBanxaInitOptions),
       bitsofgold: asOptional(asBitsofgoldInitOptions),
+      dfx: asOptional(asDfxInitOptions),
       libertyx: asOptional(asLibertyxInitOptions),
       moonpay: asOptional(asMoonpayInitOptions),
       infinite: asOptional(asInfiniteInitOptions),
@@ -196,6 +198,7 @@ export const asEnvConfig = asObject({
     () => ({
       banxa: undefined,
       bitsofgold: undefined,
+      dfx: undefined,
       libertyx: undefined,
       moonpay: undefined,
       infinite: undefined,

--- a/src/plugins/ramps/allRampPlugins.ts
+++ b/src/plugins/ramps/allRampPlugins.ts
@@ -1,5 +1,6 @@
 import { banxaRampPlugin } from './banxa/banxaRampPlugin'
 import { bitsofgoldRampPlugin } from './bitsofgold/bitsofgoldRampPlugin'
+import { dfxRampPlugin } from './dfx/dfxRampPlugin'
 import { infiniteRampPlugin } from './infinite/infiniteRampPlugin'
 import { libertyxRampPlugin } from './libertyx/libertyxRampPlugin'
 import { moonpayRampPlugin } from './moonpay/moonpayRampPlugin'
@@ -11,6 +12,7 @@ import { simplexRampPlugin } from './simplex/simplexRampPlugin'
 export const pluginFactories: Record<string, RampPluginFactory> = {
   banxa: banxaRampPlugin,
   bitsofgold: bitsofgoldRampPlugin,
+  dfx: dfxRampPlugin,
   infinite: infiniteRampPlugin,
   libertyx: libertyxRampPlugin,
   moonpay: moonpayRampPlugin,

--- a/src/plugins/ramps/dfx/dfxRampPlugin.ts
+++ b/src/plugins/ramps/dfx/dfxRampPlugin.ts
@@ -1,0 +1,92 @@
+import { guiPlugins } from '../../../constants/plugins/GuiPlugins'
+import type { RampPluginFactory, SettlementRange } from '../rampPluginTypes'
+import { createExternalRampPlugin } from '../utils/createExternalRampPlugin'
+import { asInitOptions } from './dfxRampTypes'
+
+// DFX settles SEPA bank transfers within a few business days.
+const SETTLEMENT_ONE_TO_THREE_DAYS: SettlementRange = {
+  min: { value: 1, unit: 'days' },
+  max: { value: 3, unit: 'days' }
+}
+
+// SEPA region plus Switzerland and Liechtenstein, where DFX operates.
+const DFX_COUNTRIES = [
+  'AT',
+  'BE',
+  'BG',
+  'CH',
+  'CY',
+  'CZ',
+  'DE',
+  'DK',
+  'EE',
+  'ES',
+  'FI',
+  'FR',
+  'GR',
+  'HR',
+  'HU',
+  'IE',
+  'IT',
+  'LI',
+  'LT',
+  'LU',
+  'LV',
+  'MT',
+  'NL',
+  'PL',
+  'PT',
+  'RO',
+  'SE',
+  'SI',
+  'SK'
+]
+
+const DFX_FIAT_CURRENCY_CODES = ['EUR', 'CHF']
+
+const DFX_CRYPTO_ASSETS = [
+  { pluginId: 'bitcoin', tokenId: null },
+  { pluginId: 'ethereum', tokenId: null },
+  { pluginId: 'arbitrum', tokenId: null },
+  { pluginId: 'optimism', tokenId: null },
+  { pluginId: 'polygon', tokenId: null },
+  { pluginId: 'base', tokenId: null },
+  { pluginId: 'binancesmartchain', tokenId: null },
+  { pluginId: 'solana', tokenId: null },
+  { pluginId: 'monero', tokenId: null }
+]
+
+export const dfxRampPlugin: RampPluginFactory = config => {
+  const initOptions = asInitOptions(config.initOptions)
+  const deepQuery = {
+    wallet: initOptions.wallet,
+    lang: 'en'
+  }
+
+  return createExternalRampPlugin(
+    'dfx',
+    {
+      guiPlugin: guiPlugins.dfx,
+      partnerIcon: initOptions.partnerIcon,
+      buy: {
+        paymentTypes: ['sepa'],
+        countries: DFX_COUNTRIES,
+        fiatCurrencyCodes: DFX_FIAT_CURRENCY_CODES,
+        cryptoAssets: DFX_CRYPTO_ASSETS,
+        settlementRange: SETTLEMENT_ONE_TO_THREE_DAYS,
+        deepPath: '/buy',
+        deepQuery
+      },
+      sell: {
+        paymentTypes: ['sepa'],
+        countries: DFX_COUNTRIES,
+        fiatCurrencyCodes: DFX_FIAT_CURRENCY_CODES,
+        cryptoAssets: DFX_CRYPTO_ASSETS,
+        settlementRange: SETTLEMENT_ONE_TO_THREE_DAYS,
+        deepPath: '/sell',
+        deepQuery
+      }
+    },
+    config
+  )
+}

--- a/src/plugins/ramps/dfx/dfxRampTypes.ts
+++ b/src/plugins/ramps/dfx/dfxRampTypes.ts
@@ -1,0 +1,13 @@
+import { asObject, asOptional, asString } from 'cleaners'
+
+export interface InitOptions {
+  readonly partnerIcon: string
+  // Partner/wallet identifier sent to the DFX widget. Override per build so
+  // white-label apps do not identify as Edge.
+  readonly wallet: string
+}
+
+export const asInitOptions = asObject<InitOptions>({
+  partnerIcon: asOptional(asString, `https://content.edge.app/dfx-logo.png`),
+  wallet: asOptional(asString, 'Edge')
+}).withRest


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Integrate [DFX](https://app.dfx.swiss) ([API](https://api.dfx.swiss/swagger), [docs](https://github.com/DFXswiss/api)) as a new SEPA fiat buy/sell ramp (no swap), using the new `src/plugins/ramps/` external-ramp pattern (same shape as `bitsofgold`/`libertyx`): no quoting API, the user is deeplinked into the DFX web widget to complete the buy/sell.

What this adds:

- `src/plugins/ramps/dfx/dfxRampPlugin.ts` and `dfxRampTypes.ts` — the DFX external ramp factory plus its init-options cleaner.
- Registers `dfx` in `allRampPlugins.ts`.
- Adds the `dfx` GUI plugin (`baseUri: https://app.dfx.swiss`, camera permission for QR scanning) and wires `dfx` into `RAMP_PLUGIN_INITS` in `envConfig.ts` (default `undefined`, i.e. off until enabled via env/info-server).

Support matrix: `sepa` payment type, EUR/CHF, SEPA region plus Switzerland and Liechtenstein, for Bitcoin, Ethereum, Arbitrum, Optimism, Polygon, Base, BNB Smart Chain, Solana and Monero; buy → `/buy`, sell → `/sell`.

A second commit adds `testID`s to the ramp create scene's fiat/crypto dropdown buttons so UI tests can drive the selectors by id.

Testing: drove the Buy flow on the iOS simulator with region Germany / fiat EUR / Bitcoin. DFX surfaces as the "SEPA Bank Transfer" payment method ("Powered By: DFX", settlement 1-3 days), and selecting it opens the DFX web widget (`app.dfx.swiss`). Screenshots attached. `tsc --noEmit`, eslint and the jest suite pass.

[Asana task](https://app.asana.com/0/1215088146871429/1216018838183206)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional ramp provider behind env init config; no changes to auth, payments, or existing ramp quoting flows beyond registration and UI test hooks.
> 
> **Overview**
> Adds **[DFX](https://app.dfx.swiss)** as a new **SEPA** fiat buy/sell ramp using the same **external-ramp** pattern as Bits of Gold and LibertyX: no in-app quoting; users are deeplinked into the DFX web widget at `https://app.dfx.swiss` (`/buy` or `/sell`).
> 
> Wiring includes a new `dfx` GUI plugin (camera permission for QR), registration in `allRampPlugins.ts`, and optional `RAMP_PLUGIN_INITS.dfx` in `envConfig.ts` (off until enabled via env/info-server). Support is **SEPA** for **EUR/CHF** in SEPA countries plus CH/LI, with settlement **1–3 days**, for BTC, ETH, several EVM L2s, BSC, Solana, and Monero. Init options allow `partnerIcon` and a `wallet` identifier for white-label builds.
> 
> Also adds **`testID`s** `rampFiatDropdown` and `rampCryptoDropdown` on `RampCreateScene` dropdown buttons for UI automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8d92718d46c1d8f4b281cc0b636a3736ff8394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->