### PR TITLE
Track marketing notification opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: Track when a user opens the app from a marketing push notification, reporting the campaign to analytics and navigating to an optional deep link.
 - added: Remote enable/disable of gift card providers via the info server's giftCardInfo config, supporting whole-provider disabling for Phaze and Bitrefill and per-brand disabling for Phaze.
 - changed: Reorganize the wallet list menu so Asset Settings is reached through Wallet Settings, and rename the Monero "Backend" card to "Server Settings".
 - fixed: Prevent imported Monero wallets from using the Edge LWS backend. Choosing to import now prompts the user to continue with a full node or configure a custom LWS server, matching the wallet settings rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - added: Sign Message option in the wallet list menu for Bitcoin-family wallets, letting users prove self-hosted wallet ownership to exchanges by signing an exchange-provided message.
 - added: `edge://buy` and `edge://sell` deep links (and their `https://deep.edge.app` equivalents) that open the buy/sell flow, optionally pinning a provider and payment method to the top of the quote options for that visit.
 - added: Provider priority in the buy/sell options for affiliated accounts, configured through the info server promo card data.
+- added: Track when a user opens the app from a marketing push notification, reporting the campaign to analytics and navigating to an optional deep link.
 - changed: Target Android 16 (API level 36), which Google Play requires for app updates submitted after Aug 30, 2026. Predictive back is opted out of for now, since React Native 0.79 cannot handle it, so the back button behaves exactly as it did before.
 - changed: Sign MoonPay buy/sell widget URLs and bind them to the customer's IP via the info server, for MoonPay's on-ramp IP-matching security upgrade.
 - changed: Style the entire "Already have an account? Sign in" line in the getting-started USP carousel with the tertiary link color, not just "Sign in".

--- a/src/__tests__/PushMessageParser.test.ts
+++ b/src/__tests__/PushMessageParser.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from '@jest/globals'
+import type { FirebaseMessagingTypes } from '@react-native-firebase/messaging'
+
+import { parsePushMessage } from '../util/PushMessageParser'
+
+// The parser only uses `showDevError` from AirshipInstance; stub it so the test
+// avoids pulling in the native Airship module.
+jest.mock('../components/services/AirshipInstance', () => ({
+  showDevError: () => undefined
+}))
+
+/**
+ * Builds a minimal RemoteMessage; the parser only reads `data` and
+ * `notification`.
+ */
+function makeMessage(
+  data: Record<string, string> | undefined,
+  notification?: { title?: string; body?: string }
+): FirebaseMessagingTypes.RemoteMessage {
+  return {
+    data,
+    notification
+  } as unknown as FirebaseMessagingTypes.RemoteMessage
+}
+
+describe('parsePushMessage', () => {
+  it('captures the campaignId from a marketing payload', () => {
+    expect(
+      parsePushMessage(makeMessage({ type: 'marketing', campaignId: 'abc123' }))
+    ).toEqual({
+      type: 'marketing',
+      campaignId: 'abc123',
+      link: undefined
+    })
+  })
+
+  it('parses an optional deep-link url into a nested navigation link', () => {
+    expect(
+      parsePushMessage(
+        makeMessage({
+          type: 'marketing',
+          campaignId: 'abc123',
+          url: 'edge://swap'
+        })
+      )
+    ).toEqual({
+      type: 'marketing',
+      campaignId: 'abc123',
+      link: { type: 'swap' }
+    })
+  })
+
+  it('degrades to track-only when the url is unparseable', () => {
+    expect(
+      parsePushMessage(
+        makeMessage({
+          type: 'marketing',
+          campaignId: 'abc123',
+          url: 'not a url'
+        })
+      )
+    ).toEqual({
+      type: 'marketing',
+      campaignId: 'abc123',
+      link: undefined
+    })
+  })
+
+  it('ignores a non-marketing payload', () => {
+    expect(parsePushMessage(makeMessage({ foo: 'bar' }))).toBeUndefined()
+  })
+
+  it('still parses a price-change payload', () => {
+    expect(
+      parsePushMessage(
+        makeMessage(
+          { type: 'price-change', pluginId: 'bitcoin' },
+          { body: 'BTC is up' }
+        )
+      )
+    ).toEqual({
+      type: 'price-change',
+      pluginId: 'bitcoin',
+      body: 'BTC is up'
+    })
+  })
+})

