### PR TITLE
Keep the Import Wallet Next button clear of the keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed: Notification center cards no longer shrink their text to fit. Long titles and messages now truncate with an ellipsis so every card renders at the same size.
 - fixed: Sort the Privacy Settings Nym Mix Net asset list alphabetically by display name
 - fixed: Next button overlapping the wallet list on the Choose Wallets to Add scene
+- fixed: Keyboard no longer covers the Next button on the Import Wallet scene. The scene ends flush against the keyboard instead of leaving a band of dead space the content cannot scroll into, its spacing no longer stretches or compresses with the length of the seed phrase, and the button sits just above the keyboard rather than 3 rem clear of it.
 - fixed: Wrap the fiat value in parentheses on the Stake/Unstake/Claim amount row, and remove the space between the fiat symbol and amount to match the network fee tile.
 - fixed: Staked "locked" balance in the wallet view no longer gets cut off. The crypto amount is truncated to an exchange-rate-appropriate number of decimals, and the text is no longer clamped to a fraction of the card width.
 - fixed: Improve the unstake error experience by replacing the popup alert and generic "unknown error occurred" with the real error in the scene's error field, and showing a clear message when the wallet lacks the balance to cover the unstaking network fee.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,13 +137,12 @@ export default [
       'src/actions/WalletListActions.tsx',
 
       'src/app.ts',
-      'src/components/buttons/ButtonsView.tsx',
+
       'src/components/buttons/EdgeSwitch.tsx',
       'src/components/buttons/IconButton.tsx',
       'src/components/buttons/MinimalButton.tsx',
       'src/components/buttons/ModalButtons.tsx',
       'src/components/buttons/ReturnKeyTypeButton.tsx',
-      'src/components/buttons/SceneButtons.tsx',
 
       'src/components/cards/BalanceCard.tsx',
       'src/components/cards/EarnOptionCard.tsx',

--- a/maestro/07-wallets/C000029a-migrate-wallets.yaml
+++ b/maestro/07-wallets/C000029a-migrate-wallets.yaml
@@ -96,20 +96,14 @@ tags:
 - tapOn: Private Key or Private Seed
 - inputText: ${IMPORT_SEED}
 
-# Drop keyboard - Android
-- runFlow:
-    when:
-      platform: Android
-    commands:
-        - hideKeyboard
-        # - tapOn: Next # odd additional tap required on android sometimes
-# Drop keyboard - iOS
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-        - tapOn: "Private Key or Private Seed"
-        
+# The Import Wallet scene keeps Next clear of the keyboard on both platforms, so
+# neither one drops the keyboard to reach it. A long phrase can still push Next
+# past the bottom of the scroll viewport, which the scene scrolls to reveal.
+- scrollUntilVisible:
+    element:
+      text: Next
+    direction: DOWN
+    timeout: 20000
 - tapOn: Next
 
 # Sometimes android requires additional tap

--- a/maestro/common/import-wallets.yaml
+++ b/maestro/common/import-wallets.yaml
@@ -39,28 +39,15 @@ env:
 - tapOn: Private Key or Private Seed
 - inputText: ${SEED_PHRASE}
 
-# Drop keyboard - Android
-- runFlow:
-    when:
-      platform: Android
-    commands:
-        - hideKeyboard
-        - tapOn: "Enter your.*"
-# Drop keyboard - iOS
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-        - tapOn: "Private Key or Private Seed"
-
+# The Import Wallet scene keeps Next clear of the keyboard on both platforms, so
+# neither one drops the keyboard to reach it. A long phrase can still push Next
+# past the bottom of the scroll viewport, which the scene scrolls to reveal.
+- scrollUntilVisible:
+    element:
+      text: Next
+    direction: DOWN
+    timeout: 20000
 - tapOn: Next
-
-# # Sometimes android requires additional tap
-# - runFlow:
-#     when:
-#       visible: Import Wallet
-#     commands:
-#       - tapOn: Next
 
 # Add birthday height for Zcash and Pirate Chain
 # Index for targetting the correct "edit" icon 

--- a/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/BalanceCard.test.tsx.snap
@@ -1505,6 +1505,7 @@ exports[`BalanceCard should render with loading props 1`] = `
   </View>
   <View
     absolute={false}
+    keyboardOpen={false}
     layout="row"
     style={
       {

--- a/src/__tests__/components/__snapshots__/Buttons.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/Buttons.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
 >
   <View
     absolute={false}
+    keyboardOpen={false}
     layout="column"
     style={
       {
@@ -437,6 +438,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
   </View>
   <View
     absolute={false}
+    keyboardOpen={false}
     layout="column"
     style={
       {
@@ -592,6 +594,7 @@ exports[`Buttons should render in a ButtonsView in a column layout in a flex:1 V
 exports[`Buttons should render in a ButtonsView in a column layout with 1 buttons 1`] = `
 <View
   absolute={false}
+  keyboardOpen={false}
   layout="column"
   style={
     {
@@ -899,6 +902,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 1 button
 exports[`Buttons should render in a ButtonsView in a column layout with 2 buttons 1`] = `
 <View
   absolute={false}
