### PR TITLE
Prefer Banxa's current payment processor over the one it supersedes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed: Staked "locked" balance in the wallet view no longer gets cut off. The crypto amount is truncated to an exchange-rate-appropriate number of decimals, and the text is no longer clamped to a fraction of the card width.
 - fixed: Improve the unstake error experience by replacing the popup alert and generic "unknown error occurred" with the real error in the scene's error field, and showing a clear message when the wallet lacks the balance to cover the unstaking network fee.
 - fixed: Tapping Max on the Sell scene no longer briefly shows the entered fiat amount in the crypto field while the max is being calculated.
+- fixed: Banxa Google Pay purchases now use Banxa's current Google Pay processor instead of the legacy one it replaced. Banxa keeps both live during a migration, and Edge was picking whichever processor had the lower id, which was always the legacy one.
 - fixed: An info card no longer disappears into an empty gap when the carousel's card list shrinks. A card's position comes entirely from an animated transform keyed on its index, and that transform is not re-applied when a surviving card shifts slots, so dropping a card left the ones after it parked a full card-width off-screen. The carousel now remounts a card whose slot changes. Reproduces wherever the list shrinks after mount - most visibly when a `noBalance` card is filtered out as balances finish loading.
 
 ## 4.50.2 (2026-08-06)

--- a/src/__tests__/plugins/ramps/banxa/pickPreferredPayment.test.ts
+++ b/src/__tests__/plugins/ramps/banxa/pickPreferredPayment.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals'
+
+import type { BanxaPaymentIdLimit } from '../../../../plugins/ramps/banxa/banxaRampPlugin'
+import { pickPreferredPayment } from '../../../../plugins/ramps/banxa/banxaRampPlugin'
+
+// Banxa's live USD Google Pay methods: four legacy WorldPay PSPs that all sort
+// below the consolidated PRIMERGP PSP that replaced them.
+const worldpayGoogleUsd: BanxaPaymentIdLimit = {
+  id: 6036,
+  paymentType: 'WORLDPAYGOOGLE',
+  type: 'googlepay',
+  min: '20',
+  max: '15000'
+}
+const primerGooglePay: BanxaPaymentIdLimit = {
+  id: 6142,
+  paymentType: 'PRIMERGP',
+  type: 'googlepay',
+  min: '20',
+  max: '15000'
+}
+const primerCredit: BanxaPaymentIdLimit = {
+  id: 6098,
+  paymentType: 'PRIMERCC',
+  type: 'credit',
+  min: '20',
+  max: '15000'
+}
+
+describe('pickPreferredPayment', function () {
+  it('prefers the current PSP over the deprecated one it replaced', function () {
+    const payments = [worldpayGoogleUsd, primerGooglePay]
+
+    expect(pickPreferredPayment(payments, 'googlepay')).toBe(primerGooglePay)
+  })
+
+  it('ignores the order Banxa payment ids happen to iterate in', function () {
+    const payments = [primerGooglePay, worldpayGoogleUsd]
+
+    expect(pickPreferredPayment(payments, 'googlepay')).toBe(primerGooglePay)
+  })
+
+  it('falls back to the deprecated PSP when it is the only candidate', function () {
+    const payments = [worldpayGoogleUsd, primerCredit]
+
+    expect(pickPreferredPayment(payments, 'googlepay')).toBe(worldpayGoogleUsd)
+  })
+
+  it('returns undefined when no payment method matches the type', function () {
+    const payments = [worldpayGoogleUsd, primerGooglePay]
+
+    expect(pickPreferredPayment(payments, 'ach')).toBeUndefined()
+  })
+})

