### PR TITLE
Group Dependabot security updates into a single pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    # Required key, but inert here: security updates are triggered by Dependabot
+    # alerts, not by this interval, and version updates are disabled below.
+    schedule:
+      interval: weekly
+    # 0 disables version updates entirely. Security updates are exempt from this
+    # limit and keep flowing, which is the only Dependabot traffic we want.
+    open-pull-requests-limit: 0
+    groups:
+      # Collapse every security update into one PR instead of one PR per
+      # advisory. Without `applies-to`, grouping would only cover version
+      # updates and would do nothing here.
+      all-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Collapses Dependabot's security update PRs into a single grouped PR. We currently have 27 open, going back to March 2023.

**Why it got this bad:** this repo has no `.github/dependabot.yml` at all, so every Dependabot PR here is an alert-driven *security* update, and security updates are explicitly exempt from `open-pull-requests-limit`. There was no setting to turn down without adding a config file first.

**What the config does:**

- `groups.all-security-updates` with `applies-to: security-updates` and `patterns: ['*']` puts every security fix in one PR. The `applies-to` key is load-bearing: without it, grouping defaults to version updates only and would change nothing here.
- `open-pull-requests-limit: 0` keeps version updates off, so adding this file does not trade 27 security PRs for a larger firehose of routine version bumps. GitHub documents this value for the security-updates-only case.
- `schedule.interval` is required syntax but inert. Security updates fire on new advisories, not on an interval, and there are no version updates left for it to govern.

**What to expect after merge:**

Per [GitHub's docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates), "When grouped security updates are first enabled, Dependabot will immediately try to create grouped pull requests. You may notice Dependabot closing old pull requests and opening new ones." So this should not wait for a scheduled tick.

Dependabot closes an old PR once the new grouped PR covers the same dependency. Anything it cannot fit into the group, most likely the transitive bumps blocked by a pinned parent, will stay open and need closing by hand. Use a plain close for those, not `@dependabot close`, which suppresses recreation and would drop the dependency from future grouped PRs.

Steady state after this is at most one open Dependabot PR. New advisories fold into that PR while it is open rather than opening another, so it is worth merging promptly instead of letting it sit and rebase underneath us.

Reference: [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Dependabot configuration with no application runtime or dependency manifest changes in this diff.
> 
> **Overview**
> Adds **`.github/dependabot.yml`** so npm security fixes land in **one grouped PR** instead of one per advisory (the repo had no config before, which left many alert-driven security PRs open).
> 
> The config sets **`groups.all-security-updates`** with **`applies-to: security-updates`** and **`patterns: ['*']`** so grouping applies to security updates (not only version bumps). **`open-pull-requests-limit: 0`** turns off routine version-update PRs while security updates still flow. **`schedule.interval: weekly`** is required but does not drive security timing.
> 
> After merge, Dependabot may close older security PRs and open a single grouped one; steady state should be at most one open Dependabot PR for npm at the repo root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b946e7fa22b0211164c58ccdd9fc0e2b11859006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->