### PR TITLE
Fix Share button referral link to use dl.edge.app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added: NYM swap provider (`nymswap`)
 - changed: Route maestro test builds to a dedicated Zealot channel so they no longer appear in the production release list.
 - changed: Hide the wallet "Get Raw Keys" option behind Developer Mode, while still showing it for wallets that fail to load.
+- fixed: Share button referral link now uses the dl.edge.app deep-link domain so appreferred attribution is tracked
 - removed: SideShift `privateKey` from env config; the swap integration no longer sends the affiliate secret header.
 
 ## 4.49.0 (staging)

--- a/src/components/themed/SideMenu.tsx
+++ b/src/components/themed/SideMenu.tsx
@@ -199,7 +199,13 @@ export function SideMenuComponent(props: Props): React.ReactElement {
       .replace('0x', '')
       .substring(0, 10)
 
-    const url = `${config.website}?af=appreferred_${refId}`
+    // Share the app via the AppsFlyer deep-link URL so the appreferred referral
+    // attribution (refDeviceInstallerId) is tracked. Defaults to dl.edge.app for
+    // Edge; white-label builds fall back to their own website domain. The trailing
+    // slash before the query matches the dl.edge.app deep-link format (see
+    // DeepLinkParser), which AppsFlyer needs to resolve the attribution.
+    const shareUrlBase = config.referralAppShareUrl ?? config.website
+    const url = `${shareUrlBase}/?af=appreferred_${refId}`
     const subject = sprintf(lstrings.share_subject, config.appName)
 
     await Share.open({

--- a/src/theme/edgeConfig.ts
+++ b/src/theme/edgeConfig.ts
@@ -37,6 +37,7 @@ export const edgeConfig: AppConfig = {
   supportSite: 'https://help.edge.app/support/tickets/new',
   termsOfServiceSite: 'https://edge.app/tos/',
   website: 'https://edge.app',
+  referralAppShareUrl: 'https://dl.edge.app',
   supportChatSite: 'https://support.edge.app/hc/en-us?chat=open',
   quickActions: {
     uninstallWarningUrl:

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -376,6 +376,12 @@ export interface AppConfig {
   supportSite: string
   termsOfServiceSite: string
   website: string
+  /**
+   * Base URL used when sharing the app for referral attribution (the AppsFlyer
+   * deep-link domain). Falls back to `website` when unset so white-label builds
+   * share links on their own domain.
+   */
+  referralAppShareUrl?: string
   disableSwaps?: boolean
   disableSurveyModal?: boolean
   /**


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

The side-menu "Share Edge" action built its referral URL from the bare website
domain (`config.website` = `https://edge.app`), producing
`https://edge.app?af=appreferred_<refId>`. AppsFlyer `refDeviceInstallerId`
attribution works for other `af=` links but not for `appreferred` shares.

This routes the share link through the AppsFlyer deep-link subdomain so the
`appreferred` attribution is tracked, matching how other `af=` attributions
already resolve:

`https://dl.edge.app?af=appreferred_<refId>`

Only `SideMenu.handleShareApp` changes. `config.website` is untouched, so the
Help modal official-site link still points at `edge.app`.

Tested on the iOS simulator: opened the side menu, tapped "Share Edge", and the
native share sheet link preview resolves to `dl.edge.app` (screenshot below).

Asana: https://app.asana.com/0/1215088146871429/1206924232175184

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single share-handler URL change with config fallback; no auth, payments, or wallet logic touched.
> 
> **Overview**
> Side-menu **Share Edge** no longer builds referral URLs from `config.website` (`https://edge.app?af=appreferred_…`). It now uses a dedicated AppsFlyer deep-link base so `appreferred` shares get **`refDeviceInstallerId`** attribution like other `af=` links.
> 
> Adds optional **`referralAppShareUrl`** on app config (Edge sets **`https://dl.edge.app`**). Share links become `https://dl.edge.app/?af=appreferred_<refId>` with the **`/?`** path shape expected by **`DeepLinkParser`** and AppsFlyer. White-label builds without the field still fall back to **`website`**. **`config.website`** is unchanged elsewhere (e.g. Help official site).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6950fe4449ae0aaeb960db9c59354cfd1094808c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->