### PR TITLE
Add app/device attestation for gated info-server requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: App/device attestation for gated info-server requests
 - added: "-m" tag on the version number in the Help scene for Maestro test builds
 - changed: Style the entire "Already have an account? Sign in" line in the getting-started USP carousel with the tertiary link color, not just "Sign in".
 - changed: Refresh the buy, sell, sort, scan-QR and FIO names icons to the updated design.

--- a/android/app/src/main/java/co/edgesecure/app/EdgeAttestationModule.kt
+++ b/android/app/src/main/java/co/edgesecure/app/EdgeAttestationModule.kt
@@ -1,0 +1,312 @@
+package co.edgesecure.app
+
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.security.keystore.StrongBoxUnavailableException
+import android.util.Base64
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.spec.ECGenParameterSpec
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * Native bridge for Android Keystore hardware key attestation (device-level
+ * attestation). Generates a fresh EC key in the AndroidKeyStore with the given
+ * attestation challenge and returns the resulting X.509 certificate chain, which
+ * the info server verifies against Google's hardware attestation roots.
+ *
+ * This stays fully open source: it uses only the platform KeyStore APIs, not the
+ * closed-source Play Integrity / SafetyNet SDKs.
+ */
+class EdgeAttestationModule(
+  reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+  companion object {
+    // Stable alias: the key is enrolled once via attestation and then reused
+    // to sign challenges (see signChallenge). Cleared only on clearKey or
+    // when re-enrollment is needed.
+    private const val KEY_ALIAS = "edge_attestation_key"
+
+    // Serializes all AndroidKeyStore access to KEY_ALIAS. getAttestation,
+    // signChallenge and clearKey each mutate/read the single shared alias; the
+    // JS engine's watchdog can release its in-flight lock and start a new
+    // handshake while an older native Thread is still running, so without this
+    // lock two overlapping getAttestation calls could delete/regenerate the key
+    // out from under each other and return cross-wired certificate chains.
+    private val keystoreLock = ReentrantLock()
+
+    // Caps how long an operation waits for keystoreLock. Keystore work is local
+    // and synchronous, so a wedged generateKeyPair or sign cannot be interrupted
+    // - but the operations queued behind it can refuse to wait forever, which is
+    // what stops one wedge from taking down every later attestation, refresh and
+    // clear for the life of the process. Well above a slow-but-healthy attested
+    // key generation, and below the JS watchdog so JS gets a real rejection
+    // instead of timing out blind.
+    private const val LOCK_TIMEOUT_SECONDS = 60L
+
+    private enum class AttestCode(
+      val code: String,
+    ) {
+      UNSUPPORTED("unsupported"),
+      LOCK_TIMEOUT("lockTimeout"),
+      NO_KEY("noKey"),
+      ATTESTATION_ERROR("attestationError"),
+      SIGN_CHALLENGE("signChallenge"),
+    }
+  }
+
+  override fun getName(): String = "EdgeAttestation"
+
+  /**
+   * Runs [body] holding [keystoreLock], rejecting with `lockTimeout` if the lock
+   * cannot be acquired within [LOCK_TIMEOUT_SECONDS].
+   *
+   * That rejection code matters twice over. The JS engine reads it as saying
+   * nothing about whether the enrolled key can sign, so it retries the cheap
+   * refresh path instead of escalating to a full attestation. It also reads it as
+   * proof that no attestation was spent - this fires before the lock is held, so
+   * [body] never ran and no key was generated - which keeps a contended lock from
+   * doubling the failure backoff. It is deliberately not the `timeout` iOS
+   * reports: that one fires while waiting on an App Attest callback, so the
+   * platform operation did start and may have counted against the quota.
+   */
+  private fun withKeystoreLock(
+    promise: Promise,
+    body: () -> Unit,
+  ) {
+    try {
+      if (!keystoreLock.tryLock(LOCK_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        promise.reject(AttestCode.LOCK_TIMEOUT.code, "Timed out waiting for the Keystore lock")
+        return
+      }
+    } catch (interrupted: InterruptedException) {
+      // Nothing interrupts these threads today: they are plain Threads and no
+      // reference to them is kept. But this call sits outside the try/catch the
+      // callers wrap their own work in, so an escape here would leave the
+      // promise unsettled and take the process down with an uncaught exception
+      // on a background thread. Swapping Thread for an executor or a coroutine,
+      // where interruption is how cancellation arrives, would make that
+      // reachable without anyone touching this file. The same code as the
+      // timeout is right: the lock was never held, so nothing was spent.
+      //
+      // Catching clears the interrupt flag, so restore it: under an executor or
+      // coroutine the layer above reads that flag to see the cancellation, and
+      // swallowing it here would strand a pool thread that should be winding
+      // down.
+      Thread.currentThread().interrupt()
+      promise.reject(AttestCode.LOCK_TIMEOUT.code, "Interrupted waiting for the Keystore lock")
+      return
+    }
+    try {
+      body()
+    } finally {
+      keystoreLock.unlock()
+    }
+  }
+
+  /**
+   * `keyId = base64url(SHA-256(leaf SPKI))` for the enrolled key, matching the
+   * server's derivation. Null when no key is enrolled.
+   */
+  private fun currentKeyId(keyStore: KeyStore): String? {
+    val cert = keyStore.getCertificate(KEY_ALIAS) ?: return null
+    return Base64.encodeToString(
+      MessageDigest.getInstance("SHA-256").digest(cert.publicKey.encoded),
+      Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+    )
+  }
+
+  @ReactMethod
+  fun isSupported(promise: Promise) {
+    // Key attestation (setAttestationChallenge) requires API 24+.
+    promise.resolve(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+  }
+
+  @ReactMethod
+  fun getAttestation(
+    challenge: String,
+    promise: Promise,
+  ) {
+    // Key generation can be slow; run off the JS thread. Serialize all Keystore
+    // access so an overlapping handshake cannot corrupt the shared alias.
+    Thread {
+      withKeystoreLock(promise) {
+        val keyAlias = KEY_ALIAS
+        try {
+          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            promise.reject(
+              AttestCode.UNSUPPORTED.code,
+              "Key attestation requires Android 7.0 (API 24) or later",
+            )
+            return@withKeystoreLock
+          }
+
+          // getAttestation is only called when (re-)enrollment is required, so
+          // a leftover key under the stable alias is stale; delete it first.
+          try {
+            val existing = KeyStore.getInstance("AndroidKeyStore")
+            existing.load(null)
+            existing.deleteEntry(keyAlias)
+          } catch (ignored: Exception) {
+            // Best effort.
+          }
+
+          val generator =
+            KeyPairGenerator.getInstance(
+              KeyProperties.KEY_ALGORITHM_EC,
+              "AndroidKeyStore",
+            )
+
+          // The challenge's UTF-8 bytes are bound into the attestation
+          // extension; the server compares them against the challenge it
+          // issued. Builds the spec, optionally requesting a StrongBox-backed
+          // key. A StrongBox (dedicated secure element, e.g. Pixel Titan M) key
+          // attests at `attestationSecurityLevel = strongBox`, which the info
+          // server maps to `secureElement`; a plain TEE key attests as
+          // `trustedEnvironment` -> `hardware`.
+          fun buildSpec(strongBox: Boolean): KeyGenParameterSpec {
+            val builder =
+              KeyGenParameterSpec
+                .Builder(
+                  keyAlias,
+                  KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
+                ).setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+                .setDigests(KeyProperties.DIGEST_SHA256)
+                .setAttestationChallenge(challenge.toByteArray(Charsets.UTF_8))
+            if (strongBox && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+              builder.setIsStrongBoxBacked(true)
+            }
+            return builder.build()
+          }
+
+          // Prefer the highest assurance (StrongBox / secure element) and fall
+          // back to the TEE only when this device has no StrongBox.
+          val wantStrongBox = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+          try {
+            generator.initialize(buildSpec(wantStrongBox))
+            generator.generateKeyPair()
+          } catch (e: StrongBoxUnavailableException) {
+            // No StrongBox on this device; fall back to the TEE (hardware).
+            generator.initialize(buildSpec(false))
+            generator.generateKeyPair()
+          }
+
+          val keyStore = KeyStore.getInstance("AndroidKeyStore")
+          keyStore.load(null)
+          val chain = keyStore.getCertificateChain(keyAlias)
+          if (chain == null || chain.isEmpty()) {
+            // Throw so the catch below deletes the half-created key rather than
+            // leaving it enrolled with an attestation never returned to JS.
+            throw IllegalStateException("Empty attestation certificate chain")
+          }
+
+          val certChain = Arguments.createArray()
+          for (cert in chain) {
+            certChain.pushString(
+              Base64.encodeToString(cert.encoded, Base64.NO_WRAP),
+            )
+          }
+
+          val result = Arguments.createMap()
+          result.putArray("certChain", certChain)
+          promise.resolve(result)
+        } catch (e: Exception) {
+          // A failed enrollment should not leave a half-created key behind. The
+          // key is intentionally NOT deleted on success: it survives so
+          // signChallenge can reuse it for token refreshes.
+          try {
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            keyStore.deleteEntry(keyAlias)
+          } catch (ignored: Exception) {
+            // Best effort cleanup.
+          }
+          promise.reject(AttestCode.ATTESTATION_ERROR.code, e.message, e)
+        }
+      }
+    }.start()
+  }
+
+  @ReactMethod
+  fun signChallenge(
+    challenge: String,
+    promise: Promise,
+  ) {
+    Thread {
+      withKeystoreLock(promise) {
+        try {
+          val keyStore = KeyStore.getInstance("AndroidKeyStore")
+          keyStore.load(null)
+          val entry =
+            keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.PrivateKeyEntry
+          if (entry == null) {
+            promise.reject(AttestCode.NO_KEY.code, "No attested key is stored")
+            return@withKeystoreLock
+          }
+          val keyId = currentKeyId(keyStore)
+          if (keyId == null) {
+            promise.reject(AttestCode.NO_KEY.code, "No attested key is stored")
+            return@withKeystoreLock
+          }
+          val signer = java.security.Signature.getInstance("SHA256withECDSA")
+          signer.initSign(entry.privateKey)
+          signer.update(challenge.toByteArray(Charsets.UTF_8))
+          val signature = Base64.encodeToString(signer.sign(), Base64.NO_WRAP)
+
+          val result = Arguments.createMap()
+          result.putString("keyId", keyId)
+          result.putString("signature", signature)
+          promise.resolve(result)
+        } catch (e: Exception) {
+          promise.reject(AttestCode.SIGN_CHALLENGE.code, e.message, e)
+        }
+      }
+    }.start()
+  }
+
+  @ReactMethod
+  fun clearKey(
+    keyId: String?,
+    promise: Promise,
+  ) {
+    // Off the caller's thread like the other two methods. This runs on the
+    // shared native-modules thread, and keystoreLock can be held for seconds by
+    // an in-progress getAttestation - attested EC key generation is slow, more
+    // so for StrongBox. Waiting for it here would stall every native module in
+    // the app, and JS calls this exactly when a handshake is already in flight.
+    Thread {
+      // Best-effort: force re-enrollment when the server rejects an assertion
+      // (unknown key, revoked serial, disabled app). Resolves even when the
+      // delete fails, since JS treats this as advisory - the only case that
+      // rejects is failing to acquire the lock, and JS ignores that too. A
+      // getAttestation replaces the alias regardless of whether this succeeded.
+      try {
+        withKeystoreLock(promise) {
+          val keyStore = KeyStore.getInstance("AndroidKeyStore")
+          keyStore.load(null)
+          // Only the key JS named. Waiting for the lock can take a while, and a
+          // newer handshake may have enrolled a replacement in the meantime -
+          // deleting that one would discard a working key over a verdict about
+          // its predecessor. A null id means discard whatever is stored.
+          if (keyId != null && currentKeyId(keyStore) != keyId) {
+            promise.resolve(null)
+            return@withKeystoreLock
+          }
+          keyStore.deleteEntry(KEY_ALIAS)
+          promise.resolve(null)
+        }
+      } catch (ignored: Exception) {
+        // Best effort.
+        promise.resolve(null)
+      }
+    }.start()
+  }
+}

--- a/android/app/src/main/java/co/edgesecure/app/EdgeAttestationPackage.kt
+++ b/android/app/src/main/java/co/edgesecure/app/EdgeAttestationPackage.kt
@@ -1,0 +1,15 @@
+package co.edgesecure.app
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+/** Registers the EdgeAttestation native module with React Native. */
+class EdgeAttestationPackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+    listOf(EdgeAttestationModule(reactContext))
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+    emptyList()
+}

--- a/android/app/src/main/java/co/edgesecure/app/MainApplication.kt
+++ b/android/app/src/main/java/co/edgesecure/app/MainApplication.kt
@@ -34,7 +34,9 @@ class MainApplication :
           // Packages that cannot be autolinked yet can be added manually here, for
           // example:
           // packages.add(new MyReactNativePackage());
-          return PackageList(this).packages
+          val packages = PackageList(this).packages
+          packages.add(EdgeAttestationPackage())
+          return packages
         }
 
         override fun getJSMainModuleName(): String = "index"

