### PR TITLE
Add per-ABI split APKs to the Android release pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased (develop)
 
 - added: Cash App Pay as a MoonPay buy and sell payment method, for US customers.
-- added: Per-ABI Android release APKs (arm64-v8a and armeabi-v7a) alongside the universal APK, for distribution outside Google Play. Each is roughly 30 MiB smaller than the universal APK. Branches opt in through a `splitArchitectures` list in their deploy-config block, which maps each ABI to its own Zealot channel. The universal APK keeps serving the main channel and direct downloads.
+- added: Per-ABI Android release APKs (arm64-v8a and armeabi-v7a) alongside the universal APK, for distribution outside Google Play. Each is roughly 31 MB smaller than the universal APK. Branches opt in through a `splitArchitectures` list in their deploy-config block, which maps each ABI to its own Zealot channel. The universal APK keeps serving the main channel and direct downloads.
 - added: Verbose logging for exchange rate queries: the request body, resolved/rate-less counts, and errors are captured when the Verbose Logging setting is enabled.
 - added: Exchange-rate cache snapshot in the support log output, plus a `rates-cache-replay` script that re-runs those queries against the rates server and reports the result for each pair.
 - added: "-m" tag on the version number in the Help scene for Maestro test builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - added: Cash App Pay as a MoonPay buy and sell payment method, for US customers.
+- added: Per-ABI Android release APKs (arm64-v8a and armeabi-v7a) alongside the universal APK, for distribution outside Google Play. Each is roughly 30 MiB smaller than the universal APK. Branches opt in through a `splitArchitectures` list in their deploy-config block, which maps each ABI to its own Zealot channel. The universal APK keeps serving the main channel and direct downloads.
 - added: Verbose logging for exchange rate queries: the request body, resolved/rate-less counts, and errors are captured when the Verbose Logging setting is enabled.
 - added: Exchange-rate cache snapshot in the support log output, plus a `rates-cache-replay` script that re-runs those queries against the rates server and reports the result for each pair.
 - added: "-m" tag on the version number in the Help scene for Maestro test builds

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -191,6 +191,13 @@ android {
             useLegacyPackaging true
         }
 
+        // Compress dex, matching how the universal APK that bundletool
+        // derives from the AAB is packaged. AGP stores dex uncompressed
+        // by default at minSdk 28+, which adds ~28 MB to a sideloaded APK:
+        dex {
+            useLegacyPackaging true
+        }
+
         // Edge hacks for zcash and piratechain conflicts:
         resources {
             pickFirst 'compact_formats.proto'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -105,6 +105,30 @@ android {
         }
     }
 
+    // Edge addition: sideloadable per-ABI APKs for distribution outside
+    // Google Play (Play already serves per-ABI installs from the AAB).
+    // Each one is roughly 31 MB smaller than the universal APK (about
+    // 78-80 MB vs 110 MB as measured). Off by default so normal builds
+    // are unchanged; the deploy script opts in:
+    //   ./gradlew assembleRelease -PabiSplits
+    // A split build emits three APKs: the universal plus one per ABI,
+    // so the universal stays available across the board. The property is
+    // a boolean flag, so -PabiSplits=false (from the command line,
+    // gradle.properties, or CI) disables the feature:
+    def abiSplitsEnabled = project.hasProperty('abiSplits') &&
+        project.property('abiSplits') != 'false'
+    splits {
+        abi {
+            reset()
+            enable abiSplitsEnabled
+            universalApk true
+            // Adding an ABI here also needs an abiVersionOffsets entry
+            // below and a matching supportedAbis entry in
+            // scripts/deploy.ts, which validates the deploy-config:
+            include 'armeabi-v7a', 'arm64-v8a' // Exclude Intel
+        }
+    }
+
     signingConfigs {
         release {
         }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -129,6 +129,39 @@ android {
         }
     }
 
