### PR TITLE
Add n.exchange transaction icon mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed: MoonPay "Send with Edge" sell link now opens the app to a pre-filled Send scene. All ramp redirect URLs (payment, success, fail, cancel) point at the claimed deep.edge.app.
 - fixed: Banxa Google Pay and ACH sell payment methods after Banxa consolidated its Google Pay PSPs (`PRIMERGP`) and migrated ACH sell (`BRDGACHSELL`).
 - fixed: Add NYM swap partner icon mapping for transaction history and details.
+- fixed: Add n.exchange icon mapping for transaction history and details.
 - removed: SideShift `privateKey` from env config; the swap integration no longer sends the affiliate secret header.
 
 ## 4.49.1 (2026-07-09)

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -720,6 +720,7 @@ export const pluginIdIcons: Record<string, string> = {
   letsexchange: EDGE_CONTENT_SERVER_URI + '/letsexchange-logo.png',
   lifi: EDGE_CONTENT_SERVER_URI + '/lifi.png',
   mayaprotocol: EDGE_CONTENT_SERVER_URI + '/mayaprotocol.png',
+  nexchange: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/nexchange/icon.png',
   nymswap: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/nymswap/icon.png',
   rango: EDGE_CONTENT_SERVER_URI + '/rango.png',
   sideshift: EDGE_CONTENT_SERVER_URI + '/sideshift-logo.png',


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

n.exchange (`nexchange`) swap transactions rendered the generic "Swap Funds" icon in transaction history and details because `pluginIdIcons` in `src/actions/CategoriesActions.ts` had no entry for the `nexchange` plugin id. This adds that mapping so the partner icon renders.

Path note: the icon asset is served at `https://content.edge.app/exchangeIcons/nexchange/icon.png` (verified `200 image/png`), not the flat `/nexchange.png` path used by [EdgeApp/edge-react-gui#6075](https://github.com/EdgeApp/edge-react-gui/pull/6075) (`403`). This uses the `exchangeIcons/<pluginId>/icon.png` convention, the same pattern already merged for `nymswap` in [EdgeApp/edge-react-gui#6078](https://github.com/EdgeApp/edge-react-gui/pull/6078).

Supersedes #6075 with the corrected icon path.

Testing: forced `pluginIdIcons` lookup to `nexchange` on existing swap transaction rows via a throwaway local harness (reverted before commit) and confirmed the n.exchange logo loads from the content server and renders in both the transaction list and transaction detail scene on the iOS simulator (edge-funds, My Base 4 wallet). `tsc`, jest, and eslint pass via `verify-repo.sh`. Proof screenshots attached below.

Asana task: https://app.asana.com/0/0/1214071268047343

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only icon URL mapping with no auth, payment, or swap logic changes.
> 
> **Overview**
> **n.exchange** swap rows no longer fall back to the generic swap icon in **transaction list** and **transaction details**.
> 
> Adds `nexchange` to `pluginIdIcons` in `CategoriesActions.ts`, loading the partner logo from `exchangeIcons/nexchange/icon.png` on the content server (same convention as `nymswap`). CHANGELOG updated under 4.50.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c965bcdbbc92a52a9d907f4bbf06b0a75c9b185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->