--- a/docs/APP_ATTESTATION.md
+++ b/docs/APP_ATTESTATION.md
@@ -1,0 +1,551 @@
+# App attestation for gated info-server requests: prove the caller is the real Edge app on real hardware
+
+| | |
+|---|---|
+| Status | In review |
+| Authors | Paul Puey (implementation, repo docs), Jon Tzeng (this document) |
+| Reviewer | Jon Tzeng (code review, 2026-08-07: 8 comments, 6 fixed, 2 declined) |
+| Last updated | 2026-08-07 |
+| Repos | [edge-info-server](https://github.com/EdgeApp/edge-info-server), [edge-react-gui](https://github.com/EdgeApp/edge-react-gui) |
+| Implementation | info [#156](https://github.com/EdgeApp/edge-info-server/pull/156) (merged), info [#158](https://github.com/EdgeApp/edge-info-server/pull/158), gui [#6137](https://github.com/EdgeApp/edge-react-gui/pull/6137) |
+| Supersedes | - |
+| Related | [Asana task](https://app.asana.com/0/1215088146871429/1216536848508307) |
+
+This document describes what is built on the branches above: `paul/attestationLifetimeFloor` in edge-info-server (on top of the merged #156) and `paul/appAttestationV2` in edge-react-gui. Each code block below is captioned with a link to that file pinned at the branch commit it was taken from.
+
+## Contents
+
+1. [Problem](#1-problem)
+2. [Prior art](#2-prior-art)
+3. [Goals and non-goals](#3-goals-and-non-goals)
+4. [Design overview](#4-design-overview)
+5. [Detailed design: edge-info-server](#5-detailed-design-edge-info-server)
+6. [Detailed design: edge-react-gui](#6-detailed-design-edge-react-gui)
+7. [Testing](#7-testing)
+8. [Phase history](#8-phase-history)
+9. [Decisions](#9-decisions)
+10. [Glossary](#10-glossary)
+11. [References](#11-references)
+
+## 1. Problem
+
+The info server signs on behalf of Edge's ramp partners. `POST /v1/jwtSign/:provider` mints a [JWT](#jwt-json-web-token) with a partner secret, and `POST /v1/createHmac/:provider` returns an [HMAC](#hmac-hash-based-message-authentication-code) over caller-supplied data with a partner key. Simplex and Banxa both accept those signatures as proof that the request came from Edge.
+
+Neither endpoint can tell who is calling. They are reachable by anyone who can reach the host, so any script can obtain a signature that Simplex and Banxa will honor as Edge's. The partner secrets never leave the server, but the ability to use them does not.
+
+What the server needs is evidence that the caller is the genuine Edge app running on a real device, checkable server-side and cheap enough to sit in front of a purchase flow.
+
+## 2. Prior art
+
+**A shared API key or bearer token in the app.** Anything shipped in the binary is extractable. It raises the effort to pull a key out of an APK, and nothing more.
+
+**Play Integrity / SafetyNet.** Google's hosted attestation answers the question directly, but it is closed source. Edge ships an open-source app, and a build that depends on Google's proprietary SDK cannot be reproduced from source by the people who audit it. That rules it out on licensing grounds before any technical comparison.
+
+**Platform attestation on every request.** Apple [App Attest](#app-attest) and [Android Keystore attestation](#android-keystore-key-attestation) are both rate limited and slow (a network round trip to Apple, a certificate chain to build on Android). The Banxa order poll runs every 3 seconds; attesting per request would trip the platform limits and lock out the devices it was meant to protect.
+
+**A per-request [nonce](#nonce) in Redis (the V1 design, built and then removed).** Redis gives every worker a shared single-use store, which is the obvious way to stop challenge replay across a cluster. It costs a managed database per region, and it puts a network dependency in front of enrollment. See [decision 1](#91-self-validating-hmac-challenges-instead-of-a-redis-nonce-store) for why it was replaced and [section 8](#8-phase-history) for what changed.
+
+## 3. Goals and non-goals
+
+Goals:
+
+- Prove application identity (the genuine `co.edgesecure.app` binary) and hardware backing, using only open platform APIs.
+- Gate the two signing endpoints per provider, switchable from data with no code deploy, so rollout and rollback are a Couch edit.
+- Keep every pre-existing info-server route working when attestation is degraded or misconfigured.
+- Spend a rate-limited platform attestation only when nothing cheaper can work.
+- Survive a device whose wall clock is wrong.
+
+Non-goals:
+
+- Per-user authentication. Attestation proves the app and the device, never the account.
+- Blocking rooted or jailbroken devices outright. `requireVerifiedBoot` exists per provider and gates on [verified boot](#verified-boot), but the default posture accepts a [TEE](#tee-trusted-execution-environment)-backed key on an unlocked bootloader.
+- Protecting anything beyond the two signing endpoints. edge-core-js does not participate.
+- Cross-host replay protection inside the challenge window. See [decision 2](#92-per-host-nonce-cache-on-the-cluster-master).
+
+## 4. Design overview
+
+Two repos, one seam: the client obtains a short-lived attestation token from the info server and attaches it to the two gated endpoints.
+
+| Repo | Deliverable | Scope |
+|---|---|---|
+| edge-info-server | [#156](https://github.com/EdgeApp/edge-info-server/pull/156) merged, [#158](https://github.com/EdgeApp/edge-info-server/pull/158) open | Challenge mint and verify, Apple/Android verification, token mint, per-provider gate. [Section 5](#5-detailed-design-edge-info-server) |
+| edge-react-gui | [#6137](https://github.com/EdgeApp/edge-react-gui/pull/6137) open | Native attestation modules, the background token engine, header injection at the Simplex and Banxa call sites. [Section 6](#6-detailed-design-edge-react-gui) |
+
+The full enrollment handshake, with participants grouped by repo:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  box edge-react-gui
+    participant Native as Native module<br/>(Keystore / App Attest)
+    participant Engine as Attestation engine<br/>(src/util/attestation.ts)
+  end
+  box edge-info-server
+    participant Attest as /v1/attest/*
+    participant Verify as Apple/Android verify
+    participant Couch as CouchDB
+  end
+
+  Engine->>Attest: GET /v1/attest/challenge
+  Attest->>Attest: HMAC-sign (nonce, expiry)
+  Attest-->>Engine: { challenge, expires, serverTime }
+  Engine->>Native: getAttestation(challenge)
+  Native->>Native: generate key bound to SHA256(challenge)
+  Native-->>Engine: { keyId, attestation } or { certChain }
+  Engine->>Attest: POST /v1/attest/apple | /android
+  Attest->>Attest: verify HMAC, consume nonce (single-use)
+  Attest->>Verify: verify platform attestation
+  Verify->>Couch: check allow-list, store attested key
+  Attest-->>Engine: { token, assuranceLevel, platform, expiresIn, serverTime }
+  Engine->>Engine: cache token on a monotonic deadline
+```
+
+Every later handshake refreshes with the enrolled key and never touches Apple or Google:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  box edge-react-gui
+    participant Native as Native module
+    participant Engine as Attestation engine
+    participant Plugin as Simplex / Banxa plugin
+  end
+  box edge-info-server
+    participant Attest as /v1/attest/*/assert
+    participant Sign as /v1/jwtSign/:provider<br/>/v1/createHmac/:provider
+  end
+
+  Engine->>Attest: GET /v1/attest/challenge
+  Attest-->>Engine: { challenge, expires, serverTime }
+  Engine->>Native: generateAssertion (iOS) / signChallenge (Android)
+  Native-->>Engine: signature over the challenge
+  Engine->>Attest: POST /attest/apple/assert | /android/assert
+  Attest-->>Engine: { token, expiresIn, serverTime }
+  Plugin->>Engine: getAttestationToken()
+  Engine-->>Plugin: cached token (or undefined)
+  Plugin->>Sign: POST with header x-attestation-token
+  Sign-->>Plugin: signature, or 403 when the gate is unmet
+```
+
+The token is an [ES256](#es256) [JWT](#jwt-json-web-token) the server signs with a key held in Couch. Any Edge service can verify one offline from the published [JWKS](#jwks-json-web-key-set), so a gate does not have to call the info server per request.
+
+## 5. Detailed design: edge-info-server
+
+### 5.1 Challenges are self-validating
+
+A challenge is a string with three parts: a random [nonce](#nonce), an absolute expiry in whole seconds, and an [HMAC](#hmac-hash-based-message-authentication-code) over the first two, dot-joined and [base64url](#base64url)-encoded.
+
+[`src/attestation/challenges.ts`](https://github.com/EdgeApp/edge-info-server/blob/0640c285d335179a1d62dbff070abdea7ec0d3cd/src/attestation/challenges.ts)
+```ts
+export const createChallenge = async (): Promise<Challenge> => {
+  const lifetimeSec = appAttestation.doc.data.challengeLifetimeSec
+  const expSec = Math.floor(Date.now() / 1000) + lifetimeSec
+  const nonce = base64url.encode(randomBytes(NONCE_BYTES))
+  const payload = `${nonce}.${expSec}`
+  const key = await getChallengeHmacKey()
+  const sig = signPayload(key, payload)
+  return {
+    challenge: `${payload}.${sig}`,
+    expires: expSec * 1000,
+    serverTime: new Date().toISOString()
+  }
+}
+```
+
+The HMAC key is derived with [HKDF](#hkdf-hmac-based-key-derivation-function) from the same private [JWK](#jwk-json-web-key) that signs tokens, so there is one secret to provision and rotate. Any worker on any host can verify a challenge it never issued, which is what removes the shared store.
+
+Verification rejects a malformed shape, a non-integer or past expiry, and a signature that fails a length check followed by `timingSafeEqual`. Only after all of that does it try to consume the nonce.
+
+```mermaid
+flowchart TD
+  A[consumeChallenge] --> B{3 dot-separated parts?}
+  B -->|no| R[reject]
+  B -->|yes| C{expiry an integer<br/>and in the future?}
+  C -->|no| R
+  C -->|yes| D{HMAC matches<br/>timingSafeEqual?}
+  D -->|no| R
+  D -->|yes| E[recordNonce]
+  E -->|first use| OK[accept]
+  E -->|already seen<br/>or IPC timeout| R
+```
+
+### 5.2 Single use lives on the cluster master
+
+The server runs a Node cluster. Workers do not share memory, so the nonce record lives in one Map on the [cluster master](#cluster-master) and workers ask over cluster [IPC](#ipc-inter-process-communication).
+
+```mermaid
+flowchart LR
+  subgraph host [One info-server host]
+    M["Master process<br/>Map&lt;nonce, expiryMs&gt;<br/>swept every 10s"]
+    W1[Worker 1] -->|IPC consume| M
+    W2[Worker 2] -->|IPC consume| M
+    W3[Worker N] -->|IPC consume| M
+    M -->|ok / reject| W1
+  end
+```
+
+The request carries a 2 second timeout and fails closed: a worker that gets no answer treats the challenge as unusable rather than risk accepting a replay. The master replies only through a guard that checks `worker.isConnected()` first, because an unguarded `send` to a worker that has already exited raises `ERR_IPC_CHANNEL_CLOSED` as an unhandled error event and takes the master down. The master is also the supervisor that re-forks workers, so losing it degrades every route, not just attestation.
+
+### 5.3 Platform verification
+
+iOS submits an [App Attest](#app-attest) attestation object; Android submits an X.509 certificate chain from Keystore. Both paths end at an `AttestationResult` carrying the [assurance level](#assurance-level).
+
+| Level | Meaning | Order |
+|---|---|---|
+| `debug` | Debug-keystore-signed build, whatever the hardware reports | 0 |
+| `software` | No hardware backing | 1 |
+| `hardware` | [TEE](#tee-trusted-execution-environment)-backed key (`trustedEnvironment`) | 2 |
+| `secureElement` | [StrongBox](#strongbox) / dedicated secure element | 3 |
+
+Android verification anchors the chain to Google's bundled hardware roots, checks every serial against Google's published [CRL](#crl-certificate-revocation-list), and reads [`attestationApplicationId`](#attestationapplicationid) for the package name and signing-certificate digests, which must match the allow-list in Couch. A debug-signed build is forced to `debug` regardless of the hardware it reports, so a debug build can never satisfy a `hardware` gate.
+
+iOS checks the App Attest object against Apple's root, binds it to `SHA256(challenge)`, and pins the team id from the allow-list. The App Attest environment decides the level: the development environment maps to `debug`, the production environment to `secureElement` (the key lives in the [Secure Enclave](#secure-enclave)).
+
+A successful attest upserts one Couch doc per key in `info_attestation_keys` (`_id = platform:keyId`; on Android the keyId is the base64url [SHA-256](#sha-256) of the leaf certificate's public key). The doc records the public key, the assurance level, the chain serials for later CRL re-checks, and the [verified boot](#verified-boot) outcome at enrollment. Trust anchors (Apple's App Attest root, Google's hardware roots) are bundled in `src/attestation/roots.ts`, so verification needs no fetch beyond the CRL.
+
+### 5.3.1 Refresh verification (assert)
+
+`POST /v1/attest/apple/assert` and `/android/assert` refresh a token without touching Apple or Google. Both load the stored key doc (unknown key is a 400, which the client reads as "re-enroll"), re-check the allow-list so an operator can revoke an app id, verify the signature over the challenge against the stored public key, and reuse the assurance level recorded at enrollment. The level is never recomputed on assert; what was proven once about the hardware does not change by signing again.
+
+Anti-clone differs by platform. iOS assertions carry a counter that must strictly increase over the stored `signCount`; the new value is persisted, and a concurrent assertion (Couch 409) fails the request so the client retries. Android signatures carry no counter, so the non-extractable [TEE](#tee-trusted-execution-environment)/[StrongBox](#strongbox) key is the compensating control; instead, asserts re-check the stored chain serials against the [CRL](#crl-certificate-revocation-list), which catches a keybox revoked after enrollment. Key docs written before serials were recorded skip that re-check and age out through re-enrollment.
+
+### 5.4 Token mint and the wire contract
+
+A successful attest or assert mints an [ES256](#es256) [JWT](#jwt-json-web-token). The response gives the client a relative lifetime and the server's clock, not an absolute deadline:
+
+[`src/attestation/index.ts`](https://github.com/EdgeApp/edge-info-server/blob/0640c285d335179a1d62dbff070abdea7ec0d3cd/src/attestation/index.ts)
+```ts
+const { token, expiresIn, serverTime } = await mintAttestationToken(result)
+return { token, assuranceLevel: result.assuranceLevel, platform: result.platform, expiresIn, serverTime }
+```
+
+`expiresIn` is seconds and `serverTime` is ISO 8601. The client needs neither its own clock nor agreement with the server's to know when the token dies. See [decision 3](#93-relative-expiresin-plus-servertime-instead-of-an-absolute-expiry). `serverTime` is derived from the same floored second as the JWT's `exp`, so `serverTime + expiresIn` lands exactly on `exp`; a first cut captured it after signing, overshooting by up to a second, and `src/__tests__/attestationMint.test.ts` now pins the equality.
+
+The token itself is stateless: nothing is stored per mint. Claims are `assuranceLevel`, `platform`, `appId`, `keyId`, and `verifiedBoot`, plus `iat`/`exp`/`jti`, with issuer `edge-info-server/attest` and audience `edge-info-server`. `verifiedBoot` is `true` when the device proved [verified boot](#verified-boot) with a locked bootloader at enrollment; on iOS it is always `true`, since App Attest only succeeds on an unmodified boot chain. Tokens minted before the claim existed omit it, and the verifier collapses anything but literal `true` to `false`. Any Edge service can verify a token offline with `verifyAttestationToken` from `src/public/attestation.ts` after fetching the [JWKS](#jwks-json-web-key-set) once; the signing [JWK](#jwk-json-web-key) auto-provisions on first use and is warmed at master boot. Multi-host deployments must replicate `info_data` so every host shares that one JWK; without it, challenges and tokens minted on one host fail verification on the other.
+
+Both lifetimes are operator-editable remote config and are clamped when read:
+
+[`src/types.ts`](https://github.com/EdgeApp/edge-info-server/blob/0640c285d335179a1d62dbff070abdea7ec0d3cd/src/types.ts)
+```ts
+const asLifetimeSec =
+  (defaultSec: number, minSec: number): Cleaner<number> =>
+  raw => {
+    const value = asMaybe(asNumber)(raw)
+    const resolved =
+      value == null || !Number.isFinite(value) ? defaultSec : value
+    return Math.max(minSec, Math.floor(resolved))
+  }
+```
+
+`attestationTokenLifetimeSec` has a 15 minute floor because the client refreshes 5 minutes before expiry; a shorter lifetime would leave no gap between refreshes. `challengeLifetimeSec` defaults to 30 seconds with a 10 second floor. The whole-document fallback is built by running the cleaner over `{}` rather than a hand-maintained literal, so the never-provisioned-Couch path cannot escape the clamps.
+
+### 5.5 The per-provider gate
+
+`withAttestation` parses the `x-attestation-token` header and hands each route an assurance level of `none`, `failed`, or a verified level. It never rejects on its own; each route decides.
+
+```mermaid
+flowchart TD
+  A[POST /v1/jwtSign/:provider] --> B{provider is an<br/>own property?}
+  B -->|no| E404[404]
+  B -->|yes| C{attestationLevel<br/>configured?}
+  C -->|null / bare string| SIGN[sign with the partner key]
+  C -->|a level| D{token verified and<br/>at least that level?}
+  D -->|no| E403[403]
+  D -->|yes| F{requireVerifiedBoot<br/>and claim true?}
+  F -->|no| E403
+  F -->|yes| SIGN
+```
+
+A provider stored as a bare string is ungated, which is what makes rollout incremental: providers stay strings until the attesting app is live, then become `{ key, attestationLevel }`. `requireVerifiedBoot` sits inside the gated branch, so it can never apply to an ungated provider. The provider lookup uses an own-property check, so a name like `__proto__` cannot resolve to an inherited member and skip the 404.
+
+Per-provider `requireVerifiedBoot` is distinct from the global enrollment-time `appAttestation.requireVerifiedBoot`: the global flag rejects the attestation itself, while the provider flag rejects a signing request whose token's `verifiedBoot` claim is not literally `true` (403 "Verified boot required"). One rollout wrinkle follows: an Android device enrolled before the claim was recorded asserts tokens with `verifiedBoot: false`, so a provider gated on it returns 403 until the token expires and the device re-attests, recording its real boot state. Failure messages distinguish the cases: missing token, invalid token, assurance level too low, verified boot required.
+
+### 5.6 Failure isolation
+
+Attestation is reachable only from `attestRoutes`, `withAttestation`, and the two signing routes. No pre-existing route imports anything from `src/attestation`. At boot, `provisionSigningKey()` is wrapped in a `catch`, so a signing-key failure logs and lets `forkChildren()` proceed. A completely broken attestation subsystem still leaves every existing endpoint serving.
+
+## 6. Detailed design: edge-react-gui
+
+### 6.1 The engine and its clock
+
+`src/util/attestation.ts` runs one background engine that keeps a token cached. `initInfoServer` calls `initAttestation()` from the app's NetInfo listener, so the engine starts on the first connected event at boot and is poked again on every reconnect; `initAttestation()` is idempotent (it returns immediately while a token is live, and the handshake is single-flighted and rate-limited below), so a flapping connection cannot become a handshake storm. `fetchInfo` itself carries no attestation logic; the gated plugins attach the header themselves ([section 6.5](#65-call-sites)).
+
+Every deadline is monotonic. `CachedToken.expiresMono` is `monotonicNow()` at receipt plus the server's `expiresIn`, and it is only ever compared against `monotonicNow()`:
+
+[`src/util/attestation.ts`](https://github.com/EdgeApp/edge-react-gui/blob/fc803174d734753dc4df47b539911941f1705254/src/util/attestation.ts)
+```ts
+interface CachedToken {
+  token: string
+  expiresMono: number
+}
+```
+
+A user changing the device date cannot revive an expired token or kill a live one. `serverTime` is read only to warn about clock skew above two minutes, and never enters the deadline.
+
+Server responses are parsed with `cleaners` (`asChallengeResponse`, `asTokenResponse`), matching every other info-server response shape in the client. Two checks stay outside the cleaners on purpose: `expiresIn` must be positive, finite, and longer than the 5 second skew margin (a token unusable on arrival is a failed handshake, not a cache entry), and the skew warning runs before validation so a malformed body still warns about a bad device clock.
+
+### 6.2 Refresh before attestation
+
+A full platform attestation is rate limited on both platforms, so the engine reaches for it last.
+
+```mermaid
+flowchart TD
+  S[handshake starts] --> C[GET /v1/attest/challenge]
+  C --> R[refresh with the enrolled key<br/>iOS generateAssertion / Android signChallenge]
+  R -->|200| OK[cache token, schedule refresh]
+  R -->|native says noKey / invalidKey| A[full platform attestation]
+  R -->|native timeout / lockTimeout| F[fail into backoff<br/>keep the key]
+  R -->|server 4xx, not 429| A
+  R -->|server 5xx or 429| F
+  A -->|200| OK
+  A -->|fails| F2[fail into backoff<br/>count quota if spent]
+```
+
+Two rules keep an outage from becoming a fleet-wide re-enrollment:
+
+- `isKeyRejection` treats only a sub-500, non-429 response as the server judging the key. A 5xx or a 429 says the server could not answer, which is not evidence about the key.
+- `TRANSIENT_NATIVE_CODES` (`timeout`, `lockTimeout`) mean the native module gave up without learning anything about the key, so the cheap path is retried rather than escalated.
+
+`UNSPENT_NATIVE_CODES` holds only `lockTimeout`, which Android reports before it takes the Keystore lock, so nothing was generated. iOS `timeout` is deliberately excluded: it fires while waiting on `attestKey`, so Apple may already have counted the attempt. Over-counting a spent attestation is the cheaper mistake.
+
+### 6.3 Concurrency and backoff
+
+Handshakes are single-flighted, and each attempt carries a generation. A watchdog at 150 seconds releases the in-flight lock so a lost bridge message cannot wedge the engine forever, and the generation check stops the abandoned attempt from writing state a newer one now owns. That guard covers every terminal write, including the one that retires the engine: a `false` from `isSupported()` is terminal (the device can never attest, so the engine stops rather than waking forever to ask again), but only the current attempt may say so; a watchdog-retired attempt whose `isSupported()` finally answers has no standing, and a regression test hangs one past the watchdog to prove a live token keeps refreshing. A retired attempt may still land a late valid token, which is taken only when its monotonic deadline outlives whatever is cached, so the cached expiry never moves backwards.
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `REFRESH_LEAD_MS` | 5 min | Refresh ahead of expiry, above the worst-case recovery path |
+| `MIN_REFRESH_MS` | 60 s | Floor on a scheduled refresh, since the lifetime is remote config |
+| `MIN_HANDSHAKE_SPACING_MS` | 30 s | Floor between handshake starts on the success path |
+| `GET_TOKEN_TIMEOUT_MS` | 3 s | Longest a gated caller waits on the initial handshake |
+| `HANDSHAKE_WATCHDOG_MS` | 150 s | Backstop for a native call that never answers |
+| `FAILURE_BACKOFF_MS` | 60 s | Base backoff after a failure |
+| `MAX_BACKOFF_MS` | 30 min | Ceiling once attempts start burning platform quota |
+
+The backoff grows only when an attempt actually consumed a platform attestation, tracked per attempt by `usedAttestation` and reversible once by `countedFailure` when a later verdict proves nothing was spent.
+
+### 6.4 Native modules
+
+Both platforms serialize all key operations, because the JS watchdog can start a second handshake while an older native call is still running.
+
+Android holds a `ReentrantLock` with a 60 second acquisition timeout and reports `lockTimeout` when it gives up, before the lock is held and before any key exists; an interrupt while waiting reports the same code and restores the thread's interrupt flag. Each call runs on its own spawned thread rather than the shared native-modules thread, since attested key generation can hold the lock for seconds and would otherwise stall every other native module. iOS runs a serial `DispatchQueue`, holds it across the async [App Attest](#app-attest) callback with a semaphore, and caps one operation at 120 seconds. Both timeouts sit below the JS watchdog so native answers first and JS gets a real rejection instead of timing out blind; the bridge test asserts the ordering (60s lock, 120s operation, 150s watchdog) by reading the constants out of the three files.
+
+The Android key is enrolled once under the stable `edge_attestation_key` alias, [StrongBox](#strongbox) first with a [TEE](#tee-trusted-execution-environment) fallback. It survives app updates, is destroyed by uninstall or factory reset, and never transfers through a backup, so those events surface as an unknown key the server answers with a 400 and the client re-enrolls. Late iOS callbacks cannot damage newer state: a timed-out `attestKey` that later succeeds does not enroll its key (the server never verified it), and every clear from a callback is conditional on the stored id still being the one that operation worked on.
+
+iOS keeps two Keychain entries: `keyId` for an attested key and `pendingKeyId` for a key that was generated but whose attestation failed in a way Apple says to retry. Both use `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, so a handshake behind a locked screen can still read the enrolled id, and a restored backup cannot name a [Secure Enclave](#secure-enclave) key that does not exist on the new device.
+
+`clearKey(keyId?)` takes the id the caller means to discard, and native drops the key only while it is still the stored one, so a slow clear cannot delete a key a newer handshake just enrolled.
+
+### 6.5 Call sites
+
+`getAttestationToken()` resolves with the cached token, or `undefined` after at most 3 seconds; while the engine is backing off it starts nothing and returns `undefined` immediately, so a polling caller (the Banxa order screen polls every 3 seconds) cannot outrun the backoff. The Simplex and Banxa providers attach the token as `x-attestation-token` when present and send the request either way, so the server decides. Each provider exists twice, once under `src/plugins/gui/providers` and once under `src/plugins/ramps`, and all five call sites go through one shared `attestedJsonHeaders()` helper in `attestation.ts` (content type plus the conditional header), so a change to the header name or null policy lands once; tests pin both the attached and the omitted case.
+
+## 7. Testing
+
+Numbered cases, all runnable today.
+
+1. **Challenge single use, one process.** `src/__tests__/challenges.test.ts`: create then consume succeeds once; a replay, an expired challenge, a tampered signature, an empty string, and a malformed string all fail.
+2. **Challenge single use across workers.** Not reachable from mocha, because `cluster.isWorker` is false there and `recordNonce` takes its in-process fallback. Verified by forking a real 4-worker cluster and racing the same [nonce](#nonce): exactly 1 accepted, 3 rejected.
+3. **Config clamping.** `src/__tests__/appAttestationConfig.test.ts`: a lifetime below the floor, a non-numeric value, and a fractional value all resolve to a clamped whole-second lifetime.
+4. **Whole-document fallback.** `asAppAttestationDoc({})`, the never-provisioned-Couch path that returns the fallback without running field cleaners, resolves `attestationTokenLifetimeSec` to 900. It returned a hardcoded 600 before the fallback was derived from the cleaner.
+5. **Apple and Android verification.** `appleAssert.test.ts`, `androidAssert.test.ts`, `attestationVerify.test.ts`, `revocation.test.ts` cover assertion counters, chain anchoring, and the revocation fail-open.
+6. **Route gating.** `withAttestation.test.ts`: `none` and `failed` never satisfy a gate; levels compare by order; an ungated provider signs without a token.
+7. **Live server, end to end.** A real 2-worker server against local CouchDB: health serves, a pre-existing non-attestation route serves, `GET /v1/attest/challenge` mints a 3-part challenge, the same challenge POSTed twice is accepted once and then rejected as consumed, a forged signature is rejected, and the live config resolves to 900 and 30 seconds. The raw Couch doc is read through an `asStoredAttestationDoc` cleaner, so a Couch-side field rename fails `tsc` rather than surfacing as an `undefined` read at run time.
+8. **Master survival.** An unguarded `send` to an exited worker crashes the master with `ERR_IPC_CHANNEL_CLOSED` on Node 24; through the guard the master survives.
+9. **Wire-contract alignment.** `src/__tests__/attestationMint.test.ts`: `Date.parse(serverTime) / 1000 + expiresIn` equals the [JWT](#jwt-json-web-token)'s `exp` exactly, and `serverTime` lands on a whole second matching the floored `iat`. Reverting the [section 5.4](#54-token-mint-and-the-wire-contract) fix fails it on a sub-second overshoot.
+10. **Client engine.** `src/__tests__/util/attestation.test.ts` and `attestationNativeBridge.test.ts`, 69 cases: monotonic expiry, refresh scheduling floors, watchdog release, backoff growth and the unspent-code refund, native code routing, the watchdog-retired `isSupported()` guard, and `attestedJsonHeaders()` attaching or omitting the header.
+11. **On real hardware.** The V2 Android handshake was driven end to end by Jon on a physical device: enrollment and a refresh with the enrolled key both verified against a live info server. iOS [App Attest](#app-attest) was likely exercised by Paul on a physical device during development (the entitlement, Xcode wiring, and Keychain handling all imply on-device runs), but no iOS run is recorded here, so the confirmed matrix still lists it as unverified. (Historical: Jon drove the V1 handshake on a Galaxy S9 whose factory attestation certificates expired 2026-05-24.)
+
+## 8. Phase history
+
+### V1: Redis-backed challenges
+
+Shipped in [#156](https://github.com/EdgeApp/edge-info-server/pull/156) and the first GUI PR ([#6076](https://github.com/EdgeApp/edge-react-gui/pull/6076), superseded).
+
+| Sketched | Shipped |
+|---|---|
+| Random challenge stored in Redis with a native [TTL](#ttl-time-to-live), consumed by atomic `GETDEL` | Built as designed |
+| Absolute `expires` on the token response | Built as designed |
+| Client token cache keyed on `Date.now()` | Built as designed |
+
+Divergence found in review: the Redis client used node-redis defaults, whose reconnect strategy retries forever, so `connect()` never rejected and a challenge request hung indefinitely while Redis was down. It was fixed with a bounded reconnect budget and a connect timeout, then the whole store was removed in V2.
+
+### V2: HMAC challenges, monotonic client clock
+
+Shipped in [#158](https://github.com/EdgeApp/edge-info-server/pull/158) and [#6137](https://github.com/EdgeApp/edge-react-gui/pull/6137).
+
+| Diverged in | Shipped as |
+|---|---|
+| Challenge storage | Removed. Challenges carry their own [HMAC](#hmac-hash-based-message-authentication-code) and expiry; single use moved to a master-process [nonce](#nonce) cache over cluster [IPC](#ipc-inter-process-communication) |
+| Token wire contract | `expires` (absolute epoch ms) became `expiresIn` (seconds) plus `serverTime` (ISO) |
+| Client expiry | Monotonic deadline via `src/util/monotonicTime.ts`, so device clock changes cannot affect it |
+| Lifetimes | Clamped by `asLifetimeSec`: 15 minute token floor, 30 second challenge default with a 10 second floor |
+| Native concurrency | Explicit serialization on both platforms with timeouts below the JS watchdog, plus a native error-code taxonomy that decides refresh vs re-attest |
+
+Review fixes folded into #158: the whole-document config fallback now runs through the cleaner instead of a literal that had drifted below the new floor, and the master's IPC reply is guarded so a worker dying mid-request cannot kill the cluster supervisor.
+
+Deferred: an iOS timeout can leave `pendingKeyId` set while the original `attestKey` is still in flight, so a later handshake can attest the same key twice and discard a successful attestation. The outcome is bounded and self-healing (the retry fails, the pending slot clears, the next handshake enrolls a fresh key), and both remedies cost something real, so the tradeoff is left to the feature owner. Raised on [#6137](https://github.com/EdgeApp/edge-react-gui/pull/6137).
+
+### Review round, 2026-08-07
+
+An independent multi-agent review of both PRs produced 8 comments; 6 landed as fixups and 2 were declined with evidence.
+
+| Fixed | Where |
+|---|---|
+| `serverTime` now derives from the same floored second as `exp`, with a wire-contract test pinning the equality | info [#158](https://github.com/EdgeApp/edge-info-server/pull/158) |
+| Live test reads the raw Couch doc through a cleaner instead of `any` | info #158 |
+| Generation guard on the terminal `unsupported` write, with a regression test | gui [#6137](https://github.com/EdgeApp/edge-react-gui/pull/6137) |
+| Server responses parsed via `cleaners`, matching the rest of the diff | gui #6137 |
+| The 5 copy-pasted header blocks became one `attestedJsonHeaders()` helper, with tests | gui #6137 |
+| Android restores the thread interrupt flag before rejecting `lockTimeout` | gui #6137 |
+
+Declined, both correctly: annotating `catch (error: unknown)` (the repo compiles with `strict`, so the variable is already `unknown` and the annotation is a no-op), and replacing the engine's timer with `makePeriodicTask` (it reschedules when the task settles, and `runHandshake` is fire-and-forget, so every real reschedule would race a stale gap).
+
+## 9. Decisions
+
+### 9.1 Self-validating HMAC challenges instead of a Redis nonce store
+
+**Chosen.** The challenge carries its own [nonce](#nonce), expiry, and [HMAC](#hmac-hash-based-message-authentication-code). Any worker verifies it without shared state; single use is enforced separately.
+
+**Evidence.** The V1 Redis dependency added a managed database per region to the deployment, and its failure mode was worse than the feature it protected: with Redis unreachable, `createChallenge` hung rather than failing, because node-redis retries connection forever by default.
+
+**Rejected: keep Redis.** Correct across hosts, but it is infrastructure to provision, monitor, and pay for in every region, in front of a flow whose whole purpose is a purchase. The replay window it closes is 30 seconds wide and already needs a valid platform attestation over that exact challenge.
+
+**Rejected: store challenges in CouchDB.** No new infrastructure, but it puts a write and a delete in the enrollment path on a database the rest of the server reads through synced documents, and Couch document ids are awkward for high-churn ephemeral keys.
+
+**Reopens if** the threat model starts caring about cross-host replay inside the challenge lifetime, or if challenge volume makes the master-process Map a memory concern.
+
+### 9.2 Per-host nonce cache on the cluster master
+
+**Chosen.** One in-memory Map on the master, reached from workers over cluster [IPC](#ipc-inter-process-communication), swept every 10 seconds, fail-closed on a 2 second timeout.
+
+**Evidence.** Workers cannot share memory, and the master already exists as the supervisor. A 4-worker race on one nonce accepts exactly one.
+
+**Rejected: per-worker caches.** Simplest, and wrong: with N workers a challenge could be consumed N times, which defeats single use on a single host.
+
+**Rejected: a shared store (Redis, Couch).** That is [decision 1](#91-self-validating-hmac-challenges-instead-of-a-redis-nonce-store) again.
+
+**Accepted cost.** Two hosts do not share the cache, so a challenge consumed on info1 can be replayed to info2 within its lifetime. The attacker still needs a valid platform attestation bound to that challenge, and the window is the challenge lifetime. Documented in `docs/APP_ATTESTATION.md`.
+
+**Reopens if** a multi-region deployment starts routing the same client across hosts mid-handshake often enough for the window to matter.
+
+### 9.3 Relative `expiresIn` plus `serverTime` instead of an absolute expiry
+
+**Chosen.** The token response carries seconds-until-expiry and the server's ISO clock. The client converts to a monotonic deadline on arrival.
+
+**Evidence.** An absolute epoch deadline is only meaningful if the device clock agrees with the server's. A device with a wrong date either discards live tokens or trusts dead ones, and users do change their clocks.
+
+**Rejected: absolute `expires` (the V1 shape).** Requires the device clock to be right, which is the assumption being removed.
+
+**Rejected: absolute expiry plus a client-computed skew correction.** Workable, but it keeps wall-clock arithmetic in the hot path and adds a correction that is itself wrong whenever the clock moves mid-session. A monotonic deadline has no such failure.
+
+**Reopens if** a consumer outside the app needs to reason about token expiry without having made the request that minted it.
+
+### 9.4 Refresh with the enrolled key, attest only when forced
+
+**Chosen.** Every handshake after enrollment signs the challenge with the already-attested key. A full platform attestation runs only when the key cannot sign or the server rejects it.
+
+**Evidence.** Both platform attestations are rate limited. The Banxa order poll runs every 3 seconds, so a design that attests per handshake trips the limits and locks out devices.
+
+**Rejected: attest on every handshake.** Simpler control flow, and it walks into the rate limits.
+
+**Rejected: a long-lived token with no refresh.** Fewer round trips, but a stolen token stays useful for its whole life, and revocation gets no purchase.
+
+**Reopens if** the platforms relax their attestation quotas enough that the distinction stops mattering.
+
+### 9.5 Per-provider gating from Couch data
+
+**Chosen.** A provider entry is either a bare string secret (ungated) or `{ key, attestationLevel, requireVerifiedBoot? }`.
+
+**Evidence.** Rollout has to be reversible without a deploy: the app population updates over weeks, and a gate turned on too early blocks buyers on older builds.
+
+**Rejected: a global on/off flag.** One switch for all providers means the slowest partner integration decides when anyone gets protection.
+
+**Rejected: gate in code per route.** Every rollout or rollback becomes a deploy.
+
+**Reopens if** the provider list grows enough that per-provider entries become unwieldy, which would argue for a default level plus overrides.
+
+### 9.6 Fail open on the Android revocation list
+
+**Chosen.** When Google's attestation status endpoint cannot be reached, serve the last good copy, or an empty set if there has never been one, and log.
+
+**Evidence.** The list is fetched from `android.googleapis.com`. Treating an outage as "revoke everything" would stop all Android enrollment during a Google incident.
+
+**Rejected: fail closed.** Strictly safer against a leaked keybox, and it hands Google's availability a veto over Edge purchases.
+
+**Reopens if** a keybox leak is known to be circulating, where the tradeoff inverts for the duration.
+
+## 10. Glossary
+
+Terms this design leans on, in the order a reader meets them. Each entry says what the thing is and what it does here, with a source for the full definition.
+
+### Nonce
+A number used once. Here it is 32 random bytes inside each challenge, and the server records it as spent so the same challenge cannot be replayed. Source: [RFC 4949, Internet Security Glossary](https://datatracker.ietf.org/doc/html/rfc4949).
+
+### HMAC (hash-based message authentication code)
+A short tag computed over a message with a secret key. Anyone holding the key can recompute the tag to prove the message is unmodified and came from someone who has the key; anyone without it cannot forge one. The challenge carries an HMAC over its nonce and expiry, which is what lets any worker on any host trust a challenge it never issued. Source: [RFC 2104](https://datatracker.ietf.org/doc/html/rfc2104).
+
+### HKDF (HMAC-based key derivation function)
+A standard way to turn one secret into other independent keys. The challenge-signing key is derived from the token-signing private key this way, so the deployment has one secret to provision and rotate instead of two. Source: [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869).
+
+### base64url
+Base64 text encoding with the two characters that are unsafe in URLs replaced, and padding dropped. Nonces, signatures, and key ids travel in this form so they survive being embedded in a URL or a dot-separated string. Source: [RFC 4648 section 5](https://datatracker.ietf.org/doc/html/rfc4648#section-5).
+
+### JWT (JSON Web Token)
+A signed token in three dot-separated base64url parts: a header, a set of claims, and a signature. The attestation token is a JWT, so any service holding the public key can check its claims offline instead of calling the info server. Source: [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519).
+
+### JWK (JSON Web Key)
+A cryptographic key expressed as JSON. The token-signing key is stored as a JWK in CouchDB, which is what lets every worker and host load the same key. Source: [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517).
+
+### JWKS (JSON Web Key Set)
+A JSON document holding the public half of one or more JWKs, published at a URL. `GET /v1/attest/jwks` serves one so other Edge services can verify attestation tokens without asking the info server per request. Source: [RFC 7517 section 5](https://datatracker.ietf.org/doc/html/rfc7517#section-5).
+
+### ES256
+The signing algorithm naming ECDSA on the P-256 curve with SHA-256. It is what signs the attestation token: widely supported, and its signatures are small enough to sit in a header on every gated request. Source: [RFC 7518 section 3.4](https://datatracker.ietf.org/doc/html/rfc7518#section-3.4).
+
+### App Attest
+Apple's service for proving a request comes from a genuine build of your app on genuine Apple hardware. The iOS client calls it to attest a key and later to sign challenges with that key. Source: [Apple DCAppAttestService](https://developer.apple.com/documentation/devicecheck/dcappattestservice).
+
+### Secure Enclave
+A separate hardware security processor in Apple devices. App Attest private keys live inside it and cannot be exported, so a key id restored onto a different device names a key that does not exist there. Source: [Apple Platform Security, Secure Enclave](https://support.apple.com/guide/security/secure-enclave-sec59b0b31ff/web).
+
+### Android Keystore key attestation
+The Android platform feature that generates a key inside secure hardware and returns a certificate chain proving the key's properties, signed up to a Google root. It is the Android half of this design and needs no closed-source Google SDK. Source: [Android key attestation](https://developer.android.com/privacy-and-security/security-key-attestation).
+
+### TEE (trusted execution environment)
+An isolated execution environment on the main processor, separate from the normal operating system. A key generated there attests at `trustedEnvironment`, which this design maps to the `hardware` assurance level. Source: [Android hardware-backed Keystore](https://source.android.com/docs/security/features/keystore).
+
+### StrongBox
+A dedicated secure element chip, separate from the main processor, that some Android devices ship with. A key generated there attests one tier above a TEE key and maps to `secureElement`. Source: [Android StrongBox Keymaster](https://source.android.com/docs/security/best-practices/hardware).
+
+### Verified boot
+The Android chain of checks proving the device booted an unmodified operating system with a locked bootloader. Its result is recorded at enrollment and can be required per provider. Source: [Android Verified Boot](https://source.android.com/docs/security/features/verifiedboot).
+
+### attestationApplicationId
+A field inside the Android attestation certificate, written by secure hardware rather than the app, holding the calling package name and the digests of its signing certificates. It is what proves the request came from the genuine Edge binary and not a repackaged one. Source: [Android attestation extension schema](https://developer.android.com/privacy-and-security/security-key-attestation#certificate_schema).
+
+### SHA-256
+A cryptographic hash function producing a 32-byte digest. It appears throughout this design: challenges are bound to keys via `SHA256(challenge)`, Android key ids are digests of the leaf public key, and allow-lists hold digests of signing certificates. Source: [FIPS 180-4](https://csrc.nist.gov/pubs/fips/180-4/upd1/final).
+
+### CRL (certificate revocation list)
+A published list of certificates that should no longer be trusted. Android verification checks every chain serial against Google's attestation status list at enrollment and again at each assert, cached in-process for 24 hours and failing open on a fetch error. Source: [RFC 5280 section 5](https://datatracker.ietf.org/doc/html/rfc5280#section-5).
+
+### Assurance level
+This design's own four-tier ranking of how strongly a key is protected: `debug`, `software`, `hardware`, `secureElement`. A provider gate names the minimum tier it accepts. Source: [`ASSURANCE_ORDER` in src/public/attestation.ts](https://github.com/EdgeApp/edge-info-server/blob/master/src/public/attestation.ts).
+
+### Cluster master
+In Node's cluster model one master process forks worker processes that share a listening socket. Workers cannot share memory, so the master holds the single-use nonce cache and answers workers over IPC. Source: [Node.js cluster](https://nodejs.org/api/cluster.html).
+
+### IPC (inter-process communication)
+Message passing between separate processes. Node's cluster gives each worker a channel to the master, which is how a worker asks whether a nonce is still unspent. Source: [Node.js child process IPC](https://nodejs.org/api/child_process.html#subprocesssendmessage-sendhandle-options-callback).
+
+### TTL (time to live)
+How long a cached value stays valid before it is refetched. The revocation list carries a 24 hour TTL, with a shorter back-off after a failed refresh. Source: [MDN, HTTP caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching).
+
+## 11. References
+
+- [edge-info-server `docs/APP_ATTESTATION.md`](https://github.com/EdgeApp/edge-info-server/blob/0640c288860e17e64ba98fddcfd310f0b243a2c9/docs/APP_ATTESTATION.md) (the doc this one replaces, at its last standalone revision; keeps the full HTTP request/response bodies and Couch document shapes)
+- [edge-react-gui `docs/APP_ATTESTATION.md`](https://github.com/EdgeApp/edge-react-gui/blob/fc803174df2b2e2b8cbcd8b2be1c9de8ff62861a/docs/APP_ATTESTATION.md) (the doc this one replaces, at its last standalone revision; keeps the per-file source map and local-testing notes)
+- [Apple App Attest](https://developer.apple.com/documentation/devicecheck/dcappattestservice)
+- [Android key attestation](https://developer.android.com/privacy-and-security/security-key-attestation)
+- [Asana task 1216536848508307](https://app.asana.com/0/1215088146871429/1216536848508307), including the deployment runbook attachment

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -453,7 +453,6 @@ export default [
       'src/plugins/gui/providers/mtpelerinProvider.ts',
 
       'src/plugins/gui/providers/revolutProvider.ts',
-      'src/plugins/gui/providers/simplexProvider.ts',
       'src/plugins/gui/RewardsCardPlugin.tsx',
 
       'src/plugins/gui/util/fetchRevolut.ts',

--- a/ios/edge.xcodeproj/project.pbxproj
+++ b/ios/edge.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04DBAACE71E94A3B9BCAF10A /* EdgeAttestation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6252FDC1E314D61A7E315B7 /* EdgeAttestation.swift */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		3D18A8FA2A5333DC00F3B19B /* audio_received.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 3D18A8F82A5333DC00F3B19B /* audio_received.mp3 */; };
 		3D18A8FB2A5333DC00F3B19B /* audio_sent.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 3D18A8F92A5333DC00F3B19B /* audio_sent.mp3 */; };
@@ -40,6 +41,7 @@
 		812B284944A10A722B22763D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ADAD14914ABC9FD7D54456 /* ExpoModulesProvider.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		BF115CD26A29F1C032E30289 /* Pods_edge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E261C56FB78E202F218C2DCA /* Pods_edge.framework */; };
+		E180252EBEC449FE9A1DFAE6 /* EdgeAttestation.m in Sources */ = {isa = PBXBuildFile; fileRef = 79E2D7E4637343A7B1DCB004 /* EdgeAttestation.m */; };
 		E469AC702DC43791006A2530 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E469AC6F2DC43791006A2530 /* AdServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
@@ -81,7 +83,9 @@
 		3DB299A52BCEF2A600D867B0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = edge/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-edge.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-edge.release.xcconfig"; path = "Target Support Files/Pods-edge/Pods-edge.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-edge-edgeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-edge-edgeTests.debug.xcconfig"; path = "Target Support Files/Pods-edge-edgeTests/Pods-edge-edgeTests.debug.xcconfig"; sourceTree = "<group>"; };
+		79E2D7E4637343A7B1DCB004 /* EdgeAttestation.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; name = EdgeAttestation.m; path = edge/EdgeAttestation.m; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = edge/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		A6252FDC1E314D61A7E315B7 /* EdgeAttestation.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = EdgeAttestation.swift; path = edge/EdgeAttestation.swift; sourceTree = "<group>"; };
 		E261C56FB78E202F218C2DCA /* Pods_edge.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_edge.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E469AC6F2DC43791006A2530 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -110,6 +114,8 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				3DB299A52BCEF2A600D867B0 /* PrivacyInfo.xcprivacy */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
+				A6252FDC1E314D61A7E315B7 /* EdgeAttestation.swift */,
+				79E2D7E4637343A7B1DCB004 /* EdgeAttestation.m */,
 			);
 			name = edge;
 			sourceTree = "<group>";
@@ -460,6 +466,8 @@
 				3D88EE2D2E3C3BE80086BA9D /* AppDelegate.swift in Sources */,
 				3D5BD9862A4CEFB900590088 /* EdgeCore.swift in Sources */,
 				812B284944A10A722B22763D /* ExpoModulesProvider.swift in Sources */,
+				04DBAACE71E94A3B9BCAF10A /* EdgeAttestation.swift in Sources */,
+				E180252EBEC449FE9A1DFAE6 /* EdgeAttestation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/edge/EdgeAttestation.m
+++ b/ios/edge/EdgeAttestation.m
@@ -1,0 +1,29 @@
+#import <React/RCTBridgeModule.h>
+
+// Objective-C bridge that exposes the Swift `EdgeAttestation` class to the
+// React Native (old architecture) bridge.
+@interface RCT_EXTERN_MODULE (EdgeAttestation, NSObject)
+
+RCT_EXTERN_METHOD(isSupported
+                  : (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getAttestation
+                  : (NSString *)challenge
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(generateAssertion
+                  : (NSString *)challenge
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+// keyId is nullable: JS passes the key it means to discard, or null for
+// whichever one is stored. Keep this declaration in step with the Swift
+// @objc selector - a mismatch is not a build error, it fails at runtime.
+RCT_EXTERN_METHOD(clearKey
+                  : (NSString *)keyId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/ios/edge/EdgeAttestation.swift
+++ b/ios/edge/EdgeAttestation.swift
@@ -1,0 +1,446 @@
+import CryptoKit
+import DeviceCheck
+import Foundation
+import React
+import Security
+
+/// Guarantees a React Native promise settles exactly once. The operation timeout
+/// in `getAttestation` / `generateAssertion` and a late App Attest callback can
+/// both reach for the same promise, and settling one twice is a hard error in
+/// React Native.
+private final class PromiseOnce {
+  private let lock = NSLock()
+  private var isSettled = false
+  private let resolveBlock: RCTPromiseResolveBlock
+  private let rejectBlock: RCTPromiseRejectBlock
+
+  init(
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    self.resolveBlock = resolve
+    self.rejectBlock = reject
+  }
+
+  private func claim() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    if isSettled { return false }
+    isSettled = true
+    return true
+  }
+
+  /// Whether the promise has already settled, so a callback can tell that it
+  /// outlived its operation: the only thing that settles one early is the
+  /// operation timeout, which has already handed JS a rejection for this call,
+  /// so nothing this callback produces can still reach it.
+  var hasSettled: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return isSettled
+  }
+
+  /// Returns whether this call is the one that settled the promise, so a caller
+  /// can skip work that only makes sense if JS actually receives the result.
+  @discardableResult
+  func resolve(_ value: Any?) -> Bool {
+    guard claim() else { return false }
+    resolveBlock(value)
+    return true
+  }
+
+  @discardableResult
+  func reject(_ code: String, _ message: String, _ error: Error? = nil) -> Bool {
+    guard claim() else { return false }
+    rejectBlock(code, message, error)
+    return true
+  }
+}
+
+/// Native bridge for iOS App Attest (app-level attestation).
+///
+/// Exposes to JS:
+///   - isSupported(): resolves true only on real devices that support App Attest
+///   - getAttestation(challenge): attests an App Attest key against
+///     SHA256(challenge) and resolves { keyId, attestation }, where attestation
+///     is the base64-encoded CBOR attestation object
+///   - generateAssertion(challenge): refreshes using the attested key
+///   - clearKey(): discards the attested key so the next handshake re-attests
+/// Every code this module can hand JS. JS routes retries by these strings (see
+/// TRANSIENT_NATIVE_CODES / UNSPENT_NATIVE_CODES in src/util/attestation.ts), so
+/// a new one that is not registered there is read as the expensive case.
+private enum AttestCode: String {
+  case unsupported, timeout, generateKey, attestKey, noKey, invalidKey,
+       generateAssertion
+}
+
+@objc(EdgeAttestation)
+class EdgeAttestation: NSObject {
+  @objc static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+
+  // Serializes all key operations. The JS engine normally single-flights
+  // handshakes, but its watchdog can release the lock and start a second
+  // handshake while an older native call is still running. Without this queue,
+  // overlapping getAttestation / generateAssertion / clearKey calls could race
+  // on the stored key id and leave assertions out of sync with the cached JWT.
+  // Each async App Attest operation holds the queue (via a semaphore) until it
+  // completes, so the operations never interleave.
+  private static let serialQueue = DispatchQueue(
+    label: "co.edgesecure.app.appattest.serial"
+  )
+
+  // Caps how long one operation may hold `serialQueue`. attestKey can fail to
+  // call back at all on a bad network, and an unbounded wait would wedge the
+  // queue for the life of the process: every later getAttestation,
+  // generateAssertion and clearKey would block behind it forever, including the
+  // clearKey the JS engine uses to recover. Sized below the JS watchdog so this
+  // module answers first and JS never has to abandon a call that is still alive,
+  // while staying far enough above a slow-but-healthy attestation that it does
+  // not reject one that would have succeeded.
+  //
+  // Giving up releases the queue while the App Attest callback is still
+  // outstanding, so that callback can later run alongside a newer operation. Its
+  // verdict applies only to the key it was given, which by then may not be the
+  // stored one - hence the `ifMatches` clears below.
+  private static let operationTimeout: DispatchTimeInterval = .seconds(120)
+
+  // Keychain persistence for App Attest key ids. App Attest private keys live
+  // in the Secure Enclave keyed by this id; Apple recommends storing the id in
+  // the Keychain so it survives across launches.
+  //
+  // `keyId` holds a successfully attested key, reused for assertions so later
+  // handshakes never re-attest. `pendingKeyId` holds a key that was generated
+  // but not yet attested, kept only across failures Apple says to retry (see
+  // getAttestation) so a transient outage does not burn a new key per attempt.
+  private static let keychainService = "co.edgesecure.app.appattest"
+  private static let keychainAccount = "keyId"
+  private static let keychainPendingAccount = "pendingKeyId"
+
+  // Accessibility for the stored ids. Both halves are load-bearing:
+  //
+  // `ThisDeviceOnly` keeps the id out of backups. An App Attest private key
+  // lives in the Secure Enclave and cannot leave the device, so an id restored
+  // onto a new one is guaranteed to name a key that does not exist there -
+  // costing that install an assertion round trip that fails with `invalidKey`
+  // before it re-attests.
+  //
+  // `AfterFirstUnlock` rather than the `WhenUnlocked` default, so a handshake
+  // that runs while the screen is locked can still read the enrolled id.
+  // Under the default it would read nothing, report `noKey`, and send JS down
+  // the full rate-limited attestation path to replace a key that was fine.
+  private static let keychainAccessible =
+    kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+  private func storeAccount(_ account: String, value: String) {
+    clearAccount(account)
+    guard let data = value.data(using: .utf8) else { return }
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: EdgeAttestation.keychainService,
+      kSecAttrAccount as String: account,
+      kSecAttrAccessible as String: EdgeAttestation.keychainAccessible,
+      kSecValueData as String: data
+    ]
+    let status = SecItemAdd(query as CFDictionary, nil)
+    if status != errSecSuccess {
+      // Not fatal, but not silent either: a lost id means the next handshake
+      // finds no key and spends a rate-limited attestation to enrol one we
+      // already have, and nothing else in the flow reports that.
+      NSLog(
+        "EdgeAttestation: failed to store keychain account %@ (OSStatus %d)",
+        account,
+        status
+      )
+    }
+  }
+
+  private func loadAccount(_ account: String) -> String? {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: EdgeAttestation.keychainService,
+      kSecAttrAccount as String: account,
+      kSecReturnData as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne
+    ]
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &item)
+    guard status == errSecSuccess, let data = item as? Data else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+
+  private func clearAccount(_ account: String) {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: EdgeAttestation.keychainService,
+      kSecAttrAccount as String: account
+    ]
+    SecItemDelete(query as CFDictionary)
+  }
+
+  /// Clears the stored id only while it is still the one the caller was working
+  /// on.
+  ///
+  /// An App Attest callback can arrive after `operationTimeout` released the
+  /// queue, by which point a newer handshake may have generated or enrolled a
+  /// different key. An unconditional delete would then throw away that newer
+  /// key on the strength of a verdict about an older one - costing a fresh
+  /// `generateKey`, or worse, a full rate-limited attestation to replace an
+  /// enrolled key that was working fine.
+  ///
+  /// Read-then-delete is not atomic, so a callback racing an operation that is
+  /// mid-write can still clear the newer id. That window is microseconds against
+  /// the two-minute one it closes, and it costs a retry rather than corrupting
+  /// anything.
+  private func clearAccount(_ account: String, ifMatches keyId: String) {
+    guard loadAccount(account) == keyId else { return }
+    clearAccount(account)
+  }
+
+  private func storeKeyId(_ keyId: String) {
+    storeAccount(EdgeAttestation.keychainAccount, value: keyId)
+  }
+
+  private func loadKeyId() -> String? {
+    return loadAccount(EdgeAttestation.keychainAccount)
+  }
+
+  private func clearKeyId() {
+    clearAccount(EdgeAttestation.keychainAccount)
+  }
+
+  private func clearKeyId(ifMatches keyId: String) {
+    clearAccount(EdgeAttestation.keychainAccount, ifMatches: keyId)
+  }
+
+  private func storePendingKeyId(_ keyId: String) {
+    storeAccount(EdgeAttestation.keychainPendingAccount, value: keyId)
+  }
+
+  private func loadPendingKeyId() -> String? {
+    return loadAccount(EdgeAttestation.keychainPendingAccount)
+  }
+
+  private func clearPendingKeyId(ifMatches keyId: String) {
+    clearAccount(EdgeAttestation.keychainPendingAccount, ifMatches: keyId)
+  }
+
+  @objc(isSupported:rejecter:)
+  func isSupported(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    rejecter reject: @escaping RCTPromiseRejectBlock
+  ) {
+    if #available(iOS 14.0, *) {
+      resolve(DCAppAttestService.shared.isSupported)
+    } else {
+      resolve(false)
+    }
+  }
+
+  @objc(getAttestation:resolver:rejecter:)
+  func getAttestation(
+    _ challenge: String,
+    resolver resolve: @escaping RCTPromiseResolveBlock,
+    rejecter reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard #available(iOS 14.0, *) else {
+      reject(AttestCode.unsupported.rawValue, "App Attest requires iOS 14 or later", nil)
+      return
+    }
+    let service = DCAppAttestService.shared
+    guard service.isSupported else {
+      reject(AttestCode.unsupported.rawValue, "App Attest is not supported on this device", nil)
+      return
+    }
+
+    // Serialize against other key operations; hold the queue until the async
+    // attest completes or `operationTimeout` gives up on it.
+    let promise = PromiseOnce(resolve: resolve, reject: reject)
+    EdgeAttestation.serialQueue.async {
+      let done = DispatchSemaphore(value: 0)
+
+      // The client data is the challenge's UTF-8 bytes; the server recomputes
+      // SHA256(challenge) to validate the attestation nonce.
+      let attest: (String) -> Void = { keyId in
+        let clientDataHash = Data(SHA256.hash(data: Data(challenge.utf8)))
+
+        service.attestKey(keyId, clientDataHash: clientDataHash) { attestation, error in
+          defer { done.signal() }
+          if let error = error {
+            // Apple's guidance is to retry a serverUnavailable attestation
+            // later with the same key, because generating keys is a limited
+            // resource. Any other failure may be permanent for this key, so
+            // discard it rather than retrying a dead key on every handshake
+            // for the life of the install.
+            let isRetryable = (error as? DCError)?.code == .serverUnavailable
+            if !isRetryable { self.clearPendingKeyId(ifMatches: keyId) }
+            promise.reject(AttestCode.attestKey.rawValue, error.localizedDescription, error)
+            return
+          }
+          guard let attestation = attestation else {
+            self.clearPendingKeyId(ifMatches: keyId)
+            promise.reject(AttestCode.attestKey.rawValue, "Failed to produce an attestation object")
+            return
+          }
+          // Persist the key id so subsequent handshakes refresh via assertions
+          // instead of a full (rate-limited) attestation - but only once we know
+          // JS is actually receiving this attestation. A callback that loses the
+          // race arrives after the timeout below already failed the handshake,
+          // which discarded the attestation object with it, so the server will
+          // never have verified this key. Enrolling it anyway would cost the next
+          // handshake a pointless assertion round trip before it re-attests.
+          if promise.resolve([
+            "keyId": keyId,
+            "attestation": attestation.base64EncodedString(),
+            "bundleId": Bundle.main.bundleIdentifier ?? ""
+          ]) {
+            self.storeKeyId(keyId)
+          }
+          // Either way the key is spent: attestKey succeeded, so it can never be
+          // attested again and must not be retried as a pending key.
+          self.clearPendingKeyId(ifMatches: keyId)
+        }
+      }
+
+      // A key may only be attested once, so a successful handshake always
+      // needs a new one - but a key whose attestation failed was never
+      // consumed. Retry that one before asking for another.
+      if let pendingKeyId = self.loadPendingKeyId() {
+        attest(pendingKeyId)
+      } else {
+        service.generateKey { keyId, error in
+          if let error = error {
+            promise.reject(AttestCode.generateKey.rawValue, error.localizedDescription, error)
+            done.signal()
+            return
+          }
+          guard let keyId = keyId else {
+            promise.reject(AttestCode.generateKey.rawValue, "Failed to generate an App Attest key")
+            done.signal()
+            return
+          }
+          // A callback that outlived its operation must not touch the stored
+          // state. Storing would clobber a pending key a newer handshake owns,
+          // losing it: this operation clears the slot after its own attestKey,
+          // so the next attempt would spend another `generateKey`. Attesting is
+          // worse still - the timeout has already settled the promise, so
+          // `storeKeyId` would refuse the result and a rate-limited attestation
+          // plus the key itself would be spent on something nothing can use.
+          //
+          // The promise is the ownership test rather than the state of the
+          // pending slot: an empty slot only implies no newer handshake has
+          // reached this point yet, whereas a settled promise means this one is
+          // over. Rejecting here would be a no-op for the same reason.
+          //
+          // The gap between this check and the two lines after it cannot be
+          // closed. The timeout has to answer JS at 120s whatever this callback
+          // is doing, and an attestKey already handed to Apple cannot be
+          // recalled, so any test can only ever be "unsettled a moment ago".
+          // Nothing further would help either: what saves the attestation is
+          // this check, placed as late as it can be, and a second look at the
+          // pending slot would not stop a store that wins the race to an empty
+          // one. Landing in the gap costs one attestation and leaves a pending
+          // key the next re-enrollment discards on Apple's refusal to attest it
+          // twice - bounded and self-healing, like the `ifMatches` window above.
+          if promise.hasSettled {
+            done.signal()
+            return
+          }
+          // Record the key before attesting it, so an attestKey failure Apple
+          // wants retried can reuse it instead of burning a new one.
+          self.storePendingKeyId(keyId)
+          attest(keyId)
+        }
+      }
+
+      if done.wait(timeout: .now() + EdgeAttestation.operationTimeout) == .timedOut {
+        // Leave the pending key id in place so the next attempt can retry it
+        // instead of burning a fresh generateKey. A timeout is not proof the
+        // key is still unused: Apple's attestKey may still finish and consume
+        // it, in which case the next handshake's attestKey(K) fails, the late
+        // success clears the pending slot, and the attempt after that generates
+        // a fresh key - one wasted attestation, same bounded/self-healing class
+        // as the ifMatches windows above. Clearing pending here would avoid that
+        // double-attest but would burn a key on every hang.
+        promise.reject(AttestCode.timeout.rawValue, "App Attest attestation timed out")
+      }
+    }
+  }
+
+  @objc(generateAssertion:resolver:rejecter:)
+  func generateAssertion(
+    _ challenge: String,
+    resolver resolve: @escaping RCTPromiseResolveBlock,
+    rejecter reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard #available(iOS 14.0, *), DCAppAttestService.shared.isSupported else {
+      reject(AttestCode.unsupported.rawValue, "App Attest is not supported on this device", nil)
+      return
+    }
+
+    let promise = PromiseOnce(resolve: resolve, reject: reject)
+    EdgeAttestation.serialQueue.async {
+      guard let keyId = self.loadKeyId() else {
+        promise.reject(AttestCode.noKey.rawValue, "No attested App Attest key is stored")
+        return
+      }
+      let clientDataHash = Data(SHA256.hash(data: Data(challenge.utf8)))
+      let done = DispatchSemaphore(value: 0)
+      DCAppAttestService.shared.generateAssertion(keyId, clientDataHash: clientDataHash) { assertion, error in
+        defer { done.signal() }
+        if let error = error as? DCError, error.code == .invalidKey {
+          // The key no longer exists (reinstall/restore); force re-attestation.
+          // Only if it is still the enrolled one: a callback that arrives after
+          // the timeout below may be condemning a key a newer handshake has
+          // already replaced, and deleting that replacement would spend a full
+          // attestation to enrol a key we just had.
+          self.clearKeyId(ifMatches: keyId)
+          promise.reject(AttestCode.invalidKey.rawValue, "Stored App Attest key is invalid", error)
+          return
+        }
+        if let error = error {
+          promise.reject(AttestCode.generateAssertion.rawValue, error.localizedDescription, error)
+          return
+        }
+        guard let assertion = assertion else {
+          promise.reject(AttestCode.generateAssertion.rawValue, "Failed to produce an assertion")
+          return
+        }
+        promise.resolve([
+          "keyId": keyId,
+          "assertion": assertion.base64EncodedString(),
+          "bundleId": Bundle.main.bundleIdentifier ?? ""
+        ])
+      }
+      if done.wait(timeout: .now() + EdgeAttestation.operationTimeout) == .timedOut {
+        promise.reject(AttestCode.timeout.rawValue, "App Attest assertion timed out")
+      }
+    }
+  }
+
+  @objc(clearKey:resolver:rejecter:)
+  func clearKey(
+    _ keyId: String?,
+    resolver resolve: @escaping RCTPromiseResolveBlock,
+    rejecter reject: @escaping RCTPromiseRejectBlock
+  ) {
+    EdgeAttestation.serialQueue.async {
+      // Only the attested key. JS calls this when the *server* rejects an
+      // assertion, which says nothing about a pending key the server has never
+      // seen - and discarding that one would throw away the retry it is held for.
+      //
+      // Scoped to the key JS named. This block can wait a long time for the
+      // queue, and running on "whatever is enrolled now" would let a verdict
+      // about a rejected key delete the replacement a newer handshake enrolled
+      // in the meantime - costing a full attestation to re-enrol a key that
+      // worked. A nil id means the caller really does want whatever is stored.
+      if let keyId = keyId {
+        self.clearKeyId(ifMatches: keyId)
+      } else {
+        self.clearKeyId()
+      }
+      resolve(nil)
+    }
+  }
+}

--- a/ios/edge/edge.entitlements
+++ b/ios/edge/edge.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.devicecheck.appattest-environment</key>
+	<string>production</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:dl.edge.app</string>

--- a/package-lock.json
+++ b/package-lock.json
@@ -203,7 +203,8 @@
         "typechain": "^8.3.2",
         "typescript": "5.0.4",
         "updot": "^1.2.0",
-        "vm-browserify": "^1.1.2"
+        "vm-browserify": "^1.1.2",
+        "xcode": "^3.0.1"
       },
       "engines": {
         "node": ">=18"
@@ -28216,6 +28217,8 @@
     },
     "node_modules/xcode": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
+      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
       "license": "Apache-2.0",
       "dependencies": {
         "simple-plist": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "android:release": "cd android && ./gradlew assembleRelease; cd ../",
     "android": "react-native run-android",
     "androidKeysCreate": "node -r sucrase/register scripts/createAndroidKeys.ts",
+    "extractSigningCert": "node -r sucrase/register scripts/extractSigningCert.ts",
     "configure": "node -r sucrase/register scripts/configure.ts",
     "deploy": "node -r sucrase/register scripts/deploy.ts",
     "fix-kotlin": "cd android; ./gradlew :app:ktlintFormat",
@@ -261,7 +262,8 @@
     "typechain": "^8.3.2",
     "typescript": "5.0.4",
     "updot": "^1.2.0",
-    "vm-browserify": "^1.1.2"
+    "vm-browserify": "^1.1.2",
+    "xcode": "^3.0.1"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/addAttestationIosFiles.js
+++ b/scripts/addAttestationIosFiles.js
@@ -1,0 +1,47 @@
+// One-off helper: wire the EdgeAttestation native files into the iOS Xcode
+// project (PBXBuildFile + PBXFileReference + group + Sources build phase) for
+// the `edge` target. Idempotent. Run with: node scripts/addAttestationIosFiles.js
+const fs = require('fs')
+const xcode = require('xcode')
+
+const projPath = 'ios/edge.xcodeproj/project.pbxproj'
+const proj = xcode.project(projPath)
+proj.parseSync()
+
+const unquote = s => (typeof s === 'string' ? s.replace(/^"|"$/g, '') : s)
+
+// Locate the `edge` native target (not `edgeTests`).
+const targets = proj.pbxNativeTargetSection()
+let edgeTargetKey
+for (const key of Object.keys(targets)) {
+  if (key.endsWith('_comment')) continue
+  if (unquote(targets[key].name) === 'edge') {
+    edgeTargetKey = key
+    break
+  }
+}
+if (edgeTargetKey == null) throw new Error('Could not find the `edge` target')
+
+const groupKey = proj.findPBXGroupKey({ name: 'edge' })
+if (groupKey == null) throw new Error('Could not find the `edge` group')
+
+const fileRefs = proj.pbxFileReferenceSection()
+const isPresent = relPath =>
+  Object.keys(fileRefs).some(
+    k => !k.endsWith('_comment') && unquote(fileRefs[k].path) === relPath
+  )
+
+for (const relPath of [
+  'edge/EdgeAttestation.swift',
+  'edge/EdgeAttestation.m'
+]) {
+  if (isPresent(relPath)) {
+    console.log('already present:', relPath)
+    continue
+  }
+  proj.addSourceFile(relPath, { target: edgeTargetKey }, groupKey)
+  console.log('added:', relPath)
+}
+
+fs.writeFileSync(projPath, proj.writeSync())
+console.log('wrote', projPath)

--- a/scripts/extractSigningCert.ts
+++ b/scripts/extractSigningCert.ts
@@ -1,0 +1,172 @@
+import childProcess from 'child_process'
+import prompts from 'prompts'
+
+// -----------------------------------------------------------------------------
+// extractSigningCert
+//
+// Extract the SHA-256 signing-certificate digest(s) from an Android keystore in
+// the exact form the info server's attestation allow-list expects
+// (info_data/appAttestation -> androidApps -> { release: [...], debug: [...] }).
+//
+// Android key attestation reports each signing certificate as
+// SHA-256(DER-encoded X.509 cert). `keytool -list -v` prints that same value as
+// its "SHA256:" fingerprint, so this tool runs keytool and normalizes the
+// fingerprint to lowercase hex with the colons stripped.
+//
+// This is the reusable tool for turning Edge's (decrypted) production keystore
+// into the digest that must be pinned in the info server. For local testing it
+// is also used on the fake release keystore and the debug keystore.
+//
+// Usage:
+//   node -r sucrase/register scripts/extractSigningCert.ts <keystore> [alias] \
+//     [--storepass <password>]
+//
+// Password resolution order: --storepass flag, KEYSTORE_PASSWORD env var, then
+// an interactive prompt. The password reaches keytool over stdin, so it never
+// appears in keytool's argv; note that --storepass still puts it in this
+// script's own argv, so prefer the env var or the prompt for the real keystore.
+// When no alias is given, every entry in the keystore is printed.
+// -----------------------------------------------------------------------------
+
+interface Args {
+  keystore?: string
+  alias?: string
+  storepass?: string
+}
+
+const parseArgs = (argv: string[]): Args => {
+  const args: Args = {}
+  const positional: string[] = []
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--storepass' || arg === '-p') {
+      args.storepass = argv[++i]
+    } else if (arg.startsWith('--storepass=')) {
+      args.storepass = arg.slice('--storepass='.length)
+    } else {
+      positional.push(arg)
+    }
+  }
+  args.keystore = positional[0]
+  args.alias = positional[1]
+  return args
+}
+
+const normalizeDigest = (fingerprint: string): string =>
+  fingerprint.replace(/:/g, '').trim().toLowerCase()
+
+const main = async (): Promise<void> => {
+  const args = parseArgs(process.argv.slice(2))
+
+  if (args.keystore == null || args.keystore === '') {
+    mylog(
+      'Usage: node -r sucrase/register scripts/extractSigningCert.ts <keystore> [alias] [--storepass <password>]'
+    )
+    process.exit(1)
+  }
+
+  let storepass = args.storepass ?? process.env.KEYSTORE_PASSWORD
+  if (storepass == null || storepass === '') {
+    const answer = await prompts({
+      name: 'storepass',
+      type: 'password',
+      message: `Enter store password for ${args.keystore}`,
+      validate: (v: string) => v.trim() !== ''
+    })
+    storepass = answer.storepass
+  }
+  if (storepass == null || storepass === '') {
+    mylog('No store password provided; aborting.')
+    process.exit(1)
+  }
+
+  // -J-Duser.language=en forces English labels so parsing is locale-independent.
+  const keytoolArgs = [
+    '-list',
+    '-v',
+    '-J-Duser.language=en',
+    '-keystore',
+    args.keystore
+  ]
+  if (args.alias != null) keytoolArgs.push('-alias', args.alias)
+  const output = runKeytool(keytoolArgs, storepass)
+
+  // Pair each "Alias name:" with the following "SHA256:" fingerprint. When a
+  // single alias was requested keytool omits the alias header, so fall back to
+  // the requested alias name.
+  const lines = output.split('\n')
+  const entries: Array<{ alias: string; digest: string }> = []
+  let currentAlias = args.alias ?? '(unknown)'
+  for (const line of lines) {
+    const aliasMatch = /^Alias name:\s*(.+)$/.exec(line)
+    if (aliasMatch != null) {
+      currentAlias = aliasMatch[1].trim()
+      continue
+    }
+    const shaMatch = /SHA256:\s*([0-9A-Fa-f:]+)/.exec(line)
+    if (shaMatch != null) {
+      entries.push({
+        alias: currentAlias,
+        digest: normalizeDigest(shaMatch[1])
+      })
+    }
+  }
+
+  if (entries.length === 0) {
+    mylog('No SHA-256 fingerprint found in keytool output:')
+    mylog(output)
+    process.exit(1)
+  }
+
+  mylog('')
+  mylog('Signing certificate SHA-256 digest(s):')
+  mylog(
+    '  (paste into info_data/appAttestation -> androidApps -> release/debug)'
+  )
+  mylog('')
+  for (const entry of entries) {
+    mylog(`  alias "${entry.alias}":`)
+    mylog(`    ${entry.digest}`)
+  }
+  mylog('')
+}
+
+const mylog = console.log
+
+/**
+ * Run keytool and return its stdout.
+ *
+ * Arguments are passed as an array rather than a shell string. Keystore
+ * passwords routinely contain characters the shell acts on, and interpolating
+ * them yields either a silently wrong password or an outright syntax error
+ * instead of a digest - `se$cret`x123` fails with "unexpected EOF". The
+ * password goes over stdin rather than `-storepass`, which keeps it out of the
+ * process list too; keytool prompts for it on stderr, leaving stdout parseable.
+ */
+function runKeytool(args: string[], storepass: string): string {
+  try {
+    return childProcess.execFileSync('keytool', args, {
+      encoding: 'utf8',
+      input: `${storepass}\n`,
+      timeout: 600000,
+      killSignal: 'SIGKILL',
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+  } catch (error) {
+    // keytool reports why it failed ("keystore password was incorrect", "Alias
+    // <name> does not exist") on *stdout*, followed by a Java stack trace;
+    // stderr holds only the password prompt. Surface the first line, so the
+    // developer gets the reason instead of a bare non-zero exit.
+    const stdout = (error as { stdout?: string }).stdout ?? ''
+    const reason = stdout
+      .split('\n')
+      .find(line => line.startsWith('keytool error:'))
+    mylog(reason ?? stdout.split('\n')[0])
+    throw error
+  }
+}
+
+main().catch((e: unknown) => {
+  console.log(String(e))
+  process.exit(1)
+})

--- a/src/__tests__/util/attestation.test.ts
+++ b/src/__tests__/util/attestation.test.ts
@@ -1,0 +1,2113 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest
+} from '@jest/globals'
+import { NativeModules, Platform } from 'react-native'
+
+interface MockResponse {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+  text: () => Promise<string>
+}
+
+const mockFetchInfo =
+  jest.fn<(path: string, opts?: RequestInit) => Promise<MockResponse>>()
+
+jest.mock('../../util/network', () => ({
+  fetchInfo: async (...args: unknown[]) =>
+    await mockFetchInfo(...(args as [string]))
+}))
+
+const mockShowButtonsModal = jest.fn(async () => 'ok')
+
+jest.mock('../../components/modals/ButtonsModal', () => ({
+  showButtonsModal: async (...args: unknown[]) =>
+    await mockShowButtonsModal(...(args as []))
+}))
+
+const mockIsSupported = jest.fn<() => Promise<boolean>>()
+const mockGetAttestation = jest.fn<
+  (challenge: string) => Promise<{
+    keyId?: string
+    attestation?: string
+    bundleId?: string
+    certChain?: string[]
+  }>
+>()
+const mockGenerateAssertion = jest.fn<
+  (challenge: string) => Promise<{
+    keyId?: string
+    assertion?: string
+    bundleId?: string
+  }>
+>()
+const mockClearKey = jest.fn<(keyId?: string) => Promise<void>>()
+const mockSignChallenge =
+  jest.fn<
+    (challenge: string) => Promise<{ keyId?: string; signature?: string }>
+  >()
+
+NativeModules.EdgeAttestation = {
+  isSupported: mockIsSupported,
+  getAttestation: mockGetAttestation,
+  generateAssertion: mockGenerateAssertion,
+  signChallenge: mockSignChallenge,
+  clearKey: mockClearKey
+}
+
+// Import after mocks so the module binds to mockFetchInfo / NativeModules.
+const {
+  attestationTimingForTests,
+  attestedJsonHeaders,
+  getAttestationToken,
+  initAttestation,
+  resetAttestationForTests
+} = require('../../util/attestation')
+
+/**
+ * Drain the handshake promise chain without advancing the fake clock. A
+ * handshake is a long series of awaits (challenge, assertion, second challenge,
+ * native attestation, token POST, then the commit/schedule tail), so drain
+ * generously: a short drain samples a half-finished handshake and reads as
+ * "nothing happened".
+ */
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 100; i++) await Promise.resolve()
+}
+
+const jsonResponse = (body: unknown, ok = true, status = 200): MockResponse => {
+  const response: MockResponse = {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  }
+  return response
+}
+
+describe('attestation engine', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    resetAttestationForTests()
+    mockFetchInfo.mockReset()
+    mockIsSupported.mockReset()
+    mockGetAttestation.mockReset()
+    mockGenerateAssertion.mockReset()
+    mockSignChallenge.mockReset()
+    mockClearKey.mockReset()
+    mockShowButtonsModal.mockReset()
+    mockShowButtonsModal.mockResolvedValue('ok')
+    mockIsSupported.mockResolvedValue(true)
+    mockGetAttestation.mockResolvedValue({
+      keyId: 'key',
+      attestation: 'att',
+      bundleId: 'co.edgesecure.app'
+    })
+    // Default: no stored key yet, so the assert fast path fails over to full
+    // attestation (matches first-run behavior on both platforms).
+    mockGenerateAssertion.mockRejectedValue(new Error('noKey'))
+    mockSignChallenge.mockRejectedValue(new Error('noKey'))
+    mockClearKey.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    resetAttestationForTests()
+    jest.useRealTimers()
+  })
+
+  const mockSuccessfulHandshake = (expiresIn = 600): void => {
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+        return jsonResponse({ token: 'jwt-token', expiresIn })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+  }
+
+  it('rejects attest responses with a non-finite expiresIn', async () => {
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      return jsonResponse({ token: 'jwt-token', expiresIn: 'soon' })
+    })
+
+    initAttestation()
+    const tokenPromise = getAttestationToken()
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.GET_TOKEN_TIMEOUT_MS
+    )
+    await expect(tokenPromise).resolves.toBeUndefined()
+  })
+
+  it('fails the handshake when expiresIn is at or under the clock skew', async () => {
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      return jsonResponse({ token: 'jwt-token', expiresIn: 1 })
+    })
+
+    initAttestation()
+    const tokenPromise = getAttestationToken()
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.GET_TOKEN_TIMEOUT_MS
+    )
+    await expect(tokenPromise).resolves.toBeUndefined()
+    const callsAfterMint = mockFetchInfo.mock.calls.length
+
+    // Caching an unusable token would leave the engine in its success state,
+    // free to hand the next caller straight back into another handshake.
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBe(callsAfterMint)
+  })
+
+  it('caches a token when expiresIn is a positive finite number', async () => {
+    mockSuccessfulHandshake(600)
+
+    initAttestation()
+    const tokenPromise = getAttestationToken()
+    // Flush the in-flight handshake promise chain.
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await expect(tokenPromise).resolves.toBe('jwt-token')
+  })
+
+  it('releases a hung handshake after the watchdog so a later attempt can succeed (Task 2.2)', async () => {
+    mockGetAttestation.mockImplementation(
+      async () => await new Promise(() => {}) // never settles
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-hung' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    // Let the hung handshake start and grab the lock.
+    await flush()
+
+    // Watchdog fires and clears the lock.
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.HANDSHAKE_WATCHDOG_MS
+    )
+
+    // A subsequent attempt can start once the lock is released and the hang's
+    // backoff has elapsed.
+    mockGetAttestation.mockResolvedValue({
+      keyId: 'key2',
+      attestation: 'att2',
+      bundleId: 'co.edgesecure.app'
+    })
+    mockSuccessfulHandshake(600)
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.FAILURE_BACKOFF_MS
+    )
+    await flush()
+
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+  })
+
+  it('keeps a late valid JWT when a post-watchdog retry fails into backoff', async () => {
+    // Handshake A hangs in native attestation after fetching a challenge.
+    let resolveHungAttestation:
+      | ((value: {
+          keyId?: string
+          attestation?: string
+          bundleId?: string
+        }) => void)
+      | undefined
+    mockGetAttestation.mockImplementation(
+      async () =>
+        await new Promise(resolve => {
+          resolveHungAttestation = resolve
+        })
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-hung' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    await flush()
+    expect(resolveHungAttestation).toBeDefined()
+
+    // Watchdog releases A's lock so a newer attempt can start.
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.HANDSHAKE_WATCHDOG_MS
+    )
+
+    // Handshake B starts once the hang's backoff elapses, then fails quickly at
+    // the challenge step and enters a backoff of its own.
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({}, false, 500)
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.FAILURE_BACKOFF_MS
+    )
+    await flush()
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+
+    // A finally completes with a valid JWT after B has entered backoff. The
+    // generation guard must still accept it because nothing fresher is cached.
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-late' })
+      }
+      if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+        return jsonResponse({ token: 'late-jwt', expiresIn: 600 })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    resolveHungAttestation?.({
+      keyId: 'key-late',
+      attestation: 'att-late',
+      bundleId: 'co.edgesecure.app'
+    })
+    await flush()
+
+    // During B's backoff window, callers still get A's late token.
+    await expect(getAttestationToken()).resolves.toBe('late-jwt')
+  })
+
+  it('suppresses retries during the failure backoff window (Task 2.3)', async () => {
+    // First handshake fails at the challenge step.
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({}, false, 500)
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    const firstPromise = getAttestationToken()
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.GET_TOKEN_TIMEOUT_MS
+    )
+    await expect(firstPromise).resolves.toBeUndefined()
+
+    const callsAfterFailure = mockFetchInfo.mock.calls.length
+
+    // A subsequent call during the backoff window must not start a new
+    // handshake and must return immediately without the 3s wait.
+    const backoffPromise = getAttestationToken()
+    await Promise.resolve()
+    await expect(backoffPromise).resolves.toBeUndefined()
+    expect(mockFetchInfo.mock.calls.length).toBe(callsAfterFailure)
+
+    // After the backoff elapses, a handshake can succeed again.
+    mockSuccessfulHandshake(600)
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.FAILURE_BACKOFF_MS
+    )
+
+    const retryPromise = getAttestationToken()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await expect(retryPromise).resolves.toBe('jwt-token')
+  })
+
+  it('retries a failed proactive refresh after the backoff without a gated call', async () => {
+    // First handshake succeeds with a token that refreshes in
+    // `REFRESH_UNTIL_MS` - comfortably past `MIN_REFRESH_MS`, so the floor
+    // does not decide this schedule.
+    const REFRESH_UNTIL_MS = 5 * 60 * 1000
+    mockSuccessfulHandshake(
+      (attestationTimingForTests.REFRESH_LEAD_MS + REFRESH_UNTIL_MS) / 1000
+    )
+
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    const callsAfterSuccess = mockFetchInfo.mock.calls.length
+
+    // Next proactive refresh fails at the challenge step.
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({}, false, 500)
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    await jest.advanceTimersByTimeAsync(REFRESH_UNTIL_MS)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(callsAfterSuccess)
+    const callsAfterFailedRefresh = mockFetchInfo.mock.calls.length
+
+    // Nothing happens until the backoff has fully elapsed.
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.FAILURE_BACKOFF_MS - 1
+    )
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBe(callsAfterFailedRefresh)
+
+    // After backoff, the engine retries on its own (no getAttestationToken).
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-retry' })
+      }
+      if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+        return jsonResponse({
+          token: 'jwt-retried',
+          expiresIn: 600
+        })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.FAILURE_BACKOFF_MS
+    )
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(
+      callsAfterFailedRefresh
+    )
+    await expect(getAttestationToken()).resolves.toBe('jwt-retried')
+  })
+
+  /** Fails before any platform attestation is spent (offline, server down). */
+  const mockCheapFailingHandshake = (): void => {
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({}, false, 500)
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+  }
+
+  /** Fails only after the attestation is produced (device rejected). */
+  const mockAttestFailingHandshake = (): void => {
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-rejected' })
+      }
+      if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+        return jsonResponse({}, false, 403)
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+  }
+
+  it('doubles the retry backoff after each rejected attestation', async () => {
+    const { FAILURE_BACKOFF_MS } = attestationTimingForTests
+    mockAttestFailingHandshake()
+
+    initAttestation()
+    await flush()
+    const afterFirst = mockFetchInfo.mock.calls.length
+    expect(afterFirst).toBeGreaterThan(0)
+
+    // Second attempt lands one backoff after the first failure.
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    const afterSecond = mockFetchInfo.mock.calls.length
+    expect(afterSecond).toBeGreaterThan(afterFirst)
+
+    // The third waits two backoffs, so one is not enough.
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBe(afterSecond)
+
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(afterSecond)
+  })
+
+  it('keeps retrying every backoff while failures cost no attestation', async () => {
+    const { FAILURE_BACKOFF_MS } = attestationTimingForTests
+    mockCheapFailingHandshake()
+
+    initAttestation()
+    await flush()
+
+    // An offline device must not back off into a half-hour silence: nothing
+    // rate-limited was spent, and it may be back on the network any moment.
+    for (let i = 0; i < 5; i++) {
+      const callsBefore = mockFetchInfo.mock.calls.length
+      await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+      await flush()
+      expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(callsBefore)
+    }
+  })
+
+  it('does not let a retired attempt replace a longer-lived token', async () => {
+    const { FAILURE_BACKOFF_MS, HANDSHAKE_WATCHDOG_MS } =
+      attestationTimingForTests
+    let resolveHung:
+      | ((value: {
+          keyId?: string
+          attestation?: string
+          bundleId?: string
+          certChain?: string[]
+        }) => void)
+      | undefined
+    let attestCalls = 0
+    mockGetAttestation.mockImplementation(async () => {
+      attestCalls += 1
+      if (attestCalls === 1) {
+        return await new Promise(resolve => {
+          resolveHung = resolve
+        })
+      }
+      return {
+        keyId: 'key-b',
+        attestation: 'att-b',
+        bundleId: 'co.edgesecure.app'
+      }
+    })
+
+    let token = 'jwt-stale'
+    // Shorter lifetime for A; B will outlive it. Driven by expiresIn rather than
+    // absolute expires, so the comparison is on monotonic deadlines.
+    let expiresIn = 300
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      return jsonResponse({ token, expiresIn })
+    })
+
+    // Handshake A hangs inside the native attestation, so the watchdog retires
+    // it and releases the lock.
+    initAttestation()
+    await flush()
+    expect(resolveHung).toBeDefined()
+    await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+    await flush()
+
+    // Handshake B then caches a token that outlives A's by 25 minutes.
+    token = 'jwt-fresh'
+    expiresIn = 1800
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-fresh')
+
+    // Only now does A answer. Its token is genuine but shorter-lived, so taking
+    // B's place would cost callers the longer-lived token.
+    token = 'jwt-stale'
+    expiresIn = 300
+    resolveHung?.({
+      keyId: 'key-a',
+      attestation: 'att-a',
+      bundleId: 'co.edgesecure.app'
+    })
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-fresh')
+  })
+
+  it('takes a late token that ties the cached one on expiry', async () => {
+    const { FAILURE_BACKOFF_MS, HANDSHAKE_WATCHDOG_MS } =
+      attestationTimingForTests
+    // A tie on monotonic deadline goes to the arrival (`>=`). Both handshakes
+    // return the same expiresIn; A settles in the same fake-timer instant as B
+    // finished, so the deadlines match and the late token replaces the cached one.
+    let resolveHung:
+      | ((value: {
+          keyId?: string
+          attestation?: string
+          bundleId?: string
+          certChain?: string[]
+        }) => void)
+      | undefined
+    let attestCalls = 0
+    mockGetAttestation.mockImplementation(async () => {
+      attestCalls += 1
+      if (attestCalls === 1) {
+        return await new Promise(resolve => {
+          resolveHung = resolve
+        })
+      }
+      return {
+        keyId: 'key-b',
+        attestation: 'att-b',
+        bundleId: 'co.edgesecure.app'
+      }
+    })
+
+    let token = 'jwt-b'
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      return jsonResponse({ token, expiresIn: 600 })
+    })
+
+    initAttestation()
+    await flush()
+    await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+    await flush()
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-b')
+
+    token = 'jwt-a'
+    resolveHung?.({
+      keyId: 'key-a',
+      attestation: 'att-a',
+      bundleId: 'co.edgesecure.app'
+    })
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-a')
+  })
+
+  it('ignores an absolute expiry the server should not be sending', async () => {
+    const { REFRESH_LEAD_MS, MIN_REFRESH_MS } = attestationTimingForTests
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      return jsonResponse({
+        token: 'jwt-token',
+        expiresIn: 600,
+        // Deliberately wrong absolute expiry an hour in the past - must be ignored.
+        expires: Date.now() - 60 * 60 * 1000
+      })
+    })
+
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    mockFetchInfo.mockClear()
+
+    // Refresh is scheduled off expiresIn (600s - 2 min lead = ~8 min), not the
+    // stale absolute expires.
+    const refreshDelay = Math.max(MIN_REFRESH_MS, 600 * 1000 - REFRESH_LEAD_MS)
+    await jest.advanceTimersByTimeAsync(refreshDelay - 1000)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBe(0)
+    await jest.advanceTimersByTimeAsync(2000)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(0)
+  })
+
+  it('fails the handshake when the server sends no lifetime', async () => {
+    const { FAILURE_BACKOFF_MS } = attestationTimingForTests
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      // Pre-Task-2.1 server shape: absolute expires only.
+      return jsonResponse({
+        token: 'jwt-token',
+        expires: Date.now() + 10 * 60 * 1000
+      })
+    })
+
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+    const callsAfterFailure = mockFetchInfo.mock.calls.length
+
+    // Next attempt comes on the backoff, not immediately.
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBe(callsAfterFailure)
+
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(callsAfterFailure)
+  })
+
+  it('serves a token on a device whose clock is an hour behind the server', async () => {
+    jest.setSystemTime(Date.now() - 3600_000)
+    mockSuccessfulHandshake(600)
+
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+  })
+
+  it('ignores a date change entirely', async () => {
+    mockSuccessfulHandshake(600)
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    mockFetchInfo.mockClear()
+
+    jest.setSystemTime(Date.now() - 86_400_000)
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    expect(mockFetchInfo.mock.calls.length).toBe(0)
+  })
+
+  it('warns once when the device clock is more than two minutes off', async () => {
+    const skewed = new Date(Date.now() - (2 * 60 * 1000 + 1000)).toISOString()
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1', serverTime: skewed })
+      }
+      return jsonResponse({
+        token: 'jwt-token',
+        expiresIn: 600,
+        serverTime: skewed
+      })
+    })
+
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    expect(mockShowButtonsModal.mock.calls.length).toBe(1)
+
+    // A second handshake in the same run must not re-prompt.
+    mockShowButtonsModal.mockClear()
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.MIN_HANDSHAKE_SPACING_MS
+    )
+    // Force a refresh by advancing to the refresh lead.
+    await jest.advanceTimersByTimeAsync(
+      600 * 1000 - attestationTimingForTests.REFRESH_LEAD_MS
+    )
+    await flush()
+    expect(mockShowButtonsModal.mock.calls.length).toBe(0)
+  })
+
+  it('does not warn for a few seconds of skew', async () => {
+    const slightlyOff = new Date(Date.now() - 5 * 1000).toISOString()
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1', serverTime: slightlyOff })
+      }
+      return jsonResponse({
+        token: 'jwt-token',
+        expiresIn: 600,
+        serverTime: slightlyOff
+      })
+    })
+
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    expect(mockShowButtonsModal.mock.calls.length).toBe(0)
+  })
+
+  it('still schedules from expiresIn when serverTime says the clock is wrong', async () => {
+    const { REFRESH_LEAD_MS, MIN_REFRESH_MS } = attestationTimingForTests
+    jest.setSystemTime(Date.now() - 3600_000)
+    const skewed = new Date(Date.now() + 3600_000).toISOString()
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1', serverTime: skewed })
+      }
+      return jsonResponse({
+        token: 'jwt-token',
+        expiresIn: 600,
+        serverTime: skewed
+      })
+    })
+
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    expect(mockShowButtonsModal.mock.calls.length).toBe(1)
+    mockFetchInfo.mockClear()
+
+    // Refresh delay is ~8 minutes of monotonic time, independent of the skew.
+    const refreshDelay = Math.max(MIN_REFRESH_MS, 600 * 1000 - REFRESH_LEAD_MS)
+    await jest.advanceTimersByTimeAsync(refreshDelay - 1000)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBe(0)
+    await jest.advanceTimersByTimeAsync(2000)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(0)
+  })
+
+  it('keeps retrying every backoff when native never acquired the lock', async () => {
+    const { FAILURE_BACKOFF_MS } = attestationTimingForTests
+    mockSuccessfulHandshake(600)
+    mockGetAttestation.mockRejectedValue(
+      Object.assign(new Error('Timed out waiting for the Keystore lock'), {
+        code: 'lockTimeout'
+      })
+    )
+
+    initAttestation()
+    await flush()
+
+    // Contention on the lock means some earlier native call is wedged; doubling
+    // the backoff would take a recoverable device off the air for up to
+    // MAX_BACKOFF_MS over failures that cost nothing.
+    for (let i = 0; i < 5; i++) {
+      const callsBefore = mockGetAttestation.mock.calls.length
+      await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+      await flush()
+      expect(mockGetAttestation.mock.calls.length).toBeGreaterThan(callsBefore)
+    }
+  })
+
+  it('un-counts a watchdog failure that native later says cost nothing', async () => {
+    const { FAILURE_BACKOFF_MS, HANDSHAKE_WATCHDOG_MS } =
+      attestationTimingForTests
+    // The watchdog has to count an outstanding native call as expensive, since a
+    // call that may never answer may also have spent the attestation. But the
+    // answer can still arrive afterwards: the 90s watchdog starts at the top of
+    // the handshake, so a slow challenge fetch leaves Android's 60s lock timeout
+    // landing after it. The attempt is retired by then, so without a correction
+    // the count stands for a failure that provably cost nothing.
+    let rejectLockWait: ((error: Error) => void) | undefined
+    mockGetAttestation.mockImplementation(
+      async () =>
+        await new Promise((_resolve, reject) => {
+          rejectLockWait = reject
+        })
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    await flush()
+
+    // Twice, because the backoff is `FAILURE_BACKOFF_MS * 2 ** (count - 1)`:
+    // counts of zero and one give the same flat window, so a single uncorrected
+    // count is invisible and cannot tell the two behaviours apart.
+    for (let round = 0; round < 2; round++) {
+      await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+      await flush()
+      rejectLockWait?.(
+        Object.assign(new Error('Timed out waiting for the Keystore lock'), {
+          code: 'lockTimeout'
+        })
+      )
+      await flush()
+      if (round === 0) {
+        // Let the retry the watchdog scheduled start, and hang again.
+        await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+        await flush()
+      }
+    }
+
+    // Corrected, the count is back to zero and one flat window is enough. Left
+    // standing, it would be two and this window would pass in silence.
+    mockSuccessfulHandshake(600)
+    mockGetAttestation.mockResolvedValue({
+      keyId: 'key2',
+      attestation: 'att2',
+      bundleId: 'co.edgesecure.app'
+    })
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+  })
+
+  it('keeps a watchdog failure counted when native may have spent quota', async () => {
+    const { FAILURE_BACKOFF_MS, HANDSHAKE_WATCHDOG_MS } =
+      attestationTimingForTests
+    // The mirror of the test above, and the reason the correction cannot simply
+    // undo whatever the watchdog counted. iOS raises `timeout` after attestKey
+    // was invoked, so Apple may already have counted it; taking that back would
+    // under-count real quota burn and keep a rate-limited device re-attesting.
+    let rejectNativeCall: ((error: Error) => void) | undefined
+    mockGetAttestation.mockImplementation(
+      async () =>
+        await new Promise((_resolve, reject) => {
+          rejectNativeCall = reject
+        })
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    await flush()
+
+    for (let round = 0; round < 2; round++) {
+      await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+      await flush()
+      rejectNativeCall?.(
+        Object.assign(new Error('App Attest attestation timed out'), {
+          code: 'timeout'
+        })
+      )
+      await flush()
+      if (round === 0) {
+        await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+        await flush()
+      }
+    }
+
+    // Two counted failures put the next attempt two windows out, so one window
+    // must pass in silence and the gated caller must still get nothing.
+    mockSuccessfulHandshake(600)
+    mockGetAttestation.mockResolvedValue({
+      keyId: 'key2',
+      attestation: 'att2',
+      bundleId: 'co.edgesecure.app'
+    })
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+  })
+
+  // The bodies below are parsed by the info server with strict cleaners that
+  // reject anything else with a 400, so a renamed field or a swapped path breaks
+  // attestation outright for the platform in question - and does it silently,
+  // since the engine reads a 400 as a failed handshake and simply backs off.
+  const captureBodies = (): Map<string, unknown> => {
+    const bodies = new Map<string, unknown>()
+    mockFetchInfo.mockImplementation(
+      async (path: string, opts?: RequestInit) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-1' })
+        }
+        const raw = opts?.body
+        if (typeof raw !== 'string') {
+          throw new Error(`expected a JSON string body for ${path}`)
+        }
+        bodies.set(path, JSON.parse(raw))
+        return jsonResponse({
+          token: 'jwt-token',
+          expiresIn: 600
+        })
+      }
+    )
+    return bodies
+  }
+
+  it('sends the App Attest fields iOS enrollment and refresh each need', async () => {
+    // The Android block below mutates the shared Platform mock. If its
+    // afterEach ever stops restoring, a randomized run can land here while
+    // OS is still 'android' and these assertions would still pass against
+    // whichever path the engine took - unless we pin the platform.
+    expect(Platform.OS).toBe('ios')
+
+    const bodies = captureBodies()
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    expect(bodies.get('v1/attest/apple')).toStrictEqual({
+      keyId: 'key',
+      attestation: 'att',
+      bundleId: 'co.edgesecure.app',
+      challenge: 'chal-1'
+    })
+
+    // Now with a key enrolled, the cheap path takes over.
+    mockGenerateAssertion.mockResolvedValue({
+      keyId: 'K1',
+      assertion: 'assert-1',
+      bundleId: 'co.edgesecure.app'
+    })
+    const refreshed = captureBodies()
+    await jest.advanceTimersByTimeAsync(
+      600000 - attestationTimingForTests.REFRESH_LEAD_MS
+    )
+    await flush()
+    expect(refreshed.get('v1/attest/apple/assert')).toStrictEqual({
+      keyId: 'K1',
+      assertion: 'assert-1',
+      challenge: 'chal-1'
+    })
+    // Without the timer advance the assert path is never hit, so a missing
+    // advance would leave this map empty and fail here - not silently pass.
+    expect(refreshed.has('v1/attest/apple')).toBe(false)
+  })
+
+  describe('android', () => {
+    // Every other test in this file runs as iOS, because that is what
+    // `Platform.OS` reports under jest. Android takes a different native call, a
+    // different request path and a different body shape, none of which any test
+    // reached before this block.
+    // Captured rather than assumed: restoring a hard-coded 'ios' would quietly
+    // change the platform for every later case in this file if the preset's
+    // default ever moved, and the tests above would still pass while testing
+    // something other than what they say.
+    const platform = Platform as unknown as { OS: string }
+    const originalOS = platform.OS
+    beforeEach(() => {
+      platform.OS = 'android'
+    })
+    afterEach(() => {
+      platform.OS = originalOS
+    })
+
+    it('enrols with a certificate chain, not an App Attest object', async () => {
+      expect(Platform.OS).toBe('android')
+      mockGetAttestation.mockResolvedValue({ certChain: ['cert-1', 'cert-2'] })
+      const bodies = captureBodies()
+
+      initAttestation()
+      await flush()
+      await expect(getAttestationToken()).resolves.toBe('jwt-token')
+
+      expect(bodies.get('v1/attest/android')).toStrictEqual({
+        certChain: ['cert-1', 'cert-2'],
+        challenge: 'chal-1'
+      })
+      expect(bodies.has('v1/attest/apple')).toBe(false)
+    })
+
+    it('refreshes by signing the challenge, not by asserting', async () => {
+      expect(Platform.OS).toBe('android')
+      mockSignChallenge.mockResolvedValue({ keyId: 'K1', signature: 'sig-1' })
+      const bodies = captureBodies()
+
+      initAttestation()
+      await flush()
+      await expect(getAttestationToken()).resolves.toBe('jwt-token')
+
+      expect(bodies.get('v1/attest/android/assert')).toStrictEqual({
+        keyId: 'K1',
+        signature: 'sig-1',
+        challenge: 'chal-1'
+      })
+      // The local signature was enough, so nothing rate-limited was spent.
+      expect(mockGetAttestation.mock.calls.length).toBe(0)
+      expect(mockGenerateAssertion.mock.calls.length).toBe(0)
+    })
+  })
+
+  it('stops serving a token the server has just rejected', async () => {
+    const { REFRESH_LEAD_MS } = attestationTimingForTests
+    const REFRESH_UNTIL_MS = 5 * 60 * 1000
+    mockSuccessfulHandshake((REFRESH_LEAD_MS + REFRESH_UNTIL_MS) / 1000)
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+
+    // The proactive refresh finds the enrolled key rejected, and re-enrolling
+    // then fails - so nothing arrives to replace what is cached.
+    mockGenerateAssertion.mockResolvedValue({
+      keyId: 'K1',
+      assertion: 'assert-1',
+      bundleId: 'co.edgesecure.app'
+    })
+    mockSignChallenge.mockResolvedValue({ keyId: 'K1', signature: 'sig-1' })
+    mockGetAttestation.mockRejectedValue(new Error('attestation unavailable'))
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-2' })
+      }
+      if (path.endsWith('/assert')) return jsonResponse({}, false, 401)
+      throw new Error(`unexpected path ${path}`)
+    })
+    await jest.advanceTimersByTimeAsync(REFRESH_UNTIL_MS)
+    await flush()
+
+    // The token has not expired, but the server has called the key that minted
+    // it untrusted. Handing it out anyway means every gated caller keeps
+    // presenting a credential that is already being refused.
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+  })
+
+  it('does not spend an attestation for an attempt the watchdog retired', async () => {
+    const { HANDSHAKE_WATCHDOG_MS } = attestationTimingForTests
+    // The watchdog can fire before the handshake even reaches the native call:
+    // everything before it is info-server round trips, and on a bad enough
+    // network those alone outlast the 90s window.
+    let releaseChallenge: (() => void) | undefined
+    let challenges = 0
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        challenges += 1
+        if (challenges === 1) {
+          await new Promise<void>(resolve => {
+            releaseChallenge = resolve
+          })
+        }
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    await flush()
+    await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+    await flush()
+
+    // Let the retired attempt run on. It has to stop rather than carry through
+    // into the one step that costs rate-limited quota.
+    releaseChallenge?.()
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(0)
+  })
+
+  it('leaves the lock alone when a retired attempt settles under a newer one', async () => {
+    const {
+      FAILURE_BACKOFF_MS,
+      GET_TOKEN_TIMEOUT_MS,
+      HANDSHAKE_WATCHDOG_MS,
+      MIN_HANDSHAKE_SPACING_MS
+    } = attestationTimingForTests
+    // Both handshakes hang in the native call, so the first is still unsettled
+    // when the second takes the lock.
+    const rejecters: Array<(error: Error) => void> = []
+    mockGetAttestation.mockImplementation(
+      async () =>
+        await new Promise((_resolve, reject) => {
+          rejecters.push(reject)
+        })
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    await flush()
+    await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+    await flush()
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(rejecters.length).toBe(2)
+
+    // The first answers at last, while the second still holds the lock.
+    rejecters[0](
+      Object.assign(new Error('App Attest attestation timed out'), {
+        code: 'timeout'
+      })
+    )
+    await flush()
+
+    // Its cleanup must not hand the lock back. Releasing it would let a third
+    // handshake start alongside the second, and both would spend an attestation.
+    await jest.advanceTimersByTimeAsync(
+      FAILURE_BACKOFF_MS + MIN_HANDSHAKE_SPACING_MS
+    )
+    await flush()
+    const gated = getAttestationToken()
+    await jest.advanceTimersByTimeAsync(GET_TOKEN_TIMEOUT_MS)
+    await expect(gated).resolves.toBeUndefined()
+    expect(rejecters.length).toBe(2)
+  })
+
+  // Bodies the server should never send, each of which the engine has to treat
+  // as a failed handshake. Asserting only that no token comes back is not
+  // enough: a non-finite `expiresIn` also produces no token, because every
+  // comparison against NaN is false - while `scheduleRefresh` computes NaN,
+  // `setTimeout` reads that as zero, and the engine spins as fast as the network
+  // answers. What distinguishes the two is whether the failure is *counted*.
+  it.each([
+    ['a non-string token', () => ({ token: 42, expiresIn: 600 })],
+    ['a non-finite expiresIn', () => ({ token: 'jwt', expiresIn: 'soon' })],
+    [
+      'a missing expiresIn',
+      () => ({ token: 'jwt', expires: Date.now() + 600000 })
+    ],
+    [
+      'an expiresIn at or under the clock skew',
+      () => ({ token: 'jwt', expiresIn: 1 })
+    ]
+  ])('treats %s as a failed handshake, not a success', async (_label, body) => {
+    const { FAILURE_BACKOFF_MS } = attestationTimingForTests
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-1' })
+      }
+      return jsonResponse(body())
+    })
+
+    initAttestation()
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(1)
+
+    // Each attempt spent an attestation, so the second lands one backoff later
+    // and the third two - meaning this window has to pass in silence.
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(2)
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(2)
+  })
+
+  it('stops serving a token inside the clock-skew window', async () => {
+    const LIFETIME_MS = 10 * 60 * 1000
+    mockSuccessfulHandshake(LIFETIME_MS / 1000)
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+
+    // Refreshes fail from here, so nothing replaces what is cached.
+    mockCheapFailingHandshake()
+    await jest.advanceTimersByTimeAsync(LIFETIME_MS - 2000)
+    await flush()
+
+    // Two seconds of stated life left. The request still has to travel and be
+    // verified, so a token this close to the edge arrives expired - and a 403 is
+    // worse for the caller than no token, which the info server may still
+    // answer with a fallback.
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+  })
+
+  it('fails a malformed challenge before spending an attestation', async () => {
+    // A challenge-less 200 would be POSTed as `undefined`, and on the full
+    // attest path native would be asked to attest that - spending rate-limited
+    // quota on a request the server is bound to refuse.
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') return jsonResponse({})
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(0)
+  })
+
+  it('does not start a second handshake at boot when a token is live', async () => {
+    const LIFETIME_MS = 60 * 60 * 1000
+    mockSuccessfulHandshake(LIFETIME_MS / 1000)
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    const afterBoot = mockGetAttestation.mock.calls.length
+
+    // Well past the spacing floor, so the live token is the only thing left to
+    // stop another handshake. initAttestation runs again on re-login.
+    await jest.advanceTimersByTimeAsync(5 * 60 * 1000)
+    await flush()
+    initAttestation()
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(afterBoot)
+  })
+
+  it('clears a grown backoff after a success', async () => {
+    const { FAILURE_BACKOFF_MS, REFRESH_LEAD_MS } = attestationTimingForTests
+    const LIFETIME_MS = 10 * 60 * 1000
+    mockAttestFailingHandshake()
+    initAttestation()
+    await flush()
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+
+    // Two rejected attestations, then the server accepts.
+    mockSuccessfulHandshake(LIFETIME_MS / 1000)
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS * 2)
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+
+    // The next proactive refresh fails. Counted from a forgotten run this is
+    // the first failure and sits one flat backoff out; counted from a
+    // remembered one the doubling carries on and this window passes in silence.
+    mockAttestFailingHandshake()
+    await jest.advanceTimersByTimeAsync(LIFETIME_MS - REFRESH_LEAD_MS)
+    await flush()
+    const afterFailedRefresh = mockGetAttestation.mock.calls.length
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBeGreaterThan(
+      afterFailedRefresh
+    )
+  })
+
+  it('grows the backoff when the native attestation itself fails', async () => {
+    const { FAILURE_BACKOFF_MS } = attestationTimingForTests
+    // The counterpart to the test above, and the reason it cannot simply trust
+    // any native rejection: iOS reports `timeout` after App Attest was invoked,
+    // so Apple may have counted it and the backoff must still grow.
+    mockSuccessfulHandshake(600)
+    mockGetAttestation.mockRejectedValue(
+      Object.assign(new Error('App Attest attestation timed out'), {
+        code: 'timeout'
+      })
+    )
+
+    initAttestation()
+    await flush()
+    const afterFirst = mockGetAttestation.mock.calls.length
+
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    const afterSecond = mockGetAttestation.mock.calls.length
+    expect(afterSecond).toBeGreaterThan(afterFirst)
+
+    // The third attempt waits two backoffs, so one is not enough.
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(afterSecond)
+  })
+
+  it('treats an unfamiliar native code as expensive and non-transient', async () => {
+    const { FAILURE_BACKOFF_MS } = attestationTimingForTests
+    // An unknown code is assumed to have spent quota (backoff doubles) and is
+    // not treated as a transient signing failure (assert path is not retried
+    // without re-attesting).
+    mockSuccessfulHandshake(600)
+    mockGetAttestation.mockRejectedValue(
+      Object.assign(new Error('something new'), { code: 'somethingNew' })
+    )
+
+    initAttestation()
+    await flush()
+    const afterFirst = mockGetAttestation.mock.calls.length
+    expect(afterFirst).toBe(1)
+
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    const afterSecond = mockGetAttestation.mock.calls.length
+    expect(afterSecond).toBeGreaterThan(afterFirst)
+
+    // Doubled backoff: one more FAILURE_BACKOFF_MS is not enough for a third.
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(afterSecond)
+  })
+
+  it('treats a native timeout as a plain failure, not an abandoned attempt', async () => {
+    const { FAILURE_BACKOFF_MS, HANDSHAKE_WATCHDOG_MS } =
+      attestationTimingForTests
+    // Native answers at its own 120s bound, below the 150s watchdog, so JS sees
+    // a real rejection rather than retiring the attempt and waiting for a late
+    // token.
+    mockSuccessfulHandshake(600)
+    mockGetAttestation.mockImplementation(
+      async () =>
+        await new Promise((_resolve, reject) => {
+          setTimeout(() => {
+            reject(
+              Object.assign(new Error('App Attest attestation timed out'), {
+                code: 'timeout'
+              })
+            )
+          }, 120_000)
+        })
+    )
+
+    initAttestation()
+    await flush()
+    const attestPostsBefore = mockFetchInfo.mock.calls.filter(call =>
+      ['v1/attest/apple', 'v1/attest/android'].includes(call[0])
+    ).length
+
+    await jest.advanceTimersByTimeAsync(120_000)
+    await flush()
+
+    // Settled as a counted failure before the watchdog window.
+    expect(HANDSHAKE_WATCHDOG_MS).toBeGreaterThan(120_000)
+    const callsAfterTimeout = mockGetAttestation.mock.calls.length
+    expect(callsAfterTimeout).toBe(1)
+
+    // No late-token path: the failed attempt never POSTed an attestation.
+    const attestPostsAfter = mockFetchInfo.mock.calls.filter(call =>
+      ['v1/attest/apple', 'v1/attest/android'].includes(call[0])
+    ).length
+    expect(attestPostsAfter).toBe(attestPostsBefore)
+
+    // Backoff grew once (attestation may have been spent), so the next attempt
+    // waits a full FAILURE_BACKOFF_MS from the native rejection.
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS - 1)
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(callsAfterTimeout)
+    await jest.advanceTimersByTimeAsync(1)
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBeGreaterThan(
+      callsAfterTimeout
+    )
+  })
+
+  it('suppresses gated calls for the whole grown backoff', async () => {
+    const { FAILURE_BACKOFF_MS } = attestationTimingForTests
+    mockAttestFailingHandshake()
+
+    // Two rejected attestations put the next attempt two backoffs out.
+    initAttestation()
+    await flush()
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    const callsAfterSecond = mockFetchInfo.mock.calls.length
+
+    // A gated caller one backoff later - the Banxa order poll runs every 3s -
+    // must not start a handshake, and must not wait around for one.
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    const gatedPromise = getAttestationToken()
+    await flush()
+    await expect(gatedPromise).resolves.toBeUndefined()
+    expect(mockFetchInfo.mock.calls.length).toBe(callsAfterSecond)
+  })
+
+  it('caps the retry backoff so a failing device keeps retrying', async () => {
+    const { MAX_BACKOFF_MS } = attestationTimingForTests
+    mockAttestFailingHandshake()
+
+    initAttestation()
+    await flush()
+
+    // However long the device has been failing, every window of
+    // MAX_BACKOFF_MS must still hold an attempt. Uncapped doubling goes
+    // quiet for hours instead.
+    for (let i = 0; i < 10; i++) {
+      const callsBefore = mockFetchInfo.mock.calls.length
+      await jest.advanceTimersByTimeAsync(MAX_BACKOFF_MS)
+      await flush()
+      expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(callsBefore)
+    }
+  })
+
+  it('retries on its own after a hung handshake trips the watchdog', async () => {
+    mockGetAttestation.mockImplementation(
+      async () => await new Promise(() => {}) // never settles
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-hung' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    await flush()
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.HANDSHAKE_WATCHDOG_MS
+    )
+    const callsAfterWatchdog = mockFetchInfo.mock.calls.length
+
+    // The hung attempt never settles, so only the watchdog can restart the
+    // loop. No gated call here.
+    mockGetAttestation.mockResolvedValue({
+      keyId: 'key2',
+      attestation: 'att2',
+      bundleId: 'co.edgesecure.app'
+    })
+    mockSuccessfulHandshake(600)
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.FAILURE_BACKOFF_MS
+    )
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(callsAfterWatchdog)
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+  })
+
+  it('never schedules a refresh sooner than the floor', async () => {
+    const { MIN_REFRESH_MS } = attestationTimingForTests
+    // A token lifetime below REFRESH_LEAD_MS is one operator edit away: the
+    // info server reads it from a synced config doc. It must not put the
+    // engine into a handshake loop.
+    mockSuccessfulHandshake(30)
+
+    initAttestation()
+    await flush()
+    const callsAfterMint = mockFetchInfo.mock.calls.length
+    expect(callsAfterMint).toBeGreaterThan(0)
+
+    // Make any further handshake cheap to observe and impossible to loop on.
+    mockCheapFailingHandshake()
+    await jest.advanceTimersByTimeAsync(MIN_REFRESH_MS - 1)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBe(callsAfterMint)
+
+    await jest.advanceTimersByTimeAsync(1)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(callsAfterMint)
+  })
+
+  it('counts a hang inside the attestation against the backoff', async () => {
+    const { FAILURE_BACKOFF_MS, HANDSHAKE_WATCHDOG_MS } =
+      attestationTimingForTests
+    mockGetAttestation.mockImplementation(
+      async () => await new Promise(() => {}) // never settles
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-hung' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    // First hang: watchdog releases the lock and retries one backoff later.
+    initAttestation()
+    await flush()
+    await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+
+    // Second hang. The quota is spent whether the native call answers or not,
+    // so this backoff must have doubled.
+    await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+    await flush()
+    const callsAfterSecondHang = mockFetchInfo.mock.calls.length
+
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBe(callsAfterSecondHang)
+
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(
+      callsAfterSecondHang
+    )
+  })
+
+  it('counts a hang and its late rejection as one failure', async () => {
+    const { FAILURE_BACKOFF_MS, HANDSHAKE_WATCHDOG_MS } =
+      attestationTimingForTests
+    let rejectHungAttestation: ((error: Error) => void) | undefined
+    mockGetAttestation.mockImplementation(
+      async () =>
+        await new Promise((resolve, reject) => {
+          rejectHungAttestation = reject
+        })
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-hung' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    await flush()
+    await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+    expect(rejectHungAttestation).toBeDefined()
+
+    // The watchdog already gave up on this attempt and scheduled a retry one
+    // backoff out. Its late rejection is the same failure, so it must not
+    // double the wait.
+    rejectHungAttestation?.(new Error('attestKey timed out'))
+    await flush()
+    const callsAfterRejection = mockFetchInfo.mock.calls.length
+
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(callsAfterRejection)
+  })
+
+  it('does not pull a live token refresh sooner after a failed attempt', async () => {
+    // Handshake A hangs in native attestation after fetching a challenge.
+    let resolveHungAttestation:
+      | ((value: {
+          keyId?: string
+          attestation?: string
+          bundleId?: string
+        }) => void)
+      | undefined
+    mockGetAttestation.mockImplementation(
+      async () =>
+        await new Promise(resolve => {
+          resolveHungAttestation = resolve
+        })
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-hung' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    initAttestation()
+    await flush()
+
+    // Watchdog releases A's lock and arms a retry.
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.HANDSHAKE_WATCHDOG_MS
+    )
+
+    // Handshake B stalls on its challenge so we control when it fails, while A
+    // can still complete with a long-lived token.
+    let rejectChallenge: ((error: Error) => void) | undefined
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return await new Promise<MockResponse>((resolve, reject) => {
+          rejectChallenge = reject
+        })
+      }
+      if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+        return jsonResponse({ token: 'jwt-long', expiresIn: 3600 })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.FAILURE_BACKOFF_MS
+    )
+    await flush()
+    expect(rejectChallenge).toBeDefined()
+
+    // A lands its token first, scheduling a refresh an hour out.
+    resolveHungAttestation?.({
+      keyId: 'key-late',
+      attestation: 'att-late',
+      bundleId: 'co.edgesecure.app'
+    })
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-long')
+
+    // B then fails. Its backoff retry must not replace A's refresh.
+    rejectChallenge?.(new Error('challenge failed'))
+    await flush()
+    const callsAfterFailure = mockFetchInfo.mock.calls.length
+
+    await jest.advanceTimersByTimeAsync(10 * 60 * 1000)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBe(callsAfterFailure)
+    await expect(getAttestationToken()).resolves.toBe('jwt-long')
+  })
+
+  /** Hangs forever inside the native attestation, after fetching a challenge. */
+  const mockHangingAttestation = (): void => {
+    mockGetAttestation.mockImplementation(
+      async () => await new Promise(() => {})
+    )
+    mockFetchInfo.mockImplementation(async (path: string) => {
+      if (path === 'v1/attest/challenge') {
+        return jsonResponse({ challenge: 'chal-hung' })
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+  }
+
+  it('makes a hang back off gated callers, not just the retry timer', async () => {
+    const { HANDSHAKE_WATCHDOG_MS } = attestationTimingForTests
+    mockHangingAttestation()
+
+    initAttestation()
+    await flush()
+    await jest.advanceTimersByTimeAsync(HANDSHAKE_WATCHDOG_MS)
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(1)
+
+    // The watchdog counted a burnt attestation, so the backoff has to apply to
+    // gated callers too. Recording only the failure count would leave the gate
+    // reading a `lastFailureAt` no hang ever set, and every gated call would
+    // start a fresh handshake the moment the lock was released.
+    await jest.advanceTimersByTimeAsync(1000)
+    let settled = false
+    const gated = getAttestationToken().then((token: string | undefined) => {
+      settled = true
+      return token
+    })
+    await flush()
+    expect(mockGetAttestation.mock.calls.length).toBe(1)
+    // And it must not wait GET_TOKEN_TIMEOUT_MS to say so.
+    expect(settled).toBe(true)
+    await expect(gated).resolves.toBeUndefined()
+  })
+
+  it('bounds attestations burned while the native call keeps hanging', async () => {
+    const { HANDSHAKE_WATCHDOG_MS } = attestationTimingForTests
+    mockHangingAttestation()
+
+    initAttestation()
+    await flush()
+
+    // Poll like the Banxa order screen for an hour of solid hangs.
+    const WINDOW_MS = 60 * 60 * 1000
+    const gated: Array<Promise<string | undefined>> = []
+    for (let elapsed = 0; elapsed < WINDOW_MS; elapsed += 3000) {
+      gated.push(getAttestationToken())
+      await jest.advanceTimersByTimeAsync(3000)
+    }
+    await flush()
+    await Promise.all(gated)
+
+    // Without the backoff applying to gated callers this is one attestation per
+    // watchdog window; with the doubling backoff it is a handful.
+    expect(mockGetAttestation.mock.calls.length).toBeLessThan(
+      WINDOW_MS / HANDSHAKE_WATCHDOG_MS / 2
+    )
+  })
+
+  it('retries after the bridge fails to answer isSupported', async () => {
+    mockIsSupported.mockRejectedValue(new Error('native bridge not ready'))
+
+    initAttestation()
+    await flush()
+    expect(mockIsSupported.mock.calls.length).toBe(1)
+
+    // A rejection is the bridge failing, not the device saying no, so it must
+    // not retire the engine.
+    mockIsSupported.mockResolvedValue(true)
+    mockSuccessfulHandshake(600)
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.FAILURE_BACKOFF_MS
+    )
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+  })
+
+  it('stops handshaking once the device reports it cannot attest', async () => {
+    mockIsSupported.mockResolvedValue(false)
+
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+    const callsAfterUnsupported = mockIsSupported.mock.calls.length
+
+    // Terminal: no timer should keep waking up to ask a device that will never
+    // have an answer.
+    await jest.advanceTimersByTimeAsync(60 * 60 * 1000)
+    await flush()
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+    expect(mockIsSupported.mock.calls.length).toBe(callsAfterUnsupported)
+  })
+
+  describe('attestedJsonHeaders', () => {
+    it('attaches the token every gated call site needs', async () => {
+      mockSuccessfulHandshake(600)
+      initAttestation()
+      await flush()
+
+      await expect(attestedJsonHeaders()).resolves.toEqual({
+        'Content-Type': 'application/json',
+        'x-attestation-token': 'jwt-token'
+      })
+    })
+
+    it('omits the header rather than faking one when no token is live', async () => {
+      // Terminal `unsupported`: the engine has nothing to offer and never will.
+      mockIsSupported.mockResolvedValue(false)
+      initAttestation()
+      await flush()
+
+      const headers = await attestedJsonHeaders()
+      expect(headers).toEqual({ 'Content-Type': 'application/json' })
+      expect('x-attestation-token' in headers).toBe(false)
+    })
+  })
+
+  it('does not retire the engine when a watchdog-retired isSupported finally says no', async () => {
+    // Attempt A hangs inside `isSupported()`, the one `undefined` return that
+    // can outlive the watchdog (the `EdgeAttestation == null` return is
+    // synchronous and settles long before it can fire).
+    let answerHungIsSupported: ((value: boolean) => void) | undefined
+    mockIsSupported.mockImplementationOnce(
+      async () =>
+        await new Promise<boolean>(resolve => {
+          answerHungIsSupported = resolve
+        })
+    )
+
+    initAttestation()
+    await flush()
+
+    // The watchdog retires A and frees the lock.
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.HANDSHAKE_WATCHDOG_MS
+    )
+
+    // Attempt B then runs and caches a live token.
+    mockIsSupported.mockResolvedValue(true)
+    mockSuccessfulHandshake(600)
+    await jest.advanceTimersByTimeAsync(
+      attestationTimingForTests.FAILURE_BACKOFF_MS
+    )
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+
+    // A finally answers "this device cannot attest". It is a retired attempt,
+    // so it has no standing to retire an engine B is now driving - and nothing
+    // but `resetAttestationForTests` would ever undo that.
+    answerHungIsSupported?.(false)
+    await flush()
+
+    const callsBeforeRefresh = mockIsSupported.mock.calls.length
+
+    // The engine must still refresh B's token. Without the generation guard it
+    // sits inert here, and every gated call goes out unattested once the cached
+    // token expires.
+    await jest.advanceTimersByTimeAsync(600 * 1000)
+    await flush()
+    expect(mockIsSupported.mock.calls.length).toBeGreaterThan(
+      callsBeforeRefresh
+    )
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+  })
+
+  it('gives a non-servable cache no retry floor (Phase 5 retryFloorMs)', async () => {
+    // A token past the skew margin is still sitting in `cachedToken`, but
+    // callers must not see it. The retry floor exists to protect a *servable*
+    // late token's refresh schedule; without the `!canServeToken()` guard the
+    // helper returns a large negative delay instead of zero. Math.max with the
+    // backoff hides that in the timer path, so this asserts the helper itself.
+    const { CLOCK_SKEW_MS } = attestationTimingForTests
+    const lifetimeSec = 30
+    mockSuccessfulHandshake(lifetimeSec)
+
+    initAttestation()
+    await flush()
+    await expect(getAttestationToken()).resolves.toBe('jwt-token')
+
+    await jest.advanceTimersByTimeAsync(lifetimeSec * 1000 - CLOCK_SKEW_MS + 1)
+    await flush()
+    await expect(getAttestationToken()).resolves.toBeUndefined()
+    expect(attestationTimingForTests.retryFloorMs()).toBe(0)
+  })
+
+  it('stays armed when a retry tick lands short of the backoff', async () => {
+    const { FAILURE_BACKOFF_MS } = attestationTimingForTests
+    mockCheapFailingHandshake()
+
+    initAttestation()
+    await flush()
+    const callsAfterFailure = mockFetchInfo.mock.calls.length
+
+    // The retry is armed for exactly the backoff and the gate measures it
+    // against the wall clock, so a backwards clock step (NTP) can make the tick
+    // arrive a hair early. Declining it must re-arm, not strand the engine.
+    const realNow = Date.now
+    const nowSpy = jest.spyOn(Date, 'now')
+    nowSpy.mockImplementation(() => realNow() - 1)
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    nowSpy.mockRestore()
+
+    await jest.advanceTimersByTimeAsync(FAILURE_BACKOFF_MS)
+    await flush()
+    expect(mockFetchInfo.mock.calls.length).toBeGreaterThan(callsAfterFailure)
+  })
+
+  it('spaces out handshakes when the server mints very short-lived tokens', async () => {
+    // Pinned as a literal on purpose. Deriving the bound from the constant under
+    // test makes the assertion vacuous exactly when the constant is wrong:
+    // at zero, `WINDOW_MS / MIN_HANDSHAKE_SPACING_MS` is Infinity, which every
+    // possible count satisfies. Retuning the floor has to change this line.
+    const EXPECTED_SPACING_MS = 30 * 1000
+    expect(attestationTimingForTests.MIN_HANDSHAKE_SPACING_MS).toBe(
+      EXPECTED_SPACING_MS
+    )
+
+    const POLL_MS = 3000
+    const WINDOW_MS = 5 * 60 * 1000
+    // A lifetime this short is one operator edit away - the info server reads it
+    // from a synced config doc - and it leaves most of every cycle with nothing
+    // cached. A success clears the failure backoff, so nothing else holds the
+    // gated path back.
+    mockSuccessfulHandshake(10)
+
+    // Timed at the platform attestation rather than the challenge fetch: with no
+    // enrolled key each handshake fetches a challenge twice, so challenges do not
+    // map one-to-one onto handshakes. This is also the call that spends the
+    // rate-limited resource, which is what the floor exists to protect.
+    const attestationsAt: number[] = []
+    mockGetAttestation.mockImplementation(async () => {
+      attestationsAt.push(Date.now())
+      return { keyId: 'key', attestation: 'att', bundleId: 'co.edgesecure.app' }
+    })
+
+    initAttestation()
+    await flush()
+
+    const gated: Array<Promise<string | undefined>> = []
+    for (let elapsed = 0; elapsed < WINDOW_MS; elapsed += POLL_MS) {
+      gated.push(getAttestationToken())
+      await jest.advanceTimersByTimeAsync(POLL_MS)
+    }
+    await flush()
+    await Promise.all(gated)
+
+    // Assert the observed spacing, not just a count. A count bound is also
+    // satisfied by the refresh floor on its own, so it would not notice the
+    // spacing logic disappearing - which is the whole point of this test.
+    expect(attestationsAt.length).toBeGreaterThan(1)
+    const gaps = attestationsAt
+      .slice(1)
+      .map((at, i) => at - attestationsAt[i])
+      .sort((a, b) => a - b)
+    expect(gaps[0]).toBeGreaterThanOrEqual(EXPECTED_SPACING_MS)
+    // And still far below the poll rate, so callers cannot drive the handshake.
+    expect(attestationsAt.length).toBeLessThan(WINDOW_MS / POLL_MS / 4)
+  })
+
+  describe('a handshake the watchdog has retired', () => {
+    /**
+     * Handshake A holds an enrolled key and stalls on its assert POST until the
+     * watchdog retires it. B then re-enrolls and caches a good token. Only then
+     * does A's assert answer 401.
+     */
+    const runRetiredAssertRejection = async (): Promise<void> => {
+      mockGenerateAssertion.mockResolvedValue({
+        keyId: 'K1',
+        assertion: 'assert-1',
+        bundleId: 'co.edgesecure.app'
+      })
+      mockSignChallenge.mockResolvedValue({ keyId: 'K1', signature: 'sig-1' })
+
+      let answerStalledAssert: ((value: MockResponse) => void) | undefined
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-A' })
+        }
+        if (path.endsWith('/assert')) {
+          return await new Promise<MockResponse>(resolve => {
+            answerStalledAssert = resolve
+          })
+        }
+        throw new Error(`unexpected path ${path}`)
+      })
+
+      initAttestation()
+      await flush()
+      expect(answerStalledAssert).toBeDefined()
+
+      await jest.advanceTimersByTimeAsync(
+        attestationTimingForTests.HANDSHAKE_WATCHDOG_MS
+      )
+      await flush()
+
+      // B: the server rejects its assertion, so it clears the key, re-attests,
+      // and mints a good token.
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-B' })
+        }
+        if (path.endsWith('/assert')) return jsonResponse({}, false, 401)
+        if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+          return jsonResponse({
+            token: 'jwt-B',
+            expiresIn: 3600
+          })
+        }
+        throw new Error(`unexpected path ${path}`)
+      })
+      await jest.advanceTimersByTimeAsync(
+        attestationTimingForTests.FAILURE_BACKOFF_MS
+      )
+      await flush()
+      await expect(getAttestationToken()).resolves.toBe('jwt-B')
+
+      answerStalledAssert?.(jsonResponse({}, false, 401))
+      await flush()
+    }
+
+    it('does not clear the key a newer handshake enrolled', async () => {
+      await runRetiredAssertRejection()
+      // B cleared the untrusted key once. A's late 401 says nothing about the
+      // key B enrolled afterwards, and wiping it would force a needless
+      // re-attestation on the next handshake.
+      expect(mockClearKey.mock.calls.length).toBe(1)
+    })
+
+    it('does not burn a platform attestation', async () => {
+      await runRetiredAssertRejection()
+      // Nobody is waiting on A's result, so spending rate-limited quota on it
+      // buys nothing.
+      expect(mockGetAttestation.mock.calls.length).toBe(1)
+    })
+
+    it('leaves the live token alone', async () => {
+      await runRetiredAssertRejection()
+      await expect(getAttestationToken()).resolves.toBe('jwt-B')
+    })
+  })
+
+  describe('an unusable token from the assert fast path', () => {
+    beforeEach(() => {
+      mockGenerateAssertion.mockResolvedValue({
+        keyId: 'K1',
+        assertion: 'assert-1',
+        bundleId: 'co.edgesecure.app'
+      })
+      mockSignChallenge.mockResolvedValue({ keyId: 'K1', signature: 'sig-1' })
+    })
+
+    const mockAssertMint = (body: unknown): void => {
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-1' })
+        }
+        if (path.endsWith('/assert')) return jsonResponse(body)
+        if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+          return jsonResponse(body)
+        }
+        throw new Error(`unexpected path ${path}`)
+      })
+    }
+
+    it('fails into backoff instead of re-attesting when expiresIn is too short', async () => {
+      const { MAX_BACKOFF_MS } = attestationTimingForTests
+      mockAssertMint({ token: 'jwt-stale', expiresIn: 1 })
+
+      initAttestation()
+      await flush()
+
+      // The assertion itself succeeded and cost nothing rate-limited. A bad mint
+      // is a server problem that re-attesting cannot fix, so falling through to
+      // a full attestation would only spend quota to hide it - once per backoff
+      // window, for as long as the app is open.
+      expect(mockGetAttestation.mock.calls.length).toBe(0)
+      for (let i = 0; i < 6; i++) {
+        await jest.advanceTimersByTimeAsync(MAX_BACKOFF_MS)
+        await flush()
+      }
+      expect(mockGetAttestation.mock.calls.length).toBe(0)
+    })
+
+    it('fails into backoff instead of re-attesting when expiresIn is malformed', async () => {
+      mockAssertMint({ token: 'jwt-stale', expiresIn: 'soon' })
+
+      initAttestation()
+      await flush()
+      expect(mockGetAttestation.mock.calls.length).toBe(0)
+    })
+
+    it.each([500, 502, 503, 429])(
+      'keeps the enrolled key when the assert endpoint answers %i',
+      async (status: number) => {
+        mockFetchInfo.mockImplementation(async (path: string) => {
+          if (path === 'v1/attest/challenge') {
+            return jsonResponse({ challenge: 'chal-1' })
+          }
+          if (path.endsWith('/assert')) return jsonResponse({}, false, status)
+          throw new Error(`unexpected path ${path}`)
+        })
+
+        initAttestation()
+        await flush()
+
+        // The server failed to answer, or throttled us - neither is a judgement
+        // on the key. Discarding it here would have the whole fleet re-attest
+        // during an info-server outage, which is a fleet-wide run at the
+        // platform rate limits caused by something that fixes itself.
+        expect(mockClearKey.mock.calls.length).toBe(0)
+        expect(mockGetAttestation.mock.calls.length).toBe(0)
+      }
+    )
+
+    it('re-attests when the server judges the key untrusted', async () => {
+      // The contrast case: 4xx means the server looked at the key and said no.
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-1' })
+        }
+        if (path.endsWith('/assert')) return jsonResponse({}, false, 403)
+        if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+          return jsonResponse({
+            token: 'jwt-reattested',
+            expiresIn: 600
+          })
+        }
+        throw new Error(`unexpected path ${path}`)
+      })
+
+      initAttestation()
+      await flush()
+      expect(mockClearKey.mock.calls.length).toBe(1)
+      await expect(getAttestationToken()).resolves.toBe('jwt-reattested')
+    })
+
+    it('does not re-attest when the native signature times out', async () => {
+      const timeout = Object.assign(new Error('assertion timed out'), {
+        code: 'timeout'
+      })
+      mockGenerateAssertion.mockRejectedValue(timeout)
+      mockSignChallenge.mockRejectedValue(timeout)
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-1' })
+        }
+        throw new Error(`unexpected path ${path}`)
+      })
+
+      initAttestation()
+      await flush()
+
+      // A timeout says nothing about whether the key can sign, so the cheap path
+      // deserves another try rather than a rate-limited attestation.
+      expect(mockGetAttestation.mock.calls.length).toBe(0)
+    })
+
+    it('does not re-attest when Android cannot get the Keystore lock', async () => {
+      // Android's own code for the same idea, reported when `tryLock` gives up.
+      // It has to be transient here too: escalating would spend an attestation
+      // to replace a key that signs perfectly well and was merely contended.
+      const lockTimeout = Object.assign(
+        new Error('Timed out waiting for the Keystore lock'),
+        { code: 'lockTimeout' }
+      )
+      mockGenerateAssertion.mockRejectedValue(lockTimeout)
+      mockSignChallenge.mockRejectedValue(lockTimeout)
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-1' })
+        }
+        throw new Error(`unexpected path ${path}`)
+      })
+
+      initAttestation()
+      await flush()
+
+      expect(mockGetAttestation.mock.calls.length).toBe(0)
+    })
+
+    it('re-attests when the native signature reports no usable key', async () => {
+      mockGenerateAssertion.mockRejectedValue(
+        Object.assign(new Error('no key'), { code: 'noKey' })
+      )
+      mockSignChallenge.mockRejectedValue(
+        Object.assign(new Error('no key'), { code: 'noKey' })
+      )
+      mockSuccessfulHandshake(600)
+
+      initAttestation()
+      await flush()
+      expect(mockGetAttestation.mock.calls.length).toBe(1)
+      await expect(getAttestationToken()).resolves.toBe('jwt-token')
+    })
+
+    it('still re-attests when the server rejects the assertion', async () => {
+      // The contrast case: a rejection *is* about the key, so re-enrolling is
+      // the right answer and the fast path must still fall through.
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-1' })
+        }
+        if (path.endsWith('/assert')) return jsonResponse({}, false, 401)
+        if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+          return jsonResponse({
+            token: 'jwt-reattested',
+            expiresIn: 600
+          })
+        }
+        throw new Error(`unexpected path ${path}`)
+      })
+
+      initAttestation()
+      await flush()
+      expect(mockClearKey.mock.calls.length).toBe(1)
+      expect(mockGetAttestation.mock.calls.length).toBe(1)
+      await expect(getAttestationToken()).resolves.toBe('jwt-reattested')
+    })
+
+    it('names the rejected key when asking native to clear it', async () => {
+      mockGenerateAssertion.mockResolvedValue({
+        keyId: 'key-rejected',
+        assertion: 'assertion'
+      })
+      mockSignChallenge.mockResolvedValue({
+        keyId: 'key-rejected',
+        signature: 'signature'
+      })
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-1' })
+        }
+        if (path.endsWith('/assert')) return jsonResponse({}, false, 401)
+        if (path === 'v1/attest/apple' || path === 'v1/attest/android') {
+          return jsonResponse({
+            token: 'jwt-reattested',
+            expiresIn: 600
+          })
+        }
+        throw new Error(`unexpected path ${path}`)
+      })
+
+      initAttestation()
+      await flush()
+
+      // Native can sit on this call for a long time behind a slow key
+      // operation. Passing the id scopes the delete to the key the server
+      // actually refused, so it cannot take out a replacement a newer handshake
+      // enrolled while it waited.
+      expect(mockClearKey.mock.calls[0]).toStrictEqual(['key-rejected'])
+    })
+  })
+})

