### PR TITLE
Wrap fiat value in parens on Stake amount tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Wrap the fiat value in parentheses on the Stake/Unstake/Claim amount row.
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -401,7 +401,7 @@ export default [
       'src/components/tiles/AprCard.tsx',
       'src/components/tiles/CountdownTile.tsx',
       'src/components/tiles/CryptoFiatAmountTile.tsx',
-      'src/components/tiles/EditableAmountTile.tsx',
+
       'src/components/tiles/ErrorTile.tsx',
       'src/components/tiles/FiatAmountTile.tsx',
       'src/components/tiles/InterestRateChangeTile.tsx',

--- a/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SendScene2.ui.test.tsx.snap
@@ -925,7 +925,7 @@ exports[`SendScene2 1 spendTarget 1`] = `
                       ]
                     }
                   >
-                    € 0.23
+                    (€ 0.23)
                   </Text>
                 </View>
                 <View
@@ -2703,7 +2703,7 @@ exports[`SendScene2 1 spendTarget with info tiles 1`] = `
                       ]
                     }
                   >
-                    € 0.23
+                    (€ 0.23)
                   </Text>
                 </View>
                 <View
@@ -4945,7 +4945,7 @@ exports[`SendScene2 2 spendTargets 1`] = `
                       ]
                     }
                   >
-                    € 2.26
+                    (€ 2.26)
                   </Text>
                 </View>
                 <View
@@ -6722,7 +6722,7 @@ exports[`SendScene2 2 spendTargets hide tiles 1`] = `
                       ]
                     }
                   >
-                    € 2.26
+                    (€ 2.26)
                   </Text>
                 </View>
                 <View
@@ -11382,7 +11382,7 @@ exports[`SendScene2 2 spendTargets lock tiles 1`] = `
                       ]
                     }
                   >
-                    € 2.26
+                    (€ 2.26)
                   </Text>
                 </View>
                 <View
@@ -13157,7 +13157,7 @@ exports[`SendScene2 2 spendTargets lock tiles 2`] = `
                       ]
                     }
                   >
-                    € 2.26
+                    (€ 2.26)
                   </Text>
                 </View>
               </View>
@@ -14786,7 +14786,7 @@ exports[`SendScene2 2 spendTargets lock tiles 3`] = `
                       ]
                     }
                   >
-                    € 2.26
+                    (€ 2.26)
                   </Text>
                 </View>
               </View>

--- a/src/components/tiles/EditableAmountTile.tsx
+++ b/src/components/tiles/EditableAmountTile.tsx
@@ -29,7 +29,7 @@ interface Props {
   onPress: () => void
 }
 
-export const EditableAmountTile = (props: Props) => {
+export const EditableAmountTile: React.FC<Props> = props => {
   let cryptoAmountSyntax
   let cryptoAmountStyle
   let fiatAmountSyntax
@@ -74,7 +74,7 @@ export const EditableAmountTile = (props: Props) => {
       exchangeAmount
     )
     cryptoAmountSyntax = `${displayAmount ?? '0'} ${displayDenomination.name}`
-    if (fiatAmount) {
+    if (fiatAmount !== '') {
       fiatAmountSyntax = `${fiatSymbol} ${
         toFixed(round(fiatAmount, -2), 2, 2) ?? '0'
       }`

--- a/src/components/tiles/EditableAmountTile.tsx
+++ b/src/components/tiles/EditableAmountTile.tsx
@@ -119,7 +119,7 @@ export const EditableAmountTile: React.FC<Props> = props => {
             {cryptoAmountSyntax}
           </EdgeText>
           {fiatAmountSyntax == null ? null : (
-            <EdgeText>{fiatAmountSyntax}</EdgeText>
+            <EdgeText>{`(${fiatAmountSyntax})`}</EdgeText>
           )}
         </EdgeRow>
       </EdgeAnim>


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1210364105386494/f)

The Stake/Unstake/Claim amount row (`EditableAmountTile`) rendered the fiat
value raw, right after the crypto amount, with no surrounding brackets.
Its `compressed` render branch and the sibling `CryptoFiatAmountTile`
(used on the Earn overview list) already wrap fiat text in parens; the
default (non-compressed) branch was the one instance still missing it.
Wrapped it to match.

The exact "staked / earned / unstaked" overview rows from the original
repro (`CryptoFiatAmountTile` on the Earn overview scene) were already
fixed on `develop` by an unrelated refactor (`bbd3259a6`, 2025-10-17,
predates this branch) — no change needed there.

Asana: https://app.asana.com/1/9976422036640/project/1201386023359434/task/1210364105386494

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting on a shared tile component; no payment, staking, or rate logic changes.
> 
> **Overview**
> Stake/Unstake/Claim amount rows use **`EditableAmountTile`**. The default layout showed the fiat equivalent next to the crypto amount **without** parentheses, while the compressed branch and **`CryptoFiatAmountTile`** already used `(fiat)`.
> 
> The default branch now renders fiat as **`(${fiatAmountSyntax})`**, aligned with those patterns. Fiat text is only built when **`fiatAmount !== ''`** (instead of a truthy check). The component is typed as **`React.FC`**. CHANGELOG and Send scene snapshots are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8845628b43711bd89e30219b61aa59c02ee698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->