### PR TITLE
Add BRIDGELESS_INIT env config for the swap referral id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - added: NYM swap provider (`nymswap`)
+- added: Optional Bridgeless swap referral id via the `BRIDGELESS_INIT` env config, passed through to the swap plugin.
 - changed: Route maestro test builds to a dedicated Zealot channel so they no longer appear in the production release list.
 - changed: Hide the wallet "Get Raw Keys" option behind Developer Mode, while still showing it for wallets that fail to load.
 - fixed: Share button referral link now uses the dl.edge.app deep-link domain so appreferred attribution is tracked

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -240,6 +240,14 @@ export const asEnvConfig = asObject({
     })
   ),
   BOTANIX_INIT: asCorePluginInit(asEvmApiKeys),
+  // Bridgeless is enabled by default (no key required). An optional referralId
+  // (uint16) is passed through to the swap plugin to earn referral revenue.
+  BRIDGELESS_INIT: asOptional(
+    asObject({
+      referralId: asOptional(asNumber)
+    }).withRest,
+    { referralId: undefined }
+  ),
   MAYACHAIN_INIT: asCorePluginInit(asBoolean),
   CARDANO_INIT: asCorePluginInit(
     asObject({

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -103,7 +103,7 @@ export const swapPlugins = {
   nymswap: ENV.NYM_SWAP_INIT,
 
   // Defi Swaps
-  bridgeless: true,
+  bridgeless: ENV.BRIDGELESS_INIT,
   rango: ENV.RANGO_INIT,
   spookySwap: false,
   mayaprotocol: ENV.MAYA_PROTOCOL_INIT,


### PR DESCRIPTION
Wires the Bridgeless swap plugin's new optional `referralId` init option through the GUI env config:

- `envConfig.ts`: new `BRIDGELESS_INIT` cleaner — `{ referralId?: number }` (uint16). Deliberately **not** `asCorePluginInit`: the plugin stays enabled by default when the key is absent (it was `bridgeless: true` before), and `{}`/`{ referralId }` both enable it.
- `corePlugins.ts`: `bridgeless: true` → `bridgeless: ENV.BRIDGELESS_INIT`, so the object reaches the plugin as its `initOptions`.

With no `BRIDGELESS_INIT` in env.json, behavior is identical to today (no referral in deposit payloads). Once Edge's referral id is provisioned on the Bridgeless registry, adding `"BRIDGELESS_INIT": { "referralId": <uint16> }` to env.json tags every Bridgeless deposit (EVM / Zano / BTC-BCH / Solana / TON) for referral revenue.

Companion to EdgeApp/edge-exchange-plugins referral + Solana/TON PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only wiring for an already-enabled swap plugin; no change when BRIDGELESS_INIT is omitted.
> 
> **Overview**
> Adds **`BRIDGELESS_INIT`** in `envConfig.ts` so an optional **`referralId`** (number) can be set in `env.json` and passed to the Bridgeless swap plugin as init options. The cleaner uses **`asOptional`** with a default of `{ referralId: undefined }` instead of **`asCorePluginInit`**, so Bridgeless stays **on by default** when the key is missing (matching the previous `bridgeless: true` behavior).
> 
> **`corePlugins.ts`** now maps **`bridgeless: ENV.BRIDGELESS_INIT`** instead of **`bridgeless: true`**, forwarding the config object to the plugin. With no env entry, behavior is unchanged; setting `"BRIDGELESS_INIT": { "referralId": <uint16> }` tags Bridgeless deposits for referral revenue once Edge’s id is registered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baeff179b5d8d264ad9a9ba01780a3237eef1ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216504872021061