### PR TITLE
Change MoonPay display name capitalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added: "-m" tag on the version number in the Help scene for Maestro test builds
 - changed: Style the entire "Already have an account? Sign in" line in the getting-started USP carousel with the tertiary link color, not just "Sign in".
 - changed: Refresh the buy, sell, sort, scan-QR and FIO names icons to the updated design.
+- changed: Display "MoonPay" instead of "Moonpay" wherever the partner name appears in the app.
 - changed: Use a custom chart icon for the side menu Markets row, so it matches the rest of the menu.
 - changed: Use the UI4 warning card for the Reveal Raw Keys and Reveal Master Private Key password confirmation warnings.
 - changed: Tron resource staking now describes its claim action as reclaiming your own TRX, instead of claiming a reward.

--- a/src/plugins/gui/providers/moonpayProvider.ts
+++ b/src/plugins/gui/providers/moonpayProvider.ts
@@ -56,7 +56,7 @@ import { signMoonpayUrl } from './moonpaySign'
 const providerId = 'moonpay'
 const storeId = 'com.moonpay'
 const partnerIcon = 'moonpay_symbol_prp.png'
-const pluginDisplayName = 'Moonpay'
+const pluginDisplayName = 'MoonPay'
 const supportEmail = 'support@moonpay.com'
 
 const allowedCurrencyCodes: Record<

--- a/src/plugins/ramps/moonpay/moonpayRampPlugin.ts
+++ b/src/plugins/ramps/moonpay/moonpayRampPlugin.ts
@@ -80,7 +80,7 @@ import {
 
 const pluginId = 'moonpay'
 const partnerIcon = `${EDGE_CONTENT_SERVER_URI}/moonpay_symbol_prp.png`
-const pluginDisplayName = 'Moonpay'
+const pluginDisplayName = 'MoonPay'
 const supportEmail = 'support@moonpay.com'
 
 // Local asset map type


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Display "MoonPay" instead of "Moonpay" everywhere the ramp partner name is shown to the user. Changes `pluginDisplayName` in the live ramps plugin (`src/plugins/ramps/moonpay/moonpayRampPlugin.ts`) and the legacy gui provider (`src/plugins/gui/providers/moonpayProvider.ts`), both of which feed `providerDisplayName` rendered on the Buy/Sell provider-select scene and transaction details card. No identifiers, files, or asset keys are renamed; only the display string.

[Ramps (MoonPay) - "Moonpay" -> "MoonPay"](https://app.asana.com/0/1215088146871429/1217260695616565)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-string-only branding fix with no logic, API, or identifier changes.
> 
> **Overview**
> Updates the MoonPay ramp partner **display name** from "Moonpay" to **"MoonPay"** everywhere users see it.
> 
> `pluginDisplayName` is set to `'MoonPay'` in both the legacy GUI provider (`moonpayProvider.ts`) and the ramps plugin (`moonpayRampPlugin.ts`). That string flows into buy/sell provider selection and related ramp UI. Plugin IDs, store IDs, icons, and support email are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db214ffff5883996feb6af788ac356540f32e249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->