### PR TITLE
Add n.exchange transaction icon mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Add n.exchange icon mapping for transaction history and details.
+
 ## 4.50.0 (staging)
 
 - added: Changelly swap provider

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -720,6 +720,7 @@ export const pluginIdIcons: Record<string, string> = {
   letsexchange: EDGE_CONTENT_SERVER_URI + '/letsexchange-logo.png',
   lifi: EDGE_CONTENT_SERVER_URI + '/lifi.png',
   mayaprotocol: EDGE_CONTENT_SERVER_URI + '/mayaprotocol.png',
+  nexchange: EDGE_CONTENT_SERVER_URI + '/nexchange.png',
   rango: EDGE_CONTENT_SERVER_URI + '/rango.png',
   sideshift: EDGE_CONTENT_SERVER_URI + '/sideshift-logo.png',
   simplex: EDGE_CONTENT_SERVER_URI + '/simplex.png',


### PR DESCRIPTION
## Summary
- Add `nexchange` to the transaction/category plugin icon map
- Add an Unreleased changelog entry for the transaction history/details icon fix

## Verification
- `git diff --check`
- Checked `https://content.edge.app/exchangeIcons/nexchange.png`; direct HEAD returned 403, so the app-side mapping is in place but CDN asset availability may need reviewer confirmation.

Asana task: https://app.asana.com/0/0/1214071268047343

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only icon mapping with no auth, payment, or swap logic changes.
> 
> **Overview**
> **n.exchange** swaps already use the `nexchange` plugin elsewhere; transaction history and details were missing a provider icon because `pluginIdIcons` had no entry for that id.
> 
> This PR adds **`nexchange` → `nexchange.png`** on the content server (same pattern as other swap partners) and records the fix in **Unreleased** changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6360590fe7982076cad62662c3411cdbcc4a9a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->