### PR TITLE
Wire attestation tokens into edge-core-js context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (develop)
 
+- added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.
 - added: App/device attestation for gated info-server requests
 - added: "-m" tag on the version number in the Help scene for Maestro test builds
 - added: Sign Message option in the wallet list menu for Bitcoin-family wallets, letting users prove self-hosted wallet ownership to exchanges by signing an exchange-provided message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - changed: Deep links now wait only for the account state they actually use, so a link that just opens a scene, such as the buy/sell entry, follows immediately after login instead of waiting for every wallet to finish loading.
 - fixed: The buy/sell amount field no longer reads "Amount undefined" while the app is still working out which wallet to use.
 - fixed: Show the Monero Transaction Key of a send whose key never reached the transaction's saved metadata, by falling back to the key the wallet engine mirrors into `otherParams`. Covers sends made on 4.49.0 and later while the send path reported no key, on devices that still hold the original wallet cache.
+- fixed: Force `NODE_ENV=test` in the Jest script so UI tests keep working when npm is invoked via Socket (Socket otherwise sets `NODE_ENV=development`, which makes react-native-gesture-handler treat Jest as a non-test env).
 - fixed: Bitwave CSV exports now use ISO 8601 UTC timestamps, leave the fee columns blank so Bitwave does not double-count fees, and copy the description into the second custom metadata column.
 - fixed: Bitwave account ids are no longer capitalized by the keyboard or padded with whitespace when entered, so exports import without hand-editing the account id.
 - fixed: NYM max swaps from EVM wallets now report the correct limit error instead of an unsupported-route error (edge-exchange-plugins 2.52.1).

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -15,7 +15,7 @@ PODS:
   - disklet (0.6.0):
     - React
   - DoubleConversion (1.1.6)
-  - edge-core-js (2.47.1):
+  - edge-core-js (2.48.0):
     - React-Core
   - edge-currency-accountbased (4.88.0):
     - React-Core
@@ -3340,7 +3340,7 @@ SPEC CHECKSUMS:
   CNIOWindows: 3047f2d8165848a3936a0a755fee27c6b5ee479b
   disklet: ef8ef081e35a73fbed579888d29e49edc2f327cc
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  edge-core-js: c04529b2fc93a9ffca498c8b8bff94fc9e6e4b40
+  edge-core-js: 65a405086f5a6603342edd366c5c5598284af496
   edge-currency-accountbased: 5473424f61984e99e89593835021d17bc035abff
   edge-currency-plugins: 2b0de648624d46c0e32e4530f853673a3edfeaa6
   edge-exchange-plugins: 849a09d9de22c8e1fd9e9af89f457921800cdf6a

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "deprecated-react-native-prop-types": "^5.0.0",
         "detect-bundler": "^1.1.0",
         "disklet": "^0.6.0",
-        "edge-core-js": "^2.47.1",
+        "edge-core-js": "^2.48.0",
         "edge-currency-accountbased": "^4.88.0",
         "edge-currency-plugins": "^3.12.0",
         "edge-exchange-plugins": "^2.53.0",
