### PR TITLE
Hide Get Raw Keys behind Developer Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - changed: Route maestro test builds to a dedicated Zealot channel so they no longer appear in the production release list.
+- changed: Hide the wallet "Get Raw Keys" option behind Developer Mode, while still showing it for wallets that fail to load.
 
 ## 4.49.0 (staging)
 

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -147,6 +147,9 @@ export const WalletListMenuModal: React.FC<Props> = props => {
   const pausedWallets = useSelector(
     state => state.ui.settings.userPausedWalletsSet
   )
+  const developerModeOn = useSelector(
+    state => state.ui.settings.developerModeOn
+  )
 
   const wallet = useWatch(account, 'currencyWallets')[walletId]
 
@@ -273,6 +276,11 @@ export const WalletListMenuModal: React.FC<Props> = props => {
           (value === 'getSeed' || value === 'getRawKeys')
         )
           continue
+
+        // Hide `getRawKeys` behind Developer Mode. Wallets that fail to load
+        // still expose raw keys via the `wallet == null` branch above, so a
+        // broken wallet can always be recovered regardless of this setting.
+        if (value === 'getRawKeys' && !developerModeOn) continue
 
         result.push({ label, value })
       }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

`- changed: Hide the wallet "Get Raw Keys" option behind Developer Mode, while still showing it for wallets that fail to load.`

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

[Asana task](https://app.asana.com/0/0/1208354993842606/f)

Asana: https://app.asana.com/1/9976422036640/project/1201386023359449/task/1208354993842606

Hides the `Get Raw Keys` item in the wallet overflow menu unless the account has Developer Mode enabled. Raw Keys is a power-user tool; gating it behind Developer Mode declutters the menu for normal users while keeping the capability available to those who need it.

The safety fallback is preserved: when a wallet fails to load (`wallet == null`), Raw Keys still appears unconditionally, so keys can always be recovered from a broken wallet. This is handled by a separate early-return branch that is intentionally not gated.

No change was needed to make the Raw Keys JSON read-only: `RawTextModal` already renders the content as read-only text (a `Paragraph`, not an input) and `getRawKeys` passes `disableCopy`.

Implementation: read `state.ui.settings.developerModeOn` in `WalletListMenuModal`, and skip the `getRawKeys` option in the menu loop when Developer Mode is off.

Test evidence (iOS sim, edge-funds) attached below: menu with Developer Mode ON shows Get Raw Keys; menu with Developer Mode OFF hides it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI gating change in the wallet menu with an explicit recovery exception for wallets that fail to load; no changes to key export APIs or authentication.
> 
> **Overview**
> **Get Raw Keys** in the wallet list overflow menu is now shown only when **Developer Mode** is enabled (`state.ui.settings.developerModeOn`), so normal users see a simpler menu while power users can still reach raw key export from settings.
> 
> The modal reads that flag and skips the `getRawKeys` entry when building options for loaded wallets. **Recovery is unchanged:** if the wallet object is missing (`wallet == null`), the menu still offers Get Raw Keys (and archive) with no Developer Mode check, so keys can be exported from a broken wallet. Existing rules for light accounts (no seed/raw keys when username is null) and the loaded-wallet path are otherwise the same.
> 
> CHANGELOG documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35e3d644072f4d754d44befcd9182daf2466fef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->