### PR TITLE
Show the Monero Transaction Key mirrored in otherParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - changed: Tron resource staking now describes its claim action as reclaiming your own TRX, instead of claiming a reward.
 - changed: Deep links now wait only for the account state they actually use, so a link that just opens a scene, such as the buy/sell entry, follows immediately after login instead of waiting for every wallet to finish loading.
 - fixed: The buy/sell amount field no longer reads "Amount undefined" while the app is still working out which wallet to use.
+- fixed: Show the Monero Transaction Key of a send whose key never reached the transaction's saved metadata, by falling back to the key the wallet engine mirrors into `otherParams`. Covers sends made on 4.49.0 and later while the send path reported no key, on devices that still hold the original wallet cache.
 - fixed: Bitwave CSV exports now use ISO 8601 UTC timestamps, leave the fee columns blank so Bitwave does not double-count fees, and copy the description into the second custom metadata column.
 - fixed: Bitwave account ids are no longer capitalized by the keyboard or padded with whitespace when entered, so exports import without hand-editing the account id.
 - fixed: NYM max swaps from EVM wallets now report the correct limit error instead of an unsupported-route error (edge-exchange-plugins 2.52.1).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -144,7 +144,6 @@ export default [
       'src/components/buttons/ModalButtons.tsx',
       'src/components/buttons/ReturnKeyTypeButton.tsx',
       'src/components/buttons/SceneButtons.tsx',
-      'src/components/cards/AdvancedDetailsCard.tsx',
 
       'src/components/cards/BalanceCard.tsx',
       'src/components/cards/EarnOptionCard.tsx',

--- a/src/components/cards/AdvancedDetailsCard.tsx
+++ b/src/components/cards/AdvancedDetailsCard.tsx
@@ -37,14 +37,28 @@ export class AdvancedDetailsCardComponent extends PureComponent<Props> {
     return ''
   }
 
-  openUrl = async (): Promise<void> => {
+  /**
+   * The transaction key, preferring the one the core saved with the
+   * transaction. Monero sends made while the send path reported no key only
+   * carry their key in otherParams, mirrored there by the wallet engine from
+   * its own store, so fall back to that.
+   */
+  getTxSecret = (): string | undefined => {
+    const { otherParams, txSecret } = this.props.transaction
+    if (txSecret != null) return txSecret
+    const mirrored = otherParams?.txSecret
+    return typeof mirrored === 'string' ? mirrored : undefined
+  }
+
+  handleUrlPress = async (): Promise<void> => {
     const { url } = this.props
     if (url == null || url === '') return
     await openBrowserUri(url)
   }
 
-  openProveUrl = async (): Promise<void> => {
-    const { txid, txSecret } = this.props.transaction
+  handleProveUrlPress = async (): Promise<void> => {
+    const { txid } = this.props.transaction
+    const txSecret = this.getTxSecret()
     const recipientAddress = this.getRecipientAddress()
     if (recipientAddress === '' || txid === '' || txSecret == null) return
     const url = `https://blockchair.com/monero/transaction/${txid}?address=${recipientAddress}&viewkey=${txSecret}&txprove=1`
@@ -69,7 +83,8 @@ export class AdvancedDetailsCardComponent extends PureComponent<Props> {
     let feeValueText = ''
 
     for (const feeKey of Object.keys(fees)) {
-      // @ts-expect-error
+      // @ts-expect-error - feeKey indexes an untyped fee object, so it cannot
+      // be proven to be a key of localizedFeeText
       const feeFullString = `${localizedFeeText[feeKey] ?? feeKey} ${
         fees[feeKey]
       }`
@@ -82,7 +97,7 @@ export class AdvancedDetailsCardComponent extends PureComponent<Props> {
     return feeValueText
   }
 
-  render() {
+  render(): React.ReactNode {
     const { url } = this.props
     const {
       feeRateUsed,
@@ -90,9 +105,9 @@ export class AdvancedDetailsCardComponent extends PureComponent<Props> {
       ourReceiveAddresses,
       signedTx,
       txid,
-      txSecret,
       deviceDescription
     } = this.props.transaction
+    const txSecret = this.getTxSecret()
     const recipientAddress = this.getRecipientAddress()
     let receiveAddressesString
     if (ourReceiveAddresses != null && ourReceiveAddresses.length > 0) {
@@ -106,7 +121,7 @@ export class AdvancedDetailsCardComponent extends PureComponent<Props> {
             rightButtonType="touchable"
             title={lstrings.transaction_details_view_advanced_data}
             body={lstrings.transaction_details_advance_details_show_explorer}
-            onPress={this.openUrl}
+            onPress={this.handleUrlPress}
           />
         )}
         {receiveAddressesString != null && (
@@ -140,7 +155,7 @@ export class AdvancedDetailsCardComponent extends PureComponent<Props> {
             rightButtonType="touchable"
             title={lstrings.transaction_details_advance_details_payment_proof}
             body={lstrings.transaction_details_advance_details_show_explorer}
-            onPress={this.openProveUrl}
+            onPress={this.handleProveUrlPress}
           />
         )}
         {signedTx != null && signedTx !== '' ? (


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-currency-accountbased/pull/1089 — the engine-side mirror that puts the key in `otherParams.txSecret`. This change is inert until that ships, and harmless either way: with no mirrored value the card renders exactly as today.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

No layout changes — the existing Transaction Key and Payment Proof rows simply render in one more case (key sourced from `otherParams`), verified on the iOS simulator.

### Description

Outgoing Monero transactions have shown an empty Transaction Key since Edge 4.49.0. The engine-side fix restores the key for new sends, and for sends made while the bug was live it mirrors the key the wallet engine has held all along into `otherParams.txSecret` — the one field that rides through the core untouched for transactions already on file.

`AdvancedDetailsCard` now resolves the key as `txSecret ?? otherParams.txSecret`, so the Transaction Key and Payment Proof rows appear for those 4.49-window sends too, on devices that still hold the original wallet cache. Sends made after the engine fix save their key into the transaction's metadata at broadcast and never rely on the fallback.

Also brings `AdvancedDetailsCard` up to current lint rules (which removes it from the eslint exception list): `handle*` handler names, an explained `ts-expect-error`, and an explicit `render` return type.

Verified on the iOS simulator: a send performed with the broadcast capture deliberately disabled (reproducing the 4.49 state, metadata file provably secret-less) showed no Transaction Key at send time, then showed the key and Payment Proof rows via the fallback once the engine's sync pass stored and mirrored it.

Asana: https://app.asana.com/0/1215088146871429/1216965258637021

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display logic in transaction details; no send or auth changes. Fallback is inert until the companion engine mirrors the key.
> 
> **Overview**
> **Fixes empty Monero Transaction Key** on advanced transaction details when metadata never stored `txSecret` but the wallet engine mirrored the key into `otherParams.txSecret` (4.49-era sends on devices with original cache).
> 
> `AdvancedDetailsCard` now resolves the key via **`getTxSecret()`** (`transaction.txSecret` first, then string `otherParams.txSecret`) for the Transaction Key copy row and the Blockchair payment-proof link. Handler names and lint typing align with current rules; the card is removed from the ESLint exception list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f958f9534ccc7eae8b190302e8c3bbb79a91024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217505346482157