### PR TITLE
Fix staked locked balance text cutoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Staked "locked" balance in the wallet view no longer gets cut off. The crypto amount is truncated to an exchange-rate-appropriate number of decimals, and the text is no longer clamped to a fraction of the card width.
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/src/components/themed/TransactionListTop.tsx
+++ b/src/components/themed/TransactionListTop.tsx
@@ -41,6 +41,7 @@ import type {
   WalletsTabSceneProps
 } from '../../types/routerTypes'
 import { CryptoAmount } from '../../util/CryptoAmount'
+import { getCryptoText } from '../../util/cryptoTextUtils'
 import { isKeysOnlyPlugin } from '../../util/CurrencyInfoHelpers'
 import { triggerHaptic } from '../../util/haptic'
 import {
@@ -55,6 +56,7 @@ import { getUkCompliantString } from '../../util/ukComplianceUtils'
 import {
   convertNativeToDenomination,
   DECIMAL_PRECISION,
+  getDenomFromIsoCode,
   removeIsoPrefix,
   zeroString
 } from '../../util/utils'
@@ -587,12 +589,16 @@ export const TransactionListTop: React.FC<Props> = props => {
     const nativeLocked = add(fioStatus.locked, lockedNativeAmount)
     if (nativeLocked === '0') return null
 
-    const stakingCryptoAmount = convertNativeToDenomination(
-      displayDenomination.multiplier
-    )(nativeLocked)
-    const stakingCryptoAmountFormat = formatNumber(
-      add(stakingCryptoAmount, '0')
-    )
+    // Truncate to an exchange-rate-appropriate number of decimals, so the
+    // whole "locked" message stays readable on narrow screens:
+    const stakingCryptoText = getCryptoText({
+      currencyCode: displayDenomination.name,
+      displayDenomination,
+      exchangeDenomination,
+      exchangeRate,
+      fiatDenomination: getDenomFromIsoCode(defaultIsoFiat),
+      nativeAmount: nativeLocked
+    })
 
     const stakingExchangeAmount = convertNativeToDenomination(
       exchangeDenomination.multiplier
@@ -608,7 +614,7 @@ export const TransactionListTop: React.FC<Props> = props => {
         <EdgeText style={styles.stakingStatusText}>
           {sprintf(
             lstrings.staking_status,
-            stakingCryptoAmountFormat + ' ' + displayDenomination.name,
+            stakingCryptoText,
             fiatSymbol + stakingFiatBalanceFormat + ' ' + defaultFiat
           )}
         </EdgeText>
@@ -909,15 +915,12 @@ const getStyles = cacheStyles((theme: Theme) => ({
   // Staking Box
   stakingBoxContainer: {
     height: theme.rem(1.25),
-    minWidth: theme.rem(18),
-    maxWidth: '70%',
     alignItems: 'center',
-    flexDirection: 'row',
-    justifyContent: 'space-between'
+    flexDirection: 'row'
   },
   stakingStatusText: {
+    flexShrink: 1,
     color: theme.secondaryText,
-    maxWidth: '70%',
     fontSize: theme.rem(1)
   }
 }))


### PR DESCRIPTION
### Description

The staked "locked" line under the wallet balance rendered the locked crypto amount at full native precision (e.g. `0.010457773261160339 ETH locked ($18.97 USD)`), so the message got cut off mid-string on narrow screens.

Two causes, both fixed:

- The amount was formatted with a raw `convertNativeToDenomination` + `formatNumber`, bypassing the exchange-rate-adjusted truncation every other crypto amount in the app goes through. It now uses the shared `getCryptoText` helper, which truncates to a precision appropriate for the asset's exchange rate (`0.0104577 ETH` for ETH at ~$1.9k).
- `stakingBoxContainer` carried a `maxWidth: '70%'` (contradicted by a `minWidth: 18rem`) and `stakingStatusText` carried a second `maxWidth: '70%'` on top of it, clamping the text to roughly half the card width. Both clamps are gone; the text row now spans the card and shrinks with `flexShrink`.

Asana: https://app.asana.com/0/1215088146871429/1210166111258621

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

Verified on the iOS simulator (iPhone 16 Pro Max, iOS 18.6) against the `My Ether 4` mainnet ETH wallet. The account holds no real stake position, so the locked amount was forced with a temporary uncommitted edit (`lockedNativeAmount` pinned to the bug report's `10457773261160339` wei) to render the real component with real denominations and a live exchange rate. Before/after frames are attached below; the hack was reverted and the tree verified clean before committing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized wallet-header UI and styling in TransactionListTop with no auth, payment, or data-model changes.
> 
> **Overview**
> Fixes the wallet view **staked "locked"** line being truncated on narrow screens when the crypto amount was shown at full precision.
> 
> **`TransactionListTop`** now formats the locked amount with **`getCryptoText`** (same exchange-rate-aware truncation as elsewhere) instead of raw denomination conversion plus **`formatNumber`**. Staking row styles drop the **`maxWidth: '70%'`** clamps on the container and label; the text row can use the card width and **`flexShrink: 1`** on the label.
> 
> **`CHANGELOG.md`** records the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349a27a2ac9a32daa3d5a18263bca51cd1be8656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->