### PR TITLE
Restore Banxa and Paybis sell after provider payment-method code changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - fixed: Wrap the fiat value in parentheses on the Stake/Unstake/Claim amount row, and remove the space between the fiat symbol and amount to match the network fee tile.
 - fixed: Staked "locked" balance in the wallet view no longer gets cut off. The crypto amount is truncated to an exchange-rate-appropriate number of decimals, and the text is no longer clamped to a fraction of the card width.
 - fixed: Improve the unstake error experience by replacing the popup alert and generic "unknown error occurred" with the real error in the scene's error field, and showing a clear message when the wallet lacks the balance to cover the unstaking network fee.
+- fixed: Restore Banxa and Paybis sell (off-ramp) payout methods that stopped appearing after the providers changed their payment-method codes (Banxa EUR card payout, BRL PIX, AUD bank transfer; Paybis US card payout).
 
 ## 4.50.0 (2026-07-21)
 

--- a/src/plugins/ramps/banxa/banxaRampPlugin.ts
+++ b/src/plugins/ramps/banxa/banxaRampPlugin.ts
@@ -101,6 +101,7 @@ const allowedPaymentTypes: AllowedPaymentTypes = {
   },
   sell: {
     ach: true, // Ramp constraint blocks ACH for Banxa
+    credit: true, // Banxa EUR card payout (CHECKOUTPO)
     directtobank: true,
     fasterpayments: true,
     interac: true,
@@ -144,7 +145,9 @@ const asBanxaTxLimit = asObject({
 })
 
 const asBanxaPaymentType = asValue(
+  'BCCONNECTSELL',
   'BRDGACHSELL',
+  'CHECKOUTPO',
   'CLEARJCNSELLFP',
   'CLEARJCNSELLSEPA',
   'CLEARJUNCTION',
@@ -153,6 +156,7 @@ const asBanxaPaymentType = asValue(
   'DCINTERACSELL',
   'DIRECTCREDIT',
   'DLOCALPIX',
+  'DLOCALPIXPO',
   'DLOCALZAIO',
   'IDEAL',
   'KLARNACKO',
@@ -328,7 +332,9 @@ const COIN_TO_CURRENCY_CODE_MAP: StringMap = { BTC: 'BTC' }
 const asInfoCreateHmacResponse = asObject({ signature: asString })
 
 const typeMap: Record<BanxaPaymentType, FiatPaymentType> = {
+  BCCONNECTSELL: 'directtobank',
   BRDGACHSELL: 'ach',
+  CHECKOUTPO: 'credit',
   CLEARJCNSELLFP: 'fasterpayments',
   CLEARJCNSELLSEPA: 'sepa',
   CLEARJUNCTION: 'sepa',
@@ -337,6 +343,7 @@ const typeMap: Record<BanxaPaymentType, FiatPaymentType> = {
   DCINTERACSELL: 'interac',
   DIRECTCREDIT: 'directtobank',
   DLOCALPIX: 'pix',
+  DLOCALPIXPO: 'pix',
   DLOCALZAIO: 'iobank',
   IDEAL: 'ideal',
   KLARNACKO: 'klarna',

--- a/src/plugins/ramps/paybis/paybisRampPlugin.ts
+++ b/src/plugins/ramps/paybis/paybisRampPlugin.ts
@@ -122,6 +122,7 @@ const asPaymentMethodId = asValue(
   'method-id-credit-card',
   'method-id-credit-card-out',
   'method-id-mass-pay-out',
+  'method-id-mass-pay-credit-card-out',
   'method-id_bridgerpay_revolutpay',
   'method-id-trustly',
   'fake-id-googlepay',
@@ -343,7 +344,8 @@ const PAYMENT_METHOD_MAP: Record<PaymentMethodId, FiatPaymentType> = {
   'method-id-trustly': 'ach',
   'method-id-credit-card': 'credit',
   'method-id-credit-card-out': 'credit',
-  'method-id-mass-pay-out': 'credit', // US version of credit card payout
+  'method-id-mass-pay-out': 'credit', // Legacy US card payout slug (now retired by Paybis)
+  'method-id-mass-pay-credit-card-out': 'credit', // Current US card payout slug
   'method-id_bridgerpay_revolutpay': 'revolut',
   'fake-id-googlepay': 'googlepay',
   'fake-id-applepay': 'applepay',


### PR DESCRIPTION
### CHANGELOG

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Banxa and Paybis off-ramp (sell) were broken or degraded in the live ramp flow because both providers changed their payment-method codes and the ramp plugins no longer recognized them. Confirmed against each provider's live API and reproduced in-app on the iOS sim. Scope is the new ramp plugin architecture (the live sell path); the legacy `providers/*` plugins are reachable only via DevTestScene.

**Paybis (US card payout)**

Paybis migrated its US off-ramp payout method to the slug `method-id-mass-pay-credit-card-out`. The plugin only knew `method-id-credit-card-out` and `method-id-mass-pay-out`, both of which the quote API now rejects with HTTP 422. Since `rampConstraints` allows Paybis sell only for US + card, every Paybis sell returned zero quotes. Fix: add the current slug to the payment-method allowlist and `PAYMENT_METHOD_MAP` (mapped to `credit`); the plugin already prefers the API-returned payout id via `sellPayoutMethodIds`.

**Banxa (renamed sell payout codes)**

Banxa's off-ramp codes `CHECKOUTPO` (EUR card payout), `DLOCALPIXPO` (BRL PIX) and `BCCONNECTSELL` (AUD bank transfer) were missing from the strict `asBanxaPaymentType` allowlist, so `asMaybe` dropped them and those sell methods never surfaced. Fix: add the three codes to the allowlist and `typeMap` (`CHECKOUTPO` to `credit`, `DLOCALPIXPO` to `pix`, `BCCONNECTSELL` to `directtobank`) and enable `credit` for Banxa sell so the EUR card payout is offered.

**Documented blockers / gaps (intentionally not changed)**

- Banxa USD ACH sell (`BRDGACHSELL`): blocked in `rampConstraints` "pending bank registration issue resolution" (unresolved in #banxa-dev since Oct 2025). Left blocked.
- Banxa EUR SEPA sell (`CLEARJCNSELLSEPA`): disabled via `sepa: false` ("leave this to Bity"). Left disabled.
- Paybis non-US / non-card sell (SWIFT, Colombia, Mexico, Brazil, Neteller, Skrill): blocked by `rampConstraints` (US + card only). Left as-is.

**Testing** (iOS sim, edge-funds)

- Paybis US sell ETH to USD: "Credit and Debit Card, Best Rate, Powered By: Paybis" quote surfaces (screenshot 01). Previously absent because of the 422.
- Banxa EU sell ETH to EUR (region Germany): "Credit and Debit Card, Best Rate, Powered By: Banxa" quote surfaces (screenshot 02). Previously absent.
- Live-API checks confirm the working Paybis slug returns a valid quote while the old slugs 422, and that Banxa `CHECKOUTPO` / `DLOCALPIXPO` / `BCCONNECTSELL` are ACTIVE sell methods.
- `verify-repo.sh` green (tsc, eslint, jest).
- The Banxa BRL PIX and AUD additions share the identical mapping mechanism proven by the in-app Banxa EUR card quote plus the live API; they were not separately driven in-app.
- End-to-end off-ramp completion (crypto sent to the provider) needs partner KYC and a bank/card payout account, which the sim cannot satisfy; verification stops at the restored quote, which is the fix's user-visible outcome.

Asana: [Ramps - Fix banxa+paybis sell](https://app.asana.com/0/1215088146871429/1216833234330870)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized ramp plugin mapping and allowlist updates for fiat sell quotes; no auth, custody, or payment execution logic changes.
> 
> **Overview**
> **Restores off-ramp (sell) quotes** for Banxa and Paybis after both providers changed their payout payment-method identifiers and the ramp plugins stopped recognizing them.
> 
> For **Paybis US card payout**, the live API now uses `method-id-mass-pay-credit-card-out`; older slugs return HTTP 422, so Paybis sell quotes were empty. The plugin adds that slug to the payment-method allowlist and maps it to `credit` (alongside the legacy `method-id-mass-pay-out` entry).
> 
> For **Banxa sell**, three renamed payout codes were missing from the strict `asBanxaPaymentType` allowlist and were dropped during parsing: `CHECKOUTPO` (EUR card), `DLOCALPIXPO` (BRL PIX), and `BCCONNECTSELL` (AUD bank transfer). Those codes are added to the allowlist and `typeMap`, and Banxa sell enables `credit` so EUR card payout can surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7101f9b795f1ede489649fefa6980c466a20c41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->