@@ -15337,9 +15337,9 @@
       }
     },
     "node_modules/edge-core-js": {
-      "version": "2.47.1",
-      "resolved": "https://registry.npmjs.org/edge-core-js/-/edge-core-js-2.47.1.tgz",
-      "integrity": "sha512-T9zcCQOLoeuirfddfrKn9BDAl0UVqtsXzYWGFWY+lxeKQCJ868km0LD22UnjZs1h/TFA7DHrYLVPtJ0pGvbnJw==",
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/edge-core-js/-/edge-core-js-2.48.0.tgz",
+      "integrity": "sha512-DezX4mVk7I8O7njk+XxUthg7UrAQrWzTNmcdRW6UrIXjlXwy2Srg2HTx9rWd3y5QEjaNuVv32Qjo054hZoMo+A==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@nymproject/mix-fetch": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "deprecated-react-native-prop-types": "^5.0.0",
     "detect-bundler": "^1.1.0",
     "disklet": "^0.6.0",
-    "edge-core-js": "^2.47.1",
+    "edge-core-js": "^2.48.0",
     "edge-currency-accountbased": "^4.88.0",
     "edge-currency-plugins": "^3.12.0",
     "edge-exchange-plugins": "^2.53.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "rates-cache-replay": "node -r sucrase/register scripts/ratesCacheReplay.ts",
     "server": "node ./loggingServer.js",
     "start": "react-native start",
-    "test": "TZ=America/Los_Angeles jest",
+    "test": "NODE_ENV=test TZ=America/Los_Angeles jest",
     "typechain": "rm -rf './src/plugins/contracts/' && typechain --target ethers-v5 --out-dir ./src/plugins/contracts/ './src/plugins/abis/*.json'",
     "theme": "node -r sucrase/register ./scripts/themeServer.ts",
     "updateVersion": "node -r sucrase/register scripts/updateVersion.ts",

--- a/src/__tests__/util/attestation.test.ts
+++ b/src/__tests__/util/attestation.test.ts
@@ -66,6 +66,7 @@ const {
   attestedJsonHeaders,
   getAttestationToken,
   initAttestation,
+  onAttestationToken,
   resetAttestationForTests
 } = require('../../util/attestation')
 
@@ -2108,6 +2109,124 @@ describe('attestation engine', () => {
       // actually refused, so it cannot take out a replacement a newer handshake
       // enrolled while it waited.
       expect(mockClearKey.mock.calls[0]).toStrictEqual(['key-rejected'])
+    })
+  })
+
+  describe('onAttestationToken', () => {
+    it('fires with the JWT after a successful handshake', async () => {
+      const listener = jest.fn<(token: string | undefined) => void>()
+      onAttestationToken(listener)
+      // Sync emit of the current (empty) cache on subscribe:
+      expect(listener.mock.calls).toEqual([[undefined]])
+      listener.mockClear()
+      mockSuccessfulHandshake()
+      initAttestation()
+      await flush()
+
+      expect(listener.mock.calls).toEqual([['jwt-token']])
+    })
+
+    it('fires with undefined when an assertion is rejected', async () => {
+      const { REFRESH_LEAD_MS } = attestationTimingForTests
+      const REFRESH_UNTIL_MS = 5 * 60 * 1000
+      const listener = jest.fn<(token: string | undefined) => void>()
+      onAttestationToken(listener)
+      listener.mockClear()
+      mockSuccessfulHandshake((REFRESH_LEAD_MS + REFRESH_UNTIL_MS) / 1000)
+      initAttestation()
+      await flush()
+      expect(listener.mock.calls).toEqual([['jwt-token']])
+      listener.mockClear()
+
+      mockGenerateAssertion.mockResolvedValue({
+        keyId: 'K1',
+        assertion: 'assert-1',
+        bundleId: 'co.edgesecure.app'
+      })
+      mockSignChallenge.mockResolvedValue({ keyId: 'K1', signature: 'sig-1' })
+      mockGetAttestation.mockRejectedValue(new Error('attestation unavailable'))
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-2' })
+        }
+        if (path.endsWith('/assert')) return jsonResponse({}, false, 401)
+        throw new Error(`unexpected path ${path}`)
+      })
+      await jest.advanceTimersByTimeAsync(REFRESH_UNTIL_MS)
+      await flush()
+
+      expect(listener.mock.calls).toContainEqual([undefined])
+    })
+
+    it('fires with undefined when a cached token becomes unservable', async () => {
+      // Refresh is armed while the token is still servable, and a failed
+      // refresh then waits out FAILURE_BACKOFF_MS. Listeners must still drop
+      // the JWT at the skew window - not whenever that later tick happens.
+      const { CLOCK_SKEW_MS, FAILURE_BACKOFF_MS, MIN_REFRESH_MS } =
+        attestationTimingForTests
+      const lifetimeMs = MIN_REFRESH_MS + CLOCK_SKEW_MS + 10 * 1000
+      const listener = jest.fn<(token: string | undefined) => void>()
+      onAttestationToken(listener)
+      listener.mockClear()
+      mockSuccessfulHandshake(lifetimeMs / 1000)
+      initAttestation()
+      await flush()
+      expect(listener.mock.calls).toEqual([['jwt-token']])
+      listener.mockClear()
+
+      mockCheapFailingHandshake()
+      await jest.advanceTimersByTimeAsync(MIN_REFRESH_MS)
+      await flush()
+      // Still inside the servable window, so the failure path must not clear.
+      expect(listener.mock.calls).toEqual([])
+      await expect(getAttestationToken()).resolves.toBe('jwt-token')
+
+      // Cross the skew window, but stay well short of the failure backoff.
+      await jest.advanceTimersByTimeAsync(CLOCK_SKEW_MS + 10 * 1000)
+      await flush()
+      expect(CLOCK_SKEW_MS + 10 * 1000).toBeLessThan(FAILURE_BACKOFF_MS)
+      expect(listener.mock.calls).toEqual([[undefined]])
+      await expect(getAttestationToken()).resolves.toBeUndefined()
+    })
+
+    it('stops notifying after unsubscribe', async () => {
+      const { REFRESH_LEAD_MS } = attestationTimingForTests
+      const REFRESH_UNTIL_MS = 5 * 60 * 1000
+      const listener = jest.fn<(token: string | undefined) => void>()
+      const stillListening = jest.fn<(token: string | undefined) => void>()
+      const unsubscribe = onAttestationToken(listener)
+      onAttestationToken(stillListening)
+      listener.mockClear()
+      stillListening.mockClear()
+
+      mockSuccessfulHandshake((REFRESH_LEAD_MS + REFRESH_UNTIL_MS) / 1000)
+      initAttestation()
+      await flush()
+      expect(listener.mock.calls).toEqual([['jwt-token']])
+      expect(stillListening.mock.calls).toEqual([['jwt-token']])
+      listener.mockClear()
+      stillListening.mockClear()
+      unsubscribe()
+
+      mockGenerateAssertion.mockResolvedValue({
+        keyId: 'K1',
+        assertion: 'assert-1',
+        bundleId: 'co.edgesecure.app'
+      })
+      mockSignChallenge.mockResolvedValue({ keyId: 'K1', signature: 'sig-1' })
+      mockGetAttestation.mockRejectedValue(new Error('attestation unavailable'))
+      mockFetchInfo.mockImplementation(async (path: string) => {
+        if (path === 'v1/attest/challenge') {
+          return jsonResponse({ challenge: 'chal-2' })
+        }
+        if (path.endsWith('/assert')) return jsonResponse({}, false, 401)
+        throw new Error(`unexpected path ${path}`)
+      })
+      await jest.advanceTimersByTimeAsync(REFRESH_UNTIL_MS)
+      await flush()
+
+      expect(stillListening.mock.calls).toContainEqual([undefined])
+      expect(listener.mock.calls).toEqual([])
     })
   })
 })