+    // Edge addition: distinct versionCodes for the split APKs, required
+    // by Google Play multi-APK uploads (each APK in a release needs a
+    // unique versionCode). Play serves the highest compatible code, so
+    // arm64-v8a must outrank armeabi-v7a, and the universal APK keeps
+    // the unmodified base code as the lowest-priority fallback.
+    //
+    // The offsets stay small deliberately. getBuildNumber() returns this
+    // value on Android, and the info server filters promo and info cards
+    // by comparing minBuildNum/maxBuildNum/exactBuildNum against it as
+    // strings, so the universal APK that nearly every user installs must
+    // keep reporting the plain build number. The build counter advances
+    // by 3 per build (see scripts/gitVersionFile.ts), so these offsets
+    // never collide with a neighboring build's codes:
+    def abiVersionOffsets = ['armeabi-v7a': 1, 'arm64-v8a': 2]
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {
+                // Defaulting a missing ABI to 0 would hand that split
+                // APK the universal APK's code, which Play rejects as a
+                // duplicate. Fail the build instead, so an ABI added to
+                // the include list above without an offset here cannot
+                // ship silently:
+                def abiOffset = abiVersionOffsets[abi]
+                if (abiOffset == null) {
+                    throw new GradleException(
+                        "No versionCode offset defined for ABI '${abi}'")
+                }
+                output.versionCodeOverride = variant.versionCode + abiOffset
+            }
+        }
+    }
+
     signingConfigs {
         release {
         }

--- a/deploy-config.sample.json
+++ b/deploy-config.sample.json
@@ -27,7 +27,11 @@
     },
     "android": {
       "master": {
-        "hockeyAppId": "xxxxxxxxx"
+        "hockeyAppId": "xxxxxxxxx",
+        "splitArchitectures": [
+          { "abi": "arm64-v8a", "zealotChannelKey": "xxxxxxxxxx" },
+          { "abi": "armeabi-v7a", "zealotChannelKey": "xxxxxxxxxx" }
+        ]
       },
       "develop": {
         "hockeyAppId": "xxxxxxxxx"

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -22,6 +22,15 @@ const cutoffDate = new Date()
 cutoffDate.setMonth(now.getMonth() - BUILD_ARCHIVE_MONTHS)
 
 /**
+ * One per-ABI split APK build: the ABI to package, and the Zealot
+ * channel that receives it.
+ */
+interface SplitArchitecture {
+  abi: string
+  zealotChannelKey?: string
+}
+
+/**
  * Things we expect to be set in the config file:
  */
 interface BuildConfigFile {
@@ -46,6 +55,11 @@ interface BuildConfigFile {
   zealotApiToken?: string
   zealotChannelKey?: string
   zealotMaestroChannelKey?: string
+  // Per-ABI split APKs to build, archive, and upload. Android only.
+  // Belongs in a branch block of the android config, so each branch
+  // opts in on its own. Entries without a zealotChannelKey are archived
+  // but not uploaded:
+  splitArchitectures?: SplitArchitecture[]
   hockeyAppId: string
   hockeyAppTags: string
   hockeyAppToken: string
@@ -81,6 +95,7 @@ interface BuildObj extends BuildConfigFile {
   dSymFile: string
   dSymZip: string
   ipaFile: string // Also APK
+  abiApkFiles?: Record<string, string> // Android split APKs, by ABI
 }
 
 interface LatestTestFile {
@@ -519,11 +534,51 @@ function buildAndroid(buildObj: BuildObj): void {
   const universalApk = join(apkPathDir, 'universal.apk')
   buildObj.ipaFile = join(apkPathDir, `${outfile}.apk`)
   fs.renameSync(universalApk, buildObj.ipaFile)
+
+  // Branches configured with splitArchitectures also archive sideloadable
+  // per-ABI APKs for distribution outside Google Play (Play already
+  // serves per-ABI installs from the AAB). Each one is roughly 31 MB
+  // smaller than the universal APK (about 78-80 MB vs 110 MB as
+  // measured). The gradle daemon reuses the compile work from the bundle
+  // task above, so this only pays for packaging and signing. Maestro
+  // builds skip this entirely:
+  const { splitArchitectures } = buildObj
+  if (
+    splitArchitectures != null &&
+    splitArchitectures.length > 0 &&
+    !maestroBuild
+  ) {
+    // The gradle splits block can only emit these ABIs, so anything else
+    // in the config is a typo. This list must match the splits.abi
+    // include list in android/app/build.gradle. Checking before the
+    // build turns a typo into an immediate, clear error rather than a
+    // low-signal ENOENT from the copy below after a multi-minute
+    // assemble, and keeps unvalidated config values out of the path
+    // construction:
+    const supportedAbis = ['arm64-v8a', 'armeabi-v7a']
+    for (const { abi } of splitArchitectures) {
+      if (!supportedAbis.includes(abi)) {
+        throw new Error(`Unsupported abi "${abi}" in splitArchitectures`)
+      }
+    }
+
+    call('./gradlew assembleRelease -PabiSplits')
+    const splitApkDir = join(guiPlatformDir, 'app/build/outputs/apk/release')
+
+    buildObj.abiApkFiles = {}
+    for (const { abi } of splitArchitectures) {
+      const archivedApk = join(archiveDir, `${outfile}-${abi}.apk`)
+      fs.copyFileSync(join(splitApkDir, `app-${abi}-release.apk`), archivedApk)
+      buildObj.abiApkFiles[abi] = archivedApk
+    }
+  }
 }
 
 function buildCommonPost(buildObj: BuildObj): void {
   const {
+    abiApkFiles,
     maestroBuild,
+    splitArchitectures,
     zealotApiToken,
     zealotChannelKey,
     zealotMaestroChannelKey,
@@ -564,14 +619,16 @@ function buildCommonPost(buildObj: BuildObj): void {
     mylog('\nUploaded to HockeyApp')
   }
 
+  // Shared by both Zealot uploads below:
+  const branch = encodeURIComponent(buildObj.repoBranch)
+  const gitCommit = encodeURIComponent(buildObj.guiHash)
+
   // Maestro test builds upload to their own channel so they do not pollute the
   // production channel's release list. Production builds use zealotChannelKey.
   // A maestro build with no zealotMaestroChannelKey configured skips Zealot.
   const channelKey = maestroBuild ? zealotMaestroChannelKey : zealotChannelKey
 
   if (zealotApiToken != null && zealotUrl != null && channelKey != null) {
-    const branch = encodeURIComponent(buildObj.repoBranch)
-    const gitCommit = encodeURIComponent(buildObj.guiHash)
     chdir(buildObj.guiDir)
     const changes = cmd(
       `git diff HEAD^ HEAD CHANGELOG.md | { grep '^+[^+]' || true; }`
@@ -582,10 +639,38 @@ function buildCommonPost(buildObj: BuildObj): void {
       '***********************************************************************\n'
     )
 
-    call(
-      `curl -X POST "${zealotUrl}/api/apps/upload?token=${zealotApiToken}&channel_key=${channelKey}&branch=${branch}&git_commit=${gitCommit}&changelog=${changelog}" -F "file=@${buildObj.ipaFile}"`
+    const token = encodeURIComponent(zealotApiToken)
+    const encodedChannelKey = encodeURIComponent(channelKey)
+    callRedacted(
+      `curl -X POST "${zealotUrl}/api/apps/upload?token=${token}&channel_key=${encodedChannelKey}&branch=${branch}&git_commit=${gitCommit}&changelog=${changelog}" -F "file=@${buildObj.ipaFile}"`,
+      [token, encodedChannelKey]
     )
     mylog('\n*** Upload to Zealot Complete ***')
+  }
+
+  // Architecture-specific APKs go to their own Zealot channels, one per
+  // ABI, so each channel's latest build is always the right architecture.
+  // The universal APK above keeps serving the main channel and direct
+  // downloads. Only branches whose config block lists splitArchitectures
+  // build these at all, and maestro builds never do:
+  if (
+    zealotApiToken != null &&
+    zealotUrl != null &&
+    abiApkFiles != null &&
+    splitArchitectures != null
+  ) {
+    const token = encodeURIComponent(zealotApiToken)
+    for (const { abi, zealotChannelKey: abiChannelKey } of splitArchitectures) {
+      const apkFile = abiApkFiles[abi]
+      if (abiChannelKey == null || apkFile == null) continue
+      const channelKey = encodeURIComponent(abiChannelKey)
+      mylog(`\n\nUploading ${abi} APK to Zealot: ${zealotUrl}`)
+      callRedacted(
+        `curl -X POST "${zealotUrl}/api/apps/upload?token=${token}&channel_key=${channelKey}&branch=${branch}&git_commit=${gitCommit}" -F "file=@${apkFile}"`,
+        [token, channelKey]
+      )
+      mylog(`\n*** Upload of ${abi} APK to Zealot Complete ***`)
+    }
   }
 
   if (buildObj.rsyncLocation != null) {
@@ -713,8 +798,11 @@ function chdir(path: string): void {
   _currentPath = path
 }
 
-function call(cmdstring: string): void {
-  console.log('call: ' + cmdstring)
+/**
+ * Runs a command, inheriting our stdio. Shared by `call` and
+ * `callRedacted` so both stay on the same execution options.
+ */
+function execCommand(cmdstring: string): void {
   childProcess.execSync(cmdstring, {
     encoding: 'utf8',
     timeout: 3600000,
@@ -722,6 +810,35 @@ function call(cmdstring: string): void {
     cwd: _currentPath,
     killSignal: 'SIGKILL'
   })
+}
+
+/**
+ * Like `call`, but logs the command with the given secrets masked, so
+ * tokens and keys do not land in the CI build log. A failed execSync
+ * throws an error whose message embeds the raw command, so the failure
+ * path gets the same masking as the log line.
+ */
+function callRedacted(cmdstring: string, secrets: string[]): void {
+  const redact = (text: string): string => {
+    let out = text
+    for (const secret of secrets) {
+      if (secret !== '') out = out.split(secret).join('<redacted>')
+    }
+    return out
+  }
+
+  console.log('call: ' + redact(cmdstring))
+  try {
+    execCommand(cmdstring)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(redact(message))
+  }
+}
+
+function call(cmdstring: string): void {
+  console.log('call: ' + cmdstring)
+  execCommand(cmdstring)
 }
 
 function cmd(cmdstring: string): string {

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -161,8 +161,6 @@ function makeProject(buildObj: BuildObj): void {
     buildObj,
     config[project][buildObj.platformType][buildObj.repoBranch]
   )
-
-  console.log(buildObj)
 }
 
 function makeCommonPost(buildObj: BuildObj): void {

--- a/scripts/gitVersionFile.ts
+++ b/scripts/gitVersionFile.ts
@@ -88,7 +88,28 @@ function updateVersionFile(branch: string, version: string): void {
       const { build: previousBuild } = JSON.parse(result)
       if (typeof previousBuild !== 'number')
         throw new Error(`Invalid previous buildNum ${previousBuild}`)
-      build = Math.max(previousBuild + 1, newBuildNum)
+      // Advance by 3, not 1, so each build owns a block of three
+      // versionCodes: the Android split APKs add per-ABI offsets to the
+      // build number (universal +0, armeabi-v7a +1, arm64-v8a +2, see
+      // app/build.gradle), and Google Play rejects any versionCode it
+      // has ever seen, so consecutive builds must never overlap blocks.
+      // The stride must stay >= the number of APK flavors per build,
+      // which is pinned by the gradle splits include list. Widening the
+      // gap the other way, by giving the splits their own numeric range
+      // (build * 10 + offset) and leaving this at +1, does not work: the
+      // next build's universal APK would then carry a lower code than
+      // the previous build's splits, which Play treats as a downgrade,
+      // and the universal APK has to keep reporting the plain build
+      // number because getBuildNumber() returns the versionCode and the
+      // info server string-compares it against minBuildNum/maxBuildNum/
+      // exactBuildNum rules.
+      //
+      // Costs, both accepted: iOS build numbers share this counter and
+      // simply skip by 3, and same-day capacity drops from 99 builds to
+      // 33 before the date-shaped number bleeds into the next day's
+      // range. That bleed already existed at 99, and it only misreads
+      // the date -- build numbers stay unique and increasing either way:
+      build = Math.max(previousBuild + 3, newBuildNum)
     } else {
       build = newBuildNum
     }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

No visual changes: build pipeline only.

### Description

Adds per-ABI Android APKs to release builds, distributed through dedicated Zealot channels and driven entirely by deploy-config, with a versionCode scheme that supports uploading them to Google Play as a multi-APK release (Edge uploads self-signed APKs rather than an AAB, since Play App Signing would require sharing the signing key with Google). Direct downloads keep the universal APK.

Measured on a real Jenkins build of this branch (test-gouda cheese build):

| artifact | size | vs universal |
|---|---|---|
| universal APK | 110 MB | |
| arm64-v8a APK | 80.2 MB | -29.8 MB (-27%) |
| armeabi-v7a APK | 77.5 MB | -32.5 MB (-30%) |

The split APKs compress dex the same way the bundletool-derived universal does (AGP stores dex uncompressed at minSdk 28+), which is where most of the saving comes from being preserved; the AAB is hash-identical with and without that packaging change, so Google Play delivery is untouched.

How it works:

- `app/build.gradle` gains a `splits.abi` block gated behind `-PabiSplits`, with `ndk.abiFilters` untouched and always active. A split build emits three APKs: the universal (same size and lib set as a default build, arm ABIs only, verified) plus one per ABI, so the universal stays available across the board. Default invocations (`bundleRelease`, `npm run android:release*`, dev builds) are completely unchanged.
- Branches opt in through an optional `splitArchitectures` list in their android deploy-config block, mapping each ABI to the Zealot channel that receives it:

  ```json
  "android": {
    "master": {
      "splitArchitectures": [
        { "abi": "arm64-v8a", "zealotChannelKey": "<hex>" },
        { "abi": "armeabi-v7a", "zealotChannelKey": "<hex>" }
      ]
    }
  }
  ```

  Branch scoping comes from the config file, so the deploy script itself stays branch-agnostic. Branches without the field, and all maestro builds, skip the feature entirely. Entries without a `zealotChannelKey` are archived but not uploaded.
- For configured branches, `deploy.ts` runs `assembleRelease -PabiSplits` after the existing bundle step (the gradle daemon reuses the compile work, so this only pays for packaging and signing) and archives `<outfile>-arm64-v8a.apk` and `<outfile>-armeabi-v7a.apk` next to the AAB and universal APK, with the same signing config, so cross-updates between any of these artifacts keep working.
- One Zealot channel per ABI means each channel's latest build is always the right architecture. The universal APK keeps uploading to the existing channel and the rsync location for direct downloads.
- Split APKs add per-ABI versionCode offsets (armeabi-v7a +1, arm64-v8a +2) for Google Play multi-APK uploads, which require a unique versionCode per APK. Play serves the highest compatible code, so 64-bit devices get the arm64 APK while the universal keeps the plain build number as the lowest-priority fallback. The build counter advances by 3 per build (gitVersionFile.ts), giving every build a disjoint block of three codes so offsets never collide at any release cadence. Codes stay eight-digit, so the info server's string-compared minBuildNum/maxBuildNum/exactBuildNum rules keep matching, and iOS keeps the raw build number.
- `deploy-config.sample.json` documents the new field and the previously undocumented Zealot fields.

Verified: both gradle configuration modes pass, each split APK contains exactly one `lib/<abi>/` tree (24 .so files each), the split-mode universal matches the default build's size and contains only the two arm ABI trees, versionCodes come out as base/base+1/base+2 on a split build and plain base on a default build (aapt2-checked), `updateVersion.ts` is untouched, so the universal APK and the AAB keep reporting the plain build number, and lint plus the test suite pass.

Ops steps to activate: create one Zealot channel per ABI in the Zealot admin, then add the `splitArchitectures` list to the master block of `deploy-config.json` on the build machine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release signing, versionCode allocation, and CI deploy/upload paths; mistakes could break Play uploads or leak credentials in logs, though behavior is opt-in and default builds are unchanged.
> 
> **Overview**
> Adds **optional per-ABI Android release APKs** (arm64-v8a and armeabi-v7a) for sideloading outside Google Play, while the **universal APK** still goes to the main Zealot channel and direct downloads. Branches opt in via **`splitArchitectures`** in deploy-config, each ABI mapped to its own Zealot channel.
> 
> **Gradle** (`android/app/build.gradle`): ABI splits are gated by **`-PabiSplits`** (off by default). Split builds emit universal plus per-ABI APKs, with **per-ABI `versionCode` offsets** (+1 / +2) for Play multi-APK rules. **Dex legacy packaging** is enabled to shrink sideload APKs without changing the AAB.
> 
> **Deploy** (`scripts/deploy.ts`): After the existing bundle/universal step, configured branches run **`assembleRelease -PabiSplits`**, archive split APKs, and upload each to its channel. Zealot uploads use **`callRedacted`** so tokens/keys are masked in CI logs.
> 
> **Build numbers** (`scripts/gitVersionFile.ts`): The counter advances by **3** per build so universal and split `versionCode`s never collide across releases; the universal APK still reports the plain build number for info-server rules.
> 
> CHANGELOG and **`deploy-config.sample.json`** document the new option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78adcb7c0183b21100ee2363089622cee5d0c61b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217166483159232