### PR TITLE
Add StealthEX support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added: App/device attestation for gated info-server requests
 - added: Swapter swap provider
 - added: "-m" tag on the version number in the Help scene for Maestro test builds
+- added: StealthEX as a swap provider.
 - changed: Style the entire "Already have an account? Sign in" line in the getting-started USP carousel with the tertiary link color, not just "Sign in".
 - changed: Refresh the buy, sell, sort, scan-QR and FIO names icons to the updated design.
 - changed: Display "MoonPay" instead of "Moonpay" wherever the partner name appears in the app.

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -725,6 +725,7 @@ export const pluginIdIcons: Record<string, string> = {
   rango: EDGE_CONTENT_SERVER_URI + '/rango.png',
   sideshift: EDGE_CONTENT_SERVER_URI + '/sideshift-logo.png',
   simplex: EDGE_CONTENT_SERVER_URI + '/simplex.png',
+  stealthex: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/stealthex/icon.png',
   swapter: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/swapter/icon.png',
   swapuz: EDGE_CONTENT_SERVER_URI + '/swapuz.png',
   thorchain: EDGE_CONTENT_SERVER_URI + '/thorchain.png',

--- a/src/components/modals/SwapVerifyTermsModal.tsx
+++ b/src/components/modals/SwapVerifyTermsModal.tsx
@@ -49,6 +49,11 @@ const pluginData: Record<string, TermsUri> = {
     kycUri:
       'https://help.sideshift.ai/en/articles/6230858-sideshift-ai-s-risk-management-policy'
   },
+  stealthex: {
+    termsUri: 'https://stealthex.io/terms/',
+    privacyUri: 'https://stealthex.io/privacy-policy/',
+    kycUri: 'https://stealthex.io/kyc-aml/'
+  },
   swapuz: {
     termsUri: 'https://swapuz.com/terms-of-use',
     privacyUri: 'https://swapuz.com/privacy-policy',

--- a/src/constants/MerchantContacts.ts
+++ b/src/constants/MerchantContacts.ts
@@ -79,6 +79,10 @@ export const MERCHANT_CONTACTS: MerchantContact[] = [
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/simplex.png`
   },
   {
+    displayName: 'StealthEX',
+    thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/exchangeIcons/stealthex/icon.png`
+  },
+  {
     displayName: 'Swapuz',
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/swapuz.png`
   },

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -425,6 +425,11 @@ export const asEnvConfig = asObject({
       quiknodeApiKey: asOptional(asString, '')
     }).withRest
   ),
+  STEALTHEX_INIT: asCorePluginInit(
+    asObject({
+      apiKey: asOptional(asString, '')
+    }).withRest
+  ),
   SWAPTER_INIT: asCorePluginInit(
     asObject({
       apiKey: asOptional(asString, '')

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -99,6 +99,7 @@ export const swapPlugins = {
   letsexchange: ENV.LETSEXCHANGE_INIT,
   nexchange: ENV.NEXCHANGE_INIT,
   sideshift: ENV.SIDESHIFT_INIT,
+  stealthex: ENV.STEALTHEX_INIT,
   swapter: ENV.SWAPTER_INIT,
   swapuz: ENV.SWAPUZ_INIT,
   xgram: ENV.XGRAM_INIT,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

EdgeApp/edge-exchange-plugins#485

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Wires up StealthEX as a swap provider: `STEALTHEX_INIT` in the env config, the plugin registration in `corePlugins`, the provider icon, the merchant contact entry, and the terms of service the swap flow shows before a user's first StealthEX quote.

Asana: https://app.asana.com/0/1215088146871429/1217498055202092

The plugin itself lives in EdgeApp/edge-exchange-plugins#485.

The provider icon points at `exchangeIcons/stealthex/icon.png` on the content server, which does not carry that asset yet and needs uploading before release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider integration with no changes to auth or payment flows; swap behavior depends on the separate exchange-plugins dependency.
> 
> **Overview**
> Adds **StealthEX** as a centralized swap provider in the GUI, following the same wiring as partners like Swapuz and SideShift.
> 
> Registers `stealthex` in `corePlugins` with `STEALTHEX_INIT` (optional `apiKey` in env config). The swap flow can show the first-quote **terms/KYC modal** using StealthEX’s terms, privacy, and KYC URLs. **Provider icon** mapping and a **merchant contact** entry point at the content-server `exchangeIcons/stealthex/icon.png` path (asset upload noted as a release prerequisite). Actual quoting and swap execution remain in **edge-exchange-plugins** (#485).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1897888229b8fff19cfff646bd40629e0666889a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
