### PR TITLE
Sort Privacy Settings asset list alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Sort the Privacy Settings Nym Mix Net asset list alphabetically by display name
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/src/components/scenes/PrivacySettingsScene.tsx
+++ b/src/components/scenes/PrivacySettingsScene.tsx
@@ -34,15 +34,21 @@ export const PrivacySettingsScene: React.FC<Props> = props => {
   const account = useSelector(state => state.core.account)
   const { currencyConfig } = account
 
-  // Get list of pluginIds that support network privacy
+  // Get list of pluginIds that support network privacy, sorted
+  // alphabetically by display name
   const supportedPluginIds = React.useMemo(() => {
-    return Object.keys(currencyConfig).filter(pluginId => {
+    const pluginIds = Object.keys(currencyConfig).filter(pluginId => {
       const config = currencyConfig[pluginId]
       const defaultSetting = asMaybePrivateNetworkingSetting(
         config.currencyInfo.defaultSettings
       )
       return defaultSetting != null
     })
+    return pluginIds.sort((a, b) =>
+      currencyConfig[a].currencyInfo.displayName.localeCompare(
+        currencyConfig[b].currencyInfo.displayName
+      )
+    )
   }, [currencyConfig])
 
   return (


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1213919322792026/f)

The Nym Mixnet asset list on the Privacy Settings scene was ordered by plugin registration order instead of alphabetically, so the list rendered in different, inconsistent orders on iOS vs Android (QA repro: iOS started with Monero, Android started with Abstract with Monero at the bottom).

Fix: `PrivacySettingsScene.tsx`'s `supportedPluginIds` memo now sorts the filtered plugin list by `currencyInfo.displayName` (the label actually rendered in each row) via `localeCompare`, so the list is alphabetical and platform-independent.

[Privacy Settings - List Sorting Order](https://app.asana.com/1/9976422036640/project/1201386023359434/task/1213919322792026)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

Tested on the iOS simulator only (screenshot attached below), confirming the asset list now renders alphabetically (Abstract, Amoy Testnet, Arbitrum One, Avalanche, Axelar, Base, BNB Smart Chain, BOB, ...). The sort is platform-agnostic (plain array sort on shared data), so it applies identically on Android; not separately verified on an Android device.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-order only in Privacy Settings; no changes to toggles, persistence, or network privacy behavior.
> 
> **Overview**
> **Privacy Settings** now lists Nym Mixnet-capable assets in **alphabetical order by `displayName`**, instead of whatever order `currencyConfig` keys happen to use (which differed on iOS vs Android).
> 
> The `supportedPluginIds` memo in `PrivacySettingsScene` still filters plugins with private-networking defaults; it now sorts that list with `localeCompare` on the same label each row shows. CHANGELOG updated under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69eff6269ffe5a88a49ad7789fa1c2aeb81cd464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->