### PR TITLE
Fix EVM wallets stuck at 50% sync when only evmScanApiKey is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - changed: Sign MoonPay buy/sell widget URLs and bind them to the customer's IP via the info server, for MoonPay's on-ramp IP-matching security upgrade.
 - fixed: NYM max swaps from EVM wallets now report the correct limit error instead of an unsupported-route error (edge-exchange-plugins 2.52.1).
 - fixed: Exchange rate queries no longer request each chain's own asset twice, which had been inflating every rate query with duplicate pairs.
+- fixed: EVM wallets no longer stall at 50% sync on a build whose env.json configures `evmScanApiKey` without the deprecated `etherscanApiKey`.
 
 ## 4.50.0 (2026-07-21)
 

--- a/src/__tests__/envConfig.test.ts
+++ b/src/__tests__/envConfig.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { asEnvConfig } from '../envConfig'
+
+describe('asEnvConfig EVM api keys', () => {
+  it('supplies the deprecated etherscanApiKey from evmScanApiKey', () => {
+    // edge-currency-accountbased reads only `etherscanApiKey` for
+    // api.etherscan.io, and a keyless Etherscan V2 request is rejected, which
+    // leaves EVM wallets stuck at 50% sync:
+    const env = asEnvConfig({ ETHEREUM_INIT: { evmScanApiKey: ['key1'] } })
+    expect(env.ETHEREUM_INIT).toMatchObject({
+      evmScanApiKey: ['key1'],
+      etherscanApiKey: ['key1']
+    })
+  })
+
+  it('leaves an explicit etherscanApiKey alone', () => {
+    const env = asEnvConfig({
+      ETHEREUM_INIT: { evmScanApiKey: ['key1'], etherscanApiKey: ['legacy'] }
+    })
+    expect(env.ETHEREUM_INIT).toMatchObject({
+      evmScanApiKey: ['key1'],
+      etherscanApiKey: ['legacy']
+    })
+  })
+
+  it('adds no key when evmScanApiKey is unconfigured', () => {
+    const env = asEnvConfig({ ETHEREUM_INIT: {} })
+    expect(env.ETHEREUM_INIT).toMatchObject({
+      evmScanApiKey: [],
+      etherscanApiKey: undefined
+    })
+  })
+
+  it('applies to every EVM plugin init, not just ethereum', () => {
+    const env = asEnvConfig({ BASE_INIT: { evmScanApiKey: ['key1'] } })
+    expect(env.BASE_INIT).toMatchObject({ etherscanApiKey: ['key1'] })
+  })
+
+  it('keeps a disabled plugin init disabled', () => {
+    const env = asEnvConfig({ ETHEREUM_INIT: false })
+    expect(env.ETHEREUM_INIT).toBe(false)
+  })
+})

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -35,11 +35,12 @@ function asCorePluginInit<T>(cleaner: Cleaner<T>): Cleaner<T | false> {
   }
 }
 
