### PR TITLE
Keep Android phones locked to portrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased (develop)
 
-- fixed: NYM max swaps from EVM wallets now report the correct limit error instead of an unsupported-route error (edge-exchange-plugins 2.52.1).
 - changed: Sign MoonPay buy/sell widget URLs and bind them to the customer's IP via the info server, for MoonPay's on-ramp IP-matching security upgrade.
+- fixed: NYM max swaps from EVM wallets now report the correct limit error instead of an unsupported-route error (edge-exchange-plugins 2.52.1).
+- fixed: Android phones can no longer be rotated into the unsupported landscape layout. Landscape remains available on tablets.
 
 ## 4.50.0 (2026-07-21)
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
       android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
       android:exported="true"
       android:launchMode="singleTask"
+      android:screenOrientation="portrait"
       android:windowSoftInputMode="adjustResize"
       android:theme="@style/BootTheme">
       <intent-filter>

--- a/android/app/src/main/java/co/edgesecure/app/MainActivity.kt
+++ b/android/app/src/main/java/co/edgesecure/app/MainActivity.kt
@@ -1,6 +1,7 @@
 package co.edgesecure.app
 
 import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import com.facebook.react.ReactActivity
@@ -41,9 +42,35 @@ class MainActivity : ReactActivity() {
       setRecentsScreenshotEnabled(false)
     }
 
-    // Lock the app to portrait mode:
-    if (resources.getBoolean(R.bool.portrait_only)) {
-      requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    applyOrientationLock()
+  }
+
+  // Edge addition
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+
+    // We handle orientation and screenSize config changes ourselves, so `onCreate` does not run
+    // again when the device rotates or changes size. Re-apply the lock here so that a rotation we
+    // did not ask for is corrected, and so that a device which genuinely changes screen-size class
+    // (a foldable being unfolded, or the user changing the display-size setting) is re-evaluated.
+    applyOrientationLock()
+  }
+
+  /**
+   * Restricts the app to portrait, except on tablets. Landscape is only supported on a large
+   * screen, so phones stay locked no matter how the device is turned. This mirrors what iOS does
+   * with its `UISupportedInterfaceOrientations~ipad` keys.
+   *
+   * `portrait_only` is `true` by default and overridden to `false` for tablet-sized screens, so
+   * the manifest declares portrait and this relaxes it only where landscape is actually supported.
+   */
+  private fun applyOrientationLock() {
+    val orientation =
+      if (resources.getBoolean(R.bool.portrait_only)) ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+      else ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+
+    if (requestedOrientation != orientation) {
+      requestedOrientation = orientation
     }
   }
 


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1216901482732656/f)

Asana: https://app.asana.com/1/9976422036640/project/1215088146871429/task/1216901482732656

QA hit landscape mode on an Android phone (Xiaomi 13T Pro, Android 16). Landscape is not a
supported layout on phones: content overflows the screen and PIN-login gestures stop working. It is
only meant to work on tablets, which is what iOS already does via its
`UISupportedInterfaceOrientations~ipad` keys.

The phone/tablet split itself was already correct. `R.bool.portrait_only` is `true` by default and
overridden to `false` in `values-sw600dp` and `values-xlarge`, and the reported device is ~407dp
wide, so it resolved to `true` as expected. What failed is the strength of the lock:

1. **No manifest declaration.** `MainActivity` had no `android:screenOrientation`, so the activity's
   declared `ActivityInfo` said "unspecified" and the app was only portrait once `onCreate` had run.
2. **Never re-asserted.** The activity declares `configChanges="...|orientation|screenSize|..."`, so
   it is not recreated on a configuration change and `onCreate` does not run again. If the system
   rotated the activity anyway, nothing ever put it back.
3. **No tablet branch.** The `if` had no `else`, so the orientation was never explicitly relaxed.
   That meant the decision could not be safely re-evaluated later, and a device that changes
   screen-size class at runtime (a foldable being unfolded, or a display-size change) kept whatever
   it resolved to at launch.

This declares `android:screenOrientation="portrait"` on `MainActivity` so portrait holds from the
first frame, and moves the runtime decision into `applyOrientationLock()`, called from both
`onCreate` and `onConfigurationChanged`. Tablets now explicitly relax to
`SCREEN_ORIENTATION_UNSPECIFIED`, which overrides the manifest default, so tablet landscape is
preserved and the phone lock is re-applied whenever the configuration changes.

Also reorders two existing `## Unreleased` CHANGELOG entries. That section already had `fixed`
before `changed` on `develop`, which fails `verify-repo.sh`'s CHANGELOG ordering check regardless of
where a new entry is placed. No entry text was altered.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [x] Tested on large-screen device (tablet)

Verified on an Android 16 emulator built to the reported device's panel (1220x2712 @ 480dpi, so
`sw407dp`, the same resource bucket as the Xiaomi 13T Pro). Screenshots in the comment below.

| Scenario | Smallest width | `requestedOrientation` | Result |
| --- | --- | --- | --- |
| Phone, system rotation forced to landscape | `sw407dp` | `SCREEN_ORIENTATION_PORTRAIT` | Stays portrait, 1220x2712 |
| Control: Settings app, same device and same forced rotation | `sw407dp` | n/a (rotatable) | Rotates to 2712x1220, so the emulator genuinely can rotate |
| Resized up to tablet metrics while running | `sw800dp` | `SCREEN_ORIENTATION_UNSPECIFIED` | Rotates to landscape, 2560x1600 |
| Resized back down to phone metrics while running | `sw407dp` | `SCREEN_ORIENTATION_PORTRAIT` | Re-locks to portrait |

The last two rows exercise `onConfigurationChanged`: the app re-evaluated across the tablet
threshold in both directions without being recreated, which is the foldable case the previous
one-shot `onCreate` lock could not handle. Throughout the phone rows the system rotation preference
was pinned to landscape (`user_rotation=1`, `accelerometer_rotation=0`) and the app still held
`ROTATION_0`.

Not verified: the exact Xiaomi HyperOS force-rotate trigger. It does not reproduce on stock Android
(QA already confirmed a Pixel does not reproduce it), so this proves the intended contract on both
device classes rather than replaying the OEM-specific trigger. Not installed on the physical Android
device attached to this machine, to avoid replacing a real Edge install and its wallet data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Native Android orientation only; no auth, payments, or wallet logic. Tablet landscape path is explicitly preserved via resource qualifiers.
> 
> **Overview**
> **Android phones** can no longer rotate into landscape (overflow and broken PIN gestures on devices like Xiaomi 13T Pro). **Tablets** still allow landscape, matching iOS iPad orientation behavior.
> 
> `MainActivity` now declares **`android:screenOrientation="portrait"`** in the manifest so portrait applies before `onCreate`, and **`applyOrientationLock()`** sets portrait when `R.bool.portrait_only` is true (phones) or **`SCREEN_ORIENTATION_UNSPECIFIED`** on tablet buckets (`values-sw600dp` / `values-xlarge`). The lock runs from **`onCreate`** and **`onConfigurationChanged`** so rotation or foldable/display-size changes re-apply without activity recreation (given existing `configChanges` for orientation/screenSize).
> 
> CHANGELOG **Unreleased** entries are reordered so `fixed` follows `changed` for the repo verify script; wording unchanged aside from the new Android portrait fix line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f93bbca69864ec08b05d0be2606499b9c8f457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->