### PR TITLE
Sign MoonPay widget URLs with IP binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- changed: Sign MoonPay buy/sell widget URLs and bind them to the customer's IP via the info server, for MoonPay's on-ramp IP-matching security upgrade.
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/src/components/buttons/PillButton.tsx
+++ b/src/components/buttons/PillButton.tsx
@@ -19,6 +19,7 @@ export interface PillButtonProps extends LayoutStyleProps {
   children?: React.ReactNode
   chevronDown?: boolean
   chevronRight?: boolean
+  testID?: string
 }
 
 export const PillButton: React.FC<PillButtonProps> = (
@@ -32,6 +33,7 @@ export const PillButton: React.FC<PillButtonProps> = (
     children,
     chevronDown = false,
     chevronRight = false,
+    testID,
     ...marginProps
   } = props
   const marginStyle = useLayoutStyle(marginProps)
@@ -45,6 +47,7 @@ export const PillButton: React.FC<PillButtonProps> = (
       disabled={disabled}
       hitSlop={theme.rem(0.5)}
       onPress={onPress}
+      testID={testID}
     >
       <LinearGradient
         style={styles.gradient}

--- a/src/components/cards/PaymentOptionCard.tsx
+++ b/src/components/cards/PaymentOptionCard.tsx
@@ -23,6 +23,8 @@ interface Props {
   }
   /** Show "Best Rate" badge */
   isBestOption?: boolean
+  /** Applied to the partner pill, which opens the provider picker */
+  providerTestID?: string
 
   // Events:
   onPress: () => Promise<void> | void
@@ -72,6 +74,7 @@ export const PaymentOptionCard: React.FC<Props> = (props: Props) => {
             label={props.partner?.displayName ?? ''}
             onPress={props.onProviderPress}
             chevronDown
+            testID={props.providerTestID}
           />
         </View>
       )}

--- a/src/components/scenes/RampCreateScene.tsx
+++ b/src/components/scenes/RampCreateScene.tsx
@@ -864,7 +864,10 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
             />
           ) : (
             <>
-              <DropdownInputButton onPress={handleCryptDropdown}>
+              <DropdownInputButton
+                onPress={handleCryptDropdown}
+                testID="rampCryptoDropdown"
+              >
                 {isLoadingPersistedCryptoSelection ? (
                   <ActivityIndicator />
                 ) : selectedCrypto == null || selectedWallet == null ? null : (

--- a/src/components/scenes/RampSelectOptionScene.tsx
+++ b/src/components/scenes/RampSelectOptionScene.tsx
@@ -405,6 +405,7 @@ const QuoteResult: React.FC<{
         icon: { uri: providerQuote.partnerIcon }
       }}
       isBestOption={isBestOption}
+      providerTestID={`providerPill_${providerQuote.paymentType}`}
       onPress={handlePress}
       onProviderPress={handleProviderPress}
     />

--- a/src/plugins/gui/providers/moonpayProvider.ts
+++ b/src/plugins/gui/providers/moonpayProvider.ts
@@ -52,6 +52,7 @@ import {
   RETURN_URL_PAYMENT,
   validateExactRegion
 } from './common'
+import { signMoonpayUrl } from './moonpaySign'
 const providerId = 'moonpay'
 const storeId = 'com.moonpay'
 const partnerIcon = 'moonpay_symbol_prp.png'
@@ -644,6 +645,7 @@ export const moonpayProvider: FiatProviderFactory = {
               }
               urlObj.set('query', queryObj)
               console.log('Approving moonpay buy quote url=' + urlObj.href)
+              const signedUrl = await signMoonpayUrl(urlObj.href)
               const handleBuyDeeplinkAsync = async (
                 link: unknown
               ): Promise<void> => {
@@ -696,7 +698,7 @@ export const moonpayProvider: FiatProviderFactory = {
                 handleBuyDeeplinkAsync(link).catch(() => {})
               }
               await showUi.openExternalWebView({
-                url: urlObj.href,
+                url: signedUrl,
                 providerId,
                 deeplinkHandler: handleBuyDeeplink
               })
@@ -719,6 +721,7 @@ export const moonpayProvider: FiatProviderFactory = {
               }
               urlObj.set('query', queryObj)
               console.log('Approving moonpay sell quote url=' + urlObj.href)
+              const signedUrl = await signMoonpayUrl(urlObj.href)
 
               let inPayment = false
 
@@ -868,7 +871,7 @@ export const moonpayProvider: FiatProviderFactory = {
                   onUrlChangeAsync(uri).catch(() => {})
                 }
                 await showUi.openWebView({
-                  url: urlObj.href,
+                  url: signedUrl,
                   onUrlChange,
                   onClose: () => {}
                 })

--- a/src/plugins/gui/providers/moonpaySign.ts
+++ b/src/plugins/gui/providers/moonpaySign.ts
@@ -1,0 +1,28 @@
+import { asObject, asString } from 'cleaners'
+
+import { fetchInfo } from '../../../util/network'
+
+const asMoonpaySignResponse = asObject({ signedUrl: asString })
+
+/**
+ * Ask the info server to bind a Moonpay widget URL to the caller's public IP
+ * and sign it. Moonpay's on-ramp security upgrade refuses to load widget URLs
+ * that are not signed and IP-bound, so every buy/sell widget URL must be routed
+ * through here before it is opened.
+ */
+export const signMoonpayUrl = async (url: string): Promise<string> => {
+  const response = await fetchInfo(
+    'v1/moonpay/signUrl',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url })
+    },
+    10000
+  )
+  if (!response.ok) {
+    throw new Error(`Moonpay URL signing failed: ${response.status}`)
+  }
+  const reply = await response.json()
+  return asMoonpaySignResponse(reply).signedUrl
+}

