### PR TITLE
Fix Bitwave CSV export issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - changed: Use a custom chart icon for the side menu Markets row, so it matches the rest of the menu.
 - changed: Use the UI4 warning card for the Reveal Raw Keys and Reveal Master Private Key password confirmation warnings.
 - changed: Tron resource staking now describes its claim action as reclaiming your own TRX, instead of claiming a reward.
+- fixed: Bitwave CSV exports now use ISO 8601 UTC timestamps, leave the fee columns blank so Bitwave does not double-count fees, and copy the description into the second custom metadata column.
+- fixed: Bitwave account ids are no longer capitalized by the keyboard or padded with whitespace when entered, so exports import without hand-editing the account id.
+- fixed: NYM max swaps from EVM wallets now report the correct limit error instead of an unsupported-route error (edge-exchange-plugins 2.52.1).
+- fixed: Exchange rate queries no longer request each chain's own asset twice, which had been inflating every rate query with duplicate pairs.
 - fixed: XRP minimum balance warning copy to clarify the reserve is met once the address balance reaches 1 XRP, not on top of it.
 - fixed: Round fiat balances to cents in the Wallets list, matching the wallet detail scene
 - fixed: Notification center cards no longer shrink their text to fit. Long titles and messages now truncate with an ellipsis so every card renders at the same size.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -133,7 +133,6 @@ export default [
 
       'src/actions/SoundActions.ts',
       'src/actions/TokenTermsActions.tsx',
-      'src/actions/TransactionExportActions.tsx',
 
       'src/actions/WalletListActions.tsx',
 
@@ -312,8 +311,6 @@ export default [
 
       'src/components/scenes/SwapSettingsScene.tsx',
       'src/components/scenes/SwapSuccessScene.tsx',
-
-      'src/components/scenes/TransactionsExportScene.tsx',
 
       'src/components/scenes/WalletRestoreScene.tsx',
       'src/components/scenes/WcConnectionsScene.tsx',

--- a/src/__tests__/actions/TransactionExportActions.test.ts
+++ b/src/__tests__/actions/TransactionExportActions.test.ts
@@ -3,6 +3,7 @@ import type { EdgeTransaction } from 'edge-core-js'
 import fs from 'fs'
 
 import {
+  exportTransactionsToBitwave,
   exportTransactionsToCSVInner,
   exportTransactionsToQBO
 } from '../../actions/TransactionExportActions'
@@ -13,6 +14,12 @@ const csvResult = fs.readFileSync('./src/__tests__/exportCsvResult.csv', {
 const qboResult = fs.readFileSync('./src/__tests__/exportQboResult.qbo', {
   encoding: 'utf8'
 })
+const bitwaveResult = fs.readFileSync(
+  './src/__tests__/exportBitwaveResult.csv',
+  { encoding: 'utf8' }
+)
+
+const BITWAVE_ACCOUNT_ID = 'pgM8cDt7bySnWTzs2MyI'
 
 const edgeTxs: EdgeTransaction[] = [
   {
@@ -187,4 +194,105 @@ test('export QBO matches reference data', function () {
     1524578071304
   )
   expect(out).toEqual(qboResult)
+})
+
+test('export Bitwave matches reference data', async function () {
+  const out = await exportTransactionsToBitwave(
+    BITWAVE_ACCOUNT_ID,
+    [...edgeTxs],
+    'BTC',
+    '100'
+  )
+  expect(out).toEqual(bitwaveResult)
+})
+
+/**
+ * Splits one CSV row into its fields, unwrapping quoted values and their
+ * doubled-quote escapes.
+ */
+function parseCsvRow(row: string): string[] {
+  const fields: string[] = []
+  let field = ''
+  let quoted = false
+  for (let i = 0; i < row.length; i++) {
+    const char = row[i]
+    if (quoted) {
+      if (char !== '"') field += char
+      else if (row[i + 1] === '"') {
+        field += '"'
+        i++
+      } else quoted = false
+    } else if (char === '"') quoted = true
+    else if (char === ',') {
+      fields.push(field)
+      field = ''
+    } else field += char
+  }
+  fields.push(field)
+  return fields
+}
+
+// Bitwave column letters, as the importer numbers them:
+const COLUMN_G_FEE = 6
+const COLUMN_H_FEE_TICKER = 7
+const COLUMN_I_TIME = 8
+const COLUMN_M_ACCOUNT_ID = 12
+const COLUMN_R_DESCRIPTION = 17
+const COLUMN_W_CUSTOM_METADATA2 = 22
+
+async function exportBitwaveRows(): Promise<string[][]> {
+  const out = await exportTransactionsToBitwave(
+    BITWAVE_ACCOUNT_ID,
+    [...edgeTxs],
+    'BTC',
+    '100'
+  )
+  const [header, ...rows] = out.split('\n').filter(row => row !== '')
+
+  // Guard the column letters this suite asserts on, so a reordered row object
+  // fails here rather than silently invalidating every assertion below:
+  const headerFields = parseCsvRow(header)
+  expect(headerFields[COLUMN_G_FEE]).toEqual('fee')
+  expect(headerFields[COLUMN_H_FEE_TICKER]).toEqual('feeTicker')
+  expect(headerFields[COLUMN_I_TIME]).toEqual('time')
+  expect(headerFields[COLUMN_M_ACCOUNT_ID]).toEqual('accountId')
+  expect(headerFields[COLUMN_R_DESCRIPTION]).toEqual('description')
+  expect(headerFields[COLUMN_W_CUSTOM_METADATA2]).toEqual(
+    'metadata:myCustomMetadata2'
+  )
+
+  expect(rows.length).toBeGreaterThan(0)
+  return rows.map(parseCsvRow)
+}
+
+test('export Bitwave leaves the fee columns blank', async function () {
+  for (const fields of await exportBitwaveRows()) {
+    expect(fields[COLUMN_G_FEE]).toEqual('')
+    expect(fields[COLUMN_H_FEE_TICKER]).toEqual('')
+  }
+})
+
+test('export Bitwave duplicates the description into custom metadata 2', async function () {
+  for (const fields of await exportBitwaveRows()) {
+    expect(fields[COLUMN_W_CUSTOM_METADATA2]).toEqual(
+      fields[COLUMN_R_DESCRIPTION]
+    )
+  }
+})
+
+test('export Bitwave writes ISO 8601 UTC timestamps', async function () {
+  const rows = await exportBitwaveRows()
+  for (const fields of rows) {
+    expect(fields[COLUMN_I_TIME]).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/
+    )
+  }
+  // The first transaction's date is 1524476980 (2018-04-23T09:49:40Z):
+  expect(rows[0][COLUMN_I_TIME]).toEqual('2018-04-23T09:49:40Z')
+})
+
+test('export Bitwave preserves the account id exactly', async function () {
+  for (const fields of await exportBitwaveRows()) {
+    expect(fields[COLUMN_M_ACCOUNT_ID]).toEqual(BITWAVE_ACCOUNT_ID)
+  }
 })

--- a/src/__tests__/exportBitwaveResult.csv
+++ b/src/__tests__/exportBitwaveResult.csv
@@ -1,0 +1,8 @@
+"id","remoteContactId","amount","amountTicker","cost","costTicker","fee","feeTicker","time","blockchainId","memo","transactionType","accountId","contactId","categoryId","taxExempt","tradeId","description","fromAddress","toAddress","groupId","metadata:myCustomMetadata1","metadata:myCustomMetadata2"
+"1ff0fd8529f4c5bc","","1230000","BTC","","","","","2018-04-23T09:49:40Z","txid1","Hell yeah! Thanks for the fish <<&&>>","deposit","pgM8cDt7bySnWTzs2MyI","","","FALSE","","Crazy Person","","receiveaddress1","","Income:Mo Money","Crazy Person"
+"a1734d2a42db4f78","","3210000","BTC","","","","","2018-04-24T13:36:20Z","txid2","Hell yeah! Here's a fish""","withdrawal","pgM8cDt7bySnWTzs2MyI","","","FALSE","","Crazy Person 2","","","","Expense:Less Money","Crazy Person 2"
+"4152a38fd1753fb1","","3210000","BTC","","","","","2018-04-25T17:23:00Z","txid3","","deposit","pgM8cDt7bySnWTzs2MyI","","","FALSE","","Transfer","","receiveaddress3","","Transfer:Edge","Transfer"
+"bd0499aac742810c","","3210000","BTC","","","","","2018-04-26T21:09:40Z","txid4","","withdrawal","pgM8cDt7bySnWTzs2MyI","","","FALSE","","Transfer but actually income","","","","Transfer:Edge","Transfer but actually income"
+"28b9c7c71f2f3725","","3210000","BTC","","","","","2018-04-28T00:56:20Z","txid4","","withdrawal","pgM8cDt7bySnWTzs2MyI","","","FALSE","","Transfer but no fee","","","","Transfer:Edge","Transfer but no fee"
+"a7604f215aa3ebd8","","3210000","BTC","","","","","2018-04-29T04:43:00Z","txid5","","withdrawal","pgM8cDt7bySnWTzs2MyI","","","FALSE","","Transfer but no fiat amount","","","","Transfer:Edge","Transfer but no fiat amount"
+"9a1aed86663a096c","","3210000","BTC","","","","","2018-04-30T08:29:40Z","txid6","","withdrawal","pgM8cDt7bySnWTzs2MyI","","","FALSE","","","","","","",""

--- a/src/actions/TransactionExportActions.tsx
+++ b/src/actions/TransactionExportActions.tsx
@@ -79,8 +79,8 @@ export function updateTxsFiat(
                 }
               }
             })
-            .catch(e => {
-              console.warn(e.message)
+            .catch((e: unknown) => {
+              console.warn(e instanceof Error ? e.message : String(e))
             })
         )
         if (promises.length >= UPDATE_TXS_MAX_PROMISES) {
@@ -269,6 +269,7 @@ export function exportTransactionsToQBO(
 ): string {
   const STMTTRN: any[] = []
   const now = makeOfxDate((testDateNow ?? Date.now()) / 1000)
+  const hasDenom = denom != null
 
   for (const tx of edgeTransactions) {
     const newTxs = getTransferTx(tx, fiatCurrencyCode)
@@ -280,8 +281,8 @@ export function exportTransactionsToQBO(
     }
   }
 
-  function edgeTxToQbo(edgeTx: EdgeTransaction) {
-    const TRNAMT: string = denom
+  function edgeTxToQbo(edgeTx: EdgeTransaction): void {
+    const TRNAMT: string = hasDenom
       ? div(edgeTx.nativeAmount, denom, DECIMAL_PRECISION)
       : edgeTx.nativeAmount
     const TRNTYPE = lt(edgeTx.nativeAmount, '0') ? 'DEBIT' : 'CREDIT'
@@ -394,6 +395,7 @@ export function exportTransactionsToCSVInner(
   denomName: string = ''
 ): string {
   const items: any[] = []
+  const hasDenom = denom != null
 
   for (const tx of edgeTransactions) {
     const newTxs = getTransferTx(tx, fiatCurrencyCode)
@@ -405,11 +407,11 @@ export function exportTransactionsToCSVInner(
     }
   }
 
-  function edgeTxToCsv(edgeTx: EdgeTransaction) {
-    const amount: string = denom
+  function edgeTxToCsv(edgeTx: EdgeTransaction): void {
+    const amount: string = hasDenom
       ? div(edgeTx.nativeAmount, denom, DECIMAL_PRECISION)
       : edgeTx.nativeAmount
-    const networkFeeField: string = denom
+    const networkFeeField: string = hasDenom
       ? div(edgeTx.networkFee, denom, DECIMAL_PRECISION)
       : edgeTx.networkFee
     const { date, time } = makeCsvDateTime(edgeTx.date)
@@ -459,7 +461,7 @@ export async function exportTransactionsToBitwave(
     edgeTxToCsv(tx)
   }
 
-  function edgeTxToCsv(edgeTx: EdgeTransaction) {
+  function edgeTxToCsv(edgeTx: EdgeTransaction): void {
     const {
       date,
       isSend,
@@ -486,7 +488,7 @@ export async function exportTransactionsToBitwave(
         feeTicker = currencyCode
         fee = div(networkFee, multiplier, DECIMAL_PRECISION)
       }
-      if (spendTargets && spendTargets.length > 0) {
+      if (spendTargets != null && spendTargets.length > 0) {
         // We can only choose 1 `toAddress` so pick the first spendTarget
         toAddress = spendTargets[0].publicAddress
       }

--- a/src/actions/TransactionExportActions.tsx
+++ b/src/actions/TransactionExportActions.tsx
@@ -179,15 +179,17 @@ function makeCsvDateTime(date: number): { date: string; time: string } {
   }
 }
 
+/** ISO 8601 UTC, the timestamp format Bitwave requires for imports. */
 function makeBitwaveDateTime(date: number): string {
   const d = new Date(date * 1000)
-  const yy = d.getUTCFullYear().toString().slice(-2)
+  const yyyy = d.getUTCFullYear().toString()
   const mm = padZero((d.getUTCMonth() + 1).toString())
   const dd = padZero(d.getUTCDate().toString())
   const hh = padZero(d.getUTCHours().toString())
   const min = padZero(d.getUTCMinutes().toString())
+  const ss = padZero(d.getUTCSeconds().toString())
 
-  return `${mm}/${dd}/${yy} ${hh}:${min}`
+  return `${yyyy}-${mm}-${dd}T${hh}:${min}:${ss}Z`
 }
 
 //
@@ -447,15 +449,12 @@ export function exportTransactionsToCSVInner(
 }
 
 export async function exportTransactionsToBitwave(
-  wallet: EdgeCurrencyWallet,
   accountId: string,
   edgeTransactions: EdgeTransaction[],
   currencyCode: string,
-  multiplier: string,
-  parentMultiplier: string
+  multiplier: string
 ): Promise<string> {
   const items: any[] = []
-  const parentCode = wallet.currencyInfo.currencyCode
 
   for (const tx of edgeTransactions) {
     edgeTxToCsv(tx)
@@ -469,25 +468,15 @@ export async function exportTransactionsToBitwave(
       nativeAmount,
       networkFee,
       ourReceiveAddresses,
-      parentNetworkFee,
       spendTargets,
       txid
     } = edgeTx
     const amount: string = abs(div(nativeAmount, multiplier, DECIMAL_PRECISION))
     const time = makeBitwaveDateTime(date)
-    let fee: string = ''
-    let feeTicker: string = ''
     const { name = '', category = '', notes = '' } = metadata ?? {}
 
     let toAddress = ''
     if (isSend) {
-      if (parentNetworkFee != null) {
-        feeTicker = parentCode
-        fee = div(parentNetworkFee, parentMultiplier, DECIMAL_PRECISION)
-      } else {
-        feeTicker = currencyCode
-        fee = div(networkFee, multiplier, DECIMAL_PRECISION)
-      }
       if (spendTargets != null && spendTargets.length > 0) {
         // We can only choose 1 `toAddress` so pick the first spendTarget
         toAddress = spendTargets[0].publicAddress
@@ -509,8 +498,10 @@ export async function exportTransactionsToBitwave(
       amountTicker: currencyCode,
       cost: '',
       costTicker: '',
-      fee,
-      feeTicker,
+      // Bitwave calculates transaction fees on its own side. Exporting them
+      // here duplicates the fees after import, so both columns stay blank:
+      fee: '',
+      feeTicker: '',
       time,
       blockchainId: txid,
       memo: notes,
@@ -525,7 +516,8 @@ export async function exportTransactionsToBitwave(
       toAddress,
       groupId: '',
       'metadata:myCustomMetadata1': category,
-      'metadata:myCustomMetadata2': notes
+      // Bitwave expects this to mirror the description column:
+      'metadata:myCustomMetadata2': name
     })
   }
 

--- a/src/components/scenes/TransactionsExportScene.tsx
+++ b/src/components/scenes/TransactionsExportScene.tsx
@@ -58,7 +58,6 @@ interface StateProps {
   defaultIsoFiat: string
   exchangeMultiplier: string
   multiplier: string
-  parentMultiplier: string
 }
 
 interface DispatchProps {
@@ -303,7 +302,6 @@ class TransactionsExportSceneComponent extends React.PureComponent<
       defaultIsoFiat,
       exchangeMultiplier,
       multiplier,
-      parentMultiplier,
       route
     } = this.props
     const { sourceWallet, tokenId } = route.params
@@ -327,10 +325,15 @@ class TransactionsExportSceneComponent extends React.PureComponent<
     const fileAccountId = exportTxInfo?.bitwaveAccountId ?? ''
 
     if (isExportBitwave) {
-      accountId =
+      // Bitwave account ids are case-sensitive and may start with a lowercase
+      // letter, so the platform default of capitalizing the first character
+      // would corrupt them. Trim as well, since a pasted id often carries
+      // surrounding whitespace:
+      const rawAccountId =
         (await Airship.show<string | undefined>(bridge => (
           <TextInputModal
             autoFocus
+            autoCapitalize="none"
             autoCorrect={false}
             bridge={bridge}
             initialValue={fileAccountId}
@@ -345,6 +348,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
             title={lstrings.export_transaction_bitwave_accountid_modal_title}
           />
         ))) ?? ''
+      accountId = rawAccountId.trim()
     }
 
     if (
@@ -451,12 +455,10 @@ class TransactionsExportSceneComponent extends React.PureComponent<
 
     if (isExportBitwave) {
       const bitwaveFile = await exportTransactionsToBitwave(
-        sourceWallet,
         accountId,
         txs,
         currencyCode,
-        exchangeMultiplier,
-        parentMultiplier
+        exchangeMultiplier
       )
       files.push({
         contents: bitwaveFile,
@@ -544,9 +546,7 @@ export const TransactionsExportScene = connect<
       state,
       params.sourceWallet.currencyConfig,
       params.tokenId
-    ).multiplier,
-    parentMultiplier: getExchangeDenom(params.sourceWallet.currencyConfig, null)
-      .multiplier
+    ).multiplier
   }),
   dispatch => ({
     updateTxsFiatDispatch: async (wallet, tokenId, currencyCode, txs) => {

--- a/src/components/scenes/TransactionsExportScene.tsx
+++ b/src/components/scenes/TransactionsExportScene.tsx
@@ -126,7 +126,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
     }
   }
 
-  setThisMonth = () => {
+  setThisMonth = (): void => {
     this.setState({
       startDate: new Date(
         new Date().getFullYear(),
@@ -140,7 +140,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
     })
   }
 
-  setLastMonth = () => {
+  setLastMonth = (): void => {
     const lastMonth = new Date(new Date().setMonth(new Date().getMonth() - 1))
     let lastYear = 0
     if (lastMonth.getMonth() === 11) lastYear = 1 // Decrease year by 1 if previous month was December
@@ -164,7 +164,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
     })
   }
 
-  loadInfoFile = async () => {
+  loadInfoFile = async (): Promise<void> => {
     const { sourceWallet, tokenId } = this.props.route.params
     const { disklet } = sourceWallet
     const result = await disklet.getText(EXPORT_TX_INFO_FILE)
@@ -189,7 +189,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
     })
   }
 
-  render() {
+  render(): React.ReactElement {
     const { startDate, endDate, isExportBitwave, isExportCsv, isExportQbo } =
       this.state
     const { currencyCode, theme, route } = this.props
@@ -245,7 +245,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
     )
   }
 
-  renderSwitches() {
+  renderSwitches(): React.ReactElement {
     const { isExportBitwave, isExportCsv, isExportQbo } = this.state
     return (
       <>
@@ -268,7 +268,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
     )
   }
 
-  handleStartDate = async () => {
+  handleStartDate = async (): Promise<void> => {
     const { startDate } = this.state
     const date = await Airship.show<Date>(bridge => (
       <DateModal bridge={bridge} initialValue={startDate} />
@@ -276,7 +276,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
     this.setState({ startDate: date })
   }
 
-  handleEndDate = async () => {
+  handleEndDate = async (): Promise<void> => {
     const { endDate } = this.state
     const date = await Airship.show<Date>(bridge => (
       <DateModal bridge={bridge} initialValue={endDate} />
@@ -284,15 +284,15 @@ class TransactionsExportSceneComponent extends React.PureComponent<
     this.setState({ endDate: date })
   }
 
-  handleQboToggle = () => {
+  handleQboToggle = (): void => {
     this.setState(state => ({ isExportQbo: !state.isExportQbo }))
   }
 
-  handleCsvToggle = () => {
+  handleCsvToggle = (): void => {
     this.setState(state => ({ isExportCsv: !state.isExportCsv }))
   }
 
-  handleBitwaveToggle = () => {
+  handleBitwaveToggle = (): void => {
     this.setState(state => ({ isExportBitwave: !state.isExportBitwave }))
   }
 
@@ -494,7 +494,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
         urls,
         failOnCancel: false,
         subject: title
-      }).catch(error => {
+      }).catch((error: unknown) => {
         console.log('Share error', error)
       })
     } catch (error: any) {
@@ -521,7 +521,7 @@ class TransactionsExportSceneComponent extends React.PureComponent<
       title,
       urls,
       subject: title
-    }).catch(error => {
+    }).catch((error: unknown) => {
       showError(error)
     })
   }


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1217002622650454/f)

Fixes the four Bitwave CSV export issues tracked on [CSV - Bitwave Export issues](https://app.asana.com/1/9976422036640/project/1213880789473005/task/1217002622650454). Bitwave changed its import requirements, so the export no longer matched what its importer accepts, and one input defect corrupted the account id.

**Timestamps use ISO 8601 UTC** ([subtask](https://app.asana.com/0/0/1216919101984086)). `makeBitwaveDateTime` emitted `MM/DD/YY HH:MM`; it now emits `YYYY-MM-DDTHH:MM:SSZ` (4-digit year, `T` separator, seconds, trailing `Z`).

**Fee columns stay blank** ([subtask](https://app.asana.com/0/0/1216919101984082)). Column G (`fee`) and column H (`feeTicker`) now export as empty strings for every transaction. Bitwave calculates fees itself, so populated columns duplicated them after import. Dropping them leaves the `wallet` and `parentMultiplier` arguments unused, so those are removed along with the scene prop that supplied `parentMultiplier`.

**Custom metadata 2 mirrors the description** ([subtask](https://app.asana.com/0/0/1216919101984084)). Column W (`metadata:myCustomMetadata2`) was the transaction notes; it now carries the same value as column R (`description`). The notes are still exported in column K (`memo`), so nothing is lost.

**Account id keeps the case and spacing it was entered with** ([subtask](https://app.asana.com/0/0/1216919101984088)). Root cause: the account-id `TextInputModal` never passed `autoCapitalize`, `TextInputModal` forwards that `undefined` to `ModalFilledTextInput`, and `FilledTextInput` only defaults it to `'none'` for secure inputs. So React Native's iOS default of `sentences` applied and capitalized the first character, turning `pgM8cDt7bySnWTzs2MyI` into `PgM8cDt7bySnWTzs2MyI`. The value was then persisted to disklet and reused as the modal's initial value, which is why the correction had to be reapplied at every import rather than sticking. The modal now passes `autoCapitalize="none"`, and the entered value is trimmed since a pasted id often carries surrounding whitespace.

Column letters map to the row object's key order, which `csv-stringify` uses for the header: A `id` … G `fee`, H `feeTicker`, I `time`, M `accountId`, R `description`, W `metadata:myCustomMetadata2`.

Tests: `src/__tests__/exportBitwaveResult.csv` is a reference output file compared against the whole export, matching the existing CSV and QBO reference-file tests. Four further tests assert the individual behaviors above, each checking the header name at the column index it uses first, so a reordered row object fails loudly instead of silently invalidating the assertions.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

Driven end to end on the iOS simulator against the `edge-funds` My Zano wallet: Export Transactions → Bitwave CSV → account id → share sheet. The exported file was pulled off the device and parsed; across all 7 real transactions columns G and H are empty, every timestamp matches `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`, column W equals column R, and column M is exactly `pgM8cDt7bySnWTzs2MyI`. `tsc`, eslint (0 errors) and the full jest suite (95 suites, 576 tests) pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to transaction export formatting and Bitwave account-id input; no auth, payments, or core wallet logic changes.
> 
> **Overview**
> Updates **Bitwave CSV export** so imports match Bitwave’s current rules: `time` is **ISO 8601 UTC** (`YYYY-MM-DDTHH:MM:SSZ`) instead of `MM/DD/YY HH:MM`, **`fee` and `feeTicker` are always empty** so Bitwave doesn’t double-count fees, and **`metadata:myCustomMetadata2` duplicates `description`** (transaction name) instead of notes (notes remain in `memo`).
> 
> **`exportTransactionsToBitwave`** no longer takes the wallet or parent fee multiplier—only `accountId`, transactions, currency, and exchange multiplier. The export scene collects the Bitwave account id with **`autoCapitalize="none"`** and **trims** pasted values so ids aren’t corrupted on iOS or by whitespace.
> 
> Adds a **reference CSV fixture** plus focused tests (timestamps, blank fees, metadata, account id). Small **TypeScript** tweaks in CSV/QBO export paths and the export scene; those files are dropped from an **eslint** override list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8862791d1bd0bd2b09de07e8dcff36ffdfb89d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

