### PR TITLE
Gate balance effects and FIO refresh on engine readiness (wallet cache v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- changed: Gate action-queue balance-effect checks and the login FIO address refresh on engine readiness, so wallets emitted from the core's new wallet cache (before their engines load) cannot mis-evaluate balance effects or crash the FIO refresh.
+
 ## 4.50.0 (staging)
 
 - added: Changelly swap provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - changed: Gate action-queue balance-effect checks and the login FIO address refresh on engine readiness, so wallets emitted from the core's new wallet cache (before their engines load) cannot mis-evaluate balance effects or crash the FIO refresh.
+- changed: Opening any wallet-scoped scene asks the core to prioritize that wallet's engine startup in the post-login queue.
 
 ## 4.50.0 (staging)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - changed: Standardize wallet list automation test IDs to use period separators.
 - changed: Balance-effect checks and the login FIO refresh wait for engine readiness on cache-emitted wallets
+- changed: Opening any wallet-scoped scene asks the core to prioritize that wallet's engine startup in the post-login queue.
 - fixed: USDC.e shown as USDC in the Optimism Tarot staking pools
 - fixed: Say "edit name" instead of "edit settings" on the create/split wallet scene when the listed wallets have no settings to edit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased (develop)
 
 - changed: Standardize wallet list automation test IDs to use period separators.
-- changed: Gate action-queue balance-effect checks and the login FIO address refresh on engine readiness, so wallets emitted from the core's new wallet cache (before their engines load) cannot mis-evaluate balance effects or crash the FIO refresh.
+- changed: Balance-effect checks and the login FIO refresh wait for engine readiness on cache-emitted wallets
 - fixed: USDC.e shown as USDC in the Optimism Tarot staking pools
 - fixed: Say "edit name" instead of "edit settings" on the create/split wallet scene when the listed wallets have no settings to edit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - changed: Standardize wallet list automation test IDs to use period separators.
+- changed: Gate action-queue balance-effect checks and the login FIO address refresh on engine readiness, so wallets emitted from the core's new wallet cache (before their engines load) cannot mis-evaluate balance effects or crash the FIO refresh.
 - fixed: USDC.e shown as USDC in the Optimism Tarot staking pools
 - fixed: Say "edit name" instead of "edit settings" on the create/split wallet scene when the listed wallets have no settings to edit
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -330,7 +330,6 @@ export default [
       'src/components/services/DeepLinkingManager.tsx',
       'src/components/services/EdgeContextCallbackManager.tsx',
 
-      'src/components/services/FioService.ts',
       'src/components/services/LoanManagerService.ts',
       'src/components/services/NetworkActivity.ts',
       'src/components/services/PasswordReminderService.ts',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -321,7 +321,6 @@ export default [
 
       'src/components/services/EdgeContextCallbackManager.tsx',
 
-      'src/components/services/FioService.ts',
       'src/components/services/LoanManagerService.ts',
       'src/components/services/NetworkActivity.ts',
       'src/components/services/PasswordReminderService.ts',

--- a/src/components/hoc/withWallet.tsx
+++ b/src/components/hoc/withWallet.tsx
@@ -26,6 +26,16 @@ export function withWallet<Props extends { wallet: EdgeCurrencyWallet }>(
     const currencyWallets = useWatch(account, 'currencyWallets')
     const wallet = currencyWallets[route.params.walletId]
 
+    // Opening a wallet-scoped scene is the "the user wants this wallet"
+    // signal: waitForCurrencyWallet moves the wallet's engine startup to
+    // the front of the core's post-login queue. Rejections (a deleted or
+    // broken wallet) are already handled by the effect below:
+    const { walletId } = route.params
+    React.useEffect(() => {
+      if (account.waitForCurrencyWallet == null) return
+      account.waitForCurrencyWallet(walletId).catch(() => {})
+    }, [account, walletId])
+
     React.useEffect(() => {
       if (wallet == null) navigation.goBack()
     }, [navigation, wallet])

--- a/src/components/services/FioService.ts
+++ b/src/components/services/FioService.ts
@@ -28,7 +28,7 @@ interface Props {
 
 type NameDates = Record<string, Date>
 
-export const FioService = (props: Props) => {
+export const FioService: React.FC<Props> = props => {
   const { account, navigation } = props
   const dispatch = useDispatch()
 
@@ -65,40 +65,54 @@ export const FioService = (props: Props) => {
     }
 
     if (expiredChecking.current) return
+
+    // Wallet objects can exist before their engines do (wallet cache),
+    // and refreshFioNames calls engine-backed otherMethods.
+    // Skip pre-engine wallets and let the next cycle retry them:
+    const readyWallets = fioWallets.current.filter(
+      fioWallet => fioWallet.otherMethods.getFioAddresses != null
+    )
+    if (readyWallets.length === 0) return
+
     expiredChecking.current = true
-
-    const walletsToCheck: EdgeCurrencyWallet[] = []
-    for (const fioWallet of fioWallets.current) {
-      if (!walletsCheckedForExpired.current[fioWallet.id]) {
-        walletsToCheck.push(fioWallet)
-      }
-    }
-
-    const namesToCheck: FioDomain[] = []
-    const { fioDomains, fioWalletsById } = await refreshFioNames(walletsToCheck)
-    expiredLastChecks.current ??= await getFioExpiredCheckFromDisklet(disklet)
-    for (const fioDomain of fioDomains) {
-      if (needToCheckExpired(expiredLastChecks.current, fioDomain.name)) {
-        namesToCheck.push(fioDomain)
-      }
-    }
-
-    if (namesToCheck.length !== 0) {
-      const expired: FioDomain[] = getExpiredSoonFioDomains(fioDomains)
-      if (expired.length > 0) {
-        const first: FioDomain = expired[0]
-        const fioWallet: EdgeCurrencyWallet = fioWalletsById[first.walletId]
-        await showFioExpiredModal(navigation, fioWallet, first)
-        expireReminderShown.current = true
-
-        expiredLastChecks.current[first.name] = new Date()
-        await setFioExpiredCheckToDisklet(expiredLastChecks.current, disklet)
+    try {
+      const walletsToCheck: EdgeCurrencyWallet[] = []
+      for (const fioWallet of readyWallets) {
+        if (!walletsCheckedForExpired.current[fioWallet.id]) {
+          walletsToCheck.push(fioWallet)
+        }
       }
 
-      for (const walletId in fioWalletsById) {
-        walletsCheckedForExpired.current[walletId] = true
+      const namesToCheck: FioDomain[] = []
+      const { fioDomains, fioWalletsById } = await refreshFioNames(
+        walletsToCheck
+      )
+      expiredLastChecks.current ??= await getFioExpiredCheckFromDisklet(disklet)
+      for (const fioDomain of fioDomains) {
+        if (needToCheckExpired(expiredLastChecks.current, fioDomain.name)) {
+          namesToCheck.push(fioDomain)
+        }
       }
 
+      if (namesToCheck.length !== 0) {
+        const expired: FioDomain[] = getExpiredSoonFioDomains(fioDomains)
+        if (expired.length > 0) {
+          const first: FioDomain = expired[0]
+          const fioWallet: EdgeCurrencyWallet = fioWalletsById[first.walletId]
+          await showFioExpiredModal(navigation, fioWallet, first)
+          expireReminderShown.current = true
+
+          expiredLastChecks.current[first.name] = new Date()
+          await setFioExpiredCheckToDisklet(expiredLastChecks.current, disklet)
+        }
+
+        for (const walletId in fioWalletsById) {
+          walletsCheckedForExpired.current[walletId] = true
+        }
+      }
+    } finally {
+      // Always release the latch, or a cycle with nothing to check
+      // (or an error) would disable this check for the whole session:
       expiredChecking.current = false
     }
   })
@@ -130,7 +144,10 @@ export const FioService = (props: Props) => {
   return null
 }
 
-function arraysEqual(arr1: EdgeCurrencyWallet[], arr2: EdgeCurrencyWallet[]) {
+function arraysEqual(
+  arr1: EdgeCurrencyWallet[],
+  arr2: EdgeCurrencyWallet[]
+): boolean {
   if (arr1.length !== arr2.length) return false
 
   arr1.sort((a, b) => a.id.localeCompare(b.id))

--- a/src/components/services/FioService.ts
+++ b/src/components/services/FioService.ts
@@ -28,7 +28,7 @@ interface Props {
 
 type NameDates = Record<string, Date>
 
-export const FioService = (props: Props) => {
+export const FioService: React.FC<Props> = props => {
   const { account, navigation } = props
   const dispatch = useDispatch()
 
@@ -65,40 +65,55 @@ export const FioService = (props: Props) => {
     }
 
     if (expiredChecking.current) return
+
+    // Wallet objects can exist before their engines do (wallet cache),
+    // and refreshFioNames calls engine-backed otherMethods. A cold
+    // wallet has none yet, so skip it and let the next cycle retry;
+    // a warm one carries cached stubs that await the engine per call:
+    const readyWallets = fioWallets.current.filter(
+      fioWallet => fioWallet.otherMethods.getFioAddresses != null
+    )
+    if (readyWallets.length === 0) return
+
     expiredChecking.current = true
-
-    const walletsToCheck: EdgeCurrencyWallet[] = []
-    for (const fioWallet of fioWallets.current) {
-      if (!walletsCheckedForExpired.current[fioWallet.id]) {
-        walletsToCheck.push(fioWallet)
-      }
-    }
-
-    const namesToCheck: FioDomain[] = []
-    const { fioDomains, fioWalletsById } = await refreshFioNames(walletsToCheck)
-    expiredLastChecks.current ??= await getFioExpiredCheckFromDisklet(disklet)
-    for (const fioDomain of fioDomains) {
-      if (needToCheckExpired(expiredLastChecks.current, fioDomain.name)) {
-        namesToCheck.push(fioDomain)
-      }
-    }
-
-    if (namesToCheck.length !== 0) {
-      const expired: FioDomain[] = getExpiredSoonFioDomains(fioDomains)
-      if (expired.length > 0) {
-        const first: FioDomain = expired[0]
-        const fioWallet: EdgeCurrencyWallet = fioWalletsById[first.walletId]
-        await showFioExpiredModal(navigation, fioWallet, first)
-        expireReminderShown.current = true
-
-        expiredLastChecks.current[first.name] = new Date()
-        await setFioExpiredCheckToDisklet(expiredLastChecks.current, disklet)
+    try {
+      const walletsToCheck: EdgeCurrencyWallet[] = []
+      for (const fioWallet of readyWallets) {
+        if (!walletsCheckedForExpired.current[fioWallet.id]) {
+          walletsToCheck.push(fioWallet)
+        }
       }
 
-      for (const walletId in fioWalletsById) {
-        walletsCheckedForExpired.current[walletId] = true
+      const namesToCheck: FioDomain[] = []
+      const { fioDomains, fioWalletsById } = await refreshFioNames(
+        walletsToCheck
+      )
+      expiredLastChecks.current ??= await getFioExpiredCheckFromDisklet(disklet)
+      for (const fioDomain of fioDomains) {
+        if (needToCheckExpired(expiredLastChecks.current, fioDomain.name)) {
+          namesToCheck.push(fioDomain)
+        }
       }
 
+      if (namesToCheck.length !== 0) {
+        const expired: FioDomain[] = getExpiredSoonFioDomains(fioDomains)
+        if (expired.length > 0) {
+          const first: FioDomain = expired[0]
+          const fioWallet: EdgeCurrencyWallet = fioWalletsById[first.walletId]
+          await showFioExpiredModal(navigation, fioWallet, first)
+          expireReminderShown.current = true
+
+          expiredLastChecks.current[first.name] = new Date()
+          await setFioExpiredCheckToDisklet(expiredLastChecks.current, disklet)
+        }
+
+        for (const walletId in fioWalletsById) {
+          walletsCheckedForExpired.current[walletId] = true
+        }
+      }
+    } finally {
+      // Always release the latch, or a cycle with nothing to check
+      // (or an error) would disable this check for the whole session:
       expiredChecking.current = false
     }
   })
@@ -130,7 +145,10 @@ export const FioService = (props: Props) => {
   return null
 }
 
-function arraysEqual(arr1: EdgeCurrencyWallet[], arr2: EdgeCurrencyWallet[]) {
+function arraysEqual(
+  arr1: EdgeCurrencyWallet[],
+  arr2: EdgeCurrencyWallet[]
+): boolean {
   if (arr1.length !== arr2.length) return false
 
   arr1.sort((a, b) => a.id.localeCompare(b.id))

--- a/src/components/services/Services.tsx
+++ b/src/components/services/Services.tsx
@@ -27,6 +27,7 @@ import {
   width
 } from '../../util/scaling'
 import { snooze } from '../../util/utils'
+import { waitForWalletOtherMethods } from '../../util/waitForWalletOtherMethods'
 import { AlertDropdown } from '../navigation/AlertDropdown'
 import { AccountCallbackManager } from './AccountCallbackManager'
 import { ActionQueueService } from './ActionQueueService'
@@ -87,6 +88,27 @@ export const Services: React.FC<Props> = props => {
       dispatch(registerNotificationsV2()).catch((error: unknown) => {
         console.warn('registerNotificationsV2 error:', error)
       })
+
+      // Wallet objects can exist before their engines do (wallet cache),
+      // and the FIO refreshes below call engine-backed otherMethods, so
+      // wait for each FIO wallet's methods to exist first. On a warm
+      // login the cached stubs are already there and this is a no-op:
+      const fioWallets = Object.values(account.currencyWallets).filter(
+        wallet => wallet.currencyInfo.pluginId === 'fio'
+      )
+      await Promise.all(
+        fioWallets.map(async wallet => {
+          // Per-wallet, so one broken wallet cannot reject the whole gate
+          // or hide which wallet timed out:
+          await waitForWalletOtherMethods(wallet).catch((error: unknown) => {
+            console.warn('waitForWalletOtherMethods error:', error)
+          })
+        })
+      )
+
+      // Bail out if the account logged out while we waited for engines,
+      // so the refreshes below never run against the next session:
+      if (!account.loggedIn) return
 
       await dispatch(refreshConnectedWallets).catch((error: unknown) => {
         console.warn(error)

--- a/src/components/services/Services.tsx
+++ b/src/components/services/Services.tsx
@@ -27,6 +27,7 @@ import {
   width
 } from '../../util/scaling'
 import { snooze } from '../../util/utils'
+import { waitForWalletOtherMethods } from '../../util/waitForWalletOtherMethods'
 import { AlertDropdown } from '../navigation/AlertDropdown'
 import { AccountCallbackManager } from './AccountCallbackManager'
 import { ActionQueueService } from './ActionQueueService'
@@ -87,6 +88,26 @@ export const Services: React.FC<Props> = props => {
       dispatch(registerNotificationsV2()).catch((error: unknown) => {
         console.warn('registerNotificationsV2 error:', error)
       })
+
+      // Wallet objects can exist before their engines do (wallet cache),
+      // and the FIO refreshes below call engine-backed otherMethods,
+      // so wait for each FIO wallet's engine first:
+      const fioWallets = Object.values(account.currencyWallets).filter(
+        wallet => wallet.currencyInfo.pluginId === 'fio'
+      )
+      await Promise.all(
+        fioWallets.map(async wallet => {
+          // Per-wallet, so one broken wallet cannot reject the whole gate
+          // or hide which wallet timed out:
+          await waitForWalletOtherMethods(wallet).catch((error: unknown) => {
+            console.warn('waitForWalletOtherMethods error:', error)
+          })
+        })
+      )
+
+      // Bail out if the account logged out while we waited for engines,
+      // so the refreshes below never run against the next session:
+      if (!account.loggedIn) return
 
       await dispatch(refreshConnectedWallets).catch((error: unknown) => {
         console.warn(error)

--- a/src/components/services/Services.tsx
+++ b/src/components/services/Services.tsx
@@ -110,6 +110,12 @@ export const Services: React.FC<Props> = props => {
       // so the refreshes below never run against the next session:
       if (!account.loggedIn) return
 
+      // The refreshes below read `ui.fio.fioWallets`, which FioService
+      // writes from a watch-driven effect. On a warm login the waits
+      // above resolve before that effect has run, so publish the list
+      // here first (FioService's own dispatch is idempotent with it):
+      dispatch({ type: 'UPDATE_FIO_WALLETS', data: { fioWallets } })
+
       await dispatch(refreshConnectedWallets).catch((error: unknown) => {
         console.warn(error)
       })

--- a/src/components/themed/WalletListCurrencyRow.tsx
+++ b/src/components/themed/WalletListCurrencyRow.tsx
@@ -7,6 +7,7 @@ import { useHandler } from '../../hooks/useHandler'
 import { useIconColor } from '../../hooks/useIconColor'
 import { useWalletBalance } from '../../hooks/useWalletBalance'
 import { useWalletName } from '../../hooks/useWalletName'
+import { useWatch } from '../../hooks/useWatch'
 import { lstrings } from '../../locales/strings'
 import { useSelector } from '../../types/reactRedux'
 import { isKeysOnlyPlugin } from '../../util/CurrencyInfoHelpers'
@@ -56,6 +57,13 @@ const WalletListCurrencyRowComponent: React.FC<Props> = props => {
     state => state.ui.settings.userPausedWalletsSet
   )
   const isPaused = userPausedWalletsSet?.has(wallet.id) ?? false
+
+  // A cache-seeded wallet stays in `currencyWallets` even when its
+  // engine fails, so this row is what the user sees instead of the
+  // loading row that used to carry the error:
+  const account = useSelector(state => state.core.account)
+  const currencyWalletErrors = useWatch(account, 'currencyWalletErrors')
+  const engineError = currencyWalletErrors[wallet.id]
   const isDisabled = isKeysOnlyPlugin(wallet.currencyInfo.pluginId)
   const { pluginId } = wallet.currencyInfo
   const iconColor = useIconColor({ pluginId, tokenId })
@@ -183,7 +191,11 @@ const WalletListCurrencyRowComponent: React.FC<Props> = props => {
       <EdgeCard
         icon={iconNode}
         overlay={
-          isPaused || isDisabled ? (
+          engineError != null ? (
+            <EdgeText style={styles.overlayLabel}>
+              {engineError.message}
+            </EdgeText>
+          ) : isPaused || isDisabled ? (
             <EdgeText style={styles.overlayLabel}>
               {isPaused
                 ? lstrings.fragment_wallets_wallet_paused

--- a/src/controllers/action-queue/runtime/checkActionEffect.ts
+++ b/src/controllers/action-queue/runtime/checkActionEffect.ts
@@ -1,5 +1,6 @@
 import { gte, lte } from 'biggystring'
 
+import { DONE_THRESHOLD } from '../../../constants/WalletAndCurrencyConstants'
 import { filterNull } from '../../../util/safeFilters'
 import { checkPushEvent } from '../push'
 import type {
@@ -120,6 +121,17 @@ export async function checkActionEffect(
       // TODO: Use effect.address when we can check address balances
       const { aboveAmount, belowAmount, tokenId, walletId } = effect
       const wallet = await account.waitForCurrencyWallet(walletId)
+
+      // The wallet object can exist before its engine loads (wallet cache),
+      // so don't evaluate the effect against cached, possibly stale
+      // balances. Report "not yet effective" until the engine has synced:
+      if (wallet.syncStatus.totalRatio < DONE_THRESHOLD) {
+        return {
+          delay: 15000,
+          isEffective: false
+        }
+      }
+
       const walletBalance = wallet.balanceMap.get(tokenId) ?? '0'
 
       return {

--- a/src/util/waitForWalletOtherMethods.ts
+++ b/src/util/waitForWalletOtherMethods.ts
@@ -1,0 +1,42 @@
+import type { EdgeCurrencyWallet } from 'edge-core-js'
+
+// Engine creation for a large account can take minutes on login,
+// matching how long waitForAllWallets used to take before the wallet
+// cache existed, so this is a safety valve rather than a deadline:
+const OTHER_METHODS_TIMEOUT_MS = 10 * 60 * 1000
+
+/**
+ * Waits for a wallet's engine-backed `otherMethods` to arrive.
+ *
+ * The core's wallet cache emits wallet objects before their engines
+ * exist, and `wallet.otherMethods` is guaranteed to be `{}` until the
+ * engine loads. Rejects after a timeout so a wallet whose engine never
+ * loads cannot hang callers forever.
+ */
+export async function waitForWalletOtherMethods(
+  wallet: EdgeCurrencyWallet,
+  timeoutMs: number = OTHER_METHODS_TIMEOUT_MS
+): Promise<void> {
+  if (Object.keys(wallet.otherMethods).length > 0) return
+
+  await new Promise<void>((resolve, reject) => {
+    const handleReady = (): void => {
+      clearTimeout(timeout)
+      unsubscribe()
+      resolve()
+    }
+    const timeout = setTimeout(() => {
+      unsubscribe()
+      reject(
+        new Error(`Timed out waiting for wallet ${wallet.id} engine methods`)
+      )
+    }, timeoutMs)
+    const unsubscribe = wallet.watch('otherMethods', otherMethods => {
+      if (Object.keys(otherMethods).length > 0) handleReady()
+    })
+
+    // The methods may have arrived between the caller's check and the
+    // subscription above, in which case the watcher never fires:
+    if (Object.keys(wallet.otherMethods).length > 0) handleReady()
+  })
+}

--- a/src/util/waitForWalletOtherMethods.ts
+++ b/src/util/waitForWalletOtherMethods.ts
@@ -1,0 +1,47 @@
+import type { EdgeCurrencyWallet } from 'edge-core-js'
+
+// Engine creation for a large account can take minutes on login,
+// matching how long waitForAllWallets used to take before the wallet
+// cache existed, so this is a safety valve rather than a deadline:
+const OTHER_METHODS_TIMEOUT_MS = 10 * 60 * 1000
+
+/**
+ * Waits for a wallet's `otherMethods` to carry names.
+ *
+ * The core emits wallet objects before their engines exist. A cold
+ * wallet's `otherMethods` is `{}` until its engine loads, so this wait
+ * is what stops a caller from reaching for a method that is not there
+ * yet. A warm wallet's is already populated with delegating stubs
+ * built from the cached names, so this resolves immediately and the
+ * stubs await the engine inside each call instead.
+ *
+ * Rejects after a timeout so a cold wallet whose engine never loads
+ * cannot hang callers forever.
+ */
+export async function waitForWalletOtherMethods(
+  wallet: EdgeCurrencyWallet,
+  timeoutMs: number = OTHER_METHODS_TIMEOUT_MS
+): Promise<void> {
+  if (Object.keys(wallet.otherMethods).length > 0) return
+
+  await new Promise<void>((resolve, reject) => {
+    const handleReady = (): void => {
+      clearTimeout(timeout)
+      unsubscribe()
+      resolve()
+    }
+    const timeout = setTimeout(() => {
+      unsubscribe()
+      reject(
+        new Error(`Timed out waiting for wallet ${wallet.id} engine methods`)
+      )
+    }, timeoutMs)
+    const unsubscribe = wallet.watch('otherMethods', otherMethods => {
+      if (Object.keys(otherMethods).length > 0) handleReady()
+    })
+
+    // The methods may have arrived between the caller's check and the
+    // subscription above, in which case the watcher never fires:
+    if (Object.keys(wallet.otherMethods).length > 0) handleReady()
+  })
+}


### PR DESCRIPTION
### Technical Design Document

[edge-wallet-cache-design.md](https://github.com/EdgeApp/edge-core-js/blob/jon/wallet-cache-v2/src/docs/edge-wallet-cache-design.md)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-core-js/pull/733

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

[Technical design doc](https://github.com/EdgeApp/edge-core-js/blob/jon/wallet-cache-v2/src/docs/edge-wallet-cache-design.md)

GUI-side patches for wallet cache v2 phase 1 (TDD section 7: [pinned](https://gist.github.com/j0ntz/b4476ff5d593b6b206ef17d8c6b260d6/3cb895f4b6bef65fd39bf60a4dcd982d4eebcdc6), [live](https://gist.github.com/j0ntz/b4476ff5d593b6b206ef17d8c6b260d6)). With EdgeApp/edge-core-js#733, wallet objects exist before their engines load and `waitForAllWallets` resolves in that window, so the login-path surfaces that consumed engine state at resolve-time are gated on engine readiness:

- `checkActionEffect.ts` (`address-balance`): reported the effect against `balanceMap` immediately after awaiting the wallet, which could now evaluate cached, possibly stale balances. It reports not-yet-effective until the engine has fully synced (same conservatism as the loan flow's `waitForLoanAccountSync` and the existing `< 1` treatment in spend paths, TDD 7.4), letting the action queue's normal 15s poll re-check.
- `Services.tsx`: the post-`waitForAllWallets` FIO refreshes (`refreshConnectedWallets`, `refreshAllFioAddresses`) call `wallet.otherMethods.*`, which the core guarantees is `{}` pre-engine. A new `waitForWalletOtherMethods` util watches `otherMethods` until the engine's methods land (10-minute safety-valve timeout, roughly matching how long `waitForAllWallets` could already take on large accounts before the cache existed).
- `FioService.ts`: the periodic expired-domain check calls `otherMethods.getFioAddresses` the same way. This one was NOT in the TDD's section-7 audit; it was caught live on the simulator (red dev alert `wallet.otherMethods.getFioAddresses is not a function` seconds after a warm cached login). Being a 30s periodic task, it skips pre-engine wallets and lets the next cycle retry, which also avoids wedging its one-shot `expiredChecking` latch when no wallet is ready yet.

Remaining `otherMethods` call sites (FIO scenes, staking, WalletConnect) are user-navigation surfaces audited in the TDD as safe (null-probes, or flows that imply an engine exists) and are unchanged.

Tested on the iOS simulator against the linked core build (edge-funds, 194 wallets): cold login wrote all 194 `walletCache.json` files; warm relaunch rendered the full wallet list with names and balances from the cache while engines were still loading; no FIO alert through 140s of runtime; drilling into a wallet shows live engine-backed data on the same wallet object. Screenshots attached below.

## Phase 2: tap-prioritization

The core now staggers cached wallets' engine startup through a limited-concurrency queue (EdgeApp/edge-core-js#733 phase 2). `withWallet` wraps every wallet-scoped scene, so opening one calls `account.waitForCurrencyWallet(walletId)`, which moves that wallet's engine startup to the front of the queue. The call is a fire-and-forget hint; a deleted or broken wallet is already handled by the existing goBack effect.

## Phase 6: provisional receive address (TDD section 7.5, decision 9.9)

The receive scene (`RequestScene.tsx`) waited on the engine for every address, so a rotating-address chain showed a loading state until the engine started. It now opts into the core's cached address (`getAddresses({ allowCached: true })`, EdgeApp/edge-core-js#733 phase 6) and renders it immediately.

- On a rotating chain (`!hasStableAddresses`), the cached address is provisional: a static inline affordance sits under the address (a muted circled-i glyph, "Checking for your latest address", and a spinner; informational, not tappable, not a warning color). A 350ms grace timer gates it on, so a warm engine that confirms first never flashes it; the QR is capped to reserve the row's height so toggling never reflows it.
- The confirmed address swaps in place only if it differs once the engine loads; on engine failure/timeout the row is removed and the cached address stays, with a 30s safety cap so the spinner never hangs.
- Staleness guards (from review): each refresh takes a token and captures the wallet id, so a slow reconcile from a prior wallet (the `withWallet` instance is reused across wallet switches) or after unmount is ignored rather than overwriting the current address. A later refresh / `addressChanged` rotation takes the plain engine-gated path, so it never shows a stale address.

Rotating-chain behavior is provable in-app on a UTXO chain (BTC/LTC) with no plugin change; the stable-chain skip and the core gating are covered by unit tests. Depends on the core `allowCached` option (EdgeApp/edge-core-js#733) and, for stable chains, the plugin flags (draft EdgeApp/edge-currency-accountbased#1076).

TDD ([pinned](https://gist.github.com/j0ntz/b4476ff5d593b6b206ef17d8c6b260d6/3cb895f4b6bef65fd39bf60a4dcd982d4eebcdc6), [live](https://gist.github.com/j0ntz/b4476ff5d593b6b206ef17d8c6b260d6)): implementation divergences and the decisions are documented inline in the affected sections.

Asana: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1216673467164267

## Post-review followup: the FIO refreshes read a populated wallet list

On a warm login the readiness wait in `Services.tsx` resolves before `FioService`'s watch-driven effect has published `ui.fio.fioWallets`, so `refreshConnectedWallets` and `refreshAllFioAddresses` could run against an empty list. `Services.tsx` now dispatches `UPDATE_FIO_WALLETS` with the list it already computed, right before the refreshes; `FioService`'s own dispatch stays and carries the same content.

## Phase 7: the provisional receive affordance is reverted

The commit that added the provisional address UI ("Show a provisional receive address on warm login") was dropped from this branch, along with the core `allowCached` opt-in and the `hasStableAddresses` plugin flags ([edge-currency-accountbased#1076](https://github.com/EdgeApp/edge-currency-accountbased/pull/1076), closed). Serving a cached address silently was accepted as an edge case, which removes what the affordance existed to disclose. The commit was dropped rather than reverted on top, so this branch's history never contains it.

`RequestScene.tsx` needs no replacement code. It calls `getAddresses` on mount and already subscribes to `addressChanged`, which is exactly the contract the core now provides: the first query is answered from the cache so the QR renders immediately on a warm login, and the wallet emits `addressChanged` if the engine goes on to derive a different address, so the scene re-queries and lands on it. That reconcile is in [edge-core-js#733](https://github.com/EdgeApp/edge-core-js/pull/733), and it fixes every consumer of the address rather than this one scene.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login-time FIO refresh, action-queue balance triggers, and broad wallet navigation via `withWallet`, but changes are conservative gating and UX rather than new auth or spend paths.
> 
> **Overview**
> Adapts the GUI for **wallet cache v2**, where wallet objects appear before their engines finish loading.
> 
> **Engine readiness gates:** Post-login FIO work in `Services.tsx` now waits for each FIO wallet’s `otherMethods` (via new `waitForWalletOtherMethods`), skips if the user logged out during the wait, and dispatches `UPDATE_FIO_WALLETS` before refreshes so warm logins don’t run against an empty list. `FioService`’s expired-domain loop only touches wallets with `getFioAddresses` and always clears its in-flight latch in `finally`. Action-queue **address-balance** effects stay “not effective” until `syncStatus` reaches `DONE_THRESHOLD`, avoiding decisions on cached balances.
> 
> **Tap prioritization:** `withWallet` fire-and-forgets `account.waitForCurrencyWallet(walletId)` when a wallet-scoped scene opens so that wallet’s engine jumps ahead in the core startup queue.
> 
> **Wallet list UX:** `WalletListCurrencyRow` shows the core’s `currencyWalletErrors` message on the row overlay when an engine fails but the cached wallet still appears in the list.
> 
> CHANGELOG and a small eslint list tweak for `FioService` are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0299b69f2b17626c5ca0f3c422a5d0e66e9996c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="2" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6080/commits/b96a03b9b9f73d21d6804191c7acfa7f1e39bce7"><code>b96a03b</code></a><br><sub>Gate balance effects and FIO refresh on engine readiness</sub><br><sub>🪓 <em>forced engineError to a non-null Error in WalletListCurrencyRow, since an engine failure has no natural trigger on the sim; reverted, tree clean.</em></sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/01-cold-login-wallet-7ed37e.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/01-cold-login-wallet-7ed37e.png" width="200"></a><br><sub>agent proof 1216673467164267 01 cold login wallet list</sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/02-warm-login-cached-b92196.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/02-warm-login-cached-b92196.png" width="200"></a><br><sub>agent proof 1216673467164267 02 warm login cached wallet list</sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/03-wallet-detail-engi-696006.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/03-wallet-detail-engi-696006.png" width="200"></a><br><sub>agent proof 1216673467164267 03 wallet detail engine loaded</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/04-warm-login-after-r-3f7986.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/04-warm-login-after-r-3f7986.png" width="200"></a><br><sub>agent proof 1216673467164267 04 warm login after review fixes</sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/12-warm-login-wallet-f1d0d6.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/12-warm-login-wallet-f1d0d6.png" width="200"></a><br><sub>warm login wallet list</sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/13-HACKED-engine-erro-d573f3.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/13-HACKED-engine-erro-d573f3.png" width="200"></a><br><sub>🪓 engine error row</sub></td>
</tr>
<tr>
<td rowspan="3" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6080/commits/88cbb94a55ef66dbad924265632bccbc97e27ff3"><code>88cbb94</code></a><br><sub>Prioritize an opened wallet's engine startup</sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/05-warm-login-list-988f98.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/05-warm-login-list-988f98.png" width="200"></a><br><sub>agent proof 1216673467164267 05 warm login list</sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/06-sepolia-detail-aft-fecf42.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/06-sepolia-detail-aft-fecf42.png" width="200"></a><br><sub>agent proof 1216673467164267 06 sepolia detail after tap</sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/07-p6-01-ltc-receive-1c908e.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/07-p6-01-ltc-receive-1c908e.png" width="200"></a><br><sub>agent proof 1216673467164267 p6 01 ltc receive cached</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/08-p6-02-ltc-receive-0ad1c2.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/08-p6-02-ltc-receive-0ad1c2.png" width="200"></a><br><sub>agent proof 1216673467164267 p6 02 ltc receive warmlogin</sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/09-HACKED-provisional-034303.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/09-HACKED-provisional-034303.png" width="200"></a><br><sub>🪓 🩹 HACK-FORCED: provisional affordance</sub></td>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/10-receive-address-no-8aed1e.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/10-receive-address-no-8aed1e.png" width="200"></a><br><sub>receive address no affordance</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/11-warm-login-wallet-fa7d06.png"><img src="https://pub-a869cb1372dd43279002e19efa2e6176.r2.dev/g6080/11-warm-login-wallet-fa7d06.png" width="200"></a><br><sub>warm login wallet list</sub></td>
<td width="210"></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->