### PR TITLE
Migrate raw keys and master private key warnings to UI4 card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- changed: Use the UI4 warning card for the Reveal Raw Keys and Reveal Master Private Key password confirmation warnings.
+
 ## 4.50.0 (2026-07-21)
 
 - added: Changelly swap provider

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -225,7 +225,6 @@ export default [
       'src/components/modals/ScanModal.tsx',
       'src/components/modals/StateProvinceListModal.tsx',
 
-      'src/components/modals/TextInputModal.tsx',
       'src/components/modals/TransferModal.tsx',
 
       'src/components/modals/WalletListSortModal.tsx',

--- a/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
@@ -286,12 +286,13 @@ exports[`TextInputModal should render with a blank input field 1`] = `
       </View>
     </View>
     <View
-      fullHeight={false}
       style={
-        {
-          "flexGrow": undefined,
-          "flexShrink": 1,
-        }
+        [
+          {
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
       }
     >
       <Text
@@ -1139,12 +1140,13 @@ exports[`TextInputModal should render with a populated input field 1`] = `
       </View>
     </View>
     <View
-      fullHeight={false}
       style={
-        {
-          "flexGrow": undefined,
-          "flexShrink": 1,
-        }
+        [
+          {
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
       }
     >
       <Text

--- a/src/components/modals/TextInputModal.tsx
+++ b/src/components/modals/TextInputModal.tsx
@@ -9,8 +9,8 @@ import type { AirshipBridge } from 'react-native-airship'
 
 import { lstrings } from '../../locales/strings'
 import { ModalButtons } from '../buttons/ModalButtons'
+import { AlertCardUi4 } from '../cards/AlertCard'
 import { showError } from '../services/AirshipInstance'
-import { Alert } from '../themed/Alert'
 import { Paragraph } from '../themed/EdgeText'
 import {
   type FilledTextInputReturnKeyType,
@@ -123,12 +123,11 @@ export const TextInputModal: React.FC<Props> = props => {
           <>{message}</>
         )}
         {warningMessage != null ? (
-          <Alert
+          <AlertCardUi4
             type="warning"
             title={lstrings.string_warning}
+            body={warningMessage}
             marginRem={0.5}
-            message={warningMessage}
-            numberOfLines={0}
           />
         ) : null}
         <ModalFilledTextInput

--- a/src/components/modals/TextInputModal.tsx
+++ b/src/components/modals/TextInputModal.tsx
@@ -4,12 +4,11 @@
  */
 
 import * as React from 'react'
-import { Platform, View } from 'react-native'
+import { Platform, StyleSheet, View } from 'react-native'
 import type { AirshipBridge } from 'react-native-airship'
 
 import { lstrings } from '../../locales/strings'
 import { ModalButtons } from '../buttons/ModalButtons'
-import { styled } from '../hoc/styled'
 import { showError } from '../services/AirshipInstance'
 import { Alert } from '../themed/Alert'
 import { Paragraph } from '../themed/EdgeText'
@@ -57,7 +56,7 @@ interface Props {
   secureTextEntry?: boolean
 }
 
-export function TextInputModal(props: Props) {
+export const TextInputModal: React.FC<Props> = props => {
   const {
     autoCapitalize,
     autoFocus = true,
@@ -82,12 +81,12 @@ export function TextInputModal(props: Props) {
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>()
   const [text, setText] = React.useState(initialValue)
 
-  const handleChangeText = (text: string) => {
+  const handleChangeText = (text: string): void => {
     setText(text)
     setErrorMessage(undefined)
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = (): void => {
     if (onSubmit == null) {
       bridge.resolve(text)
       return
@@ -100,7 +99,7 @@ export function TextInputModal(props: Props) {
           bridge.resolve(text)
         }
       },
-      error => {
+      (error: unknown) => {
         showError(error)
       }
     )
@@ -115,7 +114,9 @@ export function TextInputModal(props: Props) {
         bridge.resolve(undefined)
       }}
     >
-      <StyledInnerView fullHeight={multiline}>
+      <View
+        style={[styles.innerView, multiline ? styles.fullHeight : undefined]}
+      >
         {typeof message === 'string' ? (
           <Paragraph>{message}</Paragraph>
         ) : (
@@ -156,12 +157,16 @@ export function TextInputModal(props: Props) {
           blurOnSubmit={multiline ? false : undefined}
         />
         <ModalButtons primary={{ label: submitLabel, onPress: handleSubmit }} />
-      </StyledInnerView>
+      </View>
     </EdgeModal>
   )
 }
 
-const StyledInnerView = styled(View)<{ fullHeight: boolean }>(() => props => ({
-  flexShrink: 1,
-  flexGrow: props.fullHeight ? 1 : undefined
-}))
+const styles = StyleSheet.create({
+  innerView: {
+    flexShrink: 1
+  },
+  fullHeight: {
+    flexGrow: 1
+  }
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

The Reveal Raw Keys and Reveal Master Private Key password confirmation
screens still used the legacy bordered `Alert` component for their warning
text, while the Export Logs modal (the UI4 reference) uses the solid
gradient `AlertCardUi4` card. This PR swaps `TextInputModal`'s warning
render (shared by both screens) from `Alert` to `AlertCardUi4`, matching
the Export Logs style and `edge-login-ui-rn`'s own copy of `TextInputModal`,
which had already made this same change.

Verified live on the iOS sim: Wallet List menu -> Master Private Key and
Get Raw Keys both now show the gradient warning card instead of the old
outlined box (screenshots attached below).

[Asana task](https://app.asana.com/0/1215088146871429/1208764375950295)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in a shared modal; no auth, key derivation, or password-check logic is modified.
> 
> **Overview**
> Password confirmation modals for **Reveal Raw Keys** and **Reveal Master Private Key** now show warnings with the UI4 **`AlertCardUi4`** gradient card instead of the legacy bordered **`Alert`**, aligned with Export Logs and `edge-login-ui-rn`.
> 
> **`TextInputModal`** maps `warningMessage` to `AlertCardUi4` (`type="warning"`, localized title, `body` prop) and drops the old `styled` layout in favor of **`StyleSheet`** for the multiline inner container. Snapshots and ESLint coverage for the modal are updated accordingly; **CHANGELOG** notes the user-visible change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f40e807367e4f27083a522ddd15e631ed6d7f986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->