### PR TITLE
Document 1rem total spacing convention in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 - **Error Handling**: Use proper error boundaries, avoid throwing in render
 - **Text Components**: Use `EdgeText`, `Paragraph`, `SmallText`, `WarningText` instead of raw text
 - **Component Reuse**: Strongly prefer reusing existing shared components over building new ones or dropping to raw library primitives. Before adding UI, look for a component that already covers the need (e.g. text via `EdgeText`), and keep color, sizing, and styling driven by `useTheme()` rather than hard-coded per call site. When nothing suitable exists, add a reusable, themed definition instead of a one-off
+- **Spacing**: Keep a minimum of 1rem TOTAL space between an element and its neighbors, including screen edges. "Total" is the sum contributed across nearby and parent elements, so examine them rather than each element in isolation: scene-edge padding from `SceneWrapper`/`SceneContainer` (`DEFAULT_MARGIN_REM`, 0.5rem) plus an element's own 0.5rem margins via `Space`/`useSpaceStyle` compose to the 1rem total. An explicit override always takes precedence: the "unless otherwise specified" escape hatch applies to every case, screen edges included. The only built-in exception is flex layouts, which rely on flex gap and alignment for sibling spacing; even there, the 1rem screen-edge minimum still applies. Express spacing in rem through the layout primitives instead of hard-coded pixel margins
 - **Hooks**: Custom hooks in `src/hooks/`, follow `use*` naming convention
 - **Testing**: Jest with React Native Testing Library, tests in `__tests__/` directories
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

Contributor-docs only. No runtime or user-facing change.

### Dependencies

none

### Requirements

No visual changes to the GUI (AGENTS.md only), so the device-testing checklist does not apply:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Document the 1rem-total spacing convention in `AGENTS.md` so contributors and agents apply it consistently.

The rule: keep at least 1rem of total space between an element and its neighbors, including screen edges. The total is composed across nearby and parent elements rather than set on any single element, which is why it has to be reasoned about by examining neighbors and parents:

- Scene-edge padding comes from `SceneWrapper`/`SceneContainer` (`DEFAULT_MARGIN_REM`, 0.5rem).
- An element's own 0.5rem margins via `Space`/`useSpaceStyle` add the other half.
- Together they compose to the 1rem total.

Precedence and exceptions:

- An explicit override always wins. The "unless otherwise specified" escape hatch applies to every case, screen edges included.
- Flex layouts are the only built-in exception: sibling spacing can rely on flex gap and alignment. Even there, the 1rem screen-edge minimum still applies.

This is documented rather than linted on purpose. The constraint is an emergent, cross-element layout property (the total is split across parent and child components in different files), so it is not decidable by a per-file ESLint rule the way the earlier icon and color-literal rules were.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contributor documentation only; no application code or runtime behavior changes.
> 
> **Overview**
> Adds a **Spacing** guideline under Code Style in `AGENTS.md` so contributors and agents follow the same layout rule.
> 
> The new text requires at least **1rem total** space between an element and its neighbors (including screen edges), composed across parents and children—e.g. `SceneWrapper`/`SceneContainer` padding (`DEFAULT_MARGIN_REM`, 0.5rem) plus `Space`/`useSpaceStyle` margins (0.5rem)—with explicit overrides allowed, flex layouts using gap/alignment as the sibling exception, and spacing expressed in rem via layout primitives rather than pixel margins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc8c00e5c460d37a1030e2dd5f73d9f3ce13e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->