### PR TITLE
Stop notification cards from shrinking their text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Notification center cards no longer shrink their text to fit. Long titles and messages now truncate with an ellipsis so every card renders at the same size.
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -231,7 +231,6 @@ export default [
       'src/components/modals/WalletListSortModal.tsx',
       'src/components/modals/WcSmartContractModal.tsx',
 
-      'src/components/navigation/AlertDropdown.tsx',
       'src/components/navigation/BackButton.tsx',
       'src/components/navigation/CurrencySettingsTitle.tsx',
       'src/components/navigation/EdgeHeader.tsx',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -245,7 +245,7 @@ export default [
       'src/components/navigation/ParamHeaderTitle.tsx',
       'src/components/navigation/SideMenuButton.tsx',
       'src/components/navigation/TransactionDetailsTitle.tsx',
-      'src/components/notification/NotificationCenterCard.tsx',
+
       'src/components/progress-indicators/AccountSyncBar.tsx',
 
       'src/components/progress-indicators/FullScreenLoader.tsx',

--- a/src/components/navigation/AlertDropdown.tsx
+++ b/src/components/navigation/AlertDropdown.tsx
@@ -36,7 +36,7 @@ interface Props {
   onPress?: () => void | Promise<void>
 }
 
-export function AlertDropdown(props: Props) {
+export const AlertDropdown: React.FC<Props> = props => {
   const {
     bridge,
     error,
@@ -95,7 +95,7 @@ export function AlertDropdown(props: Props) {
             {message}
           </UnscaledText>
         </EdgeTouchableOpacity>
-        <EdgeTouchableOpacity onPress={handleClose}>
+        <EdgeTouchableOpacity onPress={handleClose} testID="alertDropdownClose">
           <AntDesignIcon
             name="closecircle"
             size={theme.rem(1)}

--- a/src/components/notification/NotificationCenterCard.tsx
+++ b/src/components/notification/NotificationCenterCard.tsx
@@ -98,15 +98,24 @@ const NotificationCenterCard: React.FC<NotificationCenterCardProps> = props => {
         <FastImage style={styles.icon} source={{ uri: iconUri }} />
         <View style={styles.cardContentContainer}>
           <View style={styles.titleContainer}>
-            <EdgeText style={styles.titleText} numberOfLines={2}>
+            {/* Font scaling is disabled so every card renders at the same text
+                size. Long titles and messages wrap up to their line limit and
+                then truncate with an ellipsis instead of shrinking. */}
+            <EdgeText
+              style={styles.titleText}
+              numberOfLines={2}
+              disableFontScaling
+            >
               {title}
             </EdgeText>
-            <EdgeText style={styles.timeText}>{toLocaleTime(date)}</EdgeText>
+            <EdgeText style={styles.timeText} disableFontScaling>
+              {toLocaleTime(date)}
+            </EdgeText>
           </View>
           <EdgeText
             style={styles.messageText}
             numberOfLines={3}
-            minimumFontScale={0.8}
+            disableFontScaling
           >
             {message}
           </EdgeText>

--- a/src/components/notification/NotificationCenterCard.tsx
+++ b/src/components/notification/NotificationCenterCard.tsx
@@ -2,12 +2,12 @@ import * as React from 'react'
 import { View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import { cacheStyles } from 'react-native-patina'
-import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
 import { useHandler } from '../../hooks/useHandler'
 import { toLocaleDate, toLocaleTime } from '../../locales/intl'
 import { getThemedIconUri } from '../../util/CdnUris'
 import { EdgeTouchableOpacity } from '../common/EdgeTouchableOpacity'
+import { CloseIcon } from '../icons/ThemedIcons'
 import { type Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 
@@ -23,7 +23,7 @@ interface Props {
   onClose?: () => void | Promise<void>
 }
 
-export const NotificationCenterRow = (props: Props) => {
+export const NotificationCenterRow: React.FC<Props> = props => {
   const theme = useTheme()
   const styles = getStyles(theme)
 
@@ -71,7 +71,7 @@ interface NotificationCenterCardProps {
   onClose?: () => void | Promise<void>
 }
 
-const NotificationCenterCard = (props: NotificationCenterCardProps) => {
+const NotificationCenterCard: React.FC<NotificationCenterCardProps> = props => {
   const theme = useTheme()
   const styles = getStyles(theme)
 
@@ -114,11 +114,7 @@ const NotificationCenterCard = (props: NotificationCenterCardProps) => {
       </EdgeTouchableOpacity>
       {onClose == null ? null : (
         <EdgeTouchableOpacity style={styles.closeButton} onPress={handleClose}>
-          <AntDesignIcon
-            color={theme.iconTappable}
-            name="close"
-            size={theme.rem(1.25)}
-          />
+          <CloseIcon color={theme.iconTappable} size={theme.rem(1.25)} />
         </EdgeTouchableOpacity>
       )}
     </View>


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1213213636561471/f)

Notification Center cards (side menu → Notifications) shrank their own text. `EdgeText` defaults to `adjustsFontSizeToFit={true}`, and the card passed `numberOfLines={3}` with `minimumFontScale={0.8}` on the message and the 0.65 default on the title, so any notification whose message did not fit rendered smaller than its neighbours. Because the title and message share a height-constrained content container, the shrink cascaded to the title too, which is why one card in the reported screenshot is visibly smaller top to bottom.

The card now passes `disableFontScaling` on the title, timestamp and message, so every card renders at the same size and a message longer than three lines truncates with an ellipsis instead. This matches the requested behaviour: uniform cards, three lines, then "…". The home-screen banner (`NotificationCard`) already does the same thing on Android and is unchanged here.

Also included:

- A standalone lint-fix commit for `NotificationCenterCard` (explicit `React.FC` types, shared themed `CloseIcon` instead of importing `react-native-vector-icons` directly), since committing the file graduates it off the lint suppression list.
- A `testID` on the alert drop-down's close button so UI tests can dismiss it by selector rather than by coordinate.

Asana: https://app.asana.com/1/9976422036640/project/1200382638405084/task/1213213636561471

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only notification UI and test/lint hygiene; no auth, payments, or data flow changes.
> 
> **Overview**
> **Notification center cards** no longer shrink title, time, or message text to fit. The card passes **`disableFontScaling`** on those `EdgeText` fields and drops **`minimumFontScale`** on the message, so long copy truncates at **`numberOfLines`** (2 for title, 3 for message) with an ellipsis while every card stays the same height.
> 
> **Lint / small extras:** `NotificationCenterCard` is brought in line with project rules (explicit **`React.FC`**, themed **`CloseIcon`** instead of direct vector-icons) so it can come off the ESLint suppression list. **`AlertDropdown`** gets the same **`React.FC`** typing and **`testID="alertDropdownClose"`** on the dismiss control for UI tests. **CHANGELOG** documents the notification card fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb2c1d8fe3a11d1ce8c8831b7cbf622e5ff28d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->