### PR TITLE
Send current exchange-rate requests without a device timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed: Bitwave account ids are no longer capitalized by the keyboard or padded with whitespace when entered, so exports import without hand-editing the account id.
 - fixed: NYM max swaps from EVM wallets now report the correct limit error instead of an unsupported-route error (edge-exchange-plugins 2.52.1).
 - fixed: Exchange rate queries no longer request each chain's own asset twice, which had been inflating every rate query with duplicate pairs.
+- fixed: Current exchange rates no longer show $0.00 on devices whose clock runs a few minutes fast. Current-rate requests now omit the device timestamp so the rates server uses its own clock, instead of asking for a future date the server has no rate for.
 - fixed: XRP minimum balance warning copy to clarify the reserve is met once the address balance reaches 1 XRP, not on top of it.
 - fixed: Round fiat balances to cents in the Wallets list, matching the wallet detail scene
 - fixed: Notification center cards no longer shrink their text to fit. Long titles and messages now truncate with an ellipsis so every card renders at the same size.

--- a/src/__tests__/actions/ExchangeRateActions.test.ts
+++ b/src/__tests__/actions/ExchangeRateActions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals'
 
 import {
+  convertToRatesParams,
   type ExchangeRateCache,
   mergePairCache
 } from '../../actions/ExchangeRateActions'
@@ -116,5 +117,65 @@ describe('mergePairCache', () => {
     const out = mergePairCache(rates, emptyCache, PAIR_EXPIRATION)
 
     expect(out.cryptoPairs).toHaveLength(2)
+  })
+})
+
+describe('convertToRatesParams', () => {
+  it('omits isoDate for current pairs but keeps it for historical pairs', () => {
+    // A device with a fast clock used to stamp "current" pairs with a future
+    // timestamp, which the rates server answers with no rate. Current pairs
+    // must go out with no isoDate so the server uses its own clock.
+    const cryptoPairs = new Map([
+      [
+        'current',
+        {
+          asset: { pluginId: 'bitcoin', tokenId: null },
+          targetFiat: 'iso:USD',
+          isoDate: undefined,
+          expiration: PAIR_EXPIRATION
+        }
+      ],
+      [
+        'historical',
+        {
+          asset: { pluginId: 'bitcoin', tokenId: null },
+          targetFiat: 'iso:USD',
+          isoDate: '2026-08-12T13:00:00.000Z',
+          expiration: PAIR_EXPIRATION
+        }
+      ]
+    ])
+    const fiatPairs = new Map([
+      [
+        'current',
+        {
+          fiatCode: 'iso:USD',
+          targetFiat: 'iso:USD',
+          isoDate: undefined,
+          expiration: PAIR_EXPIRATION
+        }
+      ]
+    ])
+
+    const requests = convertToRatesParams(cryptoPairs, fiatPairs)
+    expect(requests).toHaveLength(1)
+    const [request] = requests
+
+    const current = request.crypto.find(entry => entry.isoDate == null)
+    const historical = request.crypto.find(entry => entry.isoDate != null)
+    expect(current).toBeDefined()
+    expect(current?.isoDate).toBeUndefined()
+    expect(historical?.isoDate?.toISOString()).toBe('2026-08-12T13:00:00.000Z')
+    expect(request.fiat[0].isoDate).toBeUndefined()
+
+    // On the wire an undefined isoDate drops out entirely, so the server falls
+    // back to its own clock; the historical date is still sent.
+    const wireCrypto: Array<Record<string, unknown>> = JSON.parse(
+      JSON.stringify(request)
+    ).crypto
+    const wireCurrent = wireCrypto.find(entry => entry.isoDate == null)
+    expect(Object.prototype.hasOwnProperty.call(wireCurrent, 'isoDate')).toBe(
+      false
+    )
   })
 })

