### PR TITLE
Register the Swapter swap provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.
 - added: App/device attestation for gated info-server requests
+- added: Swapter swap provider
 - added: "-m" tag on the version number in the Help scene for Maestro test builds
 - added: Sign Message option in the wallet list menu for Bitcoin-family wallets, letting users prove self-hosted wallet ownership to exchanges by signing an exchange-provided message.
 - added: `edge://buy` and `edge://sell` deep links (and their `https://deep.edge.app` equivalents) that open the buy/sell flow, optionally pinning a provider and payment method to the top of the quote options for that visit.

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -725,6 +725,7 @@ export const pluginIdIcons: Record<string, string> = {
   rango: EDGE_CONTENT_SERVER_URI + '/rango.png',
   sideshift: EDGE_CONTENT_SERVER_URI + '/sideshift-logo.png',
   simplex: EDGE_CONTENT_SERVER_URI + '/simplex.png',
+  swapter: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/swapter/icon.png',
   swapuz: EDGE_CONTENT_SERVER_URI + '/swapuz.png',
   thorchain: EDGE_CONTENT_SERVER_URI + '/thorchain.png',
   unizen: EDGE_CONTENT_SERVER_URI + '/unizen.png',

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -425,6 +425,11 @@ export const asEnvConfig = asObject({
       quiknodeApiKey: asOptional(asString, '')
     }).withRest
   ),
+  SWAPTER_INIT: asCorePluginInit(
+    asObject({
+      apiKey: asOptional(asString, '')
+    }).withRest
+  ),
   SWAPUZ_INIT: asCorePluginInit(
     asObject({
       apiKey: asOptional(asString, '')

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -99,6 +99,7 @@ export const swapPlugins = {
   letsexchange: ENV.LETSEXCHANGE_INIT,
   nexchange: ENV.NEXCHANGE_INIT,
   sideshift: ENV.SIDESHIFT_INIT,
+  swapter: ENV.SWAPTER_INIT,
   swapuz: ENV.SWAPUZ_INIT,
   xgram: ENV.XGRAM_INIT,
   nymswap: ENV.NYM_SWAP_INIT,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Requires `edge-exchange-plugins@2.53.0`, which is published. The dep bump onto
`develop` lands separately as part of that package's release.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

No visual changes. The only user-visible surface is the provider icon on a
Swapter transaction row, which is a data entry pointing at an existing content
server asset, not a layout or component change.

### Description

[Asana task](https://app.asana.com/0/0/1216571782597915/f)

Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1216571782597915

Registers **Swapter** in the app so the plugin that
[EdgeApp/edge-exchange-plugins#475](https://github.com/EdgeApp/edge-exchange-plugins/pull/475)
added actually loads. The changes are data entries, with no logic:

- `src/envConfig.ts` gains `SWAPTER_INIT`, matching the `SWAPUZ_INIT` / `XGRAM_INIT`
  shape (`apiKey`, optional, `.withRest`).
- `src/util/corePlugins.ts` gains `swapter: ENV.SWAPTER_INIT` in the CEX swap block.
- `src/actions/CategoriesActions.ts` gains the `pluginIdIcons` entry so a Swapter
  transaction row renders the provider icon.

The first two are exactly the edits used locally to exercise Swapter on the
simulator during the plugin's review rounds, carried over unchanged.

#### The provider stays dark until the info server serves it

`asCorePluginInit` resolves to `false` when its key is absent from `env.json`, so
registering the plugin does not enable it. Swapter cannot appear in the app until
the info server serves `SWAPTER_INIT`, which is a separate operational step.
Landing this PR is therefore not the moment Swapter goes live for users.

#### Icon path

The icon uses `exchangeIcons/swapter/icon.png` rather than the flat `swapter.png`
that most entries in that map use. That is not a style choice: the flat path
answers 403 on the content server and the `exchangeIcons` one answers 200, which
is the same convention `nexchange` and `nymswap` already use.

#### Deliberately not included

- **No `MERCHANT_CONTACTS` entry.** That map keys off display name and expects a
  flat `swapter.png`, which does not exist on the content server. `pluginIdIcons`
  already covers the icon by plugin ID, and `nymswap` and `nexchange` ship with no
  merchant-contact entry either.
- **No `SwapVerifyTermsModal` entry.** Adding one introduces a mandatory
  terms-acceptance modal before a user's first Swapter swap, which is a product
  decision rather than part of registering the plugin. Roughly half the CEX
  providers have an entry and half do not. Swapter's pages are live
  (`https://swapter.io/terms-of-use`, `https://swapter.io/privacy-policy`) if this
  is wanted.

#### Testing

`verify-repo.sh --base origin/develop` passes: CHANGELOG, `npm run prepare`,
eslint over the 3 changed files, and the full jest suite, which ran 553 tests
across 81 suites and matched all 103 snapshots.

No simulator run for this branch, by design. These are the same edits already
exercised on the simulator during the plugin's own review rounds, where a max
DOGE to LTC swap ran through Swapter to the success scene with this exact
registration in place. That evidence and its screenshots live on
[edge-exchange-plugins#475](https://github.com/EdgeApp/edge-exchange-plugins/pull/475).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only registration with no behavior change until the info server supplies `SWAPTER_INIT`; no auth, payment, or swap execution logic touched.
> 
> **Overview**
> Registers **Swapter** in the React Native GUI so the `edge-exchange-plugins` Swapter integration can load when the info server enables it. The diff is wiring only—no swap or UI logic.
> 
> **Env and core plugins:** Adds `SWAPTER_INIT` in `envConfig.ts` (optional `apiKey`, same shape as other CEX providers) and maps `swapter: ENV.SWAPTER_INIT` in the centralized swap block in `corePlugins.ts`. When `SWAPTER_INIT` is missing from rollup/`env.json`, `asCorePluginInit` resolves to `false`, so users do not see Swapter until ops pushes config from the info server.
> 
> **Transaction UI:** Adds a `pluginIdIcons` entry in `CategoriesActions.ts` so Swapter swap rows show the provider icon from `exchangeIcons/swapter/icon.png` on the content server.
> 
> CHANGELOG notes the new provider. Depends on `edge-exchange-plugins@2.53.0` separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae488b4a57f274af04932830033e83b461ffad02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->