--- a/src/__tests__/util/attestationNativeBridge.test.ts
+++ b/src/__tests__/util/attestationNativeBridge.test.ts
@@ -1,0 +1,231 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * The Swift `EdgeAttestation` class is exposed to React Native through a
+ * hand-written Objective-C bridge, and the two declare the same selectors
+ * independently. Nothing else in the repo notices when they drift: `swiftc` does
+ * not read the bridge, and `RCT_EXTERN_METHOD` mismatches are not build errors -
+ * React Native discovers them at runtime, on the device, as a selector that does
+ * not resolve. For `clearKey` that would silently disable the only path that
+ * recovers from a key the server has rejected.
+ */
+describe('iOS attestation native bridge', () => {
+  const iosDir = join(__dirname, '../../../ios/edge')
+  const swiftSource = readFileSync(
+    join(iosDir, 'EdgeAttestation.swift'),
+    'utf8'
+  )
+  const objcSource = readFileSync(join(iosDir, 'EdgeAttestation.m'), 'utf8')
+
+  /** Selectors the Swift class exports, e.g. `clearKey:resolver:rejecter:`. */
+  const swiftSelectors = (source: string): string[] => {
+    const found = source.match(/@objc\(([^)]+)\)/g) ?? []
+    return (
+      found
+        .map(match => match.slice('@objc('.length, -1))
+        // `@objc(EdgeAttestation)` names the class, not a method.
+        .filter(selector => selector.includes(':'))
+        .sort()
+    )
+  }
+
+  /**
+   * Selectors the Objective-C bridge declares. Each `RCT_EXTERN_METHOD` body is
+   * the method name followed by argument labels interleaved with parenthesised
+   * types, so dropping every `(Type *)argName` leaves just the selector parts.
+   */
+  const objcSelectors = (source: string): string[] => {
+    const marker = 'RCT_EXTERN_METHOD('
+    const selectors: string[] = []
+    let index = source.indexOf(marker)
+    while (index !== -1) {
+      let depth = 1
+      let cursor = index + marker.length
+      while (cursor < source.length && depth > 0) {
+        if (source[cursor] === '(') depth += 1
+        if (source[cursor] === ')') depth -= 1
+        cursor += 1
+      }
+      const body = source.slice(index + marker.length, cursor - 1)
+      selectors.push(
+        body.replace(/\(\s*[^)]*\)\s*\w+/g, '').replace(/\s+/g, '')
+      )
+      index = source.indexOf(marker, cursor)
+    }
+    return selectors.sort()
+  }
+
+  it('declares every Swift selector with matching arity', () => {
+    const swift = swiftSelectors(swiftSource)
+    expect(swift.length).toBeGreaterThan(0)
+    expect(objcSelectors(objcSource)).toStrictEqual(swift)
+  })
+
+  it('passes clearKey a key id, so JS can scope the delete', () => {
+    // The check above only sees the two files disagreeing, so it would not
+    // notice clearKey losing its keyId in both at once. Pin the argument
+    // itself: without it, native deletes whatever key happens to be enrolled
+    // when the call finally runs, which may be a newer one.
+    expect(swiftSelectors(swiftSource)).toContain('clearKey:resolver:rejecter:')
+  })
+})
+
+/**
+ * Three timeouts across three files have to stay in a particular order, and each
+ * file documents its own end of the bargain without being able to check it. They
+ * are read out of the sources here rather than imported, because two of them are
+ * native and none of them is exported.
+ */
+describe('attestation timeout ordering', () => {
+  const root = join(__dirname, '../../..')
+  const source = (path: string): string =>
+    readFileSync(join(root, path), 'utf8')
+
+  /** Reads `const NAME = 90 * 1000` and multiplies out the literals. */
+  const msConstant = (text: string, name: string): number => {
+    const match = new RegExp(`const ${name} = ([0-9 *]+)`).exec(text)
+    if (match == null) throw new Error(`could not read ${name}`)
+    return match[1]
+      .split('*')
+      .reduce((total, part) => total * Number(part.trim()), 1)
+  }
+
+  const engine = source('src/util/attestation.ts')
+  const watchdogMs = msConstant(engine, 'HANDSHAKE_WATCHDOG_MS')
+
+  it('gives up on a hung Keystore lock before the JS watchdog fires', () => {
+    // Android rejects with `lockTimeout` when it cannot take the lock, and the
+    // JS engine reads that as proof no attestation was spent, so it retries the
+    // cheap path without growing the backoff. Landing after the watchdog throws
+    // that away: the attempt is already retired, so the rejection arrives to a
+    // handler that only un-counts, and the engine has spent a whole watchdog
+    // interval learning nothing.
+    const kotlin = source(
+      'android/app/src/main/java/co/edgesecure/app/EdgeAttestationModule.kt'
+    )
+    const match = /LOCK_TIMEOUT_SECONDS = (\d+)L/.exec(kotlin)
+    if (match == null) throw new Error('could not read LOCK_TIMEOUT_SECONDS')
+    expect(Number(match[1]) * 1000).toBeLessThan(watchdogMs)
+  })
+
+  it('reports every failure to take the Keystore lock as unspent', () => {
+    // Failing to acquire the lock is the one native failure that proves no
+    // platform attestation was spent, and the engine relies on that to keep a
+    // merely contended device from backing off as though it were burning quota.
+    // Every exit from the acquisition therefore has to carry a code the engine
+    // recognises. A new one carrying anything else would be silent: JS cannot
+    // tell an unfamiliar code from a genuine failure, so it would assume the
+    // expensive case, which is the safe assumption but the wrong answer here.
+    const kotlin = source(
+      'android/app/src/main/java/co/edgesecure/app/EdgeAttestationModule.kt'
+    )
+    const start = kotlin.indexOf('private fun withKeystoreLock')
+    if (start === -1) throw new Error('could not find withKeystoreLock')
+    const rest = kotlin.slice(start + 1)
+    const end = rest.search(/\n {2}(private fun|@ReactMethod)/)
+    const acquisition = end === -1 ? rest : rest.slice(0, end)
+
+    const engineSrc = source('src/util/attestation.ts')
+    const unspent = /const UNSPENT_NATIVE_CODES = new Set\(\[([^\]]*)\]\)/.exec(
+      engineSrc
+    )
+    if (unspent == null) throw new Error('could not read UNSPENT_NATIVE_CODES')
+    const known = [...unspent[1].matchAll(/'([^']+)'/g)].map(match => match[1])
+
+    // Codes come from the AttestCode enums, not string literals at reject sites.
+    const swiftCodes = extractSwiftAttestCodes(
+      source('ios/edge/EdgeAttestation.swift')
+    )
+    const kotlinCodes = extractKotlinAttestCodes(kotlin)
+    const emitted = [...new Set([...swiftCodes, ...kotlinCodes])]
+
+    const acquisitionCodes = [
+      ...acquisition.matchAll(/AttestCode\.(\w+)\.code/g)
+    ].map(match => {
+      const entry = new RegExp(`${match[1]}\\("([^"]+)"\\)`).exec(kotlin)
+      if (entry == null) {
+        throw new Error(`could not resolve AttestCode.${match[1]}`)
+      }
+      return entry[1]
+    })
+
+    expect(acquisitionCodes.length).toBeGreaterThan(0)
+    expect(
+      acquisitionCodes.filter(code => !known.includes(code))
+    ).toStrictEqual([])
+
+    // And the other way round, which is where a typo would land: a code in the
+    // set that no module emits never matches, so the engine quietly falls back
+    // to assuming quota was spent - the same wrong answer, reached from the
+    // other side, and just as invisible.
+    expect(known.filter(code => !emitted.includes(code))).toStrictEqual([])
+  })
+
+  it('declares every JS-routed native code in a platform enum', () => {
+    // TRANSIENT_NATIVE_CODES / UNSPENT_NATIVE_CODES are the JS vocabulary for
+    // native failures. Every member must appear in one of the two AttestCode
+    // enums so a rename on either side is caught here rather than at runtime.
+    const engineSrc = source('src/util/attestation.ts')
+    const readSet = (name: string): string[] => {
+      const match = new RegExp(
+        `const ${name} = new Set\\(\\[([^\\]]*)\\]\\)`
+      ).exec(engineSrc)
+      if (match == null) throw new Error(`could not read ${name}`)
+      return [...match[1].matchAll(/'([^']+)'/g)].map(m => m[1])
+    }
+    const routed = [
+      ...readSet('TRANSIENT_NATIVE_CODES'),
+      ...readSet('UNSPENT_NATIVE_CODES')
+    ]
+    const emitted = [
+      ...extractSwiftAttestCodes(source('ios/edge/EdgeAttestation.swift')),
+      ...extractKotlinAttestCodes(
+        source(
+          'android/app/src/main/java/co/edgesecure/app/EdgeAttestationModule.kt'
+        )
+      )
+    ]
+    expect(routed.filter(code => !emitted.includes(code))).toStrictEqual([])
+  })
+
+  it('holds the App Attest queue below the JS watchdog, not past it', () => {
+    // iOS must answer before the JS watchdog so a hung call arrives as a real
+    // rejection rather than an abandoned attempt. Below the watchdog, slow-but
+    // healthy attestations still complete; above it, JS would routinely retire
+    // live native work and manufacture overlapping handshakes as normal.
+    const swift = source('ios/edge/EdgeAttestation.swift')
+    const match = /operationTimeout[^=]*= \.seconds\((\d+)\)/.exec(swift)
+    if (match == null) throw new Error('could not read operationTimeout')
+    expect(Number(match[1]) * 1000).toBeLessThan(watchdogMs)
+  })
+
+  it('leaves room to recover before the token expires', () => {
+    // A hung refresh must still recover before the cached token dies. Worst
+    // case is watchdog + failure backoff + one handshake, so the lead has to
+    // cover at least the first two.
+    const failureBackoffMs = msConstant(engine, 'FAILURE_BACKOFF_MS')
+    const refreshLeadMs = msConstant(engine, 'REFRESH_LEAD_MS')
+    expect(refreshLeadMs).toBeGreaterThan(watchdogMs + failureBackoffMs)
+  })
+})
+
+/** Cases from `private enum AttestCode: String { case a, b, ... }`. */
+const extractSwiftAttestCodes = (swift: string): string[] => {
+  const start = swift.indexOf('private enum AttestCode: String')
+  if (start === -1) throw new Error('could not find Swift AttestCode enum')
+  const bodyStart = swift.indexOf('{', start)
+  const bodyEnd = swift.indexOf('}', bodyStart)
+  const body = swift.slice(bodyStart + 1, bodyEnd).replace(/\bcase\b/g, ' ')
+  return [...body.matchAll(/\b([A-Za-z][A-Za-z0-9_]*)\b/g)].map(m => m[1])
+}
+
+/** Codes from `private enum class AttestCode(val code: String) { X("x"), ... }`. */
+const extractKotlinAttestCodes = (kotlin: string): string[] => {
+  const start = kotlin.indexOf('private enum class AttestCode')
+  if (start === -1) throw new Error('could not find Kotlin AttestCode enum')
+  const bodyStart = kotlin.indexOf('{', start)
+  const bodyEnd = kotlin.indexOf('}', bodyStart)
+  const body = kotlin.slice(bodyStart + 1, bodyEnd)
+  return [...body.matchAll(/\(\s*"([^"]+)"\s*\)/g)].map(m => m[1])
+}

--- a/src/components/scenes/RampSelectOptionScene.tsx
+++ b/src/components/scenes/RampSelectOptionScene.tsx
@@ -32,7 +32,7 @@ import { SectionHeader } from '../common/SectionHeader'
 import { SceneContainer } from '../layout/SceneContainer'
 import { CardListModal } from '../modals/CardListModal'
 import { ShimmerCard } from '../progress-indicators/ShimmerCard'
-import { Airship } from '../services/AirshipInstance'
+import { Airship, showError } from '../services/AirshipInstance'
 import { cacheStyles, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 
@@ -107,6 +107,14 @@ export const RampSelectOptionScene: React.FC<Props> = (props: Props) => {
         await quote.approveQuote({
           coreWallet: rampQuoteRequest.wallet
         })
+      } catch (error) {
+        // Nothing up the chain catches this, so without it the rejection is
+        // unhandled: the spinner clears and the user is left looking at a
+        // button that did nothing. Attestation makes that reachable in ordinary
+        // use, because a gated jwtSign answers 403 whenever no token is
+        // available. Cancellation does not come through here - the plugins
+        // report that themselves - so this only fires on real failures.
+        showError(error)
       } finally {
         setIsApprovingQuote(false)
       }

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -559,6 +559,9 @@ export const asEnvConfig = asObject({
   ENABLE_FIAT_SANDBOX: asOptional(asBoolean, false),
   ENABLE_MAESTRO_BUILD: asOptional(asBoolean, false),
   ENABLE_TEST_SERVERS: asOptional(asBoolean),
+  // Optional override of the info server URL(s), e.g. for pointing a debug build
+  // at a local info server: ["http://127.0.0.1:8008"]. Absent in production.
+  INFO_SERVER: asOptional(asArray(asString)),
   ENABLE_REDUX_PERF_LOGGING: asOptional(asBoolean, false),
   LOG_SERVER: asNullable(
     asObject({

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -714,6 +714,9 @@ const strings = {
   string_close_cap: 'Close',
   string_cancel: 'CANCEL',
   string_ok_cap: 'OK',
+  clock_skew_title: 'Device clock is wrong',
+  clock_skew_message:
+    'Your device time differs from our servers by more than two minutes. Turn on automatic date & time in your system settings so one-time codes and other time-based features keep working.',
   string_forget: 'Forget',
   string_delete: 'Delete',
   string_keep: 'Keep',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -538,6 +538,8 @@
   "string_close_cap": "Close",
   "string_cancel": "CANCEL",
   "string_ok_cap": "OK",
+  "clock_skew_title": "Device clock is wrong",
+  "clock_skew_message": "Your device time differs from our servers by more than two minutes. Turn on automatic date & time in your system settings so one-time codes and other time-based features keep working.",
   "string_forget": "Forget",
   "string_delete": "Delete",
   "string_keep": "Keep",

--- a/src/plugins/gui/providers/banxaProvider.ts
+++ b/src/plugins/gui/providers/banxaProvider.ts
@@ -17,6 +17,7 @@ import { lstrings } from '../../../locales/strings'
 import { getExchangeDenom } from '../../../selectors/DenominationSelectors'
 import type { FiatProviderLink } from '../../../types/DeepLinkTypes'
 import type { StringMap } from '../../../types/types'
+import { attestedJsonHeaders } from '../../../util/attestation'
 import { CryptoAmount } from '../../../util/CryptoAmount'
 import { fetchInfo } from '../../../util/network'
 import { consify, removeIsoPrefix } from '../../../util/utils'
@@ -1019,11 +1020,14 @@ const generateHmac = async (
     `v1/createHmac/${hmacUser}`,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: await attestedJsonHeaders(),
       body
     },
     3000
   )
+  // A missing/rejected attestation token returns 403 here; fail loudly rather
+  // than parsing an error body as a signature.
+  if (!response.ok) throw new Error('Banxa failed to create HMAC signature')
   const reply = await response.json()
   const { signature } = asInfoCreateHmacResponse(reply)
 

--- a/src/plugins/gui/providers/simplexProvider.ts
+++ b/src/plugins/gui/providers/simplexProvider.ts
@@ -5,6 +5,7 @@ import { asArray, asEither, asNumber, asObject, asString } from 'cleaners'
 import { showError } from '../../../components/services/AirshipInstance'
 import { lstrings } from '../../../locales/strings'
 import type { FiatProviderLink } from '../../../types/DeepLinkTypes'
+import { attestedJsonHeaders } from '../../../util/attestation'
 import { CryptoAmount } from '../../../util/CryptoAmount'
 import { fetchInfo } from '../../../util/network'
 import { asFiatPaymentType, type FiatPaymentType } from '../fiatPluginTypes'
@@ -211,7 +212,7 @@ export const simplexProvider: FiatProviderFactory = {
 
     let simplexUserId = await store
       .getItem('simplex_user_id')
-      .catch(e => undefined)
+      .catch((e: unknown) => undefined)
     if (simplexUserId == null || simplexUserId === '') {
       simplexUserId = await makeUuid()
       await store.setItem('simplex_user_id', simplexUserId)
@@ -248,8 +249,8 @@ export const simplexProvider: FiatProviderFactory = {
         if (isDailyCheckDue(lastChecked)) {
           const response = await fetch(
             `https://api.simplexcc.com/v2/supported_fiat_currencies?public_key=${publicKey}`
-          ).catch(e => undefined)
-          if (!response?.ok) return allowedCurrencyCodes
+          ).catch((e: unknown) => undefined)
+          if (response?.ok !== true) return allowedCurrencyCodes
           const result = await response.json()
 
           const fiatCurrencies = asSimplexFiatCurrencies(result)
@@ -259,8 +260,8 @@ export const simplexProvider: FiatProviderFactory = {
 
           const response2 = await fetch(
             `https://api.simplexcc.com/v2/supported_countries?public_key=${publicKey}&payment_methods=credit_card`
-          ).catch(e => undefined)
-          if (response2 == null || !response.ok)
+          ).catch((e: unknown) => undefined)
+          if (response2?.ok !== true)
             throw new Error('Simplex failed to fetch supported countries')
           const result2 = await response2.json()
           const countries = asSimplexCountries(result2)
@@ -294,7 +295,8 @@ export const simplexProvider: FiatProviderFactory = {
           })
         }
 
-        if (!allowedCountryCodes[regionCode.countryCode])
+        const countryEntry = allowedCountryCodes[regionCode.countryCode]
+        if (countryEntry == null || countryEntry === false)
           throw new FiatProviderError({
             providerId,
             errorType: 'regionRestricted',
@@ -313,7 +315,7 @@ export const simplexProvider: FiatProviderFactory = {
         let foundPaymentType = false
         for (const type of paymentTypes) {
           const t = asFiatPaymentType(type)
-          if (allowedPaymentTypes[t]) {
+          if (allowedPaymentTypes[t] === true) {
             foundPaymentType = true
             break
           }
@@ -344,17 +346,18 @@ export const simplexProvider: FiatProviderFactory = {
           'v1/jwtSign/simplex',
           {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: await attestedJsonHeaders(),
             body: JSON.stringify({
               data: { euid: simplexUserId, ts, soam, socn, tacn }
             })
           },
           3000
-        ).catch(e => {
+        ).catch((e: unknown) => {
           console.log(e)
           return undefined
         })
-        if (!response?.ok) throw new Error('Simplex failed to fetch jwttoken')
+        if (response?.ok !== true)
+          throw new Error('Simplex failed to fetch jwttoken')
         const result = await response.json()
         const { token } = asInfoJwtSignResponse(result)
 
@@ -438,13 +441,17 @@ export const simplexProvider: FiatProviderFactory = {
 
             const response = await fetchInfo(`v1/jwtSign/${jwtTokenProvider}`, {
               method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
+              headers: await attestedJsonHeaders(),
               body: JSON.stringify({ data })
-            }).catch(e => {
+            }).catch((e: unknown) => {
               console.log(e)
               return undefined
             })
-            if (!response?.ok) return
+            // Surface the failure (mirrors the quote-fetch step above) so the
+            // user sees an error instead of the approval silently no-oping. A
+            // 403 here means attestation was required but missing/rejected.
+            if (response?.ok !== true)
+              throw new Error('Simplex failed to sign approval request')
             const result = await response.json()
             const { token } = asInfoJwtSignResponse(result)
 

--- a/src/plugins/ramps/banxa/banxaRampPlugin.ts
+++ b/src/plugins/ramps/banxa/banxaRampPlugin.ts
@@ -22,6 +22,7 @@ import { EDGE_CONTENT_SERVER_URI } from '../../../constants/CdnConstants'
 import { lstrings } from '../../../locales/strings'
 import { getExchangeDenom } from '../../../selectors/DenominationSelectors'
 import type { StringMap } from '../../../types/types'
+import { attestedJsonHeaders } from '../../../util/attestation'
 import { CryptoAmount } from '../../../util/CryptoAmount'
 import { getTokenId } from '../../../util/CurrencyInfoHelpers'
 import { fetchInfo } from '../../../util/network'
@@ -440,11 +441,14 @@ const generateHmac = async (
     `v1/createHmac/${hmacUser}`,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: await attestedJsonHeaders(),
       body
     },
     3000
   )
+  // A missing/rejected attestation token returns 403 here; fail loudly rather
+  // than parsing an error body as a signature.
+  if (!response.ok) throw new Error('Banxa failed to create HMAC signature')
   const reply = await response.json()
   const { signature } = asInfoCreateHmacResponse(reply)
 

--- a/src/plugins/ramps/simplex/simplexRampPlugin.ts
+++ b/src/plugins/ramps/simplex/simplexRampPlugin.ts
@@ -4,6 +4,7 @@ import { Platform } from 'react-native'
 import { showToast } from '../../../components/services/AirshipInstance'
 import { EDGE_CONTENT_SERVER_URI } from '../../../constants/CdnConstants'
 import { lstrings } from '../../../locales/strings'
+import { attestedJsonHeaders } from '../../../util/attestation'
 import { CryptoAmount } from '../../../util/CryptoAmount'
 import { fetchInfo } from '../../../util/network'
 import { makeUuid } from '../../../util/rnUtils'
@@ -295,7 +296,7 @@ export const simplexRampPlugin: RampPluginFactory = (
       `v1/jwtSign/${endpoint}`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: await attestedJsonHeaders(),
         body: JSON.stringify({ data })
       },
       3000

--- a/src/util/attestation.ts
+++ b/src/util/attestation.ts
@@ -1,0 +1,722 @@
+import {
+  asMaybe,
+  asNumber,
+  asObject,
+  asOptional,
+  asString,
+  asUnknown
+} from 'cleaners'
+import { NativeModules, Platform } from 'react-native'
+
+import { showButtonsModal } from '../components/modals/ButtonsModal'
+import { lstrings } from '../locales/strings'
+import { monotonicNow } from './monotonicTime'
+import { fetchInfo } from './network'
+
+/**
+ * Shape of the native EdgeAttestation module (iOS Swift / Android Kotlin).
+ * iOS returns `{ keyId, attestation }`; Android returns `{ certChain }`.
+ */
+interface NativeAttestation {
+  isSupported: () => Promise<boolean>
+  getAttestation: (challenge: string) => Promise<{
+    keyId?: string
+    attestation?: string
+    bundleId?: string
+    certChain?: string[]
+  }>
+  // iOS-only: refresh a token via an App Attest assertion using the stored key.
+  generateAssertion: (challenge: string) => Promise<{
+    keyId?: string
+    assertion?: string
+    bundleId?: string
+  }>
+  // Android-only: refresh a token by signing the challenge with the enrolled
+  // Keystore key.
+  signChallenge: (challenge: string) => Promise<{
+    keyId?: string
+    signature?: string
+  }>
+  // Discard the stored attested key so the next handshake re-attests. Available
+  // on both platforms. Guarded by Platform.OS for the assert paths.
+  //
+  // Takes the key id the caller means to discard, because this call can sit
+  // behind a slow native operation for a long time and the stored key may have
+  // been replaced by a newer handshake before it runs. Native drops the key only
+  // while it is still that one. Omit the id to discard whatever is stored.
+  clearKey: (keyId?: string) => Promise<void>
+}
+
+const EdgeAttestation: NativeAttestation | undefined =
+  NativeModules.EdgeAttestation
+
+interface CachedToken {
+  token: string
+  // Monotonic deadline: `monotonicNow()` when the token was received plus the
+  // server's `expiresIn` lifetime. Compared only against `monotonicNow()`, so a
+  // device date change cannot revive an expired token or kill a live one.
+  expiresMono: number
+}
+
+/** Per-attempt state shared between `runHandshake` and `performHandshake`. */
+interface HandshakeAttempt {
+  // Monotonic id of this attempt, so a stale (watchdog-released) handshake
+  // never mutates shared state that a newer handshake already owns.
+  generation: number
+  // Set once the attempt has consumed a platform attestation. Failures before
+  // that point cost nothing rate-limited, so they must not grow the backoff.
+  usedAttestation: boolean
+  // Whether this attempt has already been counted against the backoff, so a
+  // later verdict that it spent nothing can take that count back - exactly once.
+  countedFailure: boolean
+  // This attempt's watchdog, cleared when it settles so a handshake that
+  // finished does not leave a timer pending for the whole watchdog window.
+  watchdog?: ReturnType<typeof setTimeout>
+}
+
+// Relaunch the handshake this long before the current token expires, so a fresh
+// token is (re)fetched by the background engine well ahead of expiry. Sized
+// above the worst-case recovery path (watchdog + failure backoff + one
+// handshake) so a hung refresh can still be replaced before the cached token
+// dies.
+const REFRESH_LEAD_MS = 5 * 60 * 1000
+// Floor for a scheduled refresh. The delay is derived from the server's
+// `expiresIn`, and the token lifetime is remote config (info server
+// `attestationTokenLifetimeSec`), so treat it as untrusted: a lifetime shorter
+// than REFRESH_LEAD_MS would otherwise schedule the next handshake immediately
+// and spin the engine as fast as the network answers, for every client at once.
+const MIN_REFRESH_MS = 60 * 1000
+// Floor between handshake starts, whatever the previous one returned. The
+// backoff only covers failures and MIN_REFRESH_MS only covers the timer, but a
+// token whose lifetime is shorter than that floor leaves a window where nothing
+// is cached and every gated call would start a handshake of its own - the Banxa
+// order poll runs every 3s. Kept below FAILURE_BACKOFF_MS so it never relaxes
+// the failure backoff, only bounds the success path.
+const MIN_HANDSHAKE_SPACING_MS = 30 * 1000
+// Small skew so a token that is about to expire is treated as unusable.
+const CLOCK_SKEW_MS = 5 * 1000
+// Device vs server wall-clock gap that triggers the once-per-day skew modal.
+// Two minutes is where TOTP and similar schemes start failing reliably; a few
+// seconds of NTP noise must not trigger a modal.
+const CLOCK_WARN_MS = 2 * 60 * 1000
+// Max time getAttestationToken() blocks waiting on the initial handshake.
+const GET_TOKEN_TIMEOUT_MS = 3 * 1000
+// Watchdog: backstop for a bridge that lost the message. Each native module
+// answers first (iOS operationTimeout / Android lock timeout), so this is no
+// longer the primary hang detector - it only fires when native never replies.
+const HANDSHAKE_WATCHDOG_MS = 150 * 1000
+// After a failed handshake, don't retry (and don't make gated callers wait)
+// for this long. Keeps a persistently-failing device from adding 3s of
+// latency to every gated request.
+const FAILURE_BACKOFF_MS = 60 * 1000
+// Ceiling for the backoff once attempts start burning platform attestations.
+// A device the server keeps rejecting must not re-attest every minute for as
+// long as the app is open: Apple App Attest and Android Keystore attestation
+// are both rate-limited, and tripping those limits locks out the devices that
+// could otherwise recover.
+const MAX_BACKOFF_MS = 30 * 60 * 1000
+
+let cachedToken: CachedToken | undefined
+let inFlight: Promise<void> | undefined
+let refreshTimer: ReturnType<typeof setTimeout> | undefined
+// `undefined` means no prior stamp. Initializing these to `0` worked with
+// `Date.now()` (epoch is always far past) but a monotonic clock starts near
+// zero, so `0` would look like "just now" and park every first handshake behind
+// the backoff and spacing floors.
+let lastFailureAt: number | undefined
+let lastHandshakeAt: number | undefined
+// Attempts that burned a platform attestation and still failed, since the last
+// success. Only these grow the backoff (see `failureBackoffMs`). Reset wherever
+// `lastFailureAt` is cleared.
+let consecutiveFailures = 0
+// Monotonic id of the latest handshake attempt; used so a stale (watchdog-
+// released) completion cannot clobber a token a newer handshake already
+// cached (see runHandshake).
+let handshakeGeneration = 0
+// Set once the platform has told us it can never attest: no native module, or
+// `isSupported` resolved false. Terminal, so the engine stops rather than waking
+// up forever on a device that will never produce a token. A native *rejection*
+// is not this - that is a bridge failure, and it retries (see performHandshake).
+let unsupported = false
+// Last time we showed the clock-skew modal, by monotonic clock. At most one
+// warning per day of app uptime so the refresh cadence cannot re-prompt.
+let lastClockWarnAtMono: number | undefined
+
+/** Test-only: clear module state between Jest cases. */
+export const resetAttestationForTests = (): void => {
+  cachedToken = undefined
+  inFlight = undefined
+  if (refreshTimer != null) clearTimeout(refreshTimer)
+  refreshTimer = undefined
+  lastFailureAt = undefined
+  lastHandshakeAt = undefined
+  consecutiveFailures = 0
+  handshakeGeneration = 0
+  unsupported = false
+  lastClockWarnAtMono = undefined
+}
+
+/**
+ * Whether the cached token may be handed to a gated caller right now.
+ *
+ * Lifetime is measured on the monotonic clock from the moment the token arrived,
+ * so a device date change cannot revive an expired token or kill a live one.
+ * The skew margin treats a token about to expire as already unusable - the
+ * request still has to travel and be verified.
+ */
+const canServeToken = (): boolean =>
+  cachedToken != null &&
+  monotonicNow() < cachedToken.expiresMono - CLOCK_SKEW_MS
+
+/**
+ * Warn once per day of app uptime when the device wall clock disagrees with the
+ * server by more than `CLOCK_WARN_MS`. `serverTime` is a UX signal only - it
+ * never feeds lifetimes, backoff, or refresh math.
+ */
+const maybeWarnClockSkew = (serverTime: unknown): void => {
+  if (typeof serverTime !== 'string') return
+  const parsed = Date.parse(serverTime)
+  if (Number.isNaN(parsed)) return
+  if (Math.abs(Date.now() - parsed) < CLOCK_WARN_MS) return
+  if (
+    lastClockWarnAtMono != null &&
+    monotonicNow() - lastClockWarnAtMono < 24 * 60 * 60 * 1000
+  ) {
+    return
+  }
+  lastClockWarnAtMono = monotonicNow()
+  showButtonsModal({
+    title: lstrings.clock_skew_title,
+    message: lstrings.clock_skew_message,
+    buttons: { ok: { label: lstrings.string_ok_cap } }
+  }).catch(() => {})
+}
+
+/**
+ * `serverTime` is advisory: it only drives the clock-skew warning, and is read
+ * before the rest of the body is validated so a malformed response still warns.
+ * Parsed on its own for that reason, rather than as part of the cleaners below.
+ */
+const asServerTimeCue = asObject({ serverTime: asOptional(asUnknown) })
+
+const asChallengeResponse = asObject({ challenge: asString })
+
+const asTokenResponse = asObject({
+  token: asString,
+  expiresIn: asNumber
+})
+
+/** Obtain a single-use challenge from the info server. */
+const fetchChallenge = async (): Promise<string> => {
+  const challengeResponse = await fetchInfo('v1/attest/challenge')
+  if (!challengeResponse.ok) {
+    throw new Error(`challenge request failed: ${challengeResponse.status}`)
+  }
+  const body = await challengeResponse.json()
+  maybeWarnClockSkew(asMaybe(asServerTimeCue)(body)?.serverTime)
+  const { challenge } = asChallengeResponse(body)
+  if (challenge === '') {
+    throw new Error('challenge response missing challenge')
+  }
+  return challenge
+}
+
+/**
+ * Validate an attest/assert token response. Both `token` and `expiresIn` are
+ * validated; a malformed response throws and is treated as a failed handshake
+ * (a lifetime that is non-finite, non-positive, or at or under `CLOCK_SKEW_MS`
+ * would otherwise cache a token no caller can use). The parsed token is returned
+ * to the caller rather than cached directly, so `runHandshake` can drop a stale
+ * (watchdog-released) result before it clobbers a fresher token.
+ *
+ * `serverTime` is read only for the skew warning; it never enters `expiresMono`.
+ */
+const parseTokenResponse = (json: unknown): CachedToken => {
+  maybeWarnClockSkew(asMaybe(asServerTimeCue)(json)?.serverTime)
+  const { token, expiresIn } = asTokenResponse(json)
+  // `asNumber` admits NaN and Infinity, so the range still has to be checked
+  // here: both would otherwise become a nonsense `expiresMono` deadline.
+  if (!Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new Error('attest response missing expiresIn')
+  }
+  const lifetimeMs = expiresIn * 1000
+  // Never cache a token that is not usable on arrival (see `canServeToken`).
+  // Failing the handshake sends it into backoff, where a bad mint costs one
+  // attempt per backoff rather than a refresh loop.
+  if (lifetimeMs <= CLOCK_SKEW_MS) {
+    throw new Error('attest response expiresIn is too short')
+  }
+  return { token, expiresMono: monotonicNow() + lifetimeMs }
+}
+
+/**
+ * Abandon a handshake the watchdog has already retired. `runHandshake` ignores
+ * whatever a retired attempt settles with, so continuing only spends state and
+ * rate-limited quota that a live attempt now owns.
+ */
+const assertCurrent = (attempt: HandshakeAttempt): void => {
+  if (attempt.generation !== handshakeGeneration) {
+    throw new Error('handshake retired by watchdog')
+  }
+}
+
+/**
+ * Whether a non-OK assert response means the server actually judged our enrolled
+ * key and found it untrusted, as opposed to failing to answer at all. A 5xx is
+ * the info server (or Couch behind it) being down and a 429 is it throttling;
+ * neither says anything about the key. Reading those as a rejection would have
+ * every device in the fleet discard its key and re-attest during an outage - a
+ * fleet-wide run at the platform rate limits, caused by something that fixes
+ * itself.
+ */
+const isKeyRejection = (status: number): boolean =>
+  status < 500 && status !== 429
+
+// Native rejection codes that say nothing about whether the enrolled key can
+// sign, so the cheap path deserves another try instead of a rate-limited
+// attestation. Everything else (`noKey`, `invalidKey`, a native signing failure)
+// means the key is unusable, and re-enrolling is the only way forward.
+const TRANSIENT_NATIVE_CODES = new Set(['timeout', 'lockTimeout'])
+
+// Native rejection codes proving the platform attestation never ran, so the
+// attempt spent nothing rate-limited even though it had reached the step that
+// normally would. Android reports this when it gives up waiting for the Keystore
+// lock, before the lock is held and before any key is generated.
+//
+// iOS's `timeout` is deliberately absent: it fires while waiting on attestKey's
+// callback, so App Attest did start and Apple may already have counted it.
+// Assuming otherwise there would under-count real quota burn, which is the
+// expensive mistake; assuming it here would over-count a failure that cost
+// nothing and push a merely contended device toward MAX_BACKOFF_MS.
+const UNSPENT_NATIVE_CODES = new Set(['lockTimeout'])
+
+/**
+ * Refresh the token with the enrolled key: an assertion on iOS, a challenge
+ * signature on Android. Both are local signatures - no Apple/Google round trip
+ * and no new key - so this is the path every handshake after enrollment takes.
+ *
+ * Returns `undefined` when there is no usable enrolled key and the caller should
+ * fall back to a full platform attestation. That fallback is the expensive,
+ * rate-limited path, so it is reserved for the cases it can actually fix: a key
+ * that cannot sign, and a key the server has judged and rejected. Everything
+ * else - an unusable 200 body, a server that failed to answer, a native failure
+ * that says nothing about the key - throws and fails the handshake into backoff,
+ * because re-attesting cannot fix any of them and would spend quota every retry
+ * to hide them.
+ */
+const refreshWithEnrolledKey = async (
+  native: NativeAttestation,
+  attempt: HandshakeAttempt,
+  challenge: string
+): Promise<CachedToken | undefined> => {
+  const isIos = Platform.OS === 'ios'
+
+  let body: unknown
+  // Remembered outside the try so a rejection below can name the exact key the
+  // server refused, rather than asking native to discard whatever it holds.
+  let signedKeyId: string | undefined
+  try {
+    if (isIos) {
+      const { keyId, assertion } = await native.generateAssertion(challenge)
+      signedKeyId = keyId
+      body = { keyId, assertion, challenge }
+    } else {
+      const { keyId, signature } = await native.signChallenge(challenge)
+      signedKeyId = keyId
+      body = { keyId, signature, challenge }
+    }
+  } catch (error) {
+    const code = (error as { code?: unknown } | undefined)?.code
+    if (typeof code === 'string' && TRANSIENT_NATIVE_CODES.has(code)) {
+      throw error
+    }
+    // noKey / invalidKey / native signing failure: fall back to full attestation.
+    console.log('[attestation] assertion unavailable:', String(error))
+    return undefined
+  }
+
+  const response = await fetchInfo(
+    isIos ? 'v1/attest/apple/assert' : 'v1/attest/android/assert',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    }
+  )
+  if (response.ok) return parseTokenResponse(await response.json())
+  if (!isKeyRejection(response.status)) {
+    throw new Error(`assert request failed: ${response.status}`)
+  }
+
+  // Server rejected the assertion: the enrolled key is no longer trusted, so any
+  // previously-minted token is suspect too. Drop it now so gated callers do not
+  // keep sending a token the server already rejects while re-enrollment is in
+  // progress; discard the key and re-attest. Stop if the watchdog already retired
+  // this attempt - the key and token belong to a live handshake now, and clearing
+  // them would force it into a needless re-attestation.
+  assertCurrent(attempt)
+  cachedToken = undefined
+  console.warn(
+    `[attestation] assertion rejected (${response.status}); re-attesting`
+  )
+  // Name the key the server actually refused. This call can queue behind a slow
+  // native operation, and by the time it runs a newer handshake may have enrolled
+  // a replacement - which is working fine and must not be discarded on the
+  // strength of a verdict about its predecessor.
+  await native.clearKey(signedKeyId).catch(() => {})
+  return undefined
+}
+
+/**
+ * Run one attestation handshake and return the fresh token, or `undefined` when
+ * this device can never attest. Never caches directly; the caller commits the
+ * result. Records progress on `attempt` so the caller can tell a stale handshake
+ * from the current one, and a cheap failure from one that burned a platform
+ * attestation.
+ */
+const performHandshake = async (
+  attempt: HandshakeAttempt
+): Promise<CachedToken | undefined> => {
+  // No native module (e.g. unsupported platform / dev environment).
+  if (EdgeAttestation == null) return undefined
+
+  // Let a rejection here throw: that is the bridge failing to answer, not the
+  // device saying no, and swallowing it would retire the engine over a hiccup.
+  // Only an explicit `false` is terminal.
+  if (!(await EdgeAttestation.isSupported())) return undefined
+
+  const isIos = Platform.OS === 'ios'
+
+  // 1. Obtain a single-use challenge from the info server, and try to refresh
+  // with the key enrolled by an earlier handshake.
+  const refreshed = await refreshWithEnrolledKey(
+    EdgeAttestation,
+    attempt,
+    await fetchChallenge()
+  )
+  if (refreshed != null) return refreshed
+
+  // The challenge above was consumed (or expired); fetch a fresh one for the
+  // fallback attestation.
+  const challenge = await fetchChallenge()
+
+  // 2. Produce a platform attestation bound to the challenge. Everything up to
+  // here is a plain info-server round trip (assertions are signed locally), so
+  // only from this point on does a failure cost rate-limited quota - which is
+  // reason enough not to spend it for an attempt nobody is waiting on.
+  assertCurrent(attempt)
+  attempt.usedAttestation = true
+  let native
+  try {
+    native = await EdgeAttestation.getAttestation(challenge)
+  } catch (error) {
+    // The flag has to be set before the call, because a native call that hangs
+    // or never answers may well have spent the attestation. When native tells us
+    // it never got that far, take it back rather than growing the backoff for a
+    // failure that cost nothing.
+    const code = (error as { code?: unknown } | undefined)?.code
+    if (typeof code === 'string' && UNSPENT_NATIVE_CODES.has(code)) {
+      attempt.usedAttestation = false
+    }
+    throw error
+  }
+
+  // 3. Submit the attestation and receive a signed token.
+  const path = isIos ? 'v1/attest/apple' : 'v1/attest/android'
+  const body = isIos
+    ? {
+        keyId: native.keyId,
+        attestation: native.attestation,
+        bundleId: native.bundleId,
+        challenge
+      }
+    : { certChain: native.certChain, challenge }
+
+  const attestResponse = await fetchInfo(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+  if (!attestResponse.ok) {
+    const text = await attestResponse.text()
+    throw new Error(`attest request failed: ${attestResponse.status} ${text}`)
+  }
+  return parseTokenResponse(await attestResponse.json())
+}
+
+const delay = async (ms: number): Promise<void> => {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Arm the background timer, replacing whatever was pending. Every path that
+ * declines to start a handshake has to come through here: the engine has no
+ * other clock, so a path that neither starts a handshake nor arms a timer stalls
+ * it until the next gated call (see `runHandshake`).
+ */
+const armTimer = (delayMs: number): void => {
+  if (refreshTimer != null) clearTimeout(refreshTimer)
+  refreshTimer = setTimeout(() => {
+    runHandshake()
+  }, delayMs)
+}
+
+/**
+ * Schedule the next handshake to run `REFRESH_LEAD_MS` before the given token
+ * expiry, so the background engine keeps a fresh token cached ahead of time,
+ * but never sooner than `MIN_REFRESH_MS`.
+ */
+const scheduleRefresh = (expiresMono: number): void => {
+  armTimer(
+    Math.max(MIN_REFRESH_MS, expiresMono - monotonicNow() - REFRESH_LEAD_MS)
+  )
+}
+
+/**
+ * How long to wait before the next attempt. `FAILURE_BACKOFF_MS` while failures
+ * are cheap (offline, info server down), doubling up to `MAX_BACKOFF_MS` once
+ * attempts start burning rate-limited platform attestations.
+ *
+ * Both the background retry timer and the gate in `runHandshake` use this, so
+ * gated plugin traffic - the Banxa order poll runs every 3s - cannot outpace
+ * the policy. Keeping cheap failures at the floor is what makes that safe: a
+ * user whose network dropped still recovers within a minute of coming back,
+ * while a device the server keeps rejecting backs off. That device would fail
+ * its gated requests either way, so the only thing a faster retry buys it is
+ * burnt quota and a 3s stall per request.
+ */
+const failureBackoffMs = (): number =>
+  Math.min(
+    FAILURE_BACKOFF_MS * 2 ** Math.max(0, consecutiveFailures - 1),
+    MAX_BACKOFF_MS
+  )
+
+/**
+ * The retry after a failure is never sooner than the refresh a servable token
+ * would already have had. A token no caller can be given earns no such delay.
+ */
+const retryFloorMs = (): number =>
+  !canServeToken() || cachedToken == null
+    ? 0
+    : cachedToken.expiresMono - monotonicNow() - REFRESH_LEAD_MS
+
+/**
+ * Schedule the next handshake after a failed or hung attempt. `scheduleRefresh`
+ * only runs on success, so without this the engine would sit idle until a gated
+ * call or an app restart.
+ */
+const scheduleRetryAfterFailure = (): void => {
+  armTimer(Math.max(failureBackoffMs(), retryFloorMs()))
+}
+
+/** Test-only: expose timing constants used by unit tests. */
+export const attestationTimingForTests = {
+  CLOCK_SKEW_MS,
+  GET_TOKEN_TIMEOUT_MS,
+  HANDSHAKE_WATCHDOG_MS,
+  FAILURE_BACKOFF_MS,
+  MAX_BACKOFF_MS,
+  MIN_HANDSHAKE_SPACING_MS,
+  MIN_REFRESH_MS,
+  REFRESH_LEAD_MS,
+  /**
+   * Exposes `retryFloorMs` so Phase 5 can catch a mutant that drops the
+   * `!canServeToken()` guard. `Math.max(backoff, floor)` hides a negative floor
+   * in the timer path; asserting the helper itself is what pins the predicate.
+   */
+  retryFloorMs
+}
+
+/**
+ * Whether a late token from a retired attempt is worth taking: only when it
+ * outlives what is cached, so the cached expiry never moves backwards. Both
+ * values are monotonic deadlines derived from the server's lifetime, so this
+ * asks nothing of the device wall clock.
+ *
+ * Being retired is not evidence the token is worse. A retired attempt is by
+ * definition the one that finished last, so its remaining lifetime usually
+ * outlives the cached one. What the comparison rules out is a shorter-lived
+ * token taking a longer-lived one's place. A tie goes to the arrival (`>=`).
+ */
+const outlivesCached = (fresh: CachedToken): boolean =>
+  cachedToken == null || fresh.expiresMono >= cachedToken.expiresMono
+
+/**
+ * How long `runHandshake` must wait before it may start another attempt: the
+ * failure backoff, and a floor between handshakes that applies whatever the last
+ * one returned. Zero when an attempt may start now.
+ */
+const handshakeWaitMs = (): number =>
+  Math.max(
+    0,
+    lastFailureAt == null
+      ? 0
+      : lastFailureAt + failureBackoffMs() - monotonicNow(),
+    lastHandshakeAt == null
+      ? 0
+      : lastHandshakeAt + MIN_HANDSHAKE_SPACING_MS - monotonicNow()
+  )
+
+/**
+ * Kick off a handshake in the background if one is not already running. Never
+ * throws (failures are logged) and never blocks the caller. On success, caches
+ * the token and schedules the next refresh; on failure or hang, schedules a
+ * backoff retry. Every exit path leaves either a handshake in flight or a timer
+ * armed, unless the device is `unsupported` and there is nothing left to try.
+ */
+const runHandshake = (): void => {
+  if (unsupported) return
+  if (inFlight != null) return
+  const waitMs = handshakeWaitMs()
+  if (waitMs > 0) {
+    // Re-arm instead of just returning. This path swallows whatever tick woke
+    // us, so returning bare would strand the engine until the next gated call.
+    armTimer(waitMs)
+    return
+  }
+  lastHandshakeAt = monotonicNow()
+  // A handshake whose native call hangs past the watchdog has its `inFlight`
+  // lock released so a newer handshake can start. Tag each attempt so a stale
+  // one that finally resolves cannot clobber a token a newer handshake already
+  // produced - while still accepting a late valid JWT when nothing is cached
+  // (the newer attempt may have failed into backoff).
+  const attempt: HandshakeAttempt = {
+    generation: ++handshakeGeneration,
+    usedAttestation: false,
+    countedFailure: false
+  }
+  const handshake: Promise<void> = performHandshake(attempt)
+    .then(freshToken => {
+      if (freshToken == null) {
+        // Terminal: this device cannot attest, so stop the engine rather than
+        // waking up forever to ask again. Only the current attempt may say so:
+        // a hung `isSupported()` that answers after the watchdog retired it has
+        // no standing to retire the engine a live attempt is now driving, and
+        // nothing but `resetAttestationForTests` ever clears this flag.
+        if (attempt.generation !== handshakeGeneration) return
+        unsupported = true
+        return
+      }
+      if (
+        attempt.generation !== handshakeGeneration &&
+        !outlivesCached(freshToken)
+      ) {
+        return
+      }
+      lastFailureAt = undefined
+      consecutiveFailures = 0
+      cachedToken = freshToken
+      console.log('[attestation] handshake ok')
+      scheduleRefresh(freshToken.expiresMono)
+    })
+    .catch((error: unknown) => {
+      if (attempt.generation !== handshakeGeneration) {
+        // The watchdog counted this attempt while its native call was still
+        // outstanding, because a call that may never answer may also have spent
+        // the attestation. It has now answered saying it spent nothing, so take
+        // that count back - a later attempt's own increment is untouched, which
+        // is why this cannot simply reset the counter.
+        if (attempt.countedFailure && !attempt.usedAttestation) {
+          attempt.countedFailure = false
+          consecutiveFailures = Math.max(0, consecutiveFailures - 1)
+        }
+        return
+      }
+      lastFailureAt = monotonicNow()
+      if (attempt.usedAttestation) {
+        consecutiveFailures += 1
+        attempt.countedFailure = true
+      }
+      console.warn('[attestation] handshake failed:', String(error))
+      scheduleRetryAfterFailure()
+    })
+    .finally(() => {
+      if (attempt.watchdog != null) clearTimeout(attempt.watchdog)
+      if (inFlight === handshake) inFlight = undefined
+    })
+  inFlight = handshake
+  // A hung native call must not block all future attempts. Only clear the
+  // lock if this same handshake still holds it.
+  attempt.watchdog = setTimeout(() => {
+    if (inFlight !== handshake) return
+    console.warn('[attestation] handshake watchdog fired; releasing lock')
+    inFlight = undefined
+    // Releasing the lock abandons this attempt, so retire its generation too.
+    // Otherwise it still reads as current until some other handshake starts,
+    // and a late settle would count this one failure twice, overwrite the
+    // `lastFailureAt` set below, and push out the retry scheduled here.
+    handshakeGeneration += 1
+    // A hang is a failure and has to be recorded as one. The backoff is what
+    // stops a device whose native call never answers from starting a fresh
+    // handshake on every gated request - and stalling each of those requests
+    // for GET_TOKEN_TIMEOUT_MS, which is the latency this backoff exists to
+    // avoid. A hang inside the native attestation spends the rate-limited
+    // quota just like a rejection does, so it grows the backoff too.
+    lastFailureAt = monotonicNow()
+    if (attempt.usedAttestation) {
+      consecutiveFailures += 1
+      attempt.countedFailure = true
+    }
+    // An attempt that never settles leaves nothing else to re-arm the loop.
+    scheduleRetryAfterFailure()
+  }, HANDSHAKE_WATCHDOG_MS)
+}
+
+/**
+ * Start the background attestation engine. Kicks off an initial handshake
+ * (unless a live token is already cached) without blocking; the engine then
+ * self-reschedules to refresh the token ahead of each expiry.
+ *
+ * Called from `initInfoServer`, which runs on every network reconnect and not
+ * just at boot, so this has to be idempotent: it returns immediately while a
+ * token is live, and `runHandshake` single-flights and rate-limits the rest.
+ */
+export const initAttestation = (): void => {
+  if (canServeToken()) return
+  runHandshake()
+}
+
+/**
+ * Return the most recent attestation token for an attestation-gated caller.
+ * Resolves immediately with the cached token when one is live. Otherwise it
+ * ensures a handshake is running and waits at most `GET_TOKEN_TIMEOUT_MS`,
+ * returning `undefined` on timeout. Callers treat `undefined` as "no token" and
+ * let the info server decide (it may still serve a fallback response).
+ *
+ * A caller that arrives while the engine is backing off returns `undefined`
+ * without waiting at all: `runHandshake` declines to start one, so there is
+ * nothing to await. That is what keeps a persistently-failing device from adding
+ * `GET_TOKEN_TIMEOUT_MS` to every gated request.
+ */
+export const getAttestationToken = async (): Promise<string | undefined> => {
+  if (canServeToken()) return cachedToken?.token
+  runHandshake()
+  if (inFlight != null) {
+    await Promise.race([inFlight, delay(GET_TOKEN_TIMEOUT_MS)])
+  }
+  return canServeToken() ? cachedToken?.token : undefined
+}
+
+/**
+ * Headers for a JSON POST to an attestation-gated info-server route: the
+ * content type, plus `x-attestation-token` when the engine has a live token.
+ * The header is omitted rather than faked when it has none, and the info server
+ * decides what an unattested request gets (it may still serve a fallback).
+ *
+ * Every gated call site goes through here instead of spreading the header
+ * itself, so the header name, a second gated header, or the null-handling
+ * policy each change in one place. A site that quietly stops sending the token
+ * still succeeds locally and only surfaces as a 403 from the server, which is
+ * not a regression that announces itself.
+ */
+export const attestedJsonHeaders = async (): Promise<
+  Record<string, string>
+> => {
+  const attestationToken = await getAttestationToken()
+  return {
+    'Content-Type': 'application/json',
+    ...(attestationToken != null
+      ? { 'x-attestation-token': attestationToken }
+      : {})
+  }
+}

--- a/src/util/monotonicTime.ts
+++ b/src/util/monotonicTime.ts
@@ -1,0 +1,7 @@
+/**
+ * Milliseconds since an arbitrary fixed point, from a source no date change can
+ * move. Every interval the attestation engine measures - backoff, handshake
+ * spacing, token lifetime - is a duration, and durations must not be measured
+ * against a clock a user can set backwards.
+ */
+export const monotonicNow = (): number => performance.now()

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -8,11 +8,18 @@ import { asInfoRollup, type InfoRollup } from 'edge-info-server'
 import { Platform } from 'react-native'
 import { getVersion } from 'react-native-device-info'
 
+import { ENV } from '../env'
 import { config } from '../theme/appConfig'
+import { initAttestation } from './attestation'
 import { runOnce } from './runOnce'
 import { asyncWaterfall, getOsVersion, shuffleArray } from './utils'
 import { checkAppVersion } from './versionCheck'
-const INFO_SERVERS = ['https://info1.edge.app', 'https://info2.edge.app']
+// `ENV.INFO_SERVER` (from env.json) overrides the production info servers, e.g.
+// to point a debug build at a local info server. Absent in production builds.
+const INFO_SERVERS =
+  ENV.INFO_SERVER != null && ENV.INFO_SERVER.length > 0
+    ? ENV.INFO_SERVER
+    : ['https://info1.edge.app', 'https://info2.edge.app']
 const RATES_SERVERS = ['https://rates3.edge.app', 'https://rates4.edge.app']
 const RATES_SERVER_V2 = ['https://rates1.edge.app', 'https://rates2.edge.app']
 
@@ -127,6 +134,12 @@ export const fetchPush = async (
 export const infoServerData: { rollup?: InfoRollup } = {}
 
 export const initInfoServer = async (): Promise<void> => {
+  // Start the background attestation engine at boot (best-effort, non-blocking)
+  // so a token is usually cached before any attestation-gated request is made.
+  // This is intentionally not inside fetchInfo: the fetch wrapper carries no
+  // attestation logic; gated plugins attach the token via getAttestationToken().
+  initAttestation()
+
   const osType = Platform.OS.toLowerCase()
   const osVersion = getOsVersion()
   const version = getVersion()


### PR DESCRIPTION
## Summary
- Add a background attestation engine (`src/util/attestation.ts`) plus iOS App Attest and Android Keystore native modules that enroll once, refresh via assertion/signature, and cache JWTs on a monotonic clock with lead-ahead refresh and failure backoff.
- Wire Simplex/Banxa jwtSign and createHmac call sites to attach `x-attestation-token` when available; surface gated signing failures in ramp UI instead of silently no-oping.
- Document the client architecture in `docs/APP_ATTESTATION.md`. Depends on info-server lifetime/`expiresIn`/`serverTime` support ([edge-info-server#158](https://github.com/EdgeApp/edge-info-server/pull/158)).

## Test plan
- [ ] `npm test -- src/__tests__/util/attestation.test.ts src/__tests__/util/attestationNativeBridge.test.ts`
- [ ] `tsc` / lint on changed files; `npm run fix-kotlin` / ktlint on attestation Kotlin modules
- [ ] Physical iOS device: boot → challenge → App Attest enroll → token cached; later refresh via `generateAssertion`
- [ ] Physical Android (TEE/StrongBox): enroll via Keystore attestation; refresh via `signChallenge`
- [ ] Point `ENV.INFO_SERVER` at a local info server from [edge-info-server#158](https://github.com/EdgeApp/edge-info-server/pull/158); confirm Banxa/Simplex signing sends `x-attestation-token` and fails loudly on 403
- [ ] Simulator / unsupported device: engine stops cleanly; gated plugins omit the header

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches purchase flows and partner signing endpoints; attestation misconfiguration or token/cache bugs can block buys (403) or weaken gating until server policy is tuned.
> 
> **Overview**
> Adds **app/device attestation** so gated info-server calls (Simplex JWT sign, Banxa HMAC) can prove the real Edge app on real hardware.
> 
> A new **background attestation engine** (`src/util/attestation.ts`) talks to the info server’s `/v1/attest/*` flow: enroll once with platform attestation, then refresh with a cheap assertion/signature, cache JWTs on a **monotonic** deadline, and attach `x-attestation-token` via `attestedJsonHeaders()` when a token is available.
> 
> **Native bridges** on iOS (App Attest + Keychain) and Android (Keystore attestation, StrongBox fallback, serialized lock) implement enrollment, refresh, and scoped `clearKey` on server rejection.
> 
> **Ramp plugins** (Simplex, Banxa) use attested headers for `jwtSign` / `createHmac`; failures surface in the ramp quote flow instead of silent no-ops. Optional `INFO_SERVER` override and clock-skew UX support local testing and misconfigured device time.
> 
> Also ships `docs/APP_ATTESTATION.md`, extensive Jest coverage, signing-cert extraction tooling, and iOS Xcode wiring helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e94ab0aa1fa08c78da762a0aa25c406f1c65a54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217260695616571