### PR TITLE
Add SimpleSwap swap provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - added: "-m" tag on the version number in the Help scene for Maestro test builds
+- added: SimpleSwap as a swap provider
 - changed: Style the entire "Already have an account? Sign in" line in the getting-started USP carousel with the tertiary link color, not just "Sign in".
 - changed: Refresh the buy, sell, sort, scan-QR and FIO names icons to the updated design.
 - changed: Use a custom chart icon for the side menu Markets row, so it matches the rest of the menu.

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -725,6 +725,7 @@ export const pluginIdIcons: Record<string, string> = {
   rango: EDGE_CONTENT_SERVER_URI + '/rango.png',
   sideshift: EDGE_CONTENT_SERVER_URI + '/sideshift-logo.png',
   simplex: EDGE_CONTENT_SERVER_URI + '/simplex.png',
+  simpleswap: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/simpleswap/icon.png',
   swapuz: EDGE_CONTENT_SERVER_URI + '/swapuz.png',
   thorchain: EDGE_CONTENT_SERVER_URI + '/thorchain.png',
   unizen: EDGE_CONTENT_SERVER_URI + '/unizen.png',

--- a/src/components/modals/SwapVerifyTermsModal.tsx
+++ b/src/components/modals/SwapVerifyTermsModal.tsx
@@ -49,6 +49,11 @@ const pluginData: Record<string, TermsUri> = {
     kycUri:
       'https://help.sideshift.ai/en/articles/6230858-sideshift-ai-s-risk-management-policy'
   },
+  simpleswap: {
+    termsUri: 'https://simpleswap.io/terms-of-service',
+    privacyUri: 'https://simpleswap.io/privacy-policy',
+    kycUri: 'https://simpleswap.io/aml-kyc'
+  },
   swapuz: {
     termsUri: 'https://swapuz.com/terms-of-use',
     privacyUri: 'https://swapuz.com/privacy-policy',

--- a/src/constants/MerchantContacts.ts
+++ b/src/constants/MerchantContacts.ts
@@ -79,6 +79,10 @@ export const MERCHANT_CONTACTS: MerchantContact[] = [
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/simplex.png`
   },
   {
+    displayName: 'SimpleSwap',
+    thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/exchangeIcons/simpleswap/icon.png`
+  },
+  {
     displayName: 'Swapuz',
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/swapuz.png`
   },

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -412,6 +412,11 @@ export const asEnvConfig = asObject({
       affiliateId: asOptional(asString, '')
     })
   ),
+  SIMPLESWAP_INIT: asCorePluginInit(
+    asObject({
+      apiKey: asOptional(asString, '')
+    }).withRest
+  ),
   SOLANA_INIT: asCorePluginInit(
     asObject({
       alchemyApiKey: asOptional(asString, ''),

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -99,6 +99,7 @@ export const swapPlugins = {
   letsexchange: ENV.LETSEXCHANGE_INIT,
   nexchange: ENV.NEXCHANGE_INIT,
   sideshift: ENV.SIDESHIFT_INIT,
+  simpleswap: ENV.SIMPLESWAP_INIT,
   swapuz: ENV.SWAPUZ_INIT,
   xgram: ENV.XGRAM_INIT,
   nymswap: ENV.NYM_SWAP_INIT,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

[EdgeApp/edge-exchange-plugins#481](https://github.com/EdgeApp/edge-exchange-plugins/pull/481) — the SimpleSwap plugin itself. This PR only registers it, so it is inert until that lands and publishes.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1217205278669378

Registers SimpleSwap, the swap provider added in
[EdgeApp/edge-exchange-plugins#481](https://github.com/EdgeApp/edge-exchange-plugins/pull/481),
so the plugin the partner wrote actually loads in the app.

- `src/envConfig.ts` — `SIMPLESWAP_INIT` with an `apiKey`, matching the other
  centralized providers. An empty key makes the plugin factory throw, so builds
  without the key skip SimpleSwap entirely.
- `src/util/corePlugins.ts` — the `swapPlugins` entry.
- `src/components/modals/SwapVerifyTermsModal.tsx` — the terms, privacy and
  AML/KYC links shown before the first SimpleSwap quote.
- `src/actions/CategoriesActions.ts` and `src/constants/MerchantContacts.ts` —
  the provider icon and merchant contact.

The icon path `exchangeIcons/simpleswap/icon.png` is not on the content server
yet; the asset upload is an ops step outside this repo.

### Testing

Driven on the iOS simulator against the real SimpleSwap API, with every other
swap provider disabled locally so the engine had to route through SimpleSwap:
a live XLM to XMR swap from `My Stellar` executed to the success scene, and the
Stellar send carried SimpleSwap's numeric deposit memo. Screenshots below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registration-only GUI changes with no auth or payment logic; provider stays inactive without an API key and depends on the separate exchange-plugins release.
> 
> **Overview**
> **Adds SimpleSwap** as a centralized swap provider in the app shell, aligned with other partners like SideShift and Swapuz. The live swap logic ships in `edge-exchange-plugins`; this change only wires the provider into Edge.
> 
> **Configuration:** `SIMPLESWAP_INIT` in env config accepts an optional `apiKey` (same pattern as other centralized providers). An empty key means the plugin factory does not load SimpleSwap.
> 
> **User-facing:** First-quote **terms, privacy, and AML/KYC** links in `SwapVerifyTermsModal`, plus **exchange icon** mapping and a **MerchantContacts** entry for history/details branding.
> 
> **CHANGELOG** notes SimpleSwap as a new swap provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2138216769493637e7e27fbacb529b158a02763c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->