### PR TITLE
Wire MoonPay Trade swap provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,18 @@
 - `npm run precommit` - Full pre-commit check (localize, lint-staged, tsc, test)
 - `tsc` - TypeScript type checking (via package.json script)
 
+## Swap Provider Integration
+
+The plugin itself lives in `edge-exchange-plugins`; this repo only wires it up, and every wiring point below fails SILENTLY when missed (no error, just a blank icon or a provider that never initializes). Registering a new swap `pluginId` means all of:
+
+- `src/envConfig.ts` - `<NAME>_INIT` via `asCorePluginInit`, when the plugin takes init options (an `apiKey`)
+- `src/util/corePlugins.ts` - `swapPlugins` entry mapping the `pluginId` to that init (or `true` when it needs none)
+- `src/actions/CategoriesActions.ts` - `pluginIdIcons` entry, or swap transactions render without a provider icon
+- `src/constants/MerchantContacts.ts` - `MERCHANT_CONTACTS` entry whose `displayName` matches the plugin's `swapInfo.displayName` exactly, since the tx list matches thumbnails by that string
+- `src/components/modals/SwapVerifyTermsModal.tsx` - `pluginData` entry ONLY for centralized providers with terms/KYC to accept; DEX plugins (`isDex: true`) take none
+
+New swap icons live at `https://content.edge.app/exchangeIcons/<pluginId>/icon.png` (`getSwapPluginIconUri` in `src/util/CdnUris.ts`) and must be uploaded to the content server separately, or the URL 403s. The wiring stays inert until `package.json` bumps `edge-exchange-plugins` to a published version containing the plugin.
+
 ## Code Style Guidelines
 
 - **Formatting**: Prettier with single quotes, no semicolons, no trailing commas, 80 char width

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: swaps.xyz swap provider wiring (SWAPSXYZ_INIT core plugin init and registration).
 - added: Verbose logging for exchange rate queries: the request body, resolved/rate-less counts, and errors are captured when the Verbose Logging setting is enabled.
 - added: Exchange-rate cache snapshot in the support log output, plus a `rates-cache-replay` script that re-runs those queries against the rates server and reports the result for each pair.
 - added: "-m" tag on the version number in the Help scene for Maestro test builds

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -725,6 +725,7 @@ export const pluginIdIcons: Record<string, string> = {
   rango: EDGE_CONTENT_SERVER_URI + '/rango.png',
   sideshift: EDGE_CONTENT_SERVER_URI + '/sideshift-logo.png',
   simplex: EDGE_CONTENT_SERVER_URI + '/simplex.png',
+  swapsxyz: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/swapsxyz/icon.png',
   swapuz: EDGE_CONTENT_SERVER_URI + '/swapuz.png',
   thorchain: EDGE_CONTENT_SERVER_URI + '/thorchain.png',
   unizen: EDGE_CONTENT_SERVER_URI + '/unizen.png',

--- a/src/constants/MerchantContacts.ts
+++ b/src/constants/MerchantContacts.ts
@@ -79,6 +79,10 @@ export const MERCHANT_CONTACTS: MerchantContact[] = [
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/simplex.png`
   },
   {
+    displayName: 'swaps.xyz',
+    thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/exchangeIcons/swapsxyz/icon.png`
+  },
+  {
     displayName: 'Swapuz',
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/swapuz.png`
   },

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -425,6 +425,11 @@ export const asEnvConfig = asObject({
       quiknodeApiKey: asOptional(asString, '')
     }).withRest
   ),
+  SWAPSXYZ_INIT: asCorePluginInit(
+    asObject({
+      apiKey: asOptional(asString, '')
+    }).withRest
+  ),
   SWAPUZ_INIT: asCorePluginInit(
     asObject({
       apiKey: asOptional(asString, '')

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -99,6 +99,7 @@ export const swapPlugins = {
   letsexchange: ENV.LETSEXCHANGE_INIT,
   nexchange: ENV.NEXCHANGE_INIT,
   sideshift: ENV.SIDESHIFT_INIT,
+  swapsxyz: ENV.SWAPSXYZ_INIT,
   swapuz: ENV.SWAPUZ_INIT,
   xgram: ENV.XGRAM_INIT,
   nymswap: ENV.NYM_SWAP_INIT,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Depends on [EdgeApp/edge-exchange-plugins#480](https://github.com/EdgeApp/edge-exchange-plugins/pull/480) (the MoonPay Trade plugin). This PR is open for review now: it compiles and passes CI standalone. It should only MERGE after [EdgeApp/edge-exchange-plugins#480](https://github.com/EdgeApp/edge-exchange-plugins/pull/480) merges, edge-exchange-plugins publishes a version containing the `mptrade` and `mptradedefi` plugins, and this branch bumps `edge-exchange-plugins` to it. Without that bump the registration resolves to no plugin at runtime.

### Requirements

No visual changes (env/config wiring only).

### Description

Wire the new MoonPay Trade swap provider so the app initializes it. edge-exchange-plugins ships it as TWO registrations sharing one API key: `mptrade`, displayed as "MoonPay Trade (Centralized)", and `mptradedefi`, displayed as "MoonPay Trade (DeFi)" (DEX, Solana-to-Solana routes only); both are wired here:

- `src/envConfig.ts`: add `MPTRADE_INIT` core plugin init (`apiKey`).
- `src/util/corePlugins.ts`: register `mptrade: ENV.MPTRADE_INIT` in the Centralized Swaps block of `swapPlugins`, and `mptradedefi: ENV.MPTRADE_INIT` in the Defi Swaps block (same provider and credentials; the DEX half).
- `src/actions/CategoriesActions.ts`: `pluginIdIcons` entries for both ids so swap transactions carry the provider icon.
- `src/constants/MerchantContacts.ts`: `MERCHANT_CONTACTS` entries keyed on each registration's `swapInfo.displayName` (`MoonPay Trade (Centralized)`, `MoonPay Trade (DeFi)`) for the transaction-list thumbnail.
- `AGENTS.md` (separate commit): a `Swap Provider Integration` section listing every wiring point a new swap `pluginId` needs, since each one fails silently when missed.

No `SwapVerifyTermsModal` entry. `mptrade` is centralized (`isDex: false`, see [EdgeApp/edge-exchange-plugins#480](https://github.com/EdgeApp/edge-exchange-plugins/pull/480)), but that modal is for providers whose gate is a terms acceptance the user completes in-app; MoonPay Trade screens pre-quote and simply refuses a route it will not serve, so there is nothing to accept. The provider icons are live on content.edge.app at `/exchangeIcons/mptrade/icon.png` and `/exchangeIcons/mptradedefi/icon.png`.

The runtime key is supplied via `env.json` `MPTRADE_INIT.apiKey`. With a published edge-exchange-plugins containing the plugin, the app then offers MoonPay Trade quotes.

Verified in-app on the iOS sim (with the plugin linked via updot and the key in env.json): a real Base ETH to USDC swap executed through MoonPay Trade to the success scene, and a real SOL to USDC (Solana) swap executed through the DEX registration to the success scene (1.501804 USDC received against a 1.493 floor), while a SOL to Base USDC quote still routed through the Centralized entry. After the rename, the same Solana pair quoted as "Powered by MoonPay Trade (DeFi)", the provider sheet listed "MoonPay Trade (DeFi)" labeled DEX under both Selected Quote and Fixed Quotes, a real 0.014415 SOL to USDC (Solana) swap reached the Congratulations scene with Exchange Details naming the service "MoonPay Trade (DeFi)", and a USDC (Solana) to USDC (Base) route quoted as "Powered by MoonPay Trade (Centralized)". With the icons live, a USDC to SOL (Solana) quote shows the MoonPay icon in the "Powered by MoonPay Trade (DeFi)" card (frame 42). Swap transaction rows and details resolve their icon from the same pluginIds (`pluginIdIcons`) and displayNames (`MERCHANT_CONTACTS`), so no further gui surface needs the rename. Evidence is in the Test evidence table below and on [EdgeApp/edge-exchange-plugins#480](https://github.com/EdgeApp/edge-exchange-plugins/pull/480).

Asana: https://app.asana.com/0/1215088146871429/1217036054017879

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only registration and display wiring for a new swap provider; no auth or payment logic changes, though swap routing still depends on the external plugin and API key.
> 
> **Overview**
> Wires **MoonPay Trade** into the app as two swap plugin registrations that share one API key: **`mptrade`** (centralized) and **`mptradedefi`** (DEX, Solana-to-Solana routes). Adds `MPTRADE_INIT` in `envConfig.ts`, maps both ids in `swapPlugins`, and hooks up transaction icons plus `MERCHANT_CONTACTS` entries for **MoonPay Trade (Centralized)** and **MoonPay Trade (DeFi)**.
> 
> Documents the full swap-provider checklist in **AGENTS.md** (env init, `corePlugins`, icons, merchant contacts, optional terms modal, CDN icons, `edge-exchange-plugins` bump). **CHANGELOG** notes the new provider. No `SwapVerifyTermsModal` wiring.
> 
> Runtime quotes depend on publishing **`edge-exchange-plugins`** with these plugin ids and supplying `MPTRADE_INIT.apiKey` in env; icons must exist on the content CDN at `/exchangeIcons/mptrade/` and `/exchangeIcons/mptradedefi/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 792a1894765674a40865c94f9fe5deac53158103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="5" width="170" valign="top"><code>(earlier)</code><br><sub>Wire swaps.xyz swap provider</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260803-163726-agent-proof-1217036054017879-02-swap-success.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260803-163726-agent-proof-1217036054017879-02-swap-success.png" width="200"></a><br><sub><b>2.</b> swap success</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260803-163726-agent-proof-1217036054017879-04-tx-list-row.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260803-163726-agent-proof-1217036054017879-04-tx-list-row.png" width="200"></a><br><sub><b>4.</b> tx list row</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260901-130109-agent-proof-1217036054017879-18-solana-dex-quote.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260901-130109-agent-proof-1217036054017879-18-solana-dex-quote.png" width="200"></a><br><sub><b>18.</b> solana dex quote</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260901-130109-agent-proof-1217036054017879-19-provider-sheet-dex-label.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260901-130109-agent-proof-1217036054017879-19-provider-sheet-dex-label.png" width="200"></a><br><sub><b>19.</b> provider sheet dex label</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260901-130109-agent-proof-1217036054017879-20-solana-dex-swap-success.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260901-130109-agent-proof-1217036054017879-20-solana-dex-swap-success.png" width="200"></a><br><sub><b>20.</b> solana dex swap success</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260901-130109-agent-proof-1217036054017879-21-solana-crosschain-stays-centralized.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260901-130109-agent-proof-1217036054017879-21-solana-crosschain-stays-centralized.png" width="200"></a><br><sub><b>21.</b> solana crosschain stays centralized</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-22-defi-quote-moonpay-trade-name.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-22-defi-quote-moonpay-trade-name.png" width="200"></a><br><sub><b>22.</b> defi quote moonpay trade name</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-23-provider-sheet-defi-label.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-23-provider-sheet-defi-label.png" width="200"></a><br><sub><b>23.</b> provider sheet defi label</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-24-defi-swap-success.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-24-defi-swap-success.png" width="200"></a><br><sub><b>24.</b> defi swap success</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-25-exchange-details-service-name.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-25-exchange-details-service-name.png" width="200"></a><br><sub><b>25.</b> exchange details service name</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-26-centralized-quote-moonpay-trade-name.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260908-102454-agent-proof-1217036054017879-26-centralized-quote-moonpay-trade-name.png" width="200"></a><br><sub><b>26.</b> centralized quote moonpay trade name</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260915-163908-agent-proof-1217036054017879-30-defi-quote-after-rebase.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260915-163908-agent-proof-1217036054017879-30-defi-quote-after-rebase.png" width="200"></a><br><sub><b>30.</b> defi quote after rebase</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260915-163908-agent-proof-1217036054017879-31-defi-swap-success-after-rebase.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260915-163908-agent-proof-1217036054017879-31-defi-swap-success-after-rebase.png" width="200"></a><br><sub><b>31.</b> defi swap success after rebase</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260916-175907-agent-proof-1217036054017879-40-mptradedefi-quote-after-rename.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260916-175907-agent-proof-1217036054017879-40-mptradedefi-quote-after-rename.png" width="200"></a><br><sub><b>40.</b> mptradedefi quote after rename</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260916-175907-agent-proof-1217036054017879-41-mptradedefi-swap-success-after-rename.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260916-175907-agent-proof-1217036054017879-41-mptradedefi-swap-success-after-rename.png" width="200"></a><br><sub><b>41.</b> mptradedefi swap success after rename</sub></td>
</tr>
<tr>
<td rowspan="1" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6128/commits/792a1894765674a40865c94f9fe5deac53158103"><code>792a189</code></a><br><sub>Wire the MoonPay Trade DEX registration</sub><br><sub>2026-09-18</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260918-120645-agent-proof-1217036054017879-42-mptradedefi-powered-by-icon.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6128/20260918-120645-agent-proof-1217036054017879-42-mptradedefi-powered-by-icon.png" width="200"></a><br><sub><b>42.</b> mptradedefi powered by icon</sub></td>
<td width="210"></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->
