### PR TITLE
Add Maestro build tag to Help scene version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- added: "-m" tag on the version number in the Help scene for Maestro test builds
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/src/components/modals/HelpModal.tsx
+++ b/src/components/modals/HelpModal.tsx
@@ -11,6 +11,7 @@ import { lstrings } from '../../locales/strings'
 import { config } from '../../theme/appConfig'
 import { useSelector } from '../../types/reactRedux'
 import type { NavigationBase } from '../../types/routerTypes'
+import { isMaestro } from '../../util/maestro'
 import { openBrowserUri } from '../../util/WebUtils'
 import { ChatBubblesIcon } from '../icons/ThemedIcons'
 import { Airship } from '../services/AirshipInstance'
@@ -60,7 +61,9 @@ export const HelpModal: React.FC<Props> = (props: Props) => {
   }, [])
 
   const styles = getStyles(theme)
-  const versionText = `${lstrings.help_version} ${versionNumber}`
+  const versionText = `${lstrings.help_version} ${versionNumber}${
+    isMaestro() ? '-m' : ''
+  }`
   const buildText = `${lstrings.help_build} ${buildNumber}`
   const helpModalTitle = sprintf(
     lstrings.help_modal_title_thanks,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Appends a `-m` suffix to the version string shown in the Help modal footer when the app is a Maestro test build (`ENABLE_MAESTRO_BUILD`), so QA/devs can tell at a glance that a Maestro build is installed rather than a normal debug build.

[Asana task](https://app.asana.com/0/1215088146871429/1211115526706206)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in the Help modal; no auth, payments, or wallet logic affected.
> 
> **Overview**
> The Help modal footer **version string** now appends a **`-m` suffix** when the app is a Maestro test build (`isMaestro()`), so QA and devs can tell at a glance that a Maestro install is running instead of a normal debug build. Build number display is unchanged.
> 
> CHANGELOG updated for the unreleased section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff384fc81da0daad46f045eb4a647f3401254f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->