### PR TITLE
Add NYM swap partner icon mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed: Share button referral link now uses the dl.edge.app deep-link domain so appreferred attribution is tracked
 - fixed: MoonPay "Send with Edge" sell link now opens the app to a pre-filled Send scene. All ramp redirect URLs (payment, success, fail, cancel) point at the claimed deep.edge.app.
 - fixed: Banxa Google Pay and ACH sell payment methods after Banxa consolidated its Google Pay PSPs (`PRIMERGP`) and migrated ACH sell (`BRDGACHSELL`).
+- fixed: Add NYM swap partner icon mapping for transaction history and details.
 - removed: SideShift `privateKey` from env config; the swap integration no longer sends the affiliate secret header.
 
 ## 4.49.1 (2026-07-09)

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -720,6 +720,7 @@ export const pluginIdIcons: Record<string, string> = {
   letsexchange: EDGE_CONTENT_SERVER_URI + '/letsexchange-logo.png',
   lifi: EDGE_CONTENT_SERVER_URI + '/lifi.png',
   mayaprotocol: EDGE_CONTENT_SERVER_URI + '/mayaprotocol.png',
+  nymswap: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/nymswap/icon.png',
   rango: EDGE_CONTENT_SERVER_URI + '/rango.png',
   sideshift: EDGE_CONTENT_SERVER_URI + '/sideshift-logo.png',
   simplex: EDGE_CONTENT_SERVER_URI + '/simplex.png',


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

NYM swap partner (`nymswap`) transactions rendered the generic "Swap Funds" icon in transaction history and details because `pluginIdIcons` in `src/actions/CategoriesActions.ts` had no entry for the `nymswap` plugin id. This adds that mapping so the partner icon renders.

Path note: the icon asset is served at `https://content.edge.app/exchangeIcons/nymswap/icon.png` (verified `200 image/png`), not the flat `/nymswap.png` path (`403`), so the entry uses the `exchangeIcons/<pluginId>/icon.png` convention (the same path `src/util/CdnUris.ts` builds for exchange icons). This is the same class of bug as the n.exchange task; the flat-path form used in [EdgeApp/edge-react-gui#6075](https://github.com/EdgeApp/edge-react-gui/pull/6075) resolves to a 403, which is why that icon is still missing.

Testing: forced `pluginIdIcons.nymswap` on the transaction rows via a throwaway local harness (reverted before commit) and confirmed the NYM partner icon loads from the content server and renders in the Ethereum Network transaction list on the iOS simulator (edge-funds). `tsc --noEmit`, jest, and eslint pass. Proof screenshot attached below.

Asana task: https://app.asana.com/0/1215088146871429/1216604842190279

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CDN URL mapping for display icons; no swap, auth, or transaction logic changes.
> 
> **Overview**
> **NYM swap (`nymswap`) transactions** now show the partner icon in transaction history and details instead of the generic swap placeholder.
> 
> Adds a **`nymswap` entry** to `pluginIdIcons` in `CategoriesActions.ts`, using the content-server path `exchangeIcons/nymswap/icon.png` (the flat `/nymswap.png` URL returns 403). **CHANGELOG** updated for 4.50.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffcec6266ebd139eaf7e542d27f2429dc24f4804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->