--- a/src/plugins/ramps/moonpay/moonpayRampPlugin.ts
+++ b/src/plugins/ramps/moonpay/moonpayRampPlugin.ts
@@ -45,6 +45,7 @@ import {
   RETURN_URL_PAYMENT,
   validateExactRegion
 } from '../../gui/providers/common'
+import { signMoonpayUrl } from '../../gui/providers/moonpaySign'
 import { addTokenToArray } from '../../gui/util/providerUtils'
 import { rampDeeplinkManager } from '../rampDeeplinkHandler'
 import type {
@@ -834,9 +835,10 @@ export const moonpayRampPlugin: RampPluginFactory = (
                 }
                 urlObj.set('query', queryObj)
                 console.log('Approving moonpay buy quote url=' + urlObj.href)
+                const signedUrl = await signMoonpayUrl(urlObj.href)
 
                 deeplinkToken = await openExternalWebView({
-                  url: urlObj.href,
+                  url: signedUrl,
                   deeplink: {
                     direction: 'buy',
                     providerId: pluginId,
@@ -998,9 +1000,12 @@ export const moonpayRampPlugin: RampPluginFactory = (
                 let inPayment = false
 
                 const openWebView = async (): Promise<void> => {
+                  // Re-sign on every open: IP-bound signatures must be fresh, and
+                  // this path re-opens the widget on a failed/cancelled send.
+                  const signedUrl = await signMoonpayUrl(urlObj.href)
                   await new Promise<void>((resolve, reject) => {
                     navigation.navigate('guiPluginWebView', {
-                      url: urlObj.href,
+                      url: signedUrl,
                       onClose: () => {
                         resolve()
                       },


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> Runtime dependency on EdgeApp/edge-info-server#155 (the `POST /v1/moonpay/signUrl` route) being deployed, and ops provisioning `providers.moonpay` in the `createHmac` couch doc.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

No visual changes: this routes each MoonPay buy/sell widget URL through the info server to be IP-bound and signed before it is opened.

### Description

[Asana task](https://app.asana.com/0/0/1216403654258324/f)

MoonPay's on-ramp security upgrade ("IP Matching", hard deadline Aug 7 / prod switch Aug 8) makes MoonPay refuse to load widget URLs that are not signed and bound to a hash of the customer's device IP.

Adds a `signMoonpayUrl(url)` helper that posts the built widget URL to the info server's `POST /v1/moonpay/signUrl` (EdgeApp/edge-info-server#155), which captures the caller's public IP and returns the URL with `allowedIpAddress` + `signature` appended. The helper is wired into every MoonPay widget launch, in both live code paths:

- `src/plugins/ramps/moonpay/moonpayRampPlugin.ts` (new ramps plugin) — buy + sell
- `src/plugins/gui/providers/moonpayProvider.ts` (legacy provider, still registered via `amountQuotePlugin`) — buy + sell

Each path signs the URL immediately before opening the widget webview and opens the signed URL.

Testing: end-to-end in-app widget load is blocked on external preconditions (route not yet deployed, MoonPay secret not yet provisioned in couch, MoonPay enforcement not enabled until Aug 8). The signing mechanism is verified in edge-info-server (unit-tested against the guide's reference vector + a real HTTP round-trip whose signature passes MoonPay's re-derivation). This client change is verified by `tsc`, `npm run verify`/jest (123 related tests), and eslint.

Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1216403654258324

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All MoonPay widget launches now depend on the info server signing route and correct ops config; signing failures block buy/sell until deployed, but changes are localized to MoonPay URL handling plus test IDs.
> 
> **Overview**
> MoonPay buy and sell widget URLs are no longer opened directly. A new `signMoonpayUrl` helper POSTs each built URL to the info server (`POST v1/moonpay/signUrl`), which returns an IP-bound, signed URL MoonPay requires for its on-ramp security upgrade.
> 
> That helper is wired into **both** MoonPay integrations before the webview opens: the legacy `moonpayProvider` and `moonpayRampPlugin` (buy external webview and sell webview). On the sell path that can re-open the widget after a failed/cancelled send, the URL is **re-signed on each open** so signatures stay fresh.
> 
> The PR also threads optional `testID`s through ramp UI (`PillButton`, provider pill on payment option cards, crypto dropdown, per-payment-type provider pills) for Maestro automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94420c11aa1a159bc4170fdc863e4f62f3d75c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->