### PR TITLE
Fix Next button overlapping wallet list in Choose Wallets to Add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Next button overlapping the wallet list on the Choose Wallets to Add scene
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletSelectCryptoScene.test.tsx.snap
@@ -816,7 +816,7 @@ exports[`CreateWalletSelectCrypto should render with loading props 1`] = `
         contentContainerStyle={
           {
             "marginHorizontal": 11,
-            "paddingBottom": 112,
+            "paddingBottom": 0,
             "paddingLeft": 0,
             "paddingRight": 0,
             "paddingTop": 0,

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -22,10 +22,9 @@ import {
 import { useDispatch, useSelector } from '../../types/reactRedux'
 import type { EdgeAppSceneProps, NavigationBase } from '../../types/routerTypes'
 import type { EdgeAsset } from '../../types/types'
-import { isMaestro } from '../../util/maestro'
 import { logEvent } from '../../util/tracking'
 import { EdgeButton } from '../buttons/EdgeButton'
-import { SceneButtons } from '../buttons/SceneButtons'
+import { KavButtons } from '../buttons/KavButtons'
 import { EdgeAnim } from '../common/EdgeAnim'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { SearchIconAnimated } from '../icons/ThemedIcons'
@@ -137,6 +136,7 @@ const CreateWalletSelectCryptoComponent: React.FC<Props> = (props: Props) => {
     }
     return out
   })
+  const [isNextPending, setIsNextPending] = React.useState(false)
 
   const findMainnetItem = (pluginId: string): MainWalletCreateItem => {
     const newItem = createWalletList.find(item => item.pluginId === pluginId)
@@ -166,7 +166,17 @@ const CreateWalletSelectCryptoComponent: React.FC<Props> = (props: Props) => {
       showError(lstrings.create_wallet_no_assets_selected)
       return
     }
+    setIsNextPending(true)
+    try {
+      await handleNextPressBody()
+    } catch (error: unknown) {
+      showError(error)
+    } finally {
+      setIsNextPending(false)
+    }
+  })
 
+  const handleNextPressBody = useHandler(async () => {
     if (newAccountFlow != null)
       dispatch(
         logEvent('Signup_Wallets_Selected_Next', {
@@ -423,13 +433,14 @@ const CreateWalletSelectCryptoComponent: React.FC<Props> = (props: Props) => {
             exit={{ type: 'fadeOut', duration: 300 }}
             accessible={false}
           >
-            <SceneButtons
+            <KavButtons
               primary={{
                 label: lstrings.string_next_capitalized,
                 onPress: handleNextPress,
+                spinner: isNextPending,
+                disabled: isNextPending,
                 testID: 'nextButton'
               }}
-              absolute={!isMaestro()}
             />
           </EdgeAnim>
         )
@@ -465,7 +476,6 @@ const CreateWalletSelectCryptoComponent: React.FC<Props> = (props: Props) => {
             contentContainerStyle={{
               ...insetStyle,
               paddingTop: 0,
-              paddingBottom: insetStyle.paddingBottom + theme.rem(5),
               marginHorizontal: theme.rem(0.5)
             }}
             data={filteredCreateWalletList}

--- a/src/components/scenes/CreateWalletSelectCryptoScene.tsx
+++ b/src/components/scenes/CreateWalletSelectCryptoScene.tsx
@@ -24,7 +24,6 @@ import type { EdgeAppSceneProps, NavigationBase } from '../../types/routerTypes'
 import type { EdgeAsset } from '../../types/types'
 import { logEvent } from '../../util/tracking'
 import { EdgeButton } from '../buttons/EdgeButton'
-import { KavButtons } from '../buttons/KavButtons'
 import { EdgeAnim } from '../common/EdgeAnim'
 import { SceneWrapper } from '../common/SceneWrapper'
 import { SearchIconAnimated } from '../icons/ThemedIcons'
@@ -136,8 +135,6 @@ const CreateWalletSelectCryptoComponent: React.FC<Props> = (props: Props) => {
     }
     return out
   })
-  const [isNextPending, setIsNextPending] = React.useState(false)
-
   const findMainnetItem = (pluginId: string): MainWalletCreateItem => {
     const newItem = createWalletList.find(item => item.pluginId === pluginId)
     return newItem as MainWalletCreateItem
@@ -166,17 +163,7 @@ const CreateWalletSelectCryptoComponent: React.FC<Props> = (props: Props) => {
       showError(lstrings.create_wallet_no_assets_selected)
       return
     }
-    setIsNextPending(true)
-    try {
-      await handleNextPressBody()
-    } catch (error: unknown) {
-      showError(error)
-    } finally {
-      setIsNextPending(false)
-    }
-  })
 
-  const handleNextPressBody = useHandler(async () => {
     if (newAccountFlow != null)
       dispatch(
         logEvent('Signup_Wallets_Selected_Next', {
@@ -433,14 +420,12 @@ const CreateWalletSelectCryptoComponent: React.FC<Props> = (props: Props) => {
             exit={{ type: 'fadeOut', duration: 300 }}
             accessible={false}
           >
-            <KavButtons
-              primary={{
-                label: lstrings.string_next_capitalized,
-                onPress: handleNextPress,
-                spinner: isNextPending,
-                disabled: isNextPending,
-                testID: 'nextButton'
-              }}
+            <EdgeButton
+              type="primary"
+              layout="solo"
+              label={lstrings.string_next_capitalized}
+              onPress={handleNextPress}
+              testID="nextButton"
             />
           </EdgeAnim>
         )


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Fixes the Next button overlapping/hiding the last row(s) of the wallet list on the "Choose Wallets to Add" scene, reported from both the onboarding wallet-selection flow and the logged-in "+" add-wallet flow.

Both entry points already render the same shared component, `CreateWalletSelectCryptoScene`, registered under two route names (`createWalletSelectCryptoNewAccount` for onboarding, `createWalletSelectCrypto` for the logged-in "+" button) in `Main.tsx`. The bug was a double-absolute-positioning defect inside that one component: the Next button was rendered via `SceneButtons` with `absolute={!isMaestro()}` while already being a child of `SceneWrapper`'s `dockProps.children`, which itself renders inside its own absolutely-positioned, keyboard-aware dock. Making the button additionally `position: absolute` took it out of the dock's layout flow, so the dock's measured height collapsed and the scene under-reserved scroll clearance for it, letting the last row(s) end up behind the button when scrolled to the end. The `isMaestro()` branch meant Maestro exercised a different, correctly-docked layout than production, so this class of bug was invisible to automated tests.

Fix: switch to `KavButtons`, the same primitive every other scene in this codebase uses inside `dockProps.children` (e.g. `RampCreateScene`, `SwapCreateScene`, `GiftCardPurchaseScene`), and drop the now-unneeded manual `paddingBottom` compensation since the dock's real height is now measured correctly.

**Followup:** `KavButtons`' primary-only path renders the button at `layout="fullWidth"`, which stretches it edge to edge. Feedback on the task was that the button should not span the full screen width. Switched to `EdgeButton` directly with `layout="solo"` (documented as safe to use standalone), which renders the same narrow, centered pill the scene originally had before this PR, and removed `KavButtons` from this scene entirely. `EdgeButton`'s own `usePendingPress` hook manages the pending/spinner/error state internally when `onPress` returns a promise, so the scene-owned `isNextPending` state and try/catch/finally wrapper added for the earlier Bugbot finding are no longer needed and were removed.

Asana task: https://app.asana.com/0/1215088146871429/1211940991169286

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout fix on a single shared create-wallet scene; no auth, payments, or data-path changes.
> 
> **Overview**
> Fixes the **Next** button covering the last wallet rows on **Choose Wallets to Add** (`CreateWalletSelectCryptoScene`), used from both onboarding and the logged-in add-wallet flow.
> 
> The docked footer previously used **`SceneButtons`** with **`absolute={!isMaestro()}`** inside **`SceneWrapper`**’s **`dockProps`**, which already lays out an absolutely positioned dock—so the button left normal layout, the dock’s height collapsed, and the list didn’t reserve enough bottom space. The change replaces that with an in-flow **`EdgeButton`** (`layout="solo"`) and drops the extra **`FlatList`** **`paddingBottom`** compensation so inset sizing matches the real dock height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f3aa75671e82e0df7d208c316c8704bca2906a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
