### PR TITLE
Fix Use Biometrics toggle reverting after leaving Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - changed: Migrate package manager from yarn to npm.
 - changed: Deprecate Botanix by switching it to keys-only mode on July 9, 2026.
 - fixed: Android build failure from the home screen long-press shortcuts feature, caused by an expo-quick-actions Kotlin compile error under Kotlin 2.3.
+- fixed: Use Biometrics toggle in Settings reverting to its previous state after leaving and re-entering the scene.
 
 ## 4.48.2 (2026-06-03)
 

--- a/src/__tests__/scenes/SettingsScene.biometric.test.tsx
+++ b/src/__tests__/scenes/SettingsScene.biometric.test.tsx
@@ -1,0 +1,177 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import * as React from 'react'
+
+import { SettingsScene } from '../../components/scenes/SettingsScene'
+import { FakeProviders, type FakeState } from '../../util/fake/FakeProviders'
+import { fakeEdgeAppSceneProps } from '../../util/fake/fakeSceneProps'
+
+// Stateful biometric backend, standing in for the keychain that
+// `edge-login-ui-rn` persists the "Use Biometrics" setting to. The `mock`
+// prefix is required for jest to allow referencing it inside the factory.
+// `read` is indirected so a test can hold a refetch in-flight; it defaults to
+// reading the persisted `enabled` flag.
+const mockBiometry: {
+  enabled: boolean
+  read: () => Promise<boolean>
+} = {
+  enabled: true,
+  read: async () => mockBiometry.enabled
+}
+jest.mock('edge-login-ui-rn', () => ({
+  getSupportedBiometryType: async () => 'FaceID',
+  isTouchEnabled: async () => await mockBiometry.read(),
+  enableTouchId: async () => {
+    mockBiometry.enabled = true
+  },
+  disableTouchId: async () => {
+    mockBiometry.enabled = false
+  }
+}))
+
+const ACCOUNT_ID = 'fake-account-id'
+const BIOMETRIC_QUERY_KEY = ['biometricState', ACCOUNT_ID]
+
+const mockState: FakeState = {
+  core: {
+    account: {
+      id: ACCOUNT_ID,
+      rootLoginId: 'XXX',
+      currencyConfig: {},
+      username: 'some user',
+      watch: () => () => {}
+    },
+    context: {
+      logSettings: { defaultLogLevel: 'silent' },
+      watch: () => () => {}
+    }
+  }
+}
+
+const getCachedTouchEnabled = (client: QueryClient): boolean | undefined =>
+  client.getQueryData<{ isTouchEnabled: boolean }>(BIOMETRIC_QUERY_KEY)
+    ?.isTouchEnabled
+
+const renderSettings = (client: QueryClient): ReturnType<typeof render> =>
+  render(
+    <FakeProviders initialState={mockState}>
+      <QueryClientProvider client={client}>
+        <SettingsScene
+          {...fakeEdgeAppSceneProps('settingsOverview', undefined)}
+        />
+      </QueryClientProvider>
+    </FakeProviders>
+  )
+
+describe('SettingsScene biometric toggle persistence', () => {
+  it('keeps the cached biometric state in sync after toggling so re-entry shows the set value', async () => {
+    jest.useRealTimers()
+    mockBiometry.enabled = true
+    mockBiometry.read = async () => mockBiometry.enabled
+
+    // A client we own and can inspect, shared across both scene mounts to
+    // model the app-level query cache that survives a scene remount. Seed it
+    // with the loaded biometric state so the toggle renders deterministically.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+    client.setQueryData(BIOMETRIC_QUERY_KEY, {
+      isTouchEnabled: true,
+      isTouchSupported: true,
+      biometryType: 'FaceID'
+    })
+
+    const rendered = renderSettings(client)
+
+    // The toggle renders directly off the cached query value.
+    await rendered.findByText('Use FaceID', {}, { timeout: 15000 })
+    expect(getCachedTouchEnabled(client)).toBe(true)
+
+    // Toggle biometrics off.
+    fireEvent.press(rendered.getByText('Use FaceID'))
+
+    // The persisted backend flips off AND the query cache is kept in sync.
+    // Before the fix the cache stayed `true`, so re-entering Settings showed
+    // the stale (on) state.
+    await waitFor(
+      () => {
+        expect(mockBiometry.enabled).toBe(false)
+        expect(getCachedTouchEnabled(client)).toBe(false)
+      },
+      { timeout: 15000 }
+    )
+
+    rendered.unmount()
+
+    // Re-enter Settings: a fresh mount reads the same (now-correct) cache and
+    // shows the toggle in the state the user left it.
+    const reentered = renderSettings(client)
+    await reentered.findByText('Use FaceID', {}, { timeout: 15000 })
+    expect(getCachedTouchEnabled(client)).toBe(false)
+
+    reentered.unmount()
+  }, 60000)
+
+  it('cancels an in-flight refetch so a stale read cannot overwrite a completed toggle', async () => {
+    jest.useRealTimers()
+    mockBiometry.enabled = true
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+    // Seed the cache so the toggle renders immediately AND a background refetch
+    // fires on mount (stale-while-revalidate).
+    client.setQueryData(BIOMETRIC_QUERY_KEY, {
+      isTouchEnabled: true,
+      isTouchSupported: true,
+      biometryType: 'FaceID'
+    })
+
+    // Hold ONLY the first (mount) refetch in-flight, capturing its resolver so
+    // we can complete it with the stale pre-toggle value after the toggle
+    // persists. Any later refetch reads the real persisted flag.
+    let resolveStaleRefetch: (value: boolean) => void = () => {}
+    let signalStarted: () => void = () => {}
+    const staleRefetchStarted = new Promise<void>(resolve => {
+      signalStarted = resolve
+    })
+    let firstRead = true
+    mockBiometry.read = async () => {
+      if (firstRead) {
+        firstRead = false
+        signalStarted()
+        return await new Promise<boolean>(resolve => {
+          resolveStaleRefetch = resolve
+        })
+      }
+      return mockBiometry.enabled
+    }
+
+    const rendered = renderSettings(client)
+
+    // Toggle renders from the cached value while the mount refetch is pending.
+    await rendered.findByText('Use FaceID', {}, { timeout: 15000 })
+    await staleRefetchStarted
+
+    // Toggle biometrics off. handleUpdateTouchId cancels the in-flight refetch,
+    // optimistically writes false, and persists.
+    fireEvent.press(rendered.getByText('Use FaceID'))
+    await waitFor(
+      () => {
+        expect(mockBiometry.enabled).toBe(false)
+        expect(getCachedTouchEnabled(client)).toBe(false)
+      },
+      { timeout: 15000 }
+    )
+
+    // The stale mount refetch now resolves with the OLD (true) value. Because it
+    // was cancelled, react-query must ignore it and leave the cache at false.
+    // Without the cancelQueries guard this write flips the toggle back on.
+    resolveStaleRefetch(true)
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(getCachedTouchEnabled(client)).toBe(false)
+
+    rendered.unmount()
+  }, 60000)
+})

