### PR TITLE
NYM: label native network as Nyx instead of Nym

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed: Staked "locked" balance in the wallet view no longer gets cut off. The crypto amount is truncated to an exchange-rate-appropriate number of decimals, and the text is no longer clamped to a fraction of the card width.
 - fixed: Improve the unstake error experience by replacing the popup alert and generic "unknown error occurred" with the real error in the scene's error field, and showing a clear message when the wallet lacks the balance to cover the unstaking network fee.
 - fixed: Restore Banxa and Paybis sell (off-ramp) payout methods that stopped appearing after the providers changed their payment-method codes (Banxa EUR card payout, BRL PIX, AUD bank transfer; Paybis US card payout).
+- fixed: Native NYM wallet details now label the network as "Nyx Network" (the native chain) instead of "Nym Network", while asset labels remain Nym.
 
 ## 4.50.0 (2026-07-21)
 

--- a/src/components/scenes/WalletDetailsScene.tsx
+++ b/src/components/scenes/WalletDetailsScene.tsx
@@ -484,7 +484,7 @@ export const WalletDetailsTitle: React.FC<{ customTitle?: string }> = ({
   const wallet = account.currencyWallets[route.params.walletId]
   const computedTitle = sprintf(
     lstrings.create_wallet_account_metadata_name,
-    wallet?.currencyInfo.displayName
+    wallet?.currencyInfo.chainDisplayName
   )
   const title = customTitle ?? computedTitle
   return <HeaderTitle title={title} />


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

The native NYM wallet details scene rendered its network-context header title as "Nym Network". Nym is the asset and ecosystem name; the native blockchain is Nyx. The title now sources from `currencyInfo.chainDisplayName` ("Nyx") instead of the deprecated `currencyInfo.displayName` ("Nym"), so it reads "Nyx Network". Asset-context labels (wallet balance `NYM`, the coin-ranking section header "Nym") are unchanged.

`edge-currency-accountbased` already exposes the correct `assetDisplayName: 'Nym'` / `chainDisplayName: 'Nyx'` for the plugin; this only corrects which field the GUI title reads. No dependency changes.

Verified on the iOS simulator: opened the native NYM wallet details and confirmed the header reads "Nyx Network" while the balance and asset labels remain Nym/NYM (screenshot attached).

Asana: https://app.asana.com/0/1215088146871429/1216842613201602

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single display-field swap in the wallet details header with no security, payment, or persistence changes.
> 
> **Overview**
> The native NYM wallet details header used **`currencyInfo.displayName`** ("Nym") in the **`%s Network`** title pattern, so it read **"Nym Network"** even though the native chain is Nyx.
> 
> **`WalletDetailsTitle`** now passes **`currencyInfo.chainDisplayName`** ("Nyx"), so the header shows **"Nyx Network"**. Balance labels and other asset naming that use **`assetDisplayName`** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e579c86861bf706ebb4e9263123749960fd877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->