### PR TITLE
Integrate Robinhood Chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 4.51.0 (staging)
 
+- added: Robinhood Chain wallets
 - added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.
 - added: App/device attestation for gated info-server requests
 - added: Swapter swap provider

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -82,6 +82,7 @@ export const CURRENCY_SETTINGS_KEYS = [
   'pulsechain',
   'qtum',
   'ravencoin',
+  'robinhood',
   'rsk',
   'sepolia',
   'smartcash',
@@ -150,7 +151,8 @@ export const WALLET_TYPE_ORDER = [
   'wallet:mayachain',
   'wallet:monad',
   'wallet:opbnb',
-  'wallet:nym'
+  'wallet:nym',
+  'wallet:robinhood'
 ]
 
 export interface WalletSettingOption {
@@ -557,6 +559,17 @@ export const SPECIAL_CURRENCY_INFO: Record<string, SpecialCurrencyInfo> = {
     walletConnectV2ChainId: {
       namespace: 'eip155',
       reference: '8453'
+    }
+  },
+  robinhood: {
+    initWalletName: lstrings.string_first_robinhood_wallet_name,
+    dummyPublicAddress: '0x0d73358506663d484945ba85d0cd435ad610b0a0',
+    allowZeroTx: true,
+    isImportKeySupported: true,
+    showChainIcon: true,
+    walletConnectV2ChainId: {
+      namespace: 'eip155',
+      reference: '4663'
     }
   },
   filecoin: {

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -405,6 +405,7 @@ export const asEnvConfig = asObject({
       referrerFee: asOptional(asString, '0.75')
     }).withRest
   ),
+  ROBINHOOD_INIT: asCorePluginInit(asEvmApiKeys),
   RSK_INIT: asCorePluginInit(asEvmApiKeys),
   SEPOLIA_INIT: asCorePluginInit(asEvmApiKeys),
   SIDESHIFT_INIT: asCorePluginInit(

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -827,6 +827,7 @@ const strings = {
   string_first_sepolia_wallet_name: 'My Sepolia',
   string_first_sonic_wallet_name: 'My Sonic',
   string_first_opbnb_wallet_name: 'My opBNB',
+  string_first_robinhood_wallet_name: 'My Robinhood Chain',
   my_crypto_wallet_name: 'My %s',
   string_help: 'Help',
   string_exit: 'Exit',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -639,6 +639,7 @@
   "string_first_sepolia_wallet_name": "My Sepolia",
   "string_first_sonic_wallet_name": "My Sonic",
   "string_first_opbnb_wallet_name": "My opBNB",
+  "string_first_robinhood_wallet_name": "My Robinhood Chain",
   "my_crypto_wallet_name": "My %s",
   "string_help": "Help",
   "string_exit": "Exit",

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -47,6 +47,7 @@ export const currencyPlugins: EdgeCorePluginsInit = {
   polygon: ENV.POLYGON_INIT,
   pulsechain: ENV.PULSECHAIN_INIT,
   ripple: true,
+  robinhood: ENV.ROBINHOOD_INIT,
   rsk: ENV.RSK_INIT,
   sepolia: ENV.SEPOLIA_INIT,
   solana: ENV.SOLANA_INIT,


### PR DESCRIPTION
### Technical Design Document

[robinhood-chain.md](https://github.com/EdgeApp/edge-currency-accountbased/blob/jon/robinhood-chain/src/docs/robinhood-chain.md)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

EdgeApp/edge-currency-accountbased#1087 (the `robinhood` plugin itself)

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Registers the `robinhood` currency plugin so users can create a Robinhood Chain wallet. Robinhood Chain is an Arbitrum L2 (EVM chain 4663) that uses ETH for gas.

Asana: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1217382370104887

Five files, matching the `opbnb` and `monad` registrations: `corePlugins.ts`, `envConfig.ts`, `WalletAndCurrencyConstants.ts`, and the two locale files.

`WalletAndCurrencyConstants.ts` carries two list entries, not one. Beyond `WALLET_TYPE_ORDER` and the `SPECIAL_CURRENCY_INFO` block, `robinhood` also goes in `CURRENCY_SETTINGS_KEYS`, which `WalletSettingsModal` reads to decide whether to show the Asset Settings row and which `AssetSettingsScene` maps to build its list. Every peer EVM L2 is in it. Bugbot caught the omission; the rest of the GUI's hardcoded pluginId lists were checked and correctly exclude this chain, since they are ramp and payment-protocol asset maps for providers that do not support it.

`showChainIcon: true` is the one entry worth a look. The native asset is ETH, so without the chain badge a Robinhood Chain wallet is indistinguishable from an Ethereum mainnet wallet in the wallet list. `arbitrum` and `base` set it for the same reason.

The wallet name string is "My Robinhood Chain" rather than "My Robinhood", since the shorter form reads as a brokerage account.

**Testing.** Full jest suite, snapshots and eslint pass. Driven on the iOS simulator against EdgeApp/edge-currency-accountbased#1087 linked in: searching "Robinhood" in Choose Wallets to Add lists the chain, creating gives "My Robinhood Chain" on a wallet scene titled "Robinhood Chain Network", and importing a seed with real on-chain history renders its live balance. After the `CURRENCY_SETTINGS_KEYS` fix, re-driven to confirm the wallet's Asset Settings row renders and "Robinhood Chain" appears in the Asset Settings list between Ravencoin and Rootstock. Screenshots are attached in comments below.

One search behavior to know when testing: `filterWalletCreateItemListBySearchText` requires every whitespace-separated term to prefix-match a field, so typing the full "Robinhood Chain" returns nothing while "Robinhood" matches.

**Re-tested 2026-09-01** after the accb and exch merge histories were reworked, on a build that pins both reworked masters as tarballs (the `test-string` cheese build's exact dependency set). Wallet list renders the Robinhood Chain wallets and syncs balances, and a real 0.0005 ETH send executed to the success scene: tx `0xd5fe57cead105a391eaba43e299d414945d04ab3be7f3d216c0e6c9fea899242`, receipt status 1, block 52050785, sender nonce 1 to 2. Fee came from the Arbitrum `NodeInterface` estimate (0.0000274 ETH quoted, 0.0000099 actual).

Follow-ups:

- ~~`ROBINHOOD_INIT` needs adding to the deployed `env.json`~~, done on the build box 2026-09-01. Without it `asCorePluginInit` returns `false` and the plugin ships disabled, which is what a local build without the key does.
- Currency icons at `content.edge.app/currencyIconsV3/robinhood/` (`robinhood.png`, `chain_robinhood.png`) do not exist yet, so the wallet renders a text placeholder in the app.
- Exchange rates read `$0.00` in-app until edge-rates-server is deployed and its one-time `rates_settings` write lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Follows the existing EVM L2 registration pattern with no changes to auth, payments, or transaction signing logic in this repo.
> 
> **Overview**
> **Adds Robinhood Chain** as a creatable/importable EVM wallet in the GUI, wired the same way as other account-based L2s (e.g. opBNB, Monad).
> 
> The PR registers the `robinhood` plugin in `corePlugins.ts`, adds `ROBINHOOD_INIT` in `envConfig.ts`, and extends `WalletAndCurrencyConstants.ts` with list ordering, default wallet metadata (**EIP-155 chain 4663**, WalletConnect, import/zero-tx flags, and **`showChainIcon: true`** so ETH-native gas wallets are not confused with Ethereum mainnet). Locale strings use **"My Robinhood Chain"** for the default wallet name. CHANGELOG notes the feature for 4.51.0.
> 
> Actual chain logic lives in the separate **edge-currency-accountbased** Robinhood plugin dependency; this diff is GUI registration and copy only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f42b20ac7484b3b22860a32b49394582b9808c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