--- a/src/components/scenes/SettingsScene.tsx
+++ b/src/components/scenes/SettingsScene.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { asMaybe } from 'cleaners'
 import type { EdgeLogType } from 'edge-core-js'
 import {
@@ -67,6 +67,13 @@ import { asPrivateNetworkingSetting } from '../themed/MaybePrivateNetworkingSett
 
 type Props = EdgeAppSceneProps<'settingsOverview'>
 
+// Shared query key so the query definition and the optimistic cache update
+// can never drift apart.
+const biometricStateQueryKey = (accountId: string): [string, string] => [
+  'biometricState',
+  accountId
+]
+
 export const SettingsScene: React.FC<Props> = props => {
   const { navigation } = props
   const theme = useTheme()
@@ -84,9 +91,14 @@ export const SettingsScene: React.FC<Props> = props => {
 
   const account = useSelector(state => state.core.account)
 
-  // Load biometric state locally (not from Redux)
+  const queryClient = useQueryClient()
+
+  // Load biometric state locally (not from Redux). The toggle renders
+  // directly off this query so its on-screen value can never diverge from the
+  // cache; handleUpdateTouchId keeps the cache correct via an optimistic
+  // setQueryData.
   const { data: biometricState } = useQuery({
-    queryKey: ['biometricState', account.id],
+    queryKey: biometricStateQueryKey(account.id),
     queryFn: async () => {
       const [touchEnabled, supportedType] = await Promise.all([
         isTouchEnabled(account),
@@ -100,18 +112,6 @@ export const SettingsScene: React.FC<Props> = props => {
     },
     enabled: account != null
   })
-
-  // Local state to track touch ID enabled status (can be toggled by user)
-  const [touchIdEnabled, setTouchIdEnabled] = React.useState<boolean | null>(
-    null
-  )
-
-  // Sync local state with loaded state
-  React.useEffect(() => {
-    if (biometricState != null && touchIdEnabled == null) {
-      setTouchIdEnabled(biometricState.isTouchEnabled)
-    }
-  }, [biometricState, touchIdEnabled])
 
   const supportsTouchId = biometricState?.isTouchSupported ?? false
   const username = useWatch(account, 'username')
@@ -214,9 +214,21 @@ export const SettingsScene: React.FC<Props> = props => {
   }
 
   const handleUpdateTouchId = useHandler(async () => {
-    if (touchIdEnabled == null) return
-    const newValue = !touchIdEnabled
-    setTouchIdEnabled(newValue)
+    if (biometricState == null) return
+    const newValue = !biometricState.isTouchEnabled
+    const queryKey = biometricStateQueryKey(account.id)
+    // Cancel any in-flight refetch first: a background fetch started on mount
+    // reads the pre-toggle keychain value, and if it resolves after we persist
+    // it would clobber the cache back to the old state and flip the switch.
+    await queryClient.cancelQueries({ queryKey })
+    // Optimistically flip the cache so the toggle (which renders off the
+    // query) updates immediately and stays correct when Settings is left and
+    // re-entered. Without this the cached value stays stale and re-entry shows
+    // the previous state.
+    queryClient.setQueryData(queryKey, {
+      ...biometricState,
+      isTouchEnabled: newValue
+    })
     try {
       if (newValue) {
         await enableTouchId(account)
@@ -224,8 +236,11 @@ export const SettingsScene: React.FC<Props> = props => {
         await disableTouchId(account)
       }
     } catch (error: unknown) {
-      // Revert on error
-      setTouchIdEnabled(!newValue)
+      // Revert the optimistic update on failure.
+      queryClient.setQueryData(queryKey, {
+        ...biometricState,
+        isTouchEnabled: !newValue
+      })
       showError(error)
     }
   })
@@ -654,11 +669,11 @@ export const SettingsScene: React.FC<Props> = props => {
                 onPress={handleTogglePinLoginEnabled}
               />
             ) : null}
-            {supportsTouchId && !isLightAccount && touchIdEnabled != null ? (
+            {supportsTouchId && !isLightAccount && biometricState != null ? (
               <SettingsSwitchRow
                 key="useTouchID"
                 label={touchIdText}
-                value={touchIdEnabled}
+                value={biometricState.isTouchEnabled}
                 onPress={handleUpdateTouchId}
               />
             ) : null}


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1213428787796786

Fixes the Settings "Use Biometrics" toggle reverting to its previous state after the user leaves and re-enters the Settings scene.

Root cause: commit `acc2adbc` moved biometric state out of Redux into a `@tanstack/react-query` query (`['biometricState', account.id]`) plus a local `touchIdEnabled` state that syncs from the query only once per mount. `handleUpdateTouchId` persisted the change via `enableTouchId`/`disableTouchId` but never updated the query cache, and the app-level cache has no `staleTime` and does not refetch on focus. On re-entering Settings the scene remounts, the one-time sync reads the stale cached value, and the toggle shows the old state. Reported on Android; also reproduces on iOS, since the cause is platform-agnostic.

Fix: after the enable/disable persists, update the cached biometric state with `queryClient.setQueryData` so the cache reflects the value the user set. The next mount's sync then reads the correct value.

Testing: added a regression test (`SettingsScene.biometric.test.tsx`) that mounts the scene, toggles biometrics off, and asserts the shared query cache flips to the persisted value across a remount. It fails on the pre-fix code (cache stays `true`) and passes with the fix. Full `tsc`, eslint, and the jest suite pass. The toggle could not be exercised on the simulator because biometric enrollment is unavailable headlessly (no `simctl` biometry command; the Simulator Face ID enrollment menu requires GUI automation that is not reachable in this environment), so the deterministic test is the verification of the changed code path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI and React Query cache only; biometric enable/disable still goes through existing edge-login-ui-rn APIs, with regression tests covering the changed path.
> 
> **Overview**
> Fixes the **Use Biometrics** switch in Settings appearing to revert after you leave and come back.
> 
> Biometric on/off is loaded with React Query (`biometricState`), but toggling only called `enableTouchId` / `disableTouchId` and never updated the shared cache. On remount, the scene read stale cached data instead of what the user had set.
> 
> **`SettingsScene`** now drives the switch from query data only (drops the one-time local `touchIdEnabled` sync). **`handleUpdateTouchId`** cancels in-flight refetches, optimistically updates the cache with `setQueryData`, persists via the login UI helpers, and rolls the cache back if persistence fails. A shared **`biometricStateQueryKey`** keeps the query and updates aligned.
> 
> Adds **`SettingsScene.biometric.test.tsx`** to assert cache stays correct across remount and that a late stale refetch cannot overwrite a completed toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec579c250d8bdd69e6c38c2bbaf3f0c08c90428a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->