### PR TITLE
Target Android 16 (API level 36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added: App/device attestation for gated info-server requests
 - added: "-m" tag on the version number in the Help scene for Maestro test builds
+- changed: Target Android 16 (API level 36), which Google Play requires for app updates submitted after Aug 30, 2026. Predictive back is opted out of for now, since React Native 0.79 cannot handle it, so the back button behaves exactly as it did before.
 - changed: Style the entire "Already have an account? Sign in" line in the getting-started USP carousel with the tertiary link color, not just "Sign in".
 - changed: Refresh the buy, sell, sort, scan-QR and FIO names icons to the updated design.
 - changed: Display "MoonPay" instead of "Moonpay" wherever the partner name appears in the app.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,14 @@
     </intent>
   </queries>
 
+  <!--
+    Targeting API 36 turns on predictive back by default, which stops Android
+    from calling `onBackPressed` or dispatching KEYCODE_BACK. React Native
+    0.79's ReactActivity has no OnBackInvokedCallback, so that would silently
+    kill every `BackHandler` listener - react-navigation's back handling, modal
+    dismissal, and the "tap again to exit" guard. Opt out until we upgrade to
+    React Native 0.86, which ships its own predictive-back shim.
+  -->
   <application
     android:name=".MainApplication"
     android:label="@string/app_name"
@@ -36,6 +44,7 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:allowBackup="false"
     android:usesCleartextTraffic="true"
+    android:enableOnBackInvokedCallback="false"
     android:theme="@style/AppTheme">
     <meta-data android:name="io.sentry.auto-init" android:value="false" />
     <meta-data android:name="com.google.firebase.messaging.default_notification_icon"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 28 // Edge modified from 21
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.3.20" // Required by zcash-android-sdk >= 2.4.8 (Kotlin 2.3 metadata)
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -44,3 +44,8 @@ newArchEnabled=false
 hermesEnabled=true
 
 VisionCamera_enableCodeScanner=true
+
+# React Native 0.79 pins Android Gradle Plugin 8.8.2, which was only tested up
+# to compileSdk 35. Building against 36 works, but AGP warns on every build.
+# Drop this once the React Native 0.86 upgrade brings AGP 8.12.
+android.suppressUnsupportedCompileSdk=36


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

No visual changes, but this does change Android platform behavior. Device testing is in progress via QA on the `test-paneer` build rather than checked off here — see **QA focus** below.

### Description

Google Play rejects app updates targeting below API 36 after **Aug 30, 2026** ([Asana task](https://app.asana.com/1/9976422036640/project/1213880789473005/task/1216773001312883)). The Play Console policy warning reads "App updates with these issues will be rejected."

The compliance change itself is two lines in `android/build.gradle`. The other three files exist because of what API 36 turns on.

#### Predictive back is the real payload

Targeting API 36 enables predictive back by default, and Android then stops calling `onBackPressed` and stops dispatching `KEYCODE_BACK`. React Native 0.79's `ReactActivity` only overrides `onBackPressed` and registers no `OnBackInvokedCallback`, so every `BackHandler` listener in the app would go silently dead:

- `@react-navigation/native`'s `useBackButton` — and we use the JS stack (`@react-navigation/stack` v6), not native-stack, so **all** back navigation routes through `BackHandler`
- `EdgeModal.tsx:123` — back no longer dismisses modals
- `useBackButtonToast.tsx:34` — the "tap again to exit" guard on the wallet list

`android:enableOnBackInvokedCallback="false"` opts out, keeping back behavior byte-for-byte identical to what ships today.

React Native 0.86 fixes this properly — it ships its own `OnBackPressedCallback` shim (its `ReactActivity` carries the comment "Due to enforced predictive back on targetSdk 36, `onBackPressed()` is disabled by default") and moves to AGP 8.12. Both the opt-out and the `suppressUnsupportedCompileSdk` line come back out with that upgrade. This PR exists because RN 0.86 lands after the Play deadline.

#### Why `buildToolsVersion` stays at 35.0.0

Deliberate, not an oversight. AGP 8.8.2's `ToolsRevisionUtils` has `MIN_BUILD_TOOLS_REV = DEFAULT_BUILD_TOOLS_REVISION = 35.0.0` — and so does AGP 8.12.0, so it remains the default even after the RN upgrade. The "build-tools must be ≥ compileSdk" rule predates AGP sourcing `aapt2` from Maven (`com.android.tools.build:aapt2:8.8.2-12006047`) rather than from the build-tools folder. Nothing in the repo shells out to `zipalign`/`apksigner`/`aapt` directly.

### Verification

- `./gradlew :app:assembleDebug` succeeds (JDK 17)
- `aapt2 dump badging` on the resulting APK confirms `targetSdkVersion:'36'`, `compileSdkVersion='36'`
- `aapt2 dump xmltree` confirms `enableOnBackInvokedCallback(0x0101066c)=false` survives manifest merge into the packaged binary manifest
- AGP's "tested up to compileSdk 35" warning is gone from the build log
- `npm run prepare` + full jest suite pass (95 suites, 571 tests)

Not verified here: the runtime opt-out on a real Android 16 device. I confirmed the flag is in the shipped manifest, but had no Android 16 phone image available. That is what the QA pass covers.

### QA focus

Pushed to `test-paneer`. Expected result is **no observable change** — anything QA notices is a regression.

Requires an **Android 16+ device**; nothing reproduces below that. Test both gesture back and 3-button back.

1. Back from any nested scene pops rather than exiting the app. If the opt-out failed, this breaks everywhere at once.
2. Back dismisses modals rather than backgrounding the app.
3. Wallet list: first back shows "tap again to exit", second logs out.

Secondary, lower risk: API 36 makes the app ignore orientation and resizability restrictions on screens ≥600dp. Our manifest sets none of those, so nothing is lost, but tablets and foldables now get free rotation and multi-window. Worth a tablet look.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targeting API 36 changes platform behavior on Android 16+ devices; the predictive-back opt-out is critical—if it fails manifest merge or is ignored at runtime, back navigation could break app-wide.
> 
> **Overview**
> **Google Play compliance:** `compileSdkVersion` and `targetSdkVersion` move from **35 to 36** so updates remain acceptable after the Aug 30, 2026 deadline.
> 
> **Back navigation preserved:** API 36 enables predictive back by default, which would break React Native 0.79’s legacy back path and silence **`BackHandler`** (navigation stack pops, modal dismiss in `EdgeModal`, and the wallet-list “tap again to exit” flow in `useBackButtonToast`). The app sets **`android:enableOnBackInvokedCallback="false"`** on `<application>` with an in-manifest comment until RN 0.86.
> 
> **Build noise:** **`android.suppressUnsupportedCompileSdk=36`** is added because RN 0.79’s AGP 8.8.2 is only validated through SDK 35; **`buildToolsVersion` stays at 35.0.0** per the PR rationale.
> 
> CHANGELOG documents the user-visible expectation: no change in back-button behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e183c2f1196861681b3c2db200830c328afe4970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->