### PR TITLE
Map Banxa's consolidated Google Pay and migrated ACH sell payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - changed: Hide the wallet "Get Raw Keys" option behind Developer Mode, while still showing it for wallets that fail to load.
 - fixed: Share button referral link now uses the dl.edge.app deep-link domain so appreferred attribution is tracked
 - fixed: MoonPay "Send with Edge" sell link now opens the app to a pre-filled Send scene. All ramp redirect URLs (payment, success, fail, cancel) point at the claimed deep.edge.app.
+- fixed: Banxa Google Pay and ACH sell payment methods after Banxa consolidated its Google Pay PSPs (`PRIMERGP`) and migrated ACH sell (`BRDGACHSELL`).
 - removed: SideShift `privateKey` from env config; the swap integration no longer sends the affiliate secret header.
 
 ## 4.49.1 (2026-07-09)

--- a/src/plugins/gui/providers/banxaProvider.ts
+++ b/src/plugins/gui/providers/banxaProvider.ts
@@ -121,6 +121,7 @@ const asBanxaTxLimit = asObject({
 })
 
 const asBanxaPaymentType = asValue(
+  'BRDGACHSELL',
   'CLEARJCNSELLFP',
   'CLEARJCNSELLSEPA',
   'CLEARJUNCTION',
@@ -135,6 +136,7 @@ const asBanxaPaymentType = asValue(
   'MONOOVAPAYID',
   'PRIMERAP',
   'PRIMERCC',
+  'PRIMERGP',
   'WORLDPAYGOOGLE',
   'ZHACHSELL'
 )
@@ -1081,6 +1083,7 @@ const addToAllowedCurrencies = (
 }
 
 const typeMap: Record<BanxaPaymentType, FiatPaymentType> = {
+  BRDGACHSELL: 'ach',
   CLEARJCNSELLFP: 'fasterpayments',
   CLEARJCNSELLSEPA: 'sepa',
   CLEARJUNCTION: 'sepa',
@@ -1095,6 +1098,7 @@ const typeMap: Record<BanxaPaymentType, FiatPaymentType> = {
   MONOOVAPAYID: 'payid',
   PRIMERAP: 'applepay',
   PRIMERCC: 'credit',
+  PRIMERGP: 'googlepay',
   WORLDPAYGOOGLE: 'googlepay',
   ZHACHSELL: 'ach'
 }

--- a/src/plugins/ramps/banxa/banxaRampPlugin.ts
+++ b/src/plugins/ramps/banxa/banxaRampPlugin.ts
@@ -142,6 +142,7 @@ const asBanxaTxLimit = asObject({
 })
 
 const asBanxaPaymentType = asValue(
+  'BRDGACHSELL',
   'CLEARJCNSELLFP',
   'CLEARJCNSELLSEPA',
   'CLEARJUNCTION',
@@ -156,6 +157,7 @@ const asBanxaPaymentType = asValue(
   'MONOOVAPAYID',
   'PRIMERAP',
   'PRIMERCC',
+  'PRIMERGP',
   'WORLDPAYGOOGLE',
   'ZHACHSELL'
 )
@@ -322,6 +324,7 @@ const COIN_TO_CURRENCY_CODE_MAP: StringMap = { BTC: 'BTC' }
 const asInfoCreateHmacResponse = asObject({ signature: asString })
 
 const typeMap: Record<BanxaPaymentType, FiatPaymentType> = {
+  BRDGACHSELL: 'ach',
   CLEARJCNSELLFP: 'fasterpayments',
   CLEARJCNSELLSEPA: 'sepa',
   CLEARJUNCTION: 'sepa',
@@ -336,6 +339,7 @@ const typeMap: Record<BanxaPaymentType, FiatPaymentType> = {
   MONOOVAPAYID: 'payid',
   PRIMERAP: 'applepay',
   PRIMERCC: 'credit',
+  PRIMERGP: 'googlepay',
   WORLDPAYGOOGLE: 'googlepay',
   ZHACHSELL: 'ach'
 }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

[Asana task](https://app.asana.com/0/0/1210642564105750/f)

Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1210642564105750

Banxa consolidated its multiple per-currency Google Pay PSPs into a single new PSP and migrated its ACH sell method to a new PSP code. Edge maps Banxa `paymentType` strings to internal `FiatPaymentType`s through a strict allowlist (`asBanxaPaymentType`) plus a `typeMap`; any code not in the allowlist is dropped (via `asMaybe`). The new codes were not in the map, so:

- Google Pay: the new `PRIMERGP` PSP was dropped, which is why US Google Pay conversion fell to near zero (the legacy `WORLDPAYGOOGLE` methods Banxa is retiring were the only ones recognized).
- ACH sell: the old `ZHACHSELL` code is no longer returned by Banxa (replaced by `BRDGACHSELL`), so ACH sell was silently broken.

This adds both codes to the allowlist and `typeMap`:

- `PRIMERGP` -> `googlepay`
- `BRDGACHSELL` -> `ach`

Both Banxa integrations carry the same mapping and both are updated to stay in sync: the live ramps plugin (`src/plugins/ramps/banxa/banxaRampPlugin.ts`) and the legacy provider (`src/plugins/gui/providers/banxaProvider.ts`).

The codes were confirmed against Banxa's live production `api/payment-methods` response (`PRIMERGP` id 6142 "Google Pay", `BRDGACHSELL` id 6151 "ACH", both ACTIVE). The legacy `WORLDPAYGOOGLE` entries remain ACTIVE during Banxa's transition, so both old and new Google Pay codes are kept mapped; Banxa disables the old ones once the new code is live.

Out of scope (deferred): other newly-available Banxa PSPs (PayPal, Klarna, SPEI, Khipu, VietQR, AU bank transfer) map to payment types that are not yet wired into Edge's `allowedPaymentTypes`/UI and need broader work. SEPA is intentionally left disabled (deferred to Bity).

### Testing

Verified in-app on the iOS simulator by driving the ramps Buy and Sell flows and capturing the live `banxaRampPlugin` mapping against Banxa's production `api/payment-methods` response:

- Buy: `PRIMERGP` #6142 (ACTIVE) -> `googlepay`
- Sell: `BRDGACHSELL` #6151 (ACTIVE) -> `ach`

Without this change both would map to `undefined` and be dropped. Note: Google Pay is an Android-only payment method in Edge (`buyPluginList.json` `forPlatform: android`), so it does not render in the iOS payment-method list; the mapping itself was verified executing on-device against live data. `tsc --noEmit`, eslint, and the jest suite pass; the `Record<BanxaPaymentType, FiatPaymentType>` type also enforces union/map consistency at compile time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small allowlist/typeMap additions in fiat ramp code only; no auth, payments execution, or data-model changes beyond recognizing new Banxa API codes.
> 
> **Overview**
> Banxa changed PSP codes for **Google Pay** (`PRIMERGP`) and **ACH sell** (`BRDGACHSELL`). Edge only surfaces methods whose `paymentType` is in `asBanxaPaymentType` and mapped in `typeMap`; anything else is dropped, so US Google Pay and ACH sell stopped appearing after Banxa’s migration.
> 
> This PR adds both codes to the allowlist and maps them to `googlepay` and `ach` in **`banxaRampPlugin.ts`** and **`banxaProvider.ts`**, keeping the two integrations aligned. Legacy `WORLDPAYGOOGLE` and `ZHACHSELL` mappings stay for Banxa’s transition period. **CHANGELOG** notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a5760d5c5eaddd00c75fb75a107b4c5b1d98ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->