### PR TITLE
Add ECX GUI wiring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "disklet": "^0.6.0",
         "edge-core-js": "^2.47.1",
         "edge-currency-accountbased": "^4.88.0",
-        "edge-currency-plugins": "^3.12.0",
+        "edge-currency-plugins": "github:bobbythelobster/edge-currency-plugins#claudine/ecash-ecx-support",
         "edge-exchange-plugins": "^2.52.2",
         "edge-info-server": "^3.12.0",
         "edge-login-ui-rn": "^3.37.0",
@@ -15477,8 +15477,7 @@
     },
     "node_modules/edge-currency-plugins": {
       "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/edge-currency-plugins/-/edge-currency-plugins-3.12.0.tgz",
-      "integrity": "sha512-aughOsLWJqd9Z6U558utJEtM6MPHRT/MGndosBbGSkAnPPaiYSEY6uQs5ey/1pHf12411AMLUCmdqHBNKgB6hQ==",
+      "resolved": "git+ssh://git@github.com/bobbythelobster/edge-currency-plugins.git#4047454915becfe680098f550ca12ab6545f12d8",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "disklet": "^0.6.0",
     "edge-core-js": "^2.47.1",
     "edge-currency-accountbased": "^4.88.0",
-    "edge-currency-plugins": "^3.12.0",
+    "edge-currency-plugins": "github:bobbythelobster/edge-currency-plugins#claudine/ecash-ecx-support",
     "edge-exchange-plugins": "^2.52.2",
     "edge-info-server": "^3.12.0",
     "edge-login-ui-rn": "^3.37.0",

--- a/src/__tests__/constants/WalletAndCurrencyConstants.test.ts
+++ b/src/__tests__/constants/WalletAndCurrencyConstants.test.ts
@@ -47,3 +47,16 @@ describe('botanix keysOnlyMode', function () {
     expect(SPECIAL_CURRENCY_INFO.botanix.keysOnlyMode).toBe(true)
   })
 })
+
+describe('eCash plugin variants', function () {
+  test('keeps ECX UTXO behavior separate from XEC', function () {
+    expect(SPECIAL_CURRENCY_INFO.bitcoinecash).toMatchObject({
+      hasSegwit: true,
+      isImportKeySupported: true,
+      maxSpendTargets: 32
+    })
+    expect(SPECIAL_CURRENCY_INFO.ecash).not.toBe(
+      SPECIAL_CURRENCY_INFO.bitcoinecash
+    )
+  })
+})

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -91,6 +91,7 @@ export const WALLET_LIST_MENU: Array<{
   {
     pluginIds: [
       'bitcoincash',
+      'bitcoinecash',
       'bitcoinsv',
       'bitcoin',
       'bitcoingold',
@@ -122,6 +123,7 @@ export const WALLET_LIST_MENU: Array<{
       'bitcoin',
       'bitcoincash',
       'bitcoincashtestnet',
+      'bitcoinecash',
       'bitcoingold',
       'bitcoingoldtestnet',
       'bitcoinsv',

--- a/src/constants/WalletAndCurrencyConstants.ts
+++ b/src/constants/WalletAndCurrencyConstants.ts
@@ -524,6 +524,14 @@ export const SPECIAL_CURRENCY_INFO: Record<string, SpecialCurrencyInfo> = {
     isStakingSupported: false,
     unstoppableDomainsTicker: 'ECASH'
   },
+  bitcoinecash: {
+    maxSpendTargets: UTXO_MAX_SPEND_TARGETS,
+    hasSegwit: true,
+    initWalletName: lstrings.string_first_ecash_wallet_name,
+    displayBuyCrypto: false,
+    isImportKeySupported: true,
+    isStakingSupported: false
+  },
   ethereum: {
     initWalletName: lstrings.string_first_ethereum_wallet_name,
     dummyPublicAddress: '0x0d73358506663d484945ba85d0cd435ad610b0a0',

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -307,6 +307,11 @@ export const asEnvConfig = asObject({
       nowNodesApiKey: asOptional(asString, '')
     })
   ),
+  BITCOINECASH_INIT: asCorePluginInit(
+    asObject({
+      nowNodesApiKey: asOptional(asString, '')
+    })
+  ),
   ETHEREUM_INIT: asCorePluginInit(asEvmApiKeys),
   ETHEREUM_POW_INIT: asCorePluginInit(asEvmApiKeys),
   EXOLIX_INIT: asCorePluginInit(

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -22,6 +22,7 @@ export const currencyPlugins: EdgeCorePluginsInit = {
   coreum: ENV.COREUM_INIT,
   cosmoshub: ENV.COSMOSHUB_INIT,
   ecash: ENV.ECASH_INIT,
+  bitcoinecash: ENV.BITCOINECASH_INIT,
   eos: true,
   ethereum: ENV.ETHEREUM_INIT,
   ethereumclassic: true,


### PR DESCRIPTION
## Summary
- Register the new `bitcoinecash` currency plugin behind a separate `BITCOINECASH_INIT` gate so ECX stays distinct from existing XEC `ecash`.
- Add ECX GUI metadata for SegWit/import/max-spend behavior.
- Add ECX to wallet menu sign-message and xpub-view capability lists.
- Temporarily pin `edge-currency-plugins` to the ECX PR branch at `4047454915becfe680098f550ca12ab6545f12d8` until the plugin PR is merged and released.

Correlated plugin PR: https://github.com/EdgeApp/edge-currency-plugins/pull/456

## Testing
- `npx eslint src/util/corePlugins.ts src/envConfig.ts src/constants/WalletAndCurrencyConstants.ts src/__tests__/constants/WalletAndCurrencyConstants.test.ts src/components/modals/WalletListMenuModal.tsx`
- `git diff --check`
- `npx tsc --noEmit`
- `npm test -- src/__tests__/constants/WalletAndCurrencyConstants.test.ts --runInBand`
- `npm test -- --runInBand --findRelatedTests src/components/modals/WalletListMenuModal.tsx --passWithNoTests`
- precommit hook: `tsc` + full `npm test` (98 suites / 705 tests passed)

## Notes
- ECX remains disabled by default because missing `BITCOINECASH_INIT` cleans to `false`; this avoids enabling the pre-launch/drynet wallet unintentionally.
- ECX currently reuses the existing user-facing `My eCash` wallet-name string; no ECX-specific localization key exists yet.