### PR TITLE
Add SimpleSwap swap support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: SimpleSwap swap provider
 - added: Verbose logging for exchange rate queries: the request body, resolved/rate-less counts, and errors are captured when the Verbose Logging setting is enabled.
 - added: Exchange-rate cache snapshot in the support log output, plus a `rates-cache-replay` script that re-runs those queries against the rates server and reports the result for each pair.
 - added: "-m" tag on the version number in the Help scene for Maestro test builds

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -724,6 +724,7 @@ export const pluginIdIcons: Record<string, string> = {
   nymswap: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/nymswap/icon.png',
   rango: EDGE_CONTENT_SERVER_URI + '/rango.png',
   sideshift: EDGE_CONTENT_SERVER_URI + '/sideshift-logo.png',
+  simpleswap: EDGE_CONTENT_SERVER_URI + '/simpleswap.png',
   simplex: EDGE_CONTENT_SERVER_URI + '/simplex.png',
   swapuz: EDGE_CONTENT_SERVER_URI + '/swapuz.png',
   thorchain: EDGE_CONTENT_SERVER_URI + '/thorchain.png',

--- a/src/components/modals/SwapVerifyTermsModal.tsx
+++ b/src/components/modals/SwapVerifyTermsModal.tsx
@@ -49,6 +49,11 @@ const pluginData: Record<string, TermsUri> = {
     kycUri:
       'https://help.sideshift.ai/en/articles/6230858-sideshift-ai-s-risk-management-policy'
   },
+  simpleswap: {
+    termsUri: 'https://simpleswap.io/terms-of-service',
+    privacyUri: 'https://simpleswap.io/privacy-policy',
+    kycUri: 'https://simpleswap.io/aml-kyc'
+  },
   swapuz: {
     termsUri: 'https://swapuz.com/terms-of-use',
     privacyUri: 'https://swapuz.com/privacy-policy',

--- a/src/constants/MerchantContacts.ts
+++ b/src/constants/MerchantContacts.ts
@@ -75,6 +75,10 @@ export const MERCHANT_CONTACTS: MerchantContact[] = [
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/sideshift-logo.png`
   },
   {
+    displayName: 'SimpleSwap',
+    thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/simpleswap.png`
+  },
+  {
     displayName: 'Simplex',
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/simplex.png`
   },

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -412,6 +412,11 @@ export const asEnvConfig = asObject({
       affiliateId: asOptional(asString, '')
     })
   ),
+  SIMPLESWAP_INIT: asCorePluginInit(
+    asObject({
+      apiKey: asOptional(asString, '')
+    }).withRest
+  ),
   SOLANA_INIT: asCorePluginInit(
     asObject({
       alchemyApiKey: asOptional(asString, ''),

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -99,6 +99,7 @@ export const swapPlugins = {
   letsexchange: ENV.LETSEXCHANGE_INIT,
   nexchange: ENV.NEXCHANGE_INIT,
   sideshift: ENV.SIDESHIFT_INIT,
+  simpleswap: ENV.SIMPLESWAP_INIT,
   swapuz: ENV.SWAPUZ_INIT,
   xgram: ENV.XGRAM_INIT,
   nymswap: ENV.NYM_SWAP_INIT,


### PR DESCRIPTION
### CHANGELOG
  
  - [x] Yes
  
  ### Dependencies
  
  EdgeApp/edge-exchange-plugins#481
  
  ### Description
  
  Companion PR for the SimpleSwap swap plugin
  (EdgeApp/edge-exchange-plugins#481): env config and plugin registration,
  partner icon mapping, merchant contact entry, and terms/privacy/KYC links
  for the swap terms modal.

  Logos attached below: 64x64 (white background) and 600x210, each in 1x
  and 2x, for the content server.

<img width="600" height="210" alt="2x-ss-logo-600x210" src="https://github.com/user-attachments/assets/f7d47c6e-9fcd-46e2-b35e-919e803b8ae2" />
<img width="64" height="64" alt="ss-logo-64x64" src="https://github.com/user-attachments/assets/0c7245f4-0519-4983-a8c3-5fc6d78a61d9" />
<img width="64" height="64" alt="2x-ss-logo-64x64" src="https://github.com/user-attachments/assets/583c3924-2ed5-4c70-9f38-7e1f820af409" />
<img width="600" height="210" alt="ss-logo-600x210" src="https://github.com/user-attachments/assets/60ccca82-0ec3-4fae-99f6-57be070a9d5f" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GUI-only wiring for a new swap partner using the same env/plugin/icon/terms patterns as existing centralized providers; no auth or payment flow changes in this repo.
> 
> **Overview**
> Adds **SimpleSwap** as a centralized swap provider in the Edge React GUI, mirroring how other partners (e.g. SideShift, Swapuz) are wired in.
> 
> Registration includes optional `SIMPLESWAP_INIT` env config (`apiKey`), plugin entry in `corePlugins`, partner logo mapping, a merchant contacts row, and terms/privacy/KYC links in the swap verify-terms modal. The unreleased changelog notes the new provider. Actual swap logic lives in the companion **edge-exchange-plugins** PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b75595f58a4b0dd9015c881356238e8a1e955ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217205278669380