--- a/src/components/services/EdgeCoreManager.tsx
+++ b/src/components/services/EdgeCoreManager.tsx
@@ -38,6 +38,7 @@ import { useHandler } from '../../hooks/useHandler'
 import { useIsAppForeground } from '../../hooks/useIsAppForeground'
 import { lstrings } from '../../locales/strings'
 import { addMetadataToContext } from '../../util/addMetadataToContext'
+import { onAttestationToken } from '../../util/attestation'
 import { allPlugins } from '../../util/corePlugins'
 import { fakeUser } from '../../util/fake-user'
 import {
@@ -163,8 +164,20 @@ export const EdgeCoreManager: React.FC<Props> = props => {
 
   const handleContext = useHandler((context: EdgeContext) => {
     console.log('EdgeContext opened')
+    let active = true
+    const pushToken = (token: string | undefined): void => {
+      if (!active) return
+      context.setAttestationToken(token).catch((error: unknown) => {
+        if (!active) return
+        console.warn('[attestation] setAttestationToken failed', error)
+      })
+    }
+    const unsubscribeToken = onAttestationToken(pushToken)
+    // onAttestationToken sync-replays the current servable token on subscribe.
     context.on('close', () => {
       console.log('EdgeContext closed')
+      active = false
+      unsubscribeToken()
       setContext(null)
     })
     ++counter.current
@@ -197,8 +210,8 @@ export const EdgeCoreManager: React.FC<Props> = props => {
     ENV.DEBUG_EXCHANGES ? exchangeDebugUri : exchangeUri
   ]
 
-  let infoServer: string | undefined
-  let loginServer: string | undefined
+  let infoServer: string | string[] | undefined
+  let loginServer: string | string[] | undefined
   let syncServer: string | undefined
 
   if (shouldUseTestServers()) {
@@ -206,6 +219,13 @@ export const EdgeCoreManager: React.FC<Props> = props => {
     infoServer = INFO_TEST_SERVER
     loginServer = LOGIN_TEST_SERVER
     syncServer = SYNC_TEST_SERVER
+  }
+
+  if (ENV.LOGIN_SERVER != null && ENV.LOGIN_SERVER.length > 0) {
+    loginServer = ENV.LOGIN_SERVER
+  }
+  if (ENV.INFO_SERVER != null && ENV.INFO_SERVER.length > 0) {
+    infoServer = ENV.INFO_SERVER
   }
 
   return (

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -562,6 +562,10 @@ export const asEnvConfig = asObject({
   // Optional override of the info server URL(s), e.g. for pointing a debug build
   // at a local info server: ["http://127.0.0.1:8008"]. Absent in production.
   INFO_SERVER: asOptional(asArray(asString)),
+  // Optional override of the login server URL(s), e.g. for pointing a debug
+  // build at a local login server: ["http://192.168.1.50:3123"]. Do not include
+  // `/api` in the path. Absent in production.
+  LOGIN_SERVER: asOptional(asArray(asString)),
   ENABLE_REDUX_PERF_LOGGING: asOptional(asBoolean, false),
   LOG_SERVER: asNullable(
     asObject({

--- a/src/util/attestation.ts
+++ b/src/util/attestation.ts
@@ -119,6 +119,11 @@ const MAX_BACKOFF_MS = 30 * 60 * 1000
 let cachedToken: CachedToken | undefined
 let inFlight: Promise<void> | undefined
 let refreshTimer: ReturnType<typeof setTimeout> | undefined
+// Drop the JWT when it crosses the skew window, so push listeners (edge-core)
+// stop sending a token getAttestationToken would already withhold. The
+// handshake timer is not this clock: it is armed while the token is still
+// servable, and a failed refresh can leave the next tick behind a backoff.
+let serveUntilTimer: ReturnType<typeof setTimeout> | undefined
 // `undefined` means no prior stamp. Initializing these to `0` worked with
 // `Date.now()` (epoch is always far past) but a monotonic clock starts near
 // zero, so `0` would look like "just now" and park every first handshake behind
@@ -142,19 +147,7 @@ let unsupported = false
 // warning per day of app uptime so the refresh cadence cannot re-prompt.
 let lastClockWarnAtMono: number | undefined
 
-/** Test-only: clear module state between Jest cases. */
-export const resetAttestationForTests = (): void => {
-  cachedToken = undefined
-  inFlight = undefined
-  if (refreshTimer != null) clearTimeout(refreshTimer)
-  refreshTimer = undefined
-  lastFailureAt = undefined
-  lastHandshakeAt = undefined
-  consecutiveFailures = 0
-  handshakeGeneration = 0
-  unsupported = false
-  lastClockWarnAtMono = undefined
-}
+const tokenListeners = new Set<(token: string | undefined) => void>()
 
 /**
  * Whether the cached token may be handed to a gated caller right now.
@@ -168,6 +161,76 @@ const canServeToken = (): boolean =>
   cachedToken != null &&
   monotonicNow() < cachedToken.expiresMono - CLOCK_SKEW_MS
 
+const getServableToken = (): string | undefined =>
+  canServeToken() ? cachedToken?.token : undefined
+
+const notifyTokenListeners = (): void => {
+  const token = getServableToken()
+  for (const listener of tokenListeners) {
+    try {
+      listener(token)
+    } catch (error) {
+      console.warn('[attestation] token listener threw', error)
+    }
+  }
+}
+
+const setCachedToken = (next: CachedToken | undefined): void => {
+  cachedToken = next
+  if (serveUntilTimer != null) clearTimeout(serveUntilTimer)
+  serveUntilTimer = undefined
+  if (cachedToken != null) {
+    const serveMs = cachedToken.expiresMono - CLOCK_SKEW_MS - monotonicNow()
+    if (serveMs > 0) {
+      serveUntilTimer = setTimeout(() => {
+        serveUntilTimer = undefined
+        dropUnservableToken()
+      }, serveMs)
+    }
+  }
+  notifyTokenListeners()
+}
+
+const dropUnservableToken = (): void => {
+  if (cachedToken != null && !canServeToken()) {
+    setCachedToken(undefined)
+  }
+}
+
+/**
+ * Subscribe to attestation token changes. Returns an unsubscribe function.
+ * Immediately invokes the listener with the current servable token (if any).
+ */
+export const onAttestationToken = (
+  listener: (token: string | undefined) => void
+): (() => void) => {
+  tokenListeners.add(listener)
+  try {
+    listener(getServableToken())
+  } catch (error) {
+    console.warn('[attestation] token listener threw', error)
+  }
+  return () => {
+    tokenListeners.delete(listener)
+  }
+}
+
+/** Test-only: clear module state between Jest cases. */
+export const resetAttestationForTests = (): void => {
+  cachedToken = undefined
+  tokenListeners.clear()
+  inFlight = undefined
+  if (refreshTimer != null) clearTimeout(refreshTimer)
+  refreshTimer = undefined
+  if (serveUntilTimer != null) clearTimeout(serveUntilTimer)
+  serveUntilTimer = undefined
+  lastFailureAt = undefined
+  lastHandshakeAt = undefined
+  consecutiveFailures = 0
+  handshakeGeneration = 0
+  unsupported = false
+  lastClockWarnAtMono = undefined
+}
 /**
  * Warn once per day of app uptime when the device wall clock disagrees with the
  * server by more than `CLOCK_WARN_MS`. `serverTime` is a UX signal only - it
@@ -355,7 +418,7 @@ const refreshWithEnrolledKey = async (
   // this attempt - the key and token belong to a live handshake now, and clearing
   // them would force it into a needless re-attestation.
   assertCurrent(attempt)
-  cachedToken = undefined
+  setCachedToken(undefined)
   console.warn(
     `[attestation] assertion rejected (${response.status}); re-attesting`
   )
@@ -457,6 +520,10 @@ const delay = async (ms: number): Promise<void> => {
 const armTimer = (delayMs: number): void => {
   if (refreshTimer != null) clearTimeout(refreshTimer)
   refreshTimer = setTimeout(() => {
+    // If the cached token can no longer be served (expiry), clear it so
+    // onAttestationToken listeners (e.g. EdgeCoreManager → setAttestationToken)
+    // drop the stale JWT before the handshake runs.
+    dropUnservableToken()
     runHandshake()
   }, delayMs)
 }
@@ -605,7 +672,7 @@ const runHandshake = (): void => {
       }
       lastFailureAt = undefined
       consecutiveFailures = 0
-      cachedToken = freshToken
+      setCachedToken(freshToken)
       console.log('[attestation] handshake ok')
       scheduleRefresh(freshToken.expiresMono)
     })
@@ -628,6 +695,9 @@ const runHandshake = (): void => {
         attempt.countedFailure = true
       }
       console.warn('[attestation] handshake failed:', String(error))
+      // Drop an already-unservable JWT so listeners stop feeding edge-core a
+      // stale token for the full backoff window.
+      dropUnservableToken()
       scheduleRetryAfterFailure()
     })
     .finally(() => {
@@ -657,6 +727,9 @@ const runHandshake = (): void => {
       consecutiveFailures += 1
       attempt.countedFailure = true
     }
+    // Drop an already-unservable JWT so listeners stop feeding edge-core a
+    // stale token while we wait out the hang backoff.
+    dropUnservableToken()
     // An attempt that never settles leaves nothing else to re-arm the loop.
     scheduleRetryAfterFailure()
   }, HANDSHAKE_WATCHDOG_MS)
@@ -689,12 +762,13 @@ export const initAttestation = (): void => {
  * `GET_TOKEN_TIMEOUT_MS` to every gated request.
  */
 export const getAttestationToken = async (): Promise<string | undefined> => {
-  if (canServeToken()) return cachedToken?.token
+  const cached = getServableToken()
+  if (cached != null) return cached
   runHandshake()
   if (inFlight != null) {
     await Promise.race([inFlight, delay(GET_TOKEN_TIMEOUT_MS)])
   }
-  return canServeToken() ? cachedToken?.token : undefined
+  return getServableToken()
 }
 
 /**


### PR DESCRIPTION
## Summary
- **WIP / do not merge yet.** This PR depends on edge-core-js [#736](https://github.com/EdgeApp/edge-core-js/pull/736) (`setAttestationToken` / `x-attestation-token`). Merge that first, publish a new `edge-core-js` version, then bump `package.json` here before merging.
- Push info-server attestation tokens into core via `context.setAttestationToken` when the Edge context opens.
- Allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.
- Also includes a Jest `NODE_ENV=test` fix so Socket-wrapped `npm test` does not break GestureDetector tests.

## Dependencies
- **Blocked on:** https://github.com/EdgeApp/edge-core-js/pull/736
- Follow-up before merge: bump `edge-core-js` in `package.json` / lockfile to the published release that includes #736.

## Test plan
- [ ] Wait for [edge-core-js #736](https://github.com/EdgeApp/edge-core-js/pull/736) to land and bump the dependency
- [ ] Confirm attestation token is pushed on context open and cleared on logout/stale
- [ ] Login-server requests carry `x-attestation-token` when a token is available
- [ ] Jest suite passes under Socket-wrapped `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login-server attestation headers and depends on unreleased edge-core-js; wiring includes unsubscribe on context close, but incorrect token timing could affect CAPTCHA gating on login.
> 
> **Overview**
> **WIP — blocked on edge-core-js `setAttestationToken` (#736) before merge.**
> 
> Adds **`onAttestationToken`** so attestation JWT updates propagate to subscribers. Token cache updates now notify listeners with the current *servable* token (or `undefined` when rejected, expired, or unservable during backoff/hang). **`EdgeCoreManager`** subscribes when the Edge context opens and calls **`context.setAttestationToken`**, unsubscribing and stopping pushes when the context closes.
> 
> **Env overrides:** optional **`LOGIN_SERVER`** and **`INFO_SERVER`** arrays in env config override Maestro test servers or defaults for local E2E stacks.
> 
> **Jest:** the test script sets **`NODE_ENV=test`** so Socket-wrapped `npm test` does not break react-native-gesture-handler in UI tests.
> 
> Unit tests cover subscribe replay, success/rejection notifications, and unsubscribe behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6266f776d9561a7cc59e49cbefc9ee9da62d83c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->