### PR TITLE
Fix Sell Max showing entered fiat value in crypto field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed: Improve the unstake error experience by replacing the popup alert and generic "unknown error occurred" with the real error in the scene's error field, and showing a clear message when the wallet lacks the balance to cover the unstaking network fee.
 - fixed: Restore Banxa and Paybis sell (off-ramp) payout methods that stopped appearing after the providers changed their payment-method codes (Banxa EUR card payout, BRL PIX, AUD bank transfer; Paybis US card payout).
 - fixed: Native NYM wallet details now label the network as "Nyx Network" (the native chain) instead of "Nym Network", while asset labels remain Nym.
+- fixed: Tapping Max on the Sell scene no longer briefly shows the entered fiat amount in the crypto field while the max is being calculated.
 
 ## 4.50.0 (2026-07-21)
 

--- a/src/components/scenes/RampCreateScene.tsx
+++ b/src/components/scenes/RampCreateScene.tsx
@@ -9,6 +9,7 @@ import type {
 import * as React from 'react'
 import { useState } from 'react'
 import { ActivityIndicator, View } from 'react-native'
+import type { AirshipBridge } from 'react-native-airship'
 import FastImage from 'react-native-fast-image'
 import { ShadowedView } from 'react-native-fast-shadow'
 import { sprintf } from 'sprintf-js'
@@ -71,7 +72,7 @@ import {
   type WalletListResult,
   type WalletListWalletResult
 } from '../modals/WalletListModal'
-import { Airship, showToast } from '../services/AirshipInstance'
+import { Airship, showError, showToast } from '../services/AirshipInstance'
 import { cacheStyles, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { FilledTextInput } from '../themed/FilledTextInput'
@@ -114,6 +115,25 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
     null
   )
   const [pendingMaxNav, setPendingMaxNav] = useState(false)
+  // A monotonic id for the in-flight max flow, bumped synchronously (unlike the
+  // `pendingMaxNav` state). handleMaxPress captures the id for its request; any
+  // later Max, or a wallet/fiat switch that cancels the flow, increments it.
+  // The async sell max handler applies its result only if its captured id is
+  // still current, so a stale in-flight getMaxSpendExchangeAmount (e.g. for a
+  // since-switched asset, or a superseded earlier request) is discarded. A
+  // plain boolean cannot distinguish which request is current.
+  const maxRequestIdRef = React.useRef(0)
+  // True while a wallet/fiat picker modal is open. The transient max flow's
+  // auto-navigation is suspended while a picker is open so a max quote that
+  // resolves mid-selection cannot navigate out from under the modal; the max
+  // keeps computing and navigates once the picker closes. A counter (not a
+  // bare boolean) tolerates overlapping shows without clearing early.
+  const [isPickerOpen, setIsPickerOpen] = useState(false)
+  const pickerOpenCountRef = React.useRef(0)
+  // True while the (possibly slow) sell max amount is being computed, so the
+  // Max control can show a spinner and disable itself instead of leaving the
+  // scene blank and Max re-tappable during the await.
+  const [isComputingMax, setIsComputingMax] = useState(false)
   const hasAppliedInitialAmount = React.useRef(false)
 
   // Selected currencies
@@ -537,19 +557,55 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
   // Handlers
   //
 
+  // Cancel any in-flight transient max flow: bump the request id so a pending
+  // getMaxSpendExchangeAmount is discarded when it resolves, and reset the
+  // transient UI state (auto-nav arm + computing spinner). Centralized so every
+  // cancel path (manual edit, wallet/fiat switch) clears the spinner too,
+  // rather than leaving it up until the superseded (possibly slow) max resolves.
+  const cancelPendingMax = (): void => {
+    maxRequestIdRef.current += 1
+    setPendingMaxNav(false)
+    setIsComputingMax(false)
+  }
+
+  // Run an async operation that opens a modal while marking a picker as open,
+  // so the transient max flow's auto-navigation effect stays suspended for the
+  // modal's lifetime. A counter (not a bare boolean) tolerates overlapping
+  // shows without clearing early.
+  const withPickerOpen = async <T,>(run: () => Promise<T>): Promise<T> => {
+    pickerOpenCountRef.current += 1
+    setIsPickerOpen(true)
+    try {
+      return await run()
+    } finally {
+      pickerOpenCountRef.current -= 1
+      if (pickerOpenCountRef.current === 0) setIsPickerOpen(false)
+    }
+  }
+
+  // Show an Airship picker modal under withPickerOpen (see above).
+  const showPickerModal = async <T,>(
+    render: (bridge: AirshipBridge<T>) => React.ReactElement
+  ): Promise<T> =>
+    await withPickerOpen(async () => await Airship.show<T>(render))
+
   const handleRegionSelect = useHandler(async () => {
-    await dispatch(
-      showCountrySelectionModal({
-        account,
-        countryCode: countryCode !== '' ? countryCode : '',
-        stateProvinceCode
-      })
-    )
+    // Track the region modal as an open picker too, so a max quote resolving
+    // mid-selection can't auto-navigate out from under it.
+    await withPickerOpen(async () => {
+      await dispatch(
+        showCountrySelectionModal({
+          account,
+          countryCode: countryCode !== '' ? countryCode : '',
+          stateProvinceCode
+        })
+      )
+    })
   })
 
   const handleCryptDropdown = useHandler(async () => {
     if (account == null) return
-    const result = await Airship.show<WalletListResult>(bridge => (
+    const result = await showPickerModal<WalletListResult>(bridge => (
       <WalletListModal
         bridge={bridge}
         navigation={navigation as NavigationBase}
@@ -568,7 +624,7 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
       }
 
       // Clear amount and max state when switching crypto assets in sell mode
-      setPendingMaxNav(false)
+      cancelPendingMax()
       if (direction === 'sell') {
         setAmountQuery({ empty: true })
         setLastUsedInput(null)
@@ -585,12 +641,19 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
 
   const handleFiatDropdown = useHandler(async () => {
     if (account == null) return
-    setPendingMaxNav(false)
-    const result = await Airship.show<GuiFiatType>(bridge => (
+    const result = await showPickerModal<GuiFiatType>(bridge => (
       <FiatListModal bridge={bridge} />
     ))
     if (result != null && account != null) {
-      if (result.value !== rampLastFiatCurrencyCode) {
+      // Compare against the resolved displayed fiat, not the raw persisted
+      // rampLastFiatCurrencyCode (which is unset while the default fiat is
+      // shown). Otherwise re-selecting the displayed default would read as a
+      // change and wrongly cancel an in-flight Max.
+      if (result.value !== selectedFiatCurrencyCode) {
+        // Cancel any in-flight max flow only on a confirmed fiat change, so
+        // opening then dismissing the picker (or re-selecting the same fiat)
+        // leaves a pending Max running (mirrors handleCryptDropdown).
+        cancelPendingMax()
         await dispatch(setRampFiatCurrencyCode(account, result.value))
       }
     }
@@ -639,11 +702,18 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
   }, [bestQuote, selectedFiatCurrencyCode])
 
   const handleFiatChangeText = useHandler((amount: string) => {
+    // A manual edit supersedes any in-flight max: cancel it so a delayed max
+    // result can't overwrite the typed amount or auto-navigate on the max.
+    // (Programmatic clears in handleMaxPress use setNativeProps and do not
+    // fire onChangeText, so this only runs on real user input.)
+    cancelPendingMax()
     setAmountQuery(amount === '' ? { empty: true } : { exchangeAmount: amount })
     setLastUsedInput('fiat')
   })
 
   const handleCryptoChangeText = useHandler((amount: string) => {
+    // See handleFiatChangeText: a manual edit cancels any in-flight max.
+    cancelPendingMax()
     setAmountQuery(amount === '' ? { empty: true } : { exchangeAmount: amount })
     setLastUsedInput('crypto')
   })
@@ -659,24 +729,66 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
     ) {
       return
     }
+    // Ignore taps while a sell max is already computing (the button is also
+    // disabled meanwhile) so overlapping max requests can't stack up.
+    if (isComputingMax) return
 
-    // Trigger a transient max flow: request quotes with {max:true} and auto-navigate when ready
+    // Trigger a transient max flow: request quotes and auto-navigate when ready.
+    // Do NOT flip `lastUsedInput` before the amount query is set to the max
+    // marker. For sell, computing the max is async; if `lastUsedInput` became
+    // 'crypto' while `amountQuery` still held the previously entered fiat
+    // amount, `displayCryptoAmount` would render that fiat value in the crypto
+    // field (e.g. "100 USD" shown as "100 BTC"). Set the max amount query first
+    // so the display memos take their max branch, then set the input type.
+    const maxRequestId = ++maxRequestIdRef.current
     setPendingMaxNav(true)
-    setLastUsedInput(direction === 'buy' ? 'fiat' : 'crypto')
 
     if (direction === 'sell') {
-      const maxSpendExchangeAmount = await getMaxSpendExchangeAmount(
-        selectedWallet,
-        selectedCrypto.tokenId,
-        denomination
-      )
-      setAmountQuery({
-        maxExchangeAmount: maxSpendExchangeAmount
-      })
+      // Clear the entered amount synchronously so the scene shows no stale
+      // fiat quote and Next stays disabled while the (possibly slow) max
+      // computes. Without this the pre-Max fiat amount keeps rampQuoteRequest
+      // live, so Next could navigate on the old amount mid-await and the flow
+      // could auto-navigate on both the old and the max quotes.
+      setAmountQuery({ empty: true })
+      setLastUsedInput(null)
+      setIsComputingMax(true)
+      try {
+        const maxSpendExchangeAmount = await getMaxSpendExchangeAmount(
+          selectedWallet,
+          selectedCrypto.tokenId,
+          denomination
+        )
+        // Discard the result if a newer Max, or a wallet/fiat switch that
+        // cancelled the flow, superseded this request while
+        // getMaxSpendExchangeAmount was in flight: this (now stale) max belongs
+        // to the previously selected asset.
+        if (maxRequestIdRef.current !== maxRequestId) return
+        setAmountQuery({
+          maxExchangeAmount: maxSpendExchangeAmount
+        })
+        setLastUsedInput('crypto')
+      } catch (error) {
+        // getMaxSpendExchangeAmount can reject (e.g. wallet RPC failure). The
+        // amount was cleared synchronously above, so without recovery the
+        // scene would be stuck empty with auto-nav still armed. Cancel the
+        // pending max and surface the error so the user can retry. Skip if a
+        // newer request already superseded this one (it owns the state now).
+        if (maxRequestIdRef.current !== maxRequestId) return
+        setPendingMaxNav(false)
+        showError(error)
+      } finally {
+        // Always clear the computing spinner: only one max computes at a time
+        // (the entry guard + disabled button prevent overlap), so there is no
+        // newer compute whose spinner this could wrongly clear. An unconditional
+        // clear also prevents a stuck spinner when a wallet/fiat switch bumps the
+        // request id mid-await (that path never resets isComputingMax itself).
+        setIsComputingMax(false)
+      }
     } else {
       setAmountQuery({
         max: true
       })
+      setLastUsedInput('fiat')
     }
   })
 
@@ -690,7 +802,11 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
       pendingMaxNav &&
       isMaxRequest &&
       maxQuoteForMaxFlow != null &&
-      !isLoadingQuotes
+      !isLoadingQuotes &&
+      // Hold navigation while a picker modal is open so the max flow can't
+      // navigate out from under it; the effect re-runs and navigates once the
+      // picker closes (isPickerOpen returns to false).
+      !isPickerOpen
     ) {
       navigation.navigate('rampSelectOption', {
         rampQuoteRequest
@@ -700,6 +816,7 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
     }
   }, [
     pendingMaxNav,
+    isPickerOpen,
     maxQuoteForMaxFlow,
     isLoadingQuotes,
     rampQuoteRequest,
@@ -909,10 +1026,15 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
             <EdgeTouchableOpacity
               style={styles.maxButton}
               onPress={handleMaxPress}
+              disabled={isComputingMax}
             >
-              <EdgeText style={styles.maxButtonText}>
-                {lstrings.trade_create_max}
-              </EdgeText>
+              {isComputingMax ? (
+                <ActivityIndicator color={theme.iconTappable} />
+              ) : (
+                <EdgeText style={styles.maxButtonText}>
+                  {lstrings.trade_create_max}
+                </EdgeText>
+              )}
             </EdgeTouchableOpacity>
           </View>
         )}


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Fixes the Sell scene "Max" bug where the previously entered fiat amount was momentarily copied into the crypto field (e.g. entering `100` USD, then tapping Max, showed `100` in the crypto field before the real max resolved).

Root cause is in `handleMaxPress` in `RampCreateScene.tsx`. On the sell path it flipped `lastUsedInput` to `'crypto'` before awaiting the async max calculation, while `amountQuery` still held the previously entered fiat value `{ exchangeAmount: '100' }`. During that async gap `displayCryptoAmount` took its `lastUsedInput === 'crypto'` branch and returned `amountQuery.exchangeAmount` (the fiat number), so the crypto field rendered the fiat value. On large wallets the max calculation (`getMaxSpendable`) is slow, so the wrong value lingered and routing stalled.

The fix sets the max amount query before flipping the input type (and no longer flips it before the await), so the display memos take their max branch immediately and the crypto field only ever shows the computed max. Buy is unchanged (its branch has no await, so its state updates already batch).

Hardening around the same async max window (added while addressing review rounds, all folded into the one commit):
- A manual edit during the compute cancels the in-flight max via a shared `cancelPendingMax` helper (bumps a monotonic request id, clears the pending auto-nav and the computing spinner), so a late-resolving max cannot overwrite the typed amount or auto-navigate on it.
- Auto-navigation is suspended while a wallet, fiat, or region picker is open (`withPickerOpen` / `showPickerModal`), so a max quote resolving mid-selection cannot navigate out from under the modal; the max keeps computing and navigates once the picker closes.
- The fiat-change check compares against the resolved displayed fiat, so re-selecting the displayed default no longer cancels an in-flight max.
- The sell max compute is wrapped in try/catch: on rejection it surfaces the error and recovers instead of leaving the scene blank with auto-nav armed.
- A spinner + disabled Max shows during the compute (and overlapping Max taps are ignored), so a slow max gives feedback instead of a blank, re-tappable scene.

Asana: https://app.asana.com/0/1215088146871429/1215965639107175

**Testing (iOS sim, edge-funds, My Ether 4 / ETH, Sell scene):**
- Entered a fiat amount, tapped Max: the crypto field shows the wallet's max spendable amount, not the fiat value.
- Hack-verified the transient by temporarily widening the async window: with the fix, during the window the crypto field shows the converted value (not the entered fiat number); reverting to the old ordering under the same widened window reproduces the fiat-in-crypto flash. All temporary edits reverted; working tree clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ramp sell amount state, async max spendable, and auto-navigation timing in `RampCreateScene`; mistakes could affect quote routing or leave the UI stuck, but scope is limited to the ramp create flow.
> 
> **Overview**
> Fixes the Sell scene **Max** bug where the previously entered fiat amount briefly appeared in the crypto field while max spendable was still computing.
> 
> **`handleMaxPress`** on sell now clears the amount, defers setting `lastUsedInput` to `'crypto'` until after `getMaxSpendExchangeAmount` completes, and applies the max query first on buy so display memos use the max branch instead of treating stale fiat as crypto.
> 
> Adds **`cancelPendingMax`** (monotonic request id), **`withPickerOpen` / `showPickerModal`** so auto-nav after Max does not fire while wallet/fiat/region pickers are open, spinner + disabled Max during compute, error handling via **`showError`**, and cancels in-flight max on manual edits, wallet/fiat changes (with correct comparison to displayed fiat), and overlapping Max taps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3579488538d3857b53596bf1176f28187e5fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