+  keyboardOpen={false}
   layout="column"
   style={
     {
@@ -1206,6 +1210,7 @@ exports[`Buttons should render in a ButtonsView in a column layout with 2 button
 exports[`Buttons should render in a ButtonsView in a column layout with 3 buttons 1`] = `
 <View
   absolute={false}
+  keyboardOpen={false}
   layout="column"
   style={
     {
@@ -1643,6 +1648,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
 >
   <View
     absolute={false}
+    keyboardOpen={false}
     layout="row"
     style={
       {
@@ -2057,6 +2063,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
   </View>
   <View
     absolute={false}
+    keyboardOpen={false}
     layout="row"
     style={
       {
@@ -2210,6 +2217,7 @@ exports[`Buttons should render in a ButtonsView in a row layout in a flex:1 View
 exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1`] = `
 <View
   absolute={false}
+  keyboardOpen={false}
   layout="row"
   style={
     {
@@ -2510,6 +2518,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 1 buttons 1
 exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1`] = `
 <View
   absolute={false}
+  keyboardOpen={false}
   layout="row"
   style={
     {
@@ -2810,6 +2819,7 @@ exports[`Buttons should render in a ButtonsView in a row layout with 2 buttons 1
 exports[`Buttons should render in a ButtonsView in a row layout with 3 buttons 1`] = `
 <View
   absolute={false}
+  keyboardOpen={false}
   layout="row"
   style={
     {

--- a/src/__tests__/modals/__snapshots__/AutoLogoutModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/AutoLogoutModal.test.tsx.snap
@@ -729,6 +729,7 @@ exports[`AutoLogoutModal should render with loading props 1`] = `
     </View>
     <View
       absolute={false}
+      keyboardOpen={false}
       layout="column"
       parentType="modal"
       style={

--- a/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/LogsModal.test.tsx.snap
@@ -1020,6 +1020,7 @@ exports[`LogsModal should render with a logs modal 1`] = `
         </View>
         <View
           absolute={false}
+          keyboardOpen={false}
           layout="column"
           parentType="modal"
           style={

--- a/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/PasswordReminderModal.test.tsx.snap
@@ -888,6 +888,7 @@ Please enter your password below. A successful verification will prevent this wa
     </View>
     <View
       absolute={false}
+      keyboardOpen={false}
       layout="column"
       parentType="modal"
       style={

--- a/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
+++ b/src/__tests__/modals/__snapshots__/TextInputModal.test.tsx.snap
@@ -697,6 +697,7 @@ exports[`TextInputModal should render with a blank input field 1`] = `
       </View>
       <View
         absolute={false}
+        keyboardOpen={false}
         layout="column"
         parentType="modal"
         style={
@@ -1551,6 +1552,7 @@ exports[`TextInputModal should render with a populated input field 1`] = `
       </View>
       <View
         absolute={false}
+        keyboardOpen={false}
         layout="column"
         parentType="modal"
         style={

--- a/src/__tests__/scenes/__snapshots__/CreateWalletEditNameScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletEditNameScene.test.tsx.snap
@@ -1004,6 +1004,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
     </RCTScrollView>
     <View
       absolute={false}
+      keyboardOpen={false}
       layout="column"
       style={
         {

--- a/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletImportScene.test.tsx.snap
@@ -2,6 +2,42 @@
 
 exports[`CreateWalletImportScene should render with loading props 1`] = `
 <View
+  collapsable={false}
+  jestAnimatedProps={
+    {
+      "value": {},
+    }
+  }
+  jestAnimatedStyle={
+    {
+      "value": {
+        "maxHeight": 1334,
+      },
+    }
+  }
+  jestInlineStyle={
+    [
+      {
+        "alignItems": "stretch",
+        "flexDirection": "column",
+        "justifyContent": "flex-start",
+      },
+      {
+        "height": 1334,
+        "width": 750,
+      },
+      {
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 64,
+      },
+      {
+        "padding": 0,
+      },
+    ]
+  }
+  nativeID="0"
   style={
     [
       {
@@ -18,6 +54,9 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
         "paddingLeft": 0,
         "paddingRight": 0,
         "paddingTop": 64,
+      },
+      {
+        "maxHeight": 1334,
       },
       {
         "padding": 0,
@@ -234,8 +273,9 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
   <View
     style={
       {
-        "flexShrink": 1,
-        "margin": 11,
+        "flex": 1,
+        "marginHorizontal": 11,
+        "marginTop": 11,
       }
     }
   >
@@ -319,15 +359,31 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
       />
     </View>
     <RCTScrollView
+      contentContainerStyle={
+        {
+          "flexGrow": 0,
+        }
+      }
       keyboardShouldPersistTaps="handled"
+      scrollIndicatorInsets={
+        {
+          "right": 1,
+        }
+      }
+      style={
+        {
+          "flex": 1,
+        }
+      }
     >
       <View>
         <View
           style={
             {
+              "alignItems": "center",
               "flexDirection": "row",
               "justifyContent": "center",
-              "marginVertical": 45,
+              "marginVertical": 22,
             }
           }
         >
@@ -364,403 +420,78 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
           Enter your private seed, private key, or active key to verify and restore the associated wallet
         </Text>
         <View
-          marginRemStyle={
-            {
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
-            }
-          }
-          multiline={true}
           style={
             {
-              "flexGrow": 1,
-              "flexShrink": 1,
-              "marginBottom": 11,
-              "marginLeft": 11,
-              "marginRight": 11,
-              "marginTop": 11,
+              "flexShrink": 0,
             }
           }
         >
           <View
-            accessibilityState={
+            marginRemStyle={
               {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
               }
-            }
-            accessible={false}
-            collapsable={false}
-            disableAnimation={0}
-            focusAnimation={0}
-            focusable={true}
-            jestAnimatedProps={
-              {
-                "value": {},
-              }
-            }
-            jestAnimatedStyle={
-              {
-                "value": {
-                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
-                  "borderColor": "rgba(0, 241, 162, 0)",
-                  "marginHorizontal": 0,
-                  "opacity": 1,
-                  "paddingVertical": 22,
-                },
-              }
-            }
-            jestInlineStyle={
-              [
-                {
-                  "alignItems": "stretch",
-                  "borderRadius": 11,
-                  "borderWidth": 1,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "paddingHorizontal": 17,
-                },
-              ]
             }
             multiline={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            scale={1}
             style={
-              [
-                {
-                  "alignItems": "stretch",
-                  "borderRadius": 11,
-                  "borderWidth": 1,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "paddingHorizontal": 17,
-                },
-                {
-                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
-                  "borderColor": "rgba(0, 241, 162, 0)",
-                  "marginHorizontal": 0,
-                  "opacity": 1,
-                  "paddingVertical": 22,
-                },
-              ]
+              {
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 11,
+                "marginLeft": 11,
+                "marginRight": 11,
+                "marginTop": 11,
+              }
             }
           >
-            <View
-              collapsable={false}
-              jestAnimatedProps={
-                {
-                  "value": {},
-                }
-              }
-              jestAnimatedStyle={
-                {
-                  "value": {
-                    "opacity": 0,
-                    "width": 0,
-                  },
-                }
-              }
-              jestInlineStyle={
-                [
-                  {
-                    "alignItems": "stretch",
-                    "aspectRatio": 1,
-                  },
-                ]
-              }
-              nativeID="1"
-              scale={0}
-              style={
-                [
-                  {
-                    "alignItems": "stretch",
-                    "aspectRatio": 1,
-                  },
-                  {
-                    "opacity": 0,
-                    "width": 0,
-                  },
-                ]
-              }
-            />
-            <View
-              collapsable={false}
-              focusValue={0}
-              hasPlaceholder={true}
-              jestAnimatedProps={
-                {
-                  "value": {},
-                }
-              }
-              jestAnimatedStyle={
-                {
-                  "value": {
-                    "marginBottom": -0,
-                    "marginTop": 0,
-                  },
-                }
-              }
-              jestInlineStyle={
-                [
-                  {
-                    "alignItems": "flex-start",
-                    "alignSelf": "flex-start",
-                    "flex": 1,
-                    "flexDirection": "row",
-                    "left": 0,
-                  },
-                ]
-              }
-              nativeID="2"
-              style={
-                [
-                  {
-                    "alignItems": "flex-start",
-                    "alignSelf": "flex-start",
-                    "flex": 1,
-                    "flexDirection": "row",
-                    "left": 0,
-                  },
-                  {
-                    "marginBottom": -0,
-                    "marginTop": 0,
-                  },
-                ]
-              }
-            >
-              <View
-                collapsable={false}
-                jestAnimatedProps={
-                  {
-                    "value": {},
-                  }
-                }
-                jestAnimatedStyle={
-                  {
-                    "value": {
-                      "transform": [
-                        {
-                          "translateY": 0,
-                        },
-                        {
-                          "translateX": 0,
-                        },
-                      ],
-                    },
-                  }
-                }
-                jestInlineStyle={
-                  [
-                    {
-                      "alignItems": "flex-start",
-                      "justifyContent": "center",
-                      "left": 8.8,
-                      "margin": 0,
-                      "paddingHorizontal": 0,
-                      "paddingVertical": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                  ]
-                }
-                nativeID="3"
-                shift={0}
-                style={
-                  [
-                    {
-                      "alignItems": "flex-start",
-                      "justifyContent": "center",
-                      "left": 8.8,
-                      "margin": 0,
-                      "paddingHorizontal": 0,
-                      "paddingVertical": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    },
-                    {
-                      "transform": [
-                        {
-                          "translateY": 0,
-                        },
-                        {
-                          "translateX": 0,
-                        },
-                      ],
-                    },
-                  ]
-                }
-              >
-                <Text
-                  allowFontScaling={false}
-                  collapsable={false}
-                  disableAnimation={0}
-                  ellipsizeMode="tail"
-                  focusAnimation={0}
-                  jestAnimatedProps={
-                    {
-                      "value": {},
-                    }
-                  }
-                  jestAnimatedStyle={
-                    {
-                      "value": {
-                        "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                        "fontSize": 22,
-                      },
-                    }
-                  }
-                  jestInlineStyle={
-                    [
-                      {
-                        "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
-                        "includeFontPadding": false,
-                      },
-                    ]
-                  }
-                  nativeID="4"
-                  numberOfLines={1}
-                  scale={1}
-                  shift={0}
-                  style={
-                    [
-                      {
-                        "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
-                        "includeFontPadding": false,
-                      },
-                      {
-                        "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                        "fontSize": 22,
-                      },
-                    ]
-                  }
-                >
-                  Private Key or Private Seed
-                </Text>
-              </View>
-              <TextInput
-                accessibilityState={
-                  {
-                    "disabled": false,
-                  }
-                }
-                accessible={true}
-                allowFontScaling={false}
-                autoCapitalize="none"
-                autoComplete="off"
-                autoCorrect={false}
-                autoFocus={false}
-                blurOnSubmit={false}
-                collapsable={false}
-                defaultValue=""
-                disableAnimation={0}
-                editable={true}
-                focusAnimation={0}
-                forwardedRef={[Function]}
-                jestAnimatedProps={
-                  {
-                    "value": {},
-                  }
-                }
-                jestAnimatedStyle={
-                  {
-                    "value": {
-                      "color": "rgba(255, 255, 255, 1)",
-                      "fontSize": 22,
-                    },
-                  }
-                }
-                jestInlineStyle={
-                  [
-                    {
-                      "color": "hsla(0, 0%, 100%, 0.20)",
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                      "fontFamily": "Quicksand-Regular",
-                      "margin": 0,
-                      "paddingHorizontal": 0,
-                      "paddingVertical": 0,
-                      "transform": [
-                        {
-                          "translateY": -0,
-                        },
-                      ],
-                    },
-                  ]
-                }
-                keyboardType="email-address"
-                multiline={true}
-                nativeID="5"
-                numberOfLines={10}
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
-                onSubmitEditing={[Function]}
-                scale={1}
-                selectionColor="rgba(255, 255, 255, .25)"
-                style={
-                  [
-                    {
-                      "color": "hsla(0, 0%, 100%, 0.20)",
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                      "fontFamily": "Quicksand-Regular",
-                      "margin": 0,
-                      "paddingHorizontal": 0,
-                      "paddingVertical": 0,
-                      "transform": [
-                        {
-                          "translateY": -0,
-                        },
-                      ],
-                    },
-                    {
-                      "color": "rgba(255, 255, 255, 1)",
-                      "fontSize": 22,
-                    },
-                  ]
-                }
-                testID="undefined.textInput"
-                textAlignVertical="top"
-              />
-            </View>
             <View
               accessibilityState={
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": undefined,
+                  "disabled": false,
                   "expanded": undefined,
                   "selected": undefined,
                 }
               }
-              accessibilityValue={
+              accessible={false}
+              collapsable={false}
+              disableAnimation={0}
+              focusAnimation={0}
+              focusable={true}
+              jestAnimatedProps={
                 {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
+                  "value": {},
                 }
               }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
+              jestAnimatedStyle={
+                {
+                  "value": {
+                    "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                    "borderColor": "rgba(0, 241, 162, 0)",
+                    "marginHorizontal": 0,
+                    "opacity": 1,
+                    "paddingVertical": 22,
+                  },
+                }
+              }
+              jestInlineStyle={
+                [
+                  {
+                    "alignItems": "stretch",
+                    "borderRadius": 11,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "paddingHorizontal": 17,
+                  },
+                ]
+              }
+              multiline={true}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -768,16 +499,27 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
               onResponderTerminate={[Function]}
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
+              scale={1}
               style={
-                {
-                  "marginHorizontal": -22,
-                  "marginVertical": -28,
-                  "opacity": 1,
-                  "paddingHorizontal": 22,
-                  "paddingVertical": 28,
-                }
+                [
+                  {
+                    "alignItems": "stretch",
+                    "borderRadius": 11,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "paddingHorizontal": 17,
+                  },
+                  {
+                    "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                    "borderColor": "rgba(0, 241, 162, 0)",
+                    "marginHorizontal": 0,
+                    "opacity": 1,
+                    "paddingVertical": 22,
+                  },
+                ]
               }
-              testID="undefined.clearIcon"
             >
               <View
                 collapsable={false}
@@ -802,7 +544,7 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                     },
                   ]
                 }
-                nativeID="6"
+                nativeID="2"
                 scale={0}
                 style={
                   [
@@ -816,9 +558,53 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                     },
                   ]
                 }
+              />
+              <View
+                collapsable={false}
+                focusValue={0}
+                hasPlaceholder={true}
+                jestAnimatedProps={
+                  {
+                    "value": {},
+                  }
+                }
+                jestAnimatedStyle={
+                  {
+                    "value": {
+                      "marginBottom": -0,
+                      "marginTop": 0,
+                    },
+                  }
+                }
+                jestInlineStyle={
+                  [
+                    {
+                      "alignItems": "flex-start",
+                      "alignSelf": "flex-start",
+                      "flex": 1,
+                      "flexDirection": "row",
+                      "left": 0,
+                    },
+                  ]
+                }
+                nativeID="3"
+                style={
+                  [
+                    {
+                      "alignItems": "flex-start",
+                      "alignSelf": "flex-start",
+                      "flex": 1,
+                      "flexDirection": "row",
+                      "left": 0,
+                    },
+                    {
+                      "marginBottom": -0,
+                      "marginTop": 0,
+                    },
+                  ]
+                }
               >
-                <Text
-                  allowFontScaling={false}
+                <View
                   collapsable={false}
                   jestAnimatedProps={
                     {
@@ -828,188 +614,469 @@ exports[`CreateWalletImportScene should render with loading props 1`] = `
                   jestAnimatedStyle={
                     {
                       "value": {
-                        "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                        "fontFamily": "anticon",
-                        "fontSize": 0,
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "transform": [
+                          {
+                            "translateY": 0,
+                          },
+                          {
+                            "translateX": 0,
+                          },
+                        ],
                       },
                     }
                   }
-                  jestInlineStyle={{}}
-                  nativeID="7"
+                  jestInlineStyle={
+                    [
+                      {
+                        "alignItems": "flex-start",
+                        "justifyContent": "center",
+                        "left": 8.8,
+                        "margin": 0,
+                        "paddingHorizontal": 0,
+                        "paddingVertical": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      },
+                    ]
+                  }
+                  nativeID="4"
+                  shift={0}
                   style={
                     [
                       {
-                        "color": "rgba(255, 255, 255, 0.5019607843137255)",
-                        "fontFamily": "anticon",
-                        "fontSize": 0,
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "alignItems": "flex-start",
+                        "justifyContent": "center",
+                        "left": 8.8,
+                        "margin": 0,
+                        "paddingHorizontal": 0,
+                        "paddingVertical": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      },
+                      {
+                        "transform": [
+                          {
+                            "translateY": 0,
+                          },
+                          {
+                            "translateX": 0,
+                          },
+                        ],
                       },
                     ]
                   }
                 >
-                  
-                </Text>
+                  <Text
+                    allowFontScaling={false}
+                    collapsable={false}
+                    disableAnimation={0}
+                    ellipsizeMode="tail"
+                    focusAnimation={0}
+                    jestAnimatedProps={
+                      {
+                        "value": {},
+                      }
+                    }
+                    jestAnimatedStyle={
+                      {
+                        "value": {
+                          "color": "rgba(255, 255, 255, 0.5019607843137255)",
+                          "fontSize": 22,
+                        },
+                      }
+                    }
+                    jestInlineStyle={
+                      [
+                        {
+                          "fontFamily": "Quicksand-Regular",
+                          "fontSize": 22,
+                          "includeFontPadding": false,
+                        },
+                      ]
+                    }
+                    nativeID="5"
+                    numberOfLines={1}
+                    scale={1}
+                    shift={0}
+                    style={
+                      [
+                        {
+                          "fontFamily": "Quicksand-Regular",
+                          "fontSize": 22,
+                          "includeFontPadding": false,
+                        },
+                        {
+                          "color": "rgba(255, 255, 255, 0.5019607843137255)",
+                          "fontSize": 22,
+                        },
+                      ]
+                    }
+                  >
+                    Private Key or Private Seed
+                  </Text>
+                </View>
+                <TextInput
+                  accessibilityState={
+                    {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  allowFontScaling={false}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect={false}
+                  autoFocus={false}
+                  blurOnSubmit={false}
+                  collapsable={false}
+                  defaultValue=""
+                  disableAnimation={0}
+                  editable={true}
+                  focusAnimation={0}
+                  forwardedRef={[Function]}
+                  jestAnimatedProps={
+                    {
+                      "value": {},
+                    }
+                  }
+                  jestAnimatedStyle={
+                    {
+                      "value": {
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 22,
+                      },
+                    }
+                  }
+                  jestInlineStyle={
+                    [
+                      {
+                        "color": "hsla(0, 0%, 100%, 0.20)",
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                        "fontFamily": "Quicksand-Regular",
+                        "margin": 0,
+                        "paddingHorizontal": 0,
+                        "paddingVertical": 0,
+                        "transform": [
+                          {
+                            "translateY": -0,
+                          },
+                        ],
+                      },
+                    ]
+                  }
+                  keyboardType="email-address"
+                  multiline={true}
+                  nativeID="6"
+                  numberOfLines={10}
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
+                  onSubmitEditing={[Function]}
+                  scale={1}
+                  selectionColor="rgba(255, 255, 255, .25)"
+                  style={
+                    [
+                      {
+                        "color": "hsla(0, 0%, 100%, 0.20)",
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                        "fontFamily": "Quicksand-Regular",
+                        "margin": 0,
+                        "paddingHorizontal": 0,
+                        "paddingVertical": 0,
+                        "transform": [
+                          {
+                            "translateY": -0,
+                          },
+                        ],
+                      },
+                      {
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 22,
+                      },
+                    ]
+                  }
+                  testID="undefined.textInput"
+                  textAlignVertical="top"
+                />
+              </View>
+              <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "marginHorizontal": -22,
+                    "marginVertical": -28,
+                    "opacity": 1,
+                    "paddingHorizontal": 22,
+                    "paddingVertical": 28,
+                  }
+                }
+                testID="undefined.clearIcon"
+              >
+                <View
+                  collapsable={false}
+                  jestAnimatedProps={
+                    {
+                      "value": {},
+                    }
+                  }
+                  jestAnimatedStyle={
+                    {
+                      "value": {
+                        "opacity": 0,
+                        "width": 0,
+                      },
+                    }
+                  }
+                  jestInlineStyle={
+                    [
+                      {
+                        "alignItems": "stretch",
+                        "aspectRatio": 1,
+                      },
+                    ]
+                  }
+                  nativeID="7"
+                  scale={0}
+                  style={
+                    [
+                      {
+                        "alignItems": "stretch",
+                        "aspectRatio": 1,
+                      },
+                      {
+                        "opacity": 0,
+                        "width": 0,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    allowFontScaling={false}
+                    collapsable={false}
+                    jestAnimatedProps={
+                      {
+                        "value": {},
+                      }
+                    }
+                    jestAnimatedStyle={
+                      {
+                        "value": {
+                          "color": "rgba(255, 255, 255, 0.5019607843137255)",
+                          "fontFamily": "anticon",
+                          "fontSize": 0,
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                      }
+                    }
+                    jestInlineStyle={{}}
+                    nativeID="8"
+                    style={
+                      [
+                        {
+                          "color": "rgba(255, 255, 255, 0.5019607843137255)",
+                          "fontFamily": "anticon",
+                          "fontSize": 0,
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                      ]
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
         </View>
-        <View
-          absolute={false}
-          layout="solo"
-          parentType="scene"
-          style={
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "flexShrink": 0,
-              "justifyContent": "flex-end",
-              "margin": 11,
-              "marginBottom": 67,
-              "marginHorizontal": 11,
-              "marginTop": 22,
-            }
-          }
-        >
+        <View>
           <View
+            absolute={false}
+            keyboardOpen={false}
+            layout="solo"
+            parentType="scene"
             style={
-              [
-                {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                {
-                  "marginBottom": 0,
-                  "marginLeft": 0,
-                  "marginRight": 0,
-                  "marginTop": 0,
-                },
-              ]
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "flexShrink": 0,
+                "justifyContent": "flex-end",
+                "margin": 11,
+                "marginBottom": 67,
+                "marginHorizontal": 11,
+                "marginTop": 22,
+              }
             }
           >
             <View
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": true,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              collapsable={false}
-              focusable={false}
-              hitSlop={
-                {
-                  "bottom": 11,
-                  "left": 10000,
-                  "right": 10000,
-                  "top": 11,
-                }
-              }
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
-                {
-                  "alignItems": "center",
-                  "borderRadius": 34,
-                  "height": 67,
-                  "justifyContent": "center",
-                  "opacity": 0.3,
-                  "overflow": "visible",
-                  "paddingHorizontal": 34,
-                  "paddingVertical": 0,
-                  "position": "relative",
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "justifyContent": "center",
+                  },
+                  {
+                    "marginBottom": 0,
+                    "marginLeft": 0,
+                    "marginRight": 0,
+                    "marginTop": 0,
+                  },
+                ]
               }
             >
-              <BVLinearGradient
-                colors={
-                  [
-                    4280299823,
-                    4278214733,
-                  ]
-                }
-                endPoint={
-                  {
-                    "x": 1,
-                    "y": 0,
-                  }
-                }
-                locations={null}
-                startPoint={
-                  {
-                    "x": 0,
-                    "y": 0,
-                  }
-                }
-                style={
-                  {
-                    "borderRadius": 34,
-                    "bottom": 0,
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  }
-                }
-              />
               <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={false}
+                hitSlop={
+                  {
+                    "bottom": 11,
+                    "left": 10000,
+                    "right": 10000,
+                    "top": 11,
+                  }
+                }
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   {
                     "alignItems": "center",
-                    "flexDirection": "row",
+                    "borderRadius": 34,
+                    "height": 67,
                     "justifyContent": "center",
-                    "opacity": 1,
+                    "opacity": 0.3,
+                    "overflow": "visible",
+                    "paddingHorizontal": 34,
+                    "paddingVertical": 0,
+                    "position": "relative",
                   }
                 }
               >
-                <Text
-                  adjustsFontSizeToFit={true}
-                  allowFontScaling={false}
-                  minimumFontScale={0.65}
-                  numberOfLines={1}
-                  style={
+                <BVLinearGradient
+                  colors={
                     [
-                      {
-                        "color": "#FFFFFF",
-                        "fontFamily": "Quicksand-Regular",
-                        "fontSize": 22,
-                        "includeFontPadding": false,
-                      },
-                      [
-                        {
-                          "includeFontPadding": false,
-                        },
-                        {
-                          "color": "#FFFFFF",
-                          "fontFamily": "Quicksand-Medium",
-                          "fontSize": 22,
-                        },
-                        null,
-                      ],
-                      null,
+                      4280299823,
+                      4278214733,
                     ]
                   }
+                  endPoint={
+                    {
+                      "x": 1,
+                      "y": 0,
+                    }
+                  }
+                  locations={null}
+                  startPoint={
+                    {
+                      "x": 0,
+                      "y": 0,
+                    }
+                  }
+                  style={
+                    {
+                      "borderRadius": 34,
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                />
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "opacity": 1,
+                    }
+                  }
                 >
-                  Next
-                </Text>
+                  <Text
+                    adjustsFontSizeToFit={true}
+                    allowFontScaling={false}
+                    minimumFontScale={0.65}
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "color": "#FFFFFF",
+                          "fontFamily": "Quicksand-Regular",
+                          "fontSize": 22,
+                          "includeFontPadding": false,
+                        },
+                        [
+                          {
+                            "includeFontPadding": false,
+                          },
+                          {
+                            "color": "#FFFFFF",
+                            "fontFamily": "Quicksand-Medium",
+                            "fontSize": 22,
+                          },
+                          null,
+                        ],
+                        null,
+                      ]
+                    }
+                  >
+                    Next
+                  </Text>
+                </View>
               </View>
             </View>
           </View>

--- a/src/__tests__/scenes/__snapshots__/FioAddressListScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressListScene.test.tsx.snap
@@ -908,6 +908,7 @@ exports[`FioAddressList should render with loading props 1`] = `
     >
       <View
         absolute={false}
+        keyboardOpen={false}
         layout="column"
         style={
           {

--- a/src/__tests__/scenes/__snapshots__/FioAddressRegisterScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressRegisterScene.test.tsx.snap
@@ -903,6 +903,7 @@ exports[`FioAddressRegister should render with loading props 1`] = `
         >
           <View
             absolute={false}
+            keyboardOpen={false}
             layout="solo"
             style={
               {

--- a/src/__tests__/scenes/__snapshots__/FioAddressSettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/FioAddressSettingsScene.test.tsx.snap
@@ -499,6 +499,7 @@ exports[`FioAddressSettingsComponent should render with loading props 1`] = `
         </View>
         <View
           absolute={false}
+          keyboardOpen={false}
           layout="column"
           style={
             {

--- a/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/RequestScene.test.tsx.snap
@@ -352,6 +352,7 @@ Never share your username and password, and store your credentials securely!
     </Text>
     <View
       absolute={false}
+      keyboardOpen={false}
       layout="solo"
       parentType="scene"
       style={

--- a/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/SettingsScene.test.tsx.snap
@@ -5323,6 +5323,7 @@ exports[`SettingsScene should render SettingsScene 1`] = `
       </View>
       <View
         absolute={false}
+        keyboardOpen={false}
         layout="column"
         style={
           {

--- a/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/TransactionDetailsScene.test.tsx.snap
@@ -2765,6 +2765,7 @@ exports[`TransactionDetailsScene should render 1`] = `
         >
           <View
             absolute={false}
+            keyboardOpen={false}
             layout="solo"
             parentType="scene"
             style={
@@ -5750,6 +5751,7 @@ exports[`TransactionDetailsScene should render with negative nativeAmount and fi
         >
           <View
             absolute={false}
+            keyboardOpen={false}
             layout="solo"
             parentType="scene"
             style={

--- a/src/components/buttons/ButtonsView.tsx
+++ b/src/components/buttons/ButtonsView.tsx
@@ -33,6 +33,10 @@ export interface ButtonsViewProps {
   // ButtonInfos
   primary?: ButtonInfo
   secondary?: ButtonInfo
+  /** True while the on-screen keyboard is open, which lets a `parentType`
+   * `'scene'` layout drop the clearance it keeps from the scene's bottom edge:
+   * the keyboard is that edge, and it supplies its own separation. */
+  keyboardOpen?: boolean
   /** @deprecated - Create a separate component instead for these weird one-off cases */
   secondary2?: ButtonInfo // A secondary-styled button in the primary position (right/top side)
   tertiary?: ButtonInfo
@@ -58,6 +62,7 @@ export interface ButtonsViewProps {
 export const ButtonsView = React.memo((props: ButtonsViewProps) => {
   const {
     absolute = false,
+    keyboardOpen = false,
     primary,
     secondary,
     secondary2,
@@ -113,6 +118,7 @@ export const ButtonsView = React.memo((props: ButtonsViewProps) => {
   return (
     <StyledButtonContainer
       absolute={absolute}
+      keyboardOpen={keyboardOpen}
       layout={layout}
       parentType={parentType}
     >
@@ -156,10 +162,11 @@ export const ButtonsView = React.memo((props: ButtonsViewProps) => {
 /** @deprecated - Shouldn't use this export post-UI4 transition once all our layouts have been codified into button layout components. */
 export const StyledButtonContainer = styled(View)<{
   absolute?: boolean
+  keyboardOpen?: boolean
   layout: 'row' | 'column' | 'solo'
   parentType?: 'scene' | 'modal'
 }>(theme => props => {
-  const { absolute, layout, parentType } = props
+  const { absolute, keyboardOpen, layout, parentType } = props
 
   const marginSize = theme.rem(0.5)
 
@@ -217,7 +224,11 @@ export const StyledButtonContainer = styled(View)<{
           flexGrow: 1,
           flexShrink: 0,
           justifyContent: 'flex-end',
-          marginBottom: theme.rem(3),
+          // Clearance from the scene's bottom edge. An open keyboard becomes
+          // that edge and separates the button from the screen on its own, so
+          // this collapses the way `SceneWrapper` collapses the bottom
+          // safe-area inset, for the same reason:
+          marginBottom: keyboardOpen === true ? 0 : theme.rem(3),
           marginTop: theme.rem(1)
         }
       : {}

--- a/src/components/buttons/ButtonsView.tsx
+++ b/src/components/buttons/ButtonsView.tsx
@@ -80,7 +80,7 @@ export const ButtonsView = React.memo((props: ButtonsViewProps) => {
     type: EdgeButtonType,
     buttonProps?: ButtonInfo,
     index: number = 0
-  ) => {
+  ): React.ReactElement | null => {
     if (buttonProps == null) return null
     const { label, onPress, disabled, spinner, testID } = buttonProps
 
@@ -174,14 +174,15 @@ export const StyledButtonContainer = styled(View)<{
     margin: marginSize
   }
 
-  const absoluteStyle: ViewStyle = absolute
-    ? {
-        position: 'absolute',
-        bottom: 0,
-        left: marginSize,
-        right: marginSize
-      }
-    : {}
+  const absoluteStyle: ViewStyle =
+    absolute === true
+      ? {
+          position: 'absolute',
+          bottom: 0,
+          left: marginSize,
+          right: marginSize
+        }
+      : {}
 
   /** @deprecated Instead of a soloStyle case here, create a separate `SoloButton` component */
   const soloStyle: ViewStyle =

--- a/src/components/buttons/SceneButtons.tsx
+++ b/src/components/buttons/SceneButtons.tsx
@@ -10,6 +10,6 @@ interface Props extends Omit<Omit<ButtonsViewProps, 'parentType'>, 'layout'> {}
 /** For properly spacing out content behind floating absolute buttons */
 export const SCENE_BUTTONS_MARGIN_REM = 7
 
-export const SceneButtons = (props: Props) => {
+export const SceneButtons: React.FC<Props> = props => {
   return <ButtonsView {...props} parentType="scene" />
 }

--- a/src/components/scenes/CreateWalletImportScene.tsx
+++ b/src/components/scenes/CreateWalletImportScene.tsx
@@ -1,11 +1,11 @@
 import type { JsonObject } from 'edge-core-js'
 import * as React from 'react'
-import { Linking, Platform, View } from 'react-native'
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import { Linking, Platform, ScrollView, View } from 'react-native'
 import { sprintf } from 'sprintf-js'
 
 import { PLACEHOLDER_WALLET_ID } from '../../actions/CreateWalletActions'
 import ImportKeySvg from '../../assets/images/import-key-icon.svg'
+import { SCROLL_INDICATOR_INSET_FIX } from '../../constants/constantSettings'
 import {
   type ImportKeyOption,
   SPECIAL_CURRENCY_INFO
@@ -244,137 +244,192 @@ const CreateWalletImportComponent: React.FC<Props> = props => {
   )
 
   return (
-    <SceneWrapper>
-      <View style={styles.container}>
-        {/* We have to use the SceneHeaderUi4 component here because
+    <SceneWrapper avoidKeyboard>
+      {({ isKeyboardOpen }) => (
+        <View style={styles.container}>
+          {/* We have to use the SceneHeaderUi4 component here because
         the SceneContainer component does not implement the specific flex
         styles we need for this scene's container. These styles are a
         one-off case which has not been codified into our design hierarchy
         and made it completely into our abstraction (SceneContainer). */}
-        <SceneHeaderUi4 title={lstrings.create_wallet_import_title} />
-        <KeyboardAwareScrollView keyboardShouldPersistTaps="handled">
-          <View style={styles.icon}>
-            <ImportKeySvg
-              accessibilityHint={lstrings.import_key_icon_hint}
-              color={theme.iconTappable}
-              height={svgHeight}
-              width={svgWidth}
-            />
-          </View>
-          <Paragraph>
-            {lstrings.create_wallet_import_all_instructions}
-          </Paragraph>
-          <FilledTextInput
-            aroundRem={0.5}
-            keyboardType={keyboardType}
-            value={importText}
-            multiline
-            numberOfLines={10}
-            placeholder={lstrings.create_wallet_import_input_key_or_seed_prompt}
-            autoCapitalize="none"
-            autoCorrect={false}
-            autoComplete="off"
-            onChangeText={setImportText}
-            returnKeyType="none"
-            ref={textInputRef}
-          />
-          {importOptsEntries.length > 0 ? (
-            <EdgeText style={styles.optionsHeading}>
-              {lstrings.create_wallet_import_options_title}
-            </EdgeText>
-          ) : null}
-          {importOptsEntries.map(([pluginId, opts]) => (
-            <View key={pluginId} style={styles.optionContainer}>
-              {importOptsEntries.length > 1 ? (
-                <View style={styles.optionHeader}>
-                  <CryptoIcon
-                    sizeRem={1.25}
-                    pluginId={pluginId}
-                    tokenId={null}
-                  />
-                  <EdgeText style={styles.pluginIdText}>
-                    {currencyConfig[pluginId].currencyInfo.displayName}
-                  </EdgeText>
-                </View>
-              ) : null}
-              {[...opts].map(opt => {
-                const key = getOptionKey(pluginId, opt)
-                const item = optionValues.get(key)
-                if (item == null) return null
-
-                const { value, error } = item
-                const { knowledgeBaseUri } = opt.displayDescription ?? {}
-
-                const returnKeyType =
-                  opt.inputType === 'number-pad' && Platform.OS === 'ios'
-                    ? undefined
-                    : 'done'
-
-                return (
-                  <View key={key} style={styles.optionRow}>
-                    <FilledTextInput
-                      aroundRem={0.5}
-                      expand
-                      placeholder={`${opt.displayName}${
-                        opt.required ? ` (${lstrings.fragment_required})` : ''
-                      }`}
-                      value={value}
-                      error={
-                        error ? lstrings.create_wallet_invalid_input : undefined
-                      }
-                      keyboardType={opt.inputType}
-                      autoCapitalize="none"
-                      autoCorrect={false}
-                      autoComplete="off"
-                      onChangeText={(text: string) => {
-                        handleOptionChange(text, pluginId, opt)
-                      }}
-                      returnKeyType={returnKeyType}
-                    />
-                    {knowledgeBaseUri != null ? (
-                      <EdgeTouchableOpacity
-                        style={styles.infoButton}
-                        onPress={() => {
-                          Linking.openURL(knowledgeBaseUri).catch(
-                            (err: unknown) => {
-                              showError(err)
-                            }
-                          )
-                        }}
-                      >
-                        <InformationCircleIcon
-                          size={theme.rem(1.25)}
-                          color={theme.iconTappable}
-                        />
-                      </EdgeTouchableOpacity>
-                    ) : null}
-                  </View>
-                )
-              })}
+          {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
+          <SceneHeaderUi4 title={lstrings.create_wallet_import_title} />
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+            scrollIndicatorInsets={SCROLL_INDICATOR_INSET_FIX}
+          >
+            <View style={styles.icon}>
+              <ImportKeySvg
+                accessibilityHint={lstrings.import_key_icon_hint}
+                color={theme.iconTappable}
+                height={svgHeight}
+                width={svgWidth}
+              />
             </View>
-          ))}
-          <SceneButtons
-            primary={{
-              label: lstrings.string_next_capitalized,
-              disabled: disableNextButton,
-              onPress: handleNext
-            }}
-          />
-        </KeyboardAwareScrollView>
-      </View>
+            <Paragraph>
+              {lstrings.create_wallet_import_all_instructions}
+            </Paragraph>
+            {/* FilledTextInput's multiline containers are flexGrow/flexShrink 1,
+          and a ScrollView lays its content out against the scroll viewport, so
+          the seed box would shrink to whatever room the keyboard leaves instead
+          of showing the whole phrase. This wrapper refuses to shrink, so the
+          field sizes to its text and the scene scrolls instead.
+
+          numberOfLines is Android-only (iOS sizes the box to its text already),
+          and Android turns it into EditText.setLines, so the box holds this
+          many lines whether it is empty or full. A fixed count is the only
+          thing a caller can choose: omitting the prop falls back to
+          FilledTextInput's own default of 20, and 0 collapses the box to one
+          line that clips the phrase. Ten fits a 24-word seed on the phones we
+          support without leaving a large empty box on the ones we don't. */}
+            <View style={styles.seedInput}>
+              <FilledTextInput
+                aroundRem={0.5}
+                keyboardType={keyboardType}
+                value={importText}
+                multiline
+                numberOfLines={10}
+                placeholder={
+                  lstrings.create_wallet_import_input_key_or_seed_prompt
+                }
+                autoCapitalize="none"
+                autoCorrect={false}
+                autoComplete="off"
+                onChangeText={setImportText}
+                returnKeyType="none"
+                ref={textInputRef}
+              />
+            </View>
+            {importOptsEntries.length > 0 ? (
+              <EdgeText style={styles.optionsHeading}>
+                {lstrings.create_wallet_import_options_title}
+              </EdgeText>
+            ) : null}
+            {importOptsEntries.map(([pluginId, opts]) => (
+              <View key={pluginId} style={styles.optionContainer}>
+                {importOptsEntries.length > 1 ? (
+                  <View style={styles.optionHeader}>
+                    <CryptoIcon
+                      sizeRem={1.25}
+                      pluginId={pluginId}
+                      tokenId={null}
+                    />
+                    <EdgeText style={styles.pluginIdText}>
+                      {currencyConfig[pluginId].currencyInfo.displayName}
+                    </EdgeText>
+                  </View>
+                ) : null}
+                {[...opts].map(opt => {
+                  const key = getOptionKey(pluginId, opt)
+                  const item = optionValues.get(key)
+                  if (item == null) return null
+
+                  const { value, error } = item
+                  const { knowledgeBaseUri } = opt.displayDescription ?? {}
+
+                  const returnKeyType =
+                    opt.inputType === 'number-pad' && Platform.OS === 'ios'
+                      ? undefined
+                      : 'done'
+
+                  return (
+                    <View key={key} style={styles.optionRow}>
+                      <FilledTextInput
+                        aroundRem={0.5}
+                        expand
+                        placeholder={`${opt.displayName}${
+                          opt.required ? ` (${lstrings.fragment_required})` : ''
+                        }`}
+                        value={value}
+                        error={
+                          error
+                            ? lstrings.create_wallet_invalid_input
+                            : undefined
+                        }
+                        keyboardType={opt.inputType}
+                        autoCapitalize="none"
+                        autoCorrect={false}
+                        autoComplete="off"
+                        onChangeText={(text: string) => {
+                          handleOptionChange(text, pluginId, opt)
+                        }}
+                        returnKeyType={returnKeyType}
+                      />
+                      {knowledgeBaseUri != null ? (
+                        <EdgeTouchableOpacity
+                          style={styles.infoButton}
+                          onPress={() => {
+                            Linking.openURL(knowledgeBaseUri).catch(
+                              (err: unknown) => {
+                                showError(err)
+                              }
+                            )
+                          }}
+                        >
+                          <InformationCircleIcon
+                            size={theme.rem(1.25)}
+                            color={theme.iconTappable}
+                          />
+                        </EdgeTouchableOpacity>
+                      ) : null}
+                    </View>
+                  )
+                })}
+              </View>
+            ))}
+            {/* SceneButtons anchors itself to the bottom of a flex-sized
+            parent. This wrapper is content-sized, so the button simply follows
+            the content at its own margin instead of drifting with the amount of
+            free space: */}
+            <View>
+              <SceneButtons
+                keyboardOpen={isKeyboardOpen}
+                primary={{
+                  label: lstrings.string_next_capitalized,
+                  disabled: disableNextButton,
+                  onPress: handleNext
+                }}
+              />
+            </View>
+          </ScrollView>
+        </View>
+      )}
     </SceneWrapper>
   )
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
   container: {
-    flexShrink: 1,
-    margin: theme.rem(0.5)
+    flex: 1,
+    // No bottom margin: the scene's bottom edge IS the top of the keyboard
+    // while it is open, and a margin there is dead space the content can never
+    // scroll into:
+    marginTop: theme.rem(0.5),
+    marginHorizontal: theme.rem(0.5)
+  },
+  scroll: {
+    // Take whatever room the header leaves, and give it back as the keyboard
+    // opens, so the content scrolls instead of running off the scene:
+    flex: 1
+  },
+  scrollContent: {
+    // Content-sized on purpose. Growing this to the viewport would hand the
+    // leftover room to whichever child can flex, so the scene's spacing would
+    // change with the length of the seed phrase:
+    flexGrow: 0
   },
   icon: {
     flexDirection: 'row',
+    alignItems: 'center',
     justifyContent: 'center',
-    marginVertical: theme.rem(2)
+    // A fixed 1 rem above and below, so the logo sits the same distance from
+    // the header whether the seed field holds nothing or a 24-word phrase:
+    marginVertical: theme.rem(1)
+  },
+  seedInput: {
+    flexShrink: 0
   },
   optionsHeading: {
     fontSize: theme.rem(1),

--- a/src/components/scenes/CreateWalletImportScene.tsx
+++ b/src/components/scenes/CreateWalletImportScene.tsx
@@ -44,7 +44,7 @@ interface Props extends EdgeAppSceneProps<'createWalletImport'> {}
 const getOptionKey = (pluginId: string, opt: ImportKeyOption): string =>
   `${pluginId}${opt.optionName}`
 
-const CreateWalletImportComponent = (props: Props): React.JSX.Element => {
+const CreateWalletImportComponent: React.FC<Props> = props => {
   const { navigation, route } = props
   const { createWalletList, walletNames, walletSettingValues } = route.params
   const theme = useTheme()


### PR DESCRIPTION
### Description

[Asana task](https://app.asana.com/0/0/1217525813318788/f)

The Import Wallet scene rendered everything, including the Next button, inside a
scroll view that did not react to the keyboard. Opening the keyboard to type a
seed hid the button behind it, along with the per-asset Import Options inputs
(the Zcash / Pirate Chain birthday height). A wrapped 12- or 24-word phrase or a
short device made it worse.

The scene now shrinks to the space above the keyboard (`SceneWrapper
avoidKeyboard`, the pattern ~20 other scenes already use, backed by
`react-native-keyboard-controller`) and its content lives in a real
`ScrollView`. Because the keyboard is part of the layout, the scroll viewport
ends above it, so the bottom of the scene is reachable; on the unchanged build
the viewport's bottom edge sits underneath the keyboard and no amount of
scrolling reveals Next.

On a screen the size QA reported against (iPhone Air, 420x912pt), a 24-word phrase
makes the content taller than the room the keyboard leaves. Two things went wrong
there, and both are fixed by removing something rather than adding one:

- **The scene left a band of dead space above the keyboard.** The scene container
  carried a uniform `margin: rem(0.5)`, so the scroll viewport stopped short of the
  scene's bottom edge. With the keyboard open that edge IS the top of the keyboard,
  and the margin became space the content could never scroll into: the lowest visible
  row sat above an empty strip. The container now takes `marginTop` and
  `marginHorizontal` only, so the viewport ends flush against the keyboard.
- **The button kept 3 rem of clearance it did not need.** `ButtonsView`'s
  `parentType="scene"` layout holds the button off the screen's bottom edge. An open
  keyboard supplies that separation itself, exactly the reason `SceneWrapper` already
  collapses its bottom safe-area inset. A new opt-in `keyboardOpen` prop drops the
  margin while the keyboard is up. The prop defaults to `false`, so the other
  `SceneButtons` and `parentType="scene"` call sites are unchanged.

The scene's spacing is also fixed rather than elastic. An earlier revision grew the
scroll content container to the viewport and let the logo block flex into whatever
room was left, which meant the scene spread out with an empty field and compressed
with a full one. The content container is now content-sized (`flexGrow: 0`), the logo
keeps a fixed 1 rem above and below, and `SceneButtons` stays inside the scroll
content in a plain wrapper `View` so its own bottom-anchoring `flexGrow` has nothing
to resolve against. The logo sits the same distance from the header, and the button
the same distance from the seed box, whether the field holds nothing or 24 words.

The seed field still never collapses: `FilledTextInput` hardcodes `flexGrow: 1` /
`flexShrink: 1` on its containers when `multiline`, and a plain non-shrinking `View`
around the field in this scene stops that. No change to `FilledTextInput` itself, so
`TextInputModal`'s `fullHeight` multiline mode and `SignMessageScene`'s
`numberOfLines={4}` keep the fill behavior they want.

When the content genuinely cannot fit, the scene scrolls to reach Next, which is the
behavior the task's review asked for.

The maestro import flows used to dismiss the keyboard before tapping Next. That
workaround is gone on both platforms in both copies
(`maestro/common/import-wallets.yaml`,
`maestro/07-wallets/C000029a-migrate-wallets.yaml`): Next is reachable and
tappable with the keyboard up, and the platform-conditional `hideKeyboard` is
replaced by a `scrollUntilVisible` on Next, since a long phrase can still push
the button past the bottom of the scroll viewport. Both the iOS and the Android
form were driven on device, which the evidence below shows.

One Android limitation stays, and it predates this PR. `numberOfLines` is an
Android-only prop that React Native turns into `EditText.setLines`, so the seed
box holds a fixed line count whether it is empty or full; iOS ignores the prop
and sizes the box to its text. A caller can only choose the count: dropping the
prop falls back to `FilledTextInput`'s own default of 20 lines, and 0 collapses
the box to a single line that clips the phrase. Both were tried on an emulator
and are worse than the current 10. Content sizing on Android would mean changing
`FilledTextInput` to stop forwarding the prop, which is out of scope here.

`ButtonsView.tsx` carries a header asking that changes be synced with
edge-login-ui-rn. The `keyboardOpen` prop is additive and defaults to the current
behavior, but it still owes a sync PR there.

Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1217525813318788

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

Both platforms were driven on the current revision, and the frames in the evidence
comments below are from it.

iOS, iPhone 16 Pro Max simulator (iOS 18.6): the 24-word phrase typed through the
on-screen keyboard, Next tapped with the keyboard still up, and the import carried
through to the Create Wallets completion scene. The BTC + ZEC configuration adds the
Zcash birthday field and makes the content taller than the room the keyboard leaves,
which is the case that shows the scroll viewport ending flush against the keyboard:
scrolled to the end, the last row sits at the keyboard's top edge instead of above an
empty strip. The last evidence frame is that same scene with the pre-fix bottom
margin temporarily restored, for the comparison.

Android, emulator (Android 16): the same import driven to the Create Wallets scene
with the keyboard up, and the reverted maestro step sequence (`scrollUntilVisible` on
Next, replacing the platform-conditional `hideKeyboard`) run end to end.

Not exercised on this revision: iPhone 13 mini and iPhone Air (a run can only drive
its own simulator), a tablet, and the BTC + ZEC import past the scene to completion.