--- a/src/actions/ExchangeRateActions.ts
+++ b/src/actions/ExchangeRateActions.ts
@@ -614,7 +614,7 @@ function fiatRateLogKey(
 /**
  * Convert maps to an array of RatesParams objects grouped by targetFiat.
  */
-function convertToRatesParams(
+export function convertToRatesParams(
   cryptoPairMap: Map<string, CryptoFiatPair>,
   fiatPairMap: Map<string, FiatFiatPair>
 ): RatesParams[] {
@@ -644,21 +644,26 @@ function convertToRatesParams(
   // Convert to RatesParams[]
   const requests: RatesParams[] = []
 
-  const newDate = new Date()
   for (const [targetFiat, { crypto, fiat }] of resultMap.entries()) {
     while (crypto.length > 0 || fiat.length > 0) {
       const cryptoChunk = crypto.splice(0, RATES_SERVER_MAX_QUERY_SIZE)
       const fiatChunk = fiat.splice(0, RATES_SERVER_MAX_QUERY_SIZE)
 
+      // Leave `isoDate` off of "current" pairs (those with no date) so the
+      // rates server timestamps them with its own clock. Stamping the device
+      // clock here asked the server for a future date whenever the device ran
+      // fast, and the server returns no rate for future dates, which left the
+      // current rate at 0 and fiat balances stuck at $0.00. Historical pairs
+      // keep their explicit date.
       requests.push({
         targetFiat: removeIsoPrefix(targetFiat),
         crypto: cryptoChunk.map(pair => ({
-          isoDate: pair.isoDate == null ? newDate : new Date(pair.isoDate),
+          isoDate: pair.isoDate == null ? undefined : new Date(pair.isoDate),
           asset: pair.asset,
           rate: undefined
         })),
         fiat: fiatChunk.map(pair => ({
-          isoDate: pair.isoDate == null ? newDate : new Date(pair.isoDate),
+          isoDate: pair.isoDate == null ? undefined : new Date(pair.isoDate),
           fiatCode: removeIsoPrefix(pair.fiatCode),
           rate: undefined
         }))


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

No visual changes to the GUI — this touches the exchange-rate request logic only — so the device-testing checklist below does not apply.

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

**Symptom:** wallets render correct crypto balances but `$0.00` fiat — the same signature as the Cardano report in the ticket.

Verbose exchange-rate logging from an affected device (`4.50.2`, Android) shows every *current* rate returning no rate while *historical* rates resolve:

```
rates query 0 result: 13 resolved, 16 no-rate:
  base_USD@2026-08-13T13:04:43.935Z, bitcoin_USD@…, monero_USD@…,
  cardano_USD@…, USD_USD@2026-08-13T13:04:43.935Z
```

The 16 no-rate pairs are exactly the current-timestamp ones; the cache then stores `current: 0`, so fiat = amount × 0 = `$0.00`.

**Root cause:** `convertToRatesParams` stamped "current" pairs with the device clock (`new Date()`). The rates server returns **no rate for a timestamp more than ~2 minutes in the future**, and this device's clock runs ~2 minutes fast (its log uploads show the device UTC ahead of the server `date` header), so every current request landed right on the server's future cutoff.

Replaying the device's verbatim request against `rates3`/`rates4.edge.app/v3/rates` confirmed it: past / now / +1m resolve; +2m and beyond return null. With `isoDate` omitted, the server uses its own clock and returns the latest rate.

**Fix:** omit `isoDate` for current pairs so the server timestamps them; historical pairs keep their explicit date. Immune to device clock skew, with no behavior change when the clock is correct. Adds a `convertToRatesParams` regression test (current → no `isoDate`; historical → date preserved).

Verified: `tsc`, `eslint`, and the `ExchangeRateActions` jest suite (6/6) pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all current rate queries are built for the rates server; incorrect behavior would affect fiat display app-wide, but the change is narrow and covered by a targeted test.
> 
> **Overview**
> Fixes wallets showing correct crypto balances but **$0.00** fiat when the device clock is slightly fast. **Current** rate pairs used to get `isoDate` from `new Date()` in `convertToRatesParams`; the rates server rejects timestamps too far in the future and returns no rate, so the cache stored `current: 0`.
> 
> **`convertToRatesParams`** now leaves `isoDate` **undefined** for pairs with no historical date (crypto and fiat), so the server timestamps with its own clock. Pairs with an explicit `isoDate` still send that date for historical lookups.
> 
> Also exports `convertToRatesParams` for tests and adds a regression test that current pairs omit `isoDate` on the wire while historical pairs keep it. CHANGELOG updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c64ca15a09f743b0dd83dfb689504a64a835e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216779213469798