-const asEvmApiKeys = asObject({
+const asRawEvmApiKeys = asObject({
   alethioApiKey: asOptional(asString, ''),
   amberdataApiKey: asOptional(asString, ''),
   blockchairApiKey: asOptional(asString, ''),
   drpcApiKey: asOptional(asString, ''),
+  etherscanApiKey: asOptional(asArray(asString)),
   evmScanApiKey: asOptional(asArray(asString), () => []),
   gasStationApiKey: asOptional(asString, ''),
   infuraProjectId: asOptional(asString, ''),
@@ -47,6 +48,26 @@ const asEvmApiKeys = asObject({
   poktPortalApiKey: asOptional(asString, ''),
   quiknodeApiKey: asOptional(asString, '')
 }).withRest
+
+/**
+ * Up to edge-currency-accountbased 4.86.2, key lookup for `api.etherscan.io`
+ * reads only the deprecated `etherscanApiKey` option and throws before it
+ * considers `evmScanApiKey`. Etherscan V2 rejects keyless requests, and its
+ * adapter is the sole source of transaction history on the EVM networks that
+ * route through that host, so a build supplying only `evmScanApiKey` leaves
+ * every one of those wallets stuck at 50% sync. Supply the deprecated name
+ * from the supported one so env.json only has to carry `evmScanApiKey`.
+ *
+ * Remove once the app depends on a release carrying the plugin-side fix.
+ */
+const asEvmApiKeys: Cleaner<ReturnType<typeof asRawEvmApiKeys>> = raw => {
+  const clean = asRawEvmApiKeys(raw)
+  if (clean.etherscanApiKey != null && clean.etherscanApiKey.length > 0) {
+    return clean
+  }
+  if (clean.evmScanApiKey.length === 0) return clean
+  return { ...clean, etherscanApiKey: clean.evmScanApiKey }
+}
 
 export const asEnvConfig = asObject({
   // API keys:


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

This is a stopgap for [EdgeApp/edge-currency-accountbased#1078](https://github.com/EdgeApp/edge-currency-accountbased/pull/1078), which fixes the same defect at its source. Remove this shim once the app depends on a release carrying that fix.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

No visual changes. Tested on the iOS simulator because the fix is only observable as wallet sync behavior.

### Description

[Asana task](https://app.asana.com/0/0/1216605015325950/f)

Coinhub reported that ETH will not sync, sitting at 50% for both new and existing ETH wallets, and that resyncing does not help. It survived a full rebase of their branch onto develop because it was never a code defect in that branch, it is a configuration trap.

`edge-currency-accountbased`'s `getEvmScanApiKey` resolves the Etherscan key for `api.etherscan.io` from the deprecated `etherscanApiKey` init option, and throws before it considers `evmScanApiKey`, which is the option this repo declares and cleans in `src/envConfig.ts`:

```ts
if (serverUrl.includes('etherscan.io')) {
  if (etherscanApiKey == null)
    throw new Error(`Missing etherscanApiKey for etherscan.io`)
  return etherscanApiKey
}
if (evmScanApiKey != null) return evmScanApiKey   // never reached for etherscan.io
```

So a build box whose env.json carries only the documented `evmScanApiKey` sends no key at all, and Etherscan V2 rejects keyless requests:

```
{"status":"0","message":"NOTOK","result":"Missing/Invalid API Key"}
```

`EvmScanAdapter` is the only adapter with a non-null `fetchTxs` on the 15 EVM networks routed through that host (`RpcAdapter`, `BlockbookAdapter` and `AmberdataAdapter` all set it to `null`), so transaction history never completes. The plugin's `makeTokenSyncTracker` averages balance and history progress, so a wallet with a complete balance and no history reports exactly `0.5`, which the app renders as a wallet permanently stuck at 50%.

Edge's own env.json still carries the legacy `etherscanApiKey`, which is why the Edge app is unaffected and why this only surfaced on a white-label build. Any build box provisioned from the key set this repo documents hits it.

This supplies the deprecated option from the supported one at the env layer, which takes effect without waiting on a plugin release. An explicitly configured `etherscanApiKey` still wins, and an empty `evmScanApiKey` adds nothing.

### Testing

Verified end to end on the iOS simulator against an env.json shaped like a build box (only `evmScanApiKey`, no `etherscanApiKey`), on the same account and the same ETH wallet in both passes:

- **Before:** resyncing the ETH wallet left it at `Loading Transactions... 49.9% Complete` with an empty transaction list, exactly as reported.
- **After:** with only this commit applied and the same env.json, the transaction list fully repopulated and the sync indicator cleared.

Screenshots of both states are attached in a comment below.

Also:

- New unit tests in `src/__tests__/envConfig.test.ts` cover the derivation, an explicit `etherscanApiKey` winning, an unconfigured `evmScanApiKey` adding nothing, the behavior applying to every EVM plugin init, and a disabled plugin init staying `false`.
- `tsc --noEmit`: clean.
- `jest --ci`: 94 suites, 567 tests, 107 snapshots, all passing. Also re-run green under `APP_CONFIG=coinhub` (93 suites, 562 tests) on the coinhub branch, where this commit is cherry-picked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-layer shim with explicit precedence rules and unit tests; no auth or payment logic; temporary until the currency plugin fix ships.
> 
> **Overview**
> **Stopgap for EVM wallets stuck at ~50% sync** when `env.json` only sets `evmScanApiKey` (no legacy `etherscanApiKey`). The account-based currency plugin still resolves Etherscan keys for `api.etherscan.io` from `etherscanApiKey` only, so keyless V2 requests fail and transaction history never completes—balance sync finishes while history stays empty, which averages to ~50% in the UI.
> 
> At env load, **`asEvmApiKeys`** now copies `evmScanApiKey` into `etherscanApiKey` when the deprecated field is missing or empty; an explicit `etherscanApiKey` still wins, and empty `evmScanApiKey` adds nothing. Applies to all EVM plugin init blocks (not only Ethereum). New tests in `envConfig.test.ts` cover derivation, precedence, and disabled plugins. CHANGELOG updated. Remove this shim after the app depends on a plugin release with the upstream fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 030444b70a89c7e290fb87ffff0f536c51f70a47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->