### PR TITLE
Round fiat balances to cents in Wallets list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Round fiat balances to cents in the Wallets list, matching the wallet detail scene
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/src/components/themed/WalletListCurrencyRow.tsx
+++ b/src/components/themed/WalletListCurrencyRow.tsx
@@ -38,9 +38,7 @@ interface Props {
   ) => Promise<void> | void
 }
 
-const WalletListCurrencyRowComponent = (
-  props: Props
-): React.ReactElement | null => {
+const WalletListCurrencyRowComponent: React.FC<Props> = props => {
   const {
     customAsset,
     token,

--- a/src/components/themed/WalletListCurrencyRow.tsx
+++ b/src/components/themed/WalletListCurrencyRow.tsx
@@ -209,6 +209,7 @@ const WalletListCurrencyRowComponent: React.FC<Props> = props => {
             tokenId={tokenId}
             currencyConfig={wallet.currencyConfig}
             hideBalance={hideBalance}
+            autoPrecision={false}
             style={styles.secondaryText}
           />
         </View>


### PR DESCRIPTION
### Description

Fiat balances in the Wallets list (Assets tab) were auto-expanding to 3-6 decimal places for sub-$1 balances (e.g. `$0.000018`, `$0.635`), instead of rounding to cents like the wallet detail scene does (`$0.01 EUR`). The list row's balance `<FiatText>` relied on the default `autoPrecision` behavior meant for showing tiny unit prices legibly, not for a final balance total.

Fix: pass `autoPrecision={false}` to the balance `<FiatText>` in `WalletListCurrencyRow.tsx` so it renders at the standard 2-decimal precision, matching the detail scene. The sibling per-unit price `<FiatText>` in the same row is untouched and still auto-expands, since that's intentional for tiny unit prices.

[Limit fiat amounts to 2 decimals in Wallets list](https://app.asana.com/0/1215088146871429/1212704852394135)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

Tested on the iOS simulator only (screenshot attached below). The change is in a platform-agnostic shared RN component (`WalletListCurrencyRow.tsx` / `useFiatText`), so it applies identically on Android; not separately verified on an Android device or on small/large-screen form factors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prop on a shared list row with no auth, payment, or data-layer changes.
> 
> **Overview**
> **Wallet list fiat balances** now show standard **two-decimal** amounts (e.g. `$0.01`) instead of auto-expanded precision for tiny totals (e.g. `$0.000018`), aligning the Assets tab with the wallet detail scene.
> 
> The change sets `autoPrecision={false}` on the balance `FiatText` in `WalletListCurrencyRow`; the per-unit fiat price in the same row still uses default auto-precision for small unit prices. A CHANGELOG entry was added under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a06bf8a2535dfc2cbd70842c7b9a8f054a34390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->