--- a/src/__tests__/PushMessageParser.test.ts
+++ b/src/__tests__/PushMessageParser.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from '@jest/globals'
+import type { FirebaseMessagingTypes } from '@react-native-firebase/messaging'
+
+import { parsePushMessage } from '../util/PushMessageParser'
+
+// The parser only uses `showDevError` from AirshipInstance; stub it so the test
+// avoids pulling in the native Airship module.
+jest.mock('../components/services/AirshipInstance', () => ({
+  showDevError: () => undefined
+}))
+
+/**
+ * Builds a minimal RemoteMessage; the parser only reads `data` and
+ * `notification`.
+ */
+function makeMessage(
+  data: Record<string, string> | undefined,
+  notification?: { title?: string; body?: string }
+): FirebaseMessagingTypes.RemoteMessage {
+  return {
+    data,
+    notification
+  } as unknown as FirebaseMessagingTypes.RemoteMessage
+}
+
+describe('parsePushMessage', () => {
+  it('captures the campaignId from a marketing payload', () => {
+    expect(
+      parsePushMessage(makeMessage({ type: 'marketing', campaignId: 'abc123' }))
+    ).toEqual({
+      type: 'marketing',
+      campaignId: 'abc123',
+      link: undefined
+    })
+  })
+
+  it('parses an optional deep-link url into a nested navigation link', () => {
+    expect(
+      parsePushMessage(
+        makeMessage({
+          type: 'marketing',
+          campaignId: 'abc123',
+          url: 'edge://swap'
+        })
+      )
+    ).toEqual({
+      type: 'marketing',
+      campaignId: 'abc123',
+      link: { type: 'swap' }
+    })
+  })
+
+  it('navigates wherever the campaign url points', () => {
+    // A campaign link reaches the same places a tapped link does, including
+    // both the new and legacy fiat ramp spellings:
+    const destinations: Array<[string, string]> = [
+      ['edge://scene/edgeTabs?screen=home', 'scene'], // Home
+      ['edge://scene/walletsTab?screen=walletList', 'scene'], // Wallet list
+      ['edge://scene/earnScene', 'scene'], // Earn
+      ['edge://swap', 'swap'],
+      ['edge://buy/paybis/credit', 'rampCreate'], // Quote scene, pinned
+      ['edge://plugin/creditcard/buy/moonpay/credit', 'fiatPlugin'], // Native ramp
+      ['edge://plugin/moonpay/buy', 'plugin'], // Legacy ramp
+      ['edge://promotion/summer50', 'promotion'],
+      ['edge://modal/fundAccount', 'modal']
+    ]
+    for (const [url, expectedType] of destinations) {
+      const result = parsePushMessage(
+        makeMessage({ type: 'marketing', campaignId: 'abc123', url })
+      )
+      if (result?.type !== 'marketing') throw new Error(`not marketing: ${url}`)
+      expect(result.link?.type).toBe(expectedType)
+    }
+  })
+
+  it('degrades to track-only when the url is unparseable', () => {
+    expect(
+      parsePushMessage(
+        makeMessage({
+          type: 'marketing',
+          campaignId: 'abc123',
+          url: 'not a url'
+        })
+      )
+    ).toEqual({
+      type: 'marketing',
+      campaignId: 'abc123',
+      link: undefined
+    })
+  })
+
+  it('ignores a non-marketing payload', () => {
+    expect(parsePushMessage(makeMessage({ foo: 'bar' }))).toBeUndefined()
+  })
+
+  it('still parses a price-change payload', () => {
+    expect(
+      parsePushMessage(
+        makeMessage(
+          { type: 'price-change', pluginId: 'bitcoin' },
+          { body: 'BTC is up' }
+        )
+      )
+    ).toEqual({
+      type: 'price-change',
+      pluginId: 'bitcoin',
+      body: 'BTC is up'
+    })
+  })
+})

