### PR TITLE
Style entire signin line as tertiary link on getting-started scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- changed: Style the entire "Already have an account? Sign in" line in the getting-started USP carousel with the tertiary link color, not just "Sign in".
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/src/components/scenes/GettingStartedScene.tsx
+++ b/src/components/scenes/GettingStartedScene.tsx
@@ -533,7 +533,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
     alignItems: 'center'
   },
   tertiaryText: {
-    color: theme.textInputTextColorDisabled
+    color: theme.iconTappable
   },
   tappableText: {
     color: theme.iconTappable


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1210918230992220/f)

Style the entire "Already have an account? Sign in" line on the getting-started USP carousel as the tertiary link color (`theme.iconTappable`), not just the "Sign in" word. The line was already a single tap target (`EdgeTouchableOpacity` wraps both spans); only the color changes.

[USPs - Signin UI clarification](https://app.asana.com/1/9976422036640/project/1200382638405084/task/1210918230992220)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic color change on the getting-started screen only; no navigation, auth, or data handling changes.
> 
> **Overview**
> On the getting-started USP carousel, the **entire** “Already have an account? Sign in” row now uses the tertiary link color (`theme.iconTappable`), not only the “Sign in” span.
> 
> `tertiaryText` in `GettingStartedScene` is updated from `theme.textInputTextColorDisabled` to match `tappableText`. Tap behavior is unchanged—the row was already one `EdgeTouchableOpacity` target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6280f0b6e0179929607b199b0895765ead3e062f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->