### PR TITLE
Add SimpleSwap swap support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (develop)
 
 - added: App/device attestation for gated info-server requests
+- added: SimpleSwap swap provider
 - added: "-m" tag on the version number in the Help scene for Maestro test builds
 - added: Sign Message option in the wallet list menu for Bitcoin-family wallets, letting users prove self-hosted wallet ownership to exchanges by signing an exchange-provided message.
 - added: `edge://buy` and `edge://sell` deep links (and their `https://deep.edge.app` equivalents) that open the buy/sell flow, optionally pinning a provider and payment method to the top of the quote options for that visit.

--- a/src/actions/CategoriesActions.ts
+++ b/src/actions/CategoriesActions.ts
@@ -724,6 +724,7 @@ export const pluginIdIcons: Record<string, string> = {
   nymswap: EDGE_CONTENT_SERVER_URI + '/exchangeIcons/nymswap/icon.png',
   rango: EDGE_CONTENT_SERVER_URI + '/rango.png',
   sideshift: EDGE_CONTENT_SERVER_URI + '/sideshift-logo.png',
+  simpleswap: EDGE_CONTENT_SERVER_URI + '/simpleswap.png',
   simplex: EDGE_CONTENT_SERVER_URI + '/simplex.png',
   swapuz: EDGE_CONTENT_SERVER_URI + '/swapuz.png',
   thorchain: EDGE_CONTENT_SERVER_URI + '/thorchain.png',

--- a/src/components/modals/SwapVerifyTermsModal.tsx
+++ b/src/components/modals/SwapVerifyTermsModal.tsx
@@ -49,6 +49,11 @@ const pluginData: Record<string, TermsUri> = {
     kycUri:
       'https://help.sideshift.ai/en/articles/6230858-sideshift-ai-s-risk-management-policy'
   },
+  simpleswap: {
+    termsUri: 'https://simpleswap.io/terms-of-service',
+    privacyUri: 'https://simpleswap.io/privacy-policy',
+    kycUri: 'https://simpleswap.io/aml-kyc'
+  },
   swapuz: {
     termsUri: 'https://swapuz.com/terms-of-use',
     privacyUri: 'https://swapuz.com/privacy-policy',

--- a/src/constants/MerchantContacts.ts
+++ b/src/constants/MerchantContacts.ts
@@ -75,6 +75,10 @@ export const MERCHANT_CONTACTS: MerchantContact[] = [
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/sideshift-logo.png`
   },
   {
+    displayName: 'SimpleSwap',
+    thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/simpleswap.png`
+  },
+  {
     displayName: 'Simplex',
     thumbnailPath: `${EDGE_CONTENT_SERVER_URI}/simplex.png`
   },

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -412,6 +412,11 @@ export const asEnvConfig = asObject({
       affiliateId: asOptional(asString, '')
     })
   ),
+  SIMPLESWAP_INIT: asCorePluginInit(
+    asObject({
+      apiKey: asOptional(asString, '')
+    }).withRest
+  ),
   SOLANA_INIT: asCorePluginInit(
     asObject({
       alchemyApiKey: asOptional(asString, ''),

--- a/src/util/corePlugins.ts
+++ b/src/util/corePlugins.ts
@@ -99,6 +99,7 @@ export const swapPlugins = {
   letsexchange: ENV.LETSEXCHANGE_INIT,
   nexchange: ENV.NEXCHANGE_INIT,
   sideshift: ENV.SIDESHIFT_INIT,
+  simpleswap: ENV.SIMPLESWAP_INIT,
   swapuz: ENV.SWAPUZ_INIT,
   xgram: ENV.XGRAM_INIT,
   nymswap: ENV.NYM_SWAP_INIT,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

[EdgeApp/edge-exchange-plugins#488](https://github.com/EdgeApp/edge-exchange-plugins/pull/488): the SimpleSwap plugin itself. This PR only registers it, so it is inert until that lands and publishes.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1217205278669378

Registers SimpleSwap, the swap provider added in
[EdgeApp/edge-exchange-plugins#488](https://github.com/EdgeApp/edge-exchange-plugins/pull/488),
so the plugin loads in the app. This is SimpleSwap's own wiring from
[#6136](https://github.com/EdgeApp/edge-react-gui/pull/6136), recreated on an
EdgeApp branch so it can land from here, with their authorship on the commit.

- `src/envConfig.ts` carries `SIMPLESWAP_INIT` with an `apiKey`, matching the other
  centralized providers. An empty key makes the plugin factory throw, so builds
  without the key skip SimpleSwap entirely.
- `src/util/corePlugins.ts` carries the `swapPlugins` entry.
- `src/components/modals/SwapVerifyTermsModal.tsx` carries the terms, privacy
  and AML/KYC links shown before the first SimpleSwap quote.
- `src/actions/CategoriesActions.ts` and `src/constants/MerchantContacts.ts` carry
  the provider icon and merchant contact.

The icon at `content.edge.app/simpleswap.png` is not on the content server yet,
so the provider row renders a broken image until it is uploaded. SimpleSwap
attached the 64x64 and 600x210 assets, at 1x and 2x, to
[#6136](https://github.com/EdgeApp/edge-react-gui/pull/6136).

### Testing

Driven on the iOS simulator against the real SimpleSwap API, with every other
swap provider disabled locally so the engine had to route through SimpleSwap: an
80 XLM to XMR swap from `My Stellar` executed to the success scene, and the
Stellar send carried SimpleSwap's numeric deposit memo. The plugin's below-limit
error also renders correctly ("Amount is below the min limit of 66.9549714 XLM").
Screenshots below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bd3a86ddc6c308dcfd262880cdc5ac702d0fa324. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="2" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6167/commits/bd3a86ddc6c308dcfd262880cdc5ac702d0fa324"><code>bd3a86d</code></a><br><sub>Add SimpleSwap swap support</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-01-simpleswap-terms-modal.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-01-simpleswap-terms-modal.png" width="200"></a><br><sub>simpleswap terms modal</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-02-simpleswap-quote.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-02-simpleswap-quote.png" width="200"></a><br><sub>simpleswap quote</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-03-swap-success.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-03-swap-success.png" width="200"></a><br><sub>swap success</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-04-xlm-tx-with-memo.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-04-xlm-tx-with-memo.png" width="200"></a><br><sub>xlm tx with memo</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-05-stellar-broadcast.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6167/20260819-162430-agent-proof-1217205278669378-05-stellar-broadcast.png" width="200"></a><br><sub>stellar broadcast</sub></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->