--- a/src/actions/DeepLinkingActions.tsx
+++ b/src/actions/DeepLinkingActions.tsx
@@ -284,6 +284,23 @@ async function handleLink(
       break
     }
 
+    case 'marketing': {
+      // The user opened the app from a marketing push. Report it so the
+      // campaign's open rate can be tracked. The send UI lives in the internal
+      // tools project; the campaignId rides in the push notification payload.
+      dispatch(
+        logEvent('Marketing_Notification_Opened', {
+          campaignId: link.campaignId
+        })
+      )
+      // Optional navigation: delegate to the shared handler, mirroring the
+      // affiliate link. Unsupported targets fall through its existing guards.
+      if (link.link != null) {
+        await handleLink(navigation, dispatch, state, link.link)
+      }
+      break
+    }
+
     case 'other': {
       const matchingWalletIdsAndUris: Array<{
         walletId: string

--- a/src/actions/DeepLinkingActions.tsx
+++ b/src/actions/DeepLinkingActions.tsx
@@ -93,6 +93,16 @@ export function getDeepLinkReadiness(link: DeepLink): DeepLinkReadiness {
         : 'referral'
     }
 
+    // Tracking the open needs the account; navigation then waits for whatever
+    // the campaign's own link needs, if it carries one:
+    case 'marketing': {
+      const inner =
+        link.link == null ? 'account' : getDeepLinkReadiness(link.link)
+      return deepLinkReadinessRank[inner] > deepLinkReadinessRank.account
+        ? inner
+        : 'account'
+    }
+
     // These search `account.currencyWallets` or open a wallet picker, so a
     // half-loaded account would show an incomplete list or no match at all.
     // `walletConnect` belongs here because `WcConnectionsScene` opens the
@@ -446,6 +456,23 @@ async function handleLink(
         navigation.navigate('swapTab', { screen: 'swapCreate' })
       }
 
+      break
+    }
+
+    case 'marketing': {
+      // The user opened the app from a marketing push. Report it so the
+      // campaign's open rate can be tracked. The send UI lives in the internal
+      // tools project; the campaignId rides in the push notification payload.
+      dispatch(
+        logEvent('Push_Notification_Opened', {
+          campaignId: link.campaignId
+        })
+      )
+      // Optional navigation: delegate to the shared handler, mirroring the
+      // affiliate link. Unsupported targets fall through its existing guards.
+      if (link.link != null) {
+        await handleLink(navigation, dispatch, state, link.link)
+      }
       break
     }
 

--- a/src/types/DeepLinkTypes.ts
+++ b/src/types/DeepLinkTypes.ts
@@ -101,6 +101,12 @@ export interface PriceChangeLink {
   body: string // Human-readable message
 }
 
+export interface MarketingLink {
+  type: 'marketing'
+  campaignId: string // Correlates notification opens to a marketing campaign
+  link?: DeepLink // Optional navigation target parsed from the payload URL
+}
+
 export interface RampLink {
   type: 'ramp'
   direction: FiatDirection
@@ -165,6 +171,7 @@ export type DeepLink =
   | EdgeLoginLink
   | FiatPluginLink
   | FiatProviderLink
+  | MarketingLink
   | ModalLink
   | NoopLink
   | PasswordRecoveryLink

--- a/src/types/DeepLinkTypes.ts
+++ b/src/types/DeepLinkTypes.ts
@@ -141,6 +141,12 @@ export interface RampCreateLink {
   paymentType?: FiatPaymentType
 }
 
+export interface MarketingLink {
+  type: 'marketing'
+  campaignId: string // Correlates notification opens to a marketing campaign
+  link?: DeepLink // Optional navigation target parsed from the payload URL
+}
+
 /**
  * A provider return link (e.g. Simplex or Paybis sending the user back into the
  * app once their session finishes). Handled by the ramp deeplink manager, not
@@ -210,6 +216,7 @@ export type DeepLink =
   | EdgeLoginLink
   | FiatPluginLink
   | FiatProviderLink
+  | MarketingLink
   | ModalLink
   | NoopLink
   | PasswordRecoveryLink

--- a/src/util/PushMessageParser.ts
+++ b/src/util/PushMessageParser.ts
@@ -1,7 +1,9 @@
 import type { FirebaseMessagingTypes } from '@react-native-firebase/messaging'
-import { asMaybe, asObject, asString, asValue } from 'cleaners'
+import { asMaybe, asObject, asOptional, asString, asValue } from 'cleaners'
 
+import { showDevError } from '../components/services/AirshipInstance'
 import type { DeepLink } from '../types/DeepLinkTypes'
+import { parseDeepLink } from './DeepLinkParser'
 
 /**
  * Extracts a deep link from a push message, if present.
@@ -17,9 +19,38 @@ export function parsePushMessage(
       body: asString(message.notification?.body)
     }
   }
+
+  const marketing = asMaybe(asMarketingPayloadData)(message.data)
+  if (marketing != null) {
+    let link: DeepLink | undefined
+    if (marketing.url != null) {
+      try {
+        const parsed = parseDeepLink(marketing.url)
+        // Only navigate for a recognized Edge deep link. `parseDeepLink` is
+        // lenient and returns an `other` link for anything it does not know, so
+        // an unrecognized or malformed URL degrades to track-only.
+        if (parsed.type !== 'other') link = parsed
+      } catch (error: unknown) {
+        // parseDeepLink can still throw on some malformed input; never let that
+        // drop the push, or we would also lose the open tracking.
+        showDevError(error)
+      }
+    }
+    return {
+      type: 'marketing',
+      campaignId: marketing.campaignId,
+      link
+    }
+  }
 }
 
 const asPriceChangePayloadData = asObject({
   type: asValue('price-change'),
   pluginId: asString
+})
+
+const asMarketingPayloadData = asObject({
+  type: asValue('marketing'),
+  campaignId: asString,
+  url: asOptional(asString)
 })

--- a/src/util/PushMessageParser.ts
+++ b/src/util/PushMessageParser.ts
@@ -1,7 +1,9 @@
 import type { FirebaseMessagingTypes } from '@react-native-firebase/messaging'
-import { asMaybe, asObject, asString, asValue } from 'cleaners'
+import { asMaybe, asObject, asOptional, asString, asValue } from 'cleaners'
 
+import { showDevError } from '../components/services/AirshipInstance'
 import type { DeepLink } from '../types/DeepLinkTypes'
+import { parseDeepLink } from './DeepLinkParser'
 
 /**
  * Extracts a deep link from a push message, if present.
@@ -17,9 +19,39 @@ export function parsePushMessage(
       body: asString(message.notification?.body)
     }
   }
+
+  const marketing = asMaybe(asMarketingPayloadData)(message.data)
+  if (marketing != null) {
+    let link: DeepLink | undefined
+    if (marketing.url != null) {
+      try {
+        const parsed = parseDeepLink(marketing.url)
+        // A campaign navigates wherever its URL points, the same as a link the
+        // user taps anywhere else. `parseDeepLink` is lenient and answers
+        // `other` for anything it does not recognize, so a malformed campaign
+        // URL tracks the open without navigating.
+        if (parsed.type !== 'other') link = parsed
+      } catch (error: unknown) {
+        // parseDeepLink can still throw on some malformed input; never let that
+        // drop the push, or we would also lose the open tracking.
+        showDevError(error)
+      }
+    }
+    return {
+      type: 'marketing',
+      campaignId: marketing.campaignId,
+      link
+    }
+  }
 }
 
 const asPriceChangePayloadData = asObject({
   type: asValue('price-change'),
   pluginId: asString
+})
+
+const asMarketingPayloadData = asObject({
+  type: asValue('marketing'),
+  campaignId: asString,
+  url: asOptional(asString)
 })

--- a/src/util/tracking.ts
+++ b/src/util/tracking.ts
@@ -44,6 +44,7 @@ export type TrackingEventName =
   | 'Fio_Handle_Bundled_Tx'
   | 'Load_Install_Reason_Match'
   | 'Load_Install_Reason_Fail'
+  | 'Marketing_Notification_Opened'
   | 'Sell_Quote'
   | 'Sell_Quote_Next'
   | 'Sell_Success'
@@ -152,6 +153,7 @@ export interface TrackingValues extends LoginTrackingValues {
   surveyCategory2?: string // User's answer to a survey (first tier response)
   surveyResponse2?: string // User's answer to a survey
   appleAdsKeywordId?: string // Apple Search Ads attribution keyword ID
+  campaignId?: string // Marketing push campaign identifier (notification opens)
 
   // Conversion values
   conversionValues?:

--- a/src/util/tracking.ts
+++ b/src/util/tracking.ts
@@ -44,6 +44,7 @@ export type TrackingEventName =
   | 'Fio_Handle_Bundled_Tx'
   | 'Load_Install_Reason_Match'
   | 'Load_Install_Reason_Fail'
+  | 'Push_Notification_Opened'
   | 'Sell_Quote'
   | 'Sell_Quote_Next'
   | 'Sell_Success'
@@ -152,6 +153,7 @@ export interface TrackingValues extends LoginTrackingValues {
   surveyCategory2?: string // User's answer to a survey (first tier response)
   surveyResponse2?: string // User's answer to a survey
   appleAdsKeywordId?: string // Apple Search Ads attribution keyword ID
+  campaignId?: string // Marketing push campaign identifier (notification opens)
 
   // Conversion values
   conversionValues?:


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

No visual changes — this is push-payload parsing plus navigation/analytics, no new UI.

### Description

Recognizes a marketing push notification and, when the user opens the app from it, reports the campaign open to analytics and navigates to an optional deep link.

- `parsePushMessage` now recognizes a `{ type: 'marketing', campaignId, url? }` FCM `data` payload and returns a new `MarketingLink` deep-link type. An unrecognized or malformed `url` degrades to track-only.
- On open (background tap or cold start), the deep-link handler dispatches a `Marketing_Notification_Opened` PostHog event carrying the `campaignId`, then navigates to the optional deep link through the existing handler.
- Adds a `PushMessageParser` unit test.

Verified with the unit test and end-to-end on a real Android device against a local push server: the open was tracked in PostHog and the deep link navigated.

The sending side lives in edge-push-server (companion PR EdgeApp/edge-push-server#78). This PR is the receiving side and is safe to merge on its own — it only acts on notifications that carry the marketing payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Push URLs can drive navigation for all campaign recipients; the allow-list mitigates operator error or compromised send keys, but expanding destinations or parser gaps could still route users to sensitive flows.
> 
> **Overview**
> Marketing push notifications (`type: marketing` with `campaignId` and optional `url`) are now recognized when the user opens the app from the notification.
> 
> **`parsePushMessage`** returns a new **`MarketingLink`** deep-link type. Optional URLs are parsed through the existing deep-link parser; only allow-listed campaign destinations (home, wallets, earn, markets, swap, buy/sell quotes, promotions, fund-account modal) trigger navigation—sensitive or unlisted targets (recovery, edge-login, arbitrary scenes, provider returns) are **track-only**. Wrapped `deep.edge.app` URLs are judged by their inner destination; malformed URLs still record the open.
> 
> On handle, **`DeepLinkingActions`** logs **`Marketing_Notification_Opened`** to analytics with **`campaignId`**, then navigates via the shared link handler when a permitted link was parsed. **`PushMessageParser.test.ts`** covers destinations, refusals, attribution wrappers, and existing price-change payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cdb570641d3c2bc7177862b5568eb7c3578dff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217100567720587