### PR TITLE
Upgrade edge-exchange-plugins to 2.52.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- fixed: NYM max swaps from EVM wallets now report the correct limit error instead of an unsupported-route error (edge-exchange-plugins 2.52.1).
 - changed: Sign MoonPay buy/sell widget URLs and bind them to the customer's IP via the info server, for MoonPay's on-ramp IP-matching security upgrade.
 
 ## 4.50.0 (2026-07-21)

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "edge-core-js": "^2.47.1",
         "edge-currency-accountbased": "^4.86.2",
         "edge-currency-plugins": "^3.11.0",
-        "edge-exchange-plugins": "^2.52.0",
+        "edge-exchange-plugins": "^2.52.1",
         "edge-info-server": "^3.12.0",
         "edge-login-ui-rn": "^3.36.0",
         "ethers": "^5.7.2",
@@ -15569,9 +15569,9 @@
       }
     },
     "node_modules/edge-exchange-plugins": {
-      "version": "2.52.0",
-      "resolved": "https://registry.npmjs.org/edge-exchange-plugins/-/edge-exchange-plugins-2.52.0.tgz",
-      "integrity": "sha512-0LosZegOBXfw65YR6K5biwW+y72lDe17LgsxZOu4vmB64VvSBbUG543qnb4bcMX5yapSlkq7n/cOOTo3pD3AUw==",
+      "version": "2.52.1",
+      "resolved": "https://registry.npmjs.org/edge-exchange-plugins/-/edge-exchange-plugins-2.52.1.tgz",
+      "integrity": "sha512-JZ48+nYFrUIAK0/WmQpRgD4M0ynA07UR5LdGxwwcLj5OkxrMF9RBCjKcVLWeKmDnt82AIVGIYHcE3MJ6gM95zA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@cosmjs/encoding": "^0.32.2",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "edge-core-js": "^2.47.1",
     "edge-currency-accountbased": "^4.86.2",
     "edge-currency-plugins": "^3.11.0",
-    "edge-exchange-plugins": "^2.52.0",
+    "edge-exchange-plugins": "^2.52.1",
     "edge-info-server": "^3.12.0",
     "edge-login-ui-rn": "^3.36.0",
     "ethers": "^5.7.2",


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

[Asana task](https://app.asana.com/0/0/1216815078906704/f)

none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch dependency upgrade only; swap error messaging improves with no GUI logic changes.
> 
> **Overview**
> Bumps **`edge-exchange-plugins`** from **2.52.0** to **2.52.1** in `package.json` and `package-lock.json`, with no other application code changes.
> 
> The release fixes NYM **max** swap attempts from EVM wallets so users see the correct **limit** error instead of a misleading **unsupported route** error. The unreleased **CHANGELOG** documents this behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee140f24041da40a1bd32b5992c21aef2cfee67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->