--- a/src/plugins/gui/providers/banxaProvider.ts
+++ b/src/plugins/gui/providers/banxaProvider.ts
@@ -289,6 +289,7 @@ const asBanxaStates = asObject({
 
 interface BanxaPaymentIdLimit {
   id: number
+  paymentType: BanxaPaymentType
   type: FiatPaymentType
   min: string
   max: string
@@ -1107,6 +1108,19 @@ const typeMap: Record<BanxaPaymentType, FiatPaymentType> = {
   ZHACHSELL: 'ach'
 }
 
+/**
+ * Banxa PSPs that have been superseded by a newer PSP serving the same
+ * `FiatPaymentType`. They remain mapped because they still cover fiats and coins
+ * the replacement PSP does not, but they are only selected when no current PSP
+ * is available for the requested fiat/coin pair.
+ */
+const deprecatedPaymentTypes = new Set<BanxaPaymentType>([
+  // Superseded by PRIMERGP
+  'WORLDPAYGOOGLE',
+  // Superseded by BRDGACHSELL
+  'ZHACHSELL'
+])
+
 // While this could use Array.find(), this is an inner loop routine used hundreds of times interating over
 // hundreds entries, so I'm opting for a more optimal for loop
 const findLimit = (
@@ -1148,6 +1162,7 @@ const buildPaymentsMap = (
             // There shouldn't be an existing payment for this fiat/coin combo
             const newMap: BanxaPaymentIdLimit = {
               id: pm.id,
+              paymentType,
               min: limit.min,
               max: limit.max,
               type: pt
@@ -1179,11 +1194,28 @@ const getPaymentIdLimit = (
 ): BanxaPaymentIdLimit | undefined => {
   try {
     const payments = banxaPaymentsMap[direction][fiat][banxaCoin]
-    const paymentId = Object.values(payments).find(p => p.type === type)
-    return paymentId
+    return pickPreferredPayment(Object.values(payments), type)
   } catch (e) {
     return undefined
   }
+}
+
+/**
+ * Banxa often exposes several payment methods for the same `FiatPaymentType`,
+ * because a replacement PSP runs alongside the PSP it supersedes until the old
+ * one is switched off. Always pick a current PSP, and only fall back to a
+ * deprecated one when it is the sole option for the fiat/coin pair.
+ */
+const pickPreferredPayment = (
+  payments: BanxaPaymentIdLimit[],
+  type: FiatPaymentType
+): BanxaPaymentIdLimit | undefined => {
+  const candidates = payments.filter(payment => payment.type === type)
+  return (
+    candidates.find(
+      payment => !deprecatedPaymentTypes.has(payment.paymentType)
+    ) ?? candidates[0]
+  )
 }
 
 // Takes an EdgeAsset and returns the corresponding Banxa chain code and coin code

--- a/src/plugins/ramps/banxa/banxaRampPlugin.ts
+++ b/src/plugins/ramps/banxa/banxaRampPlugin.ts
@@ -280,8 +280,9 @@ const ensureIsoPrefix = (currencyCode: string): string => {
   return currencyCode.startsWith('iso:') ? currencyCode : `iso:${currencyCode}`
 }
 
-interface BanxaPaymentIdLimit {
+export interface BanxaPaymentIdLimit {
   id: number
+  paymentType: BanxaPaymentType
   type: FiatPaymentType
   min: string
   max: string
@@ -357,6 +358,19 @@ const typeMap: Record<BanxaPaymentType, FiatPaymentType> = {
   WORLDPAYGOOGLE: 'googlepay',
   ZHACHSELL: 'ach'
 }
+
+/**
+ * Banxa PSPs that have been superseded by a newer PSP serving the same
+ * `FiatPaymentType`. They remain mapped because they still cover fiats and coins
+ * the replacement PSP does not, but they are only selected when no current PSP
+ * is available for the requested fiat/coin pair.
+ */
+const deprecatedPaymentTypes = new Set<BanxaPaymentType>([
+  // Superseded by PRIMERGP
+  'WORLDPAYGOOGLE',
+  // Superseded by BRDGACHSELL
+  'ZHACHSELL'
+])
 
 // Provider configuration cache
 interface ProviderConfigCache {
@@ -530,6 +544,7 @@ const buildPaymentsMap = (
           } else {
             const newMap: BanxaPaymentIdLimit = {
               id: pm.id,
+              paymentType,
               min: limit.min,
               max: limit.max,
               type: pt
@@ -562,9 +577,26 @@ const getPaymentIdLimit = (
 ): BanxaPaymentIdLimit | undefined => {
   try {
     const payments = banxaPaymentsMap[direction][fiat][banxaCoin]
-    const paymentId = Object.values(payments).find(p => p.type === type)
-    return paymentId
+    return pickPreferredPayment(Object.values(payments), type)
   } catch (e) {}
+}
+
+/**
+ * Banxa often exposes several payment methods for the same `FiatPaymentType`,
+ * because a replacement PSP runs alongside the PSP it supersedes until the old
+ * one is switched off. Always pick a current PSP, and only fall back to a
+ * deprecated one when it is the sole option for the fiat/coin pair.
+ */
+export const pickPreferredPayment = (
+  payments: BanxaPaymentIdLimit[],
+  type: FiatPaymentType
+): BanxaPaymentIdLimit | undefined => {
+  const candidates = payments.filter(payment => payment.type === type)
+  return (
+    candidates.find(
+      payment => !deprecatedPaymentTypes.has(payment.paymentType)
+    ) ?? candidates[0]
+  )
 }
 
 // Takes an EdgeAsset and returns the corresponding Banxa chain code and coin code


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

[Asana task](https://app.asana.com/0/0/1210642564105750/f)

Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1210642564105750

Banxa reports that Edge orders are still arriving on the OLD Google Pay processor, a month after #6071 mapped the new one. Adding `PRIMERGP` to the allowlist was necessary but not sufficient.

Banxa runs a replacement PSP alongside the PSP it supersedes until the old one is switched off, so several ACTIVE payment methods share one Edge `FiatPaymentType`. Selection took the first match out of a map keyed by Banxa's numeric payment id:

```ts
const payments = banxaPaymentsMap[direction][fiat][banxaCoin]
const paymentId = Object.values(payments).find(p => p.type === type)
```

Integer-like object keys iterate in ascending numeric order, so the four legacy `WORLDPAYGOOGLE` ids (6033, 6034, 6035, 6036) are always found before `PRIMERGP` (6142). Every Google Pay quote and order therefore carried a legacy `payment_method_id`, which is exactly what Banxa is seeing.

This ranks the candidates instead of taking the first: a `deprecatedPaymentTypes` set marks the superseded PSPs (`WORLDPAYGOOGLE`, `ZHACHSELL`), and `pickPreferredPayment` selects a deprecated one only when no current PSP serves the fiat/coin pair.

Deleting the legacy mapping outright was rejected. Banxa's live `api/payment-methods` shows `PRIMERGP` is a superset of the `WORLDPAYGOOGLE` entries except for KRW, and covers 127 coins against the legacy entries' union of 136: APE, EURQ, EUSD, GALA, INJ, MELANIA, MYTH, S, TRUMP, USDQ and VFX exist only on the legacy PSP. Ranking keeps those combinations working while every combination Banxa has migrated moves to the new PSP.

Both Banxa integrations get the same change, as in #6071: the live ramps plugin (`src/plugins/ramps/banxa/banxaRampPlugin.ts`) and the legacy provider (`src/plugins/gui/providers/banxaProvider.ts`).

The sell side needed no equivalent fix: `ZHACHSELL` is gone from Banxa's live sell response, so `BRDGACHSELL` (6151) is already the only ACH candidate. It is in the deprecated set anyway, so a re-listing cannot regress it.

### Testing

Driven in-app on the iOS simulator against Banxa's live production API: ramps Buy, Texas/USA, USD 500 to BTC, on `edge-funds`. A temporary probe appended the resolved Banxa payment method to the provider's display name, giving a matched pair from the same running app:

- Before (pre-fix selection): `Banxa PROBE[WORLDPAYGOOGLE:6033]`, 500.00 USD to 0.00721889 BTC
- After (this change): `Banxa PROBE[PRIMERGP:6142]`, 500.00 USD to 0.00722104 BTC

Google Pay is filtered out of the iOS quote list by `useRampQuotes.ts`, so that filter was disabled locally to render the row. Both probe edits were reverted before committing.

New unit test `src/__tests__/plugins/ramps/banxa/pickPreferredPayment.test.ts` covers the selection order: the current PSP wins when both are present, the result does not depend on candidate order, the deprecated PSP is still used when it is the only candidate, and a non-matching type returns nothing.

`verify-repo.sh` passes (CHANGELOG, `npm run prepare`, eslint on changed files, jest).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Banxa `payment_method_id` is sent on buy quotes/orders (fiat on-ramp path); behavior is covered by new unit tests and matches an intentional PSP migration fix.
> 
> **Overview**
> **Banxa Google Pay (and similar overlaps)** no longer pick the legacy processor just because its numeric payment id sorts first in the internal map.
> 
> Selection for a given `FiatPaymentType` now goes through **`pickPreferredPayment`**, which treats **`WORLDPAYGOOGLE`** (superseded by **`PRIMERGP`**) and **`ZHACHSELL`** (superseded by **`BRDGACHSELL`**) as deprecated and only uses them when no current PSP exists for that fiat/coin pair. Payment map entries carry **`paymentType`** so that ranking can run.
> 
> The same logic is applied in **`banxaRampPlugin.ts`** and **`banxaProvider.ts`**, with unit tests in **`pickPreferredPayment.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5a002eadb2335691ef810d546b763faa246b103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->