### PR TITLE
Clarify XRP minimum balance warning copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: XRP minimum balance warning copy to clarify the reserve is met once the address balance reaches 1 XRP, not on top of it.
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -229,7 +229,7 @@ const strings = {
   fragment_error_report_id_copied: 'Error report ID copied',
   request_minimum_notification_title: 'Minimum Balance Required',
   request_xrp_minimum_notification_body_1xrp:
-    'Ripple (XRP) wallets require a 1 XRP minimum balance. You must deposit at least 1 XRP to this address before this wallet will show a balance or transactions. 1 XRP will be unspendable for the lifetime of this wallet address.',
+    'A minimum balance of 1 XRP is required for an address on the XRP Ledger to be active. The 1 XRP is an unspendable reserve on the network. The reserve is met as soon as the address balance reaches 1 XRP or more. Any amount above this reserve is available for transactions.',
   request_xrp_minimum_notification_alert_body_1xrp:
     'This wallet will always require a 1 XRP minimum',
   request_xlm_minimum_notification_body:

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -141,7 +141,7 @@
   "fragment_event_id": "Event ID",
   "fragment_error_report_id_copied": "Error report ID copied",
   "request_minimum_notification_title": "Minimum Balance Required",
-  "request_xrp_minimum_notification_body_1xrp": "Ripple (XRP) wallets require a 1 XRP minimum balance. You must deposit at least 1 XRP to this address before this wallet will show a balance or transactions. 1 XRP will be unspendable for the lifetime of this wallet address.",
+  "request_xrp_minimum_notification_body_1xrp": "A minimum balance of 1 XRP is required for an address on the XRP Ledger to be active. The 1 XRP is an unspendable reserve on the network. The reserve is met as soon as the address balance reaches 1 XRP or more. Any amount above this reserve is available for transactions.",
   "request_xrp_minimum_notification_alert_body_1xrp": "This wallet will always require a 1 XRP minimum",
   "request_xlm_minimum_notification_body": "Stellar (XLM) wallets require a 1 XLM minimum balance. You must deposit at least 1 XLM to this address before this wallet will show a balance or transactions. 1 XLM will be unspendable for the lifetime of this wallet address.",
   "request_xlm_minimum_notification_alert_body": "This wallet will always require a 1 XLM minimum",


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1211213306846615/f)

Replaces the XRP minimum-balance warning copy shown in the "Minimum Balance Required" modal on the Request scene. The old text implied a user needed to deposit 1 XRP on top of their balance; the new text clarifies the reserve is met once the address balance itself reaches 1 XRP.

[Asana task](https://app.asana.com/1/9976422036640/project/1200382638405084/task/1211213306846615)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in English locale strings and CHANGELOG; no logic, API, or security impact.
> 
> **Overview**
> Updates the **Minimum Balance Required** copy on the Request scene for XRP so it matches how the XRP Ledger reserve actually works.
> 
> The new text explains that **1 XRP is an unspendable network reserve**, that the address is active once the balance **reaches 1 XRP or more** (not “deposit 1 XRP on top”), and that only amounts above the reserve are spendable. The string is wired through existing `minimumPopupModals` config (`request_xrp_minimum_notification_body_1xrp` in `en_US.ts` / `enUS.json`); the short alert line is unchanged. **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e502bcee4bc85a2aa8ec3c0065ec8ef1a2cc44a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->