### PR TITLE
Use info-tester in Maestro GUI fetches

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -504,7 +504,6 @@ export default [
       'src/util/haptic.ts',
       'src/util/infoUtils.ts',
 
-      'src/util/maestro.ts',
       'src/util/memoUtils.ts',
       'src/util/middleware/perfLogger.ts',
 

--- a/src/components/services/EdgeCoreManager.tsx
+++ b/src/components/services/EdgeCoreManager.tsx
@@ -40,16 +40,17 @@ import { lstrings } from '../../locales/strings'
 import { addMetadataToContext } from '../../util/addMetadataToContext'
 import { allPlugins } from '../../util/corePlugins'
 import { fakeUser } from '../../util/fake-user'
-import { isMaestro } from '../../util/maestro'
+import {
+  INFO_TEST_SERVER,
+  LOGIN_TEST_SERVER,
+  shouldUseTestServers,
+  SYNC_TEST_SERVER
+} from '../../util/maestro'
 import { getOsVersion } from '../../util/utils'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { LoadingSplashScreen } from '../progress-indicators/LoadingSplashScreen'
 import { Airship, showError } from './AirshipInstance'
 import { Providers } from './Providers'
-
-const LOGIN_TEST_SERVER = 'https://login-tester.edge.app'
-const INFO_TEST_SERVER = 'https://info-tester.edge.app'
-const SYNC_TEST_SERVER = 'https://sync-tester-us1.edge.app'
 
 interface Props {}
 
@@ -200,10 +201,7 @@ export const EdgeCoreManager: React.FC<Props> = props => {
   let loginServer: string | undefined
   let syncServer: string | undefined
 
-  if (
-    (ENV.ENABLE_TEST_SERVERS == null && isMaestro()) ||
-    ENV.ENABLE_TEST_SERVERS === true
-  ) {
+  if (shouldUseTestServers()) {
     console.log('Using test servers')
     infoServer = INFO_TEST_SERVER
     loginServer = LOGIN_TEST_SERVER

--- a/src/util/maestro.ts
+++ b/src/util/maestro.ts
@@ -1,3 +1,16 @@
 import { ENV } from '../env'
 
-export const isMaestro = () => ENV.ENABLE_MAESTRO_BUILD
+export const LOGIN_TEST_SERVER = 'https://login-tester.edge.app'
+export const INFO_TEST_SERVER = 'https://info-tester.edge.app'
+export const SYNC_TEST_SERVER = 'https://sync-tester-us1.edge.app'
+
+export const isMaestro = (): boolean => ENV.ENABLE_MAESTRO_BUILD
+
+/**
+ * Maestro builds default to tester login/info/sync hosts unless
+ * `ENABLE_TEST_SERVERS` explicitly disables them. Non-Maestro builds only
+ * use tester hosts when `ENABLE_TEST_SERVERS` is true.
+ */
+export const shouldUseTestServers = (): boolean =>
+  (ENV.ENABLE_TEST_SERVERS == null && isMaestro()) ||
+  ENV.ENABLE_TEST_SERVERS === true

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -11,6 +11,7 @@ import { getVersion } from 'react-native-device-info'
 import { ENV } from '../env'
 import { config } from '../theme/appConfig'
 import { initAttestation } from './attestation'
+import { INFO_TEST_SERVER, shouldUseTestServers } from './maestro'
 import { runOnce } from './runOnce'
 import { asyncWaterfall, getOsVersion, shuffleArray } from './utils'
 import { checkAppVersion } from './versionCheck'
@@ -19,6 +20,8 @@ import { checkAppVersion } from './versionCheck'
 const INFO_SERVERS =
   ENV.INFO_SERVER != null && ENV.INFO_SERVER.length > 0
     ? ENV.INFO_SERVER
+    : shouldUseTestServers()
+    ? [INFO_TEST_SERVER]
     : ['https://info1.edge.app', 'https://info2.edge.app']
 const RATES_SERVERS = ['https://rates3.edge.app', 'https://rates4.edge.app']
 const RATES_SERVER_V2 = ['https://rates1.edge.app', 'https://rates2.edge.app']


### PR DESCRIPTION
## Summary
- Route GUI `fetchInfo` / info-server rollup requests through `info-tester.edge.app` when Maestro (or `ENABLE_TEST_SERVERS`) is enabled
- Centralize tester login/info/sync host selection in `shouldUseTestServers()` so Core and GUI stay aligned
- Leave change-tester / referral-tester on production

## Test plan
- [ ] Build with `ENABLE_MAESTRO_BUILD=true` and confirm GUI logs / network hits go to `info-tester.edge.app`
- [ ] Confirm Core still receives tester login/info/sync hosts in Maestro builds
- [ ] Confirm non-Maestro production builds still use `info1`/`info2`
- [ ] Confirm `ENV.INFO_SERVER` still overrides when set


Made with [Cursor](https://cursor.com)