### PR TITLE
Show ramp crypto amounts at the asset's own decimal precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - changed: Refresh the buy, sell, sort, scan-QR and FIO names icons to the updated design.
 - changed: Display "MoonPay" instead of "Moonpay" wherever the partner name appears in the app.
 - changed: Use a custom chart icon for the side menu Markets row, so it matches the rest of the menu.
+- changed: The buy/sell crypto amount field now shows as many decimals as the asset itself supports, up to nine, instead of a fixed six. MoonPay raises its buy-flow precision to eight decimals for BTC and nine for ETH and SOL on September 1, 2026, which the old limit would have truncated.
 - changed: Use the UI4 warning card for the Reveal Raw Keys and Reveal Master Private Key password confirmation warnings.
 - changed: Tron resource staking now describes its claim action as reclaiming your own TRX, instead of claiming a reward.
 - changed: Deep links now wait only for the account state they actually use, so a link that just opens a scene, such as the buy/sell entry, follows immediately after login instead of waiting for every wallet to finish loading.

--- a/src/components/scenes/RampCreateScene.tsx
+++ b/src/components/scenes/RampCreateScene.tsx
@@ -85,6 +85,13 @@ import { EdgeText } from '../themed/EdgeText'
 import { FilledTextInput } from '../themed/FilledTextInput'
 import { RampRegionSelect } from './RampCreateScene/RampRegionSelect'
 
+/**
+ * Upper bound on the decimals the crypto amount field renders, for assets whose
+ * own precision goes beyond what a ramp quote can express. See
+ * `cryptoMaxDecimals`.
+ */
+const MAX_CRYPTO_ENTRY_DECIMALS = 9
+
 export interface RampCreateParams {
   forcedWalletResult?: WalletListWalletResult
   regionCode?: string
@@ -592,6 +599,21 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
     denomination
   ])
 
+  // How many decimals the crypto field renders. Providers quote each asset at
+  // its own precision and change it over time (Moonpay moves BTC 5 -> 8 and
+  // ETH/SOL to 9 decimals on the buy flow in September 2026), so this follows
+  // the asset instead of assuming a count. The 9-decimal ceiling keeps the
+  // field readable for high-precision assets such as ETH, whose 18 decimals
+  // would expose the rounding noise of the float exchange rate that
+  // `displayCryptoAmount` divides by while the user types a fiat amount.
+  const cryptoMaxDecimals = React.useMemo(() => {
+    if (denomination == null) return MAX_CRYPTO_ENTRY_DECIMALS
+    return Math.min(
+      mulToPrecision(denomination.multiplier),
+      MAX_CRYPTO_ENTRY_DECIMALS
+    )
+  }, [denomination])
+
   // Log the quote event only when the scene is focused
   useFocusEffect(() => {
     dispatch(logEvent(direction === 'buy' ? 'Buy_Quote' : 'Sell_Quote'))
@@ -1091,7 +1113,7 @@ export const RampCreateScene: React.FC<Props> = (props: Props) => {
                 placeholder={cryptoAmountPlaceholder}
                 keyboardType="decimal-pad"
                 numeric
-                maxDecimals={6}
+                maxDecimals={cryptoMaxDecimals}
                 returnKeyType="done"
                 showSpinner={isFetchingQuotes && lastUsedInput === 'fiat'}
                 disabled={cryptoInputDisabled}


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1217660195990065

MoonPay told us it raises the decimal precision of its **buy** flow on
September 1, 2026. BTC goes from 5 to 8 decimals, ETH from 6 to 9 decimals, and
SOL from 3 to 9 decimals, while stablecoins stay at 2. MoonPay asked integrators to confirm they treat crypto
amounts as variable-precision decimals rather than assuming a fixed count per
asset. The sell flow is unaffected.

Audit of the live buy path (`src/plugins/ramps/moonpay/`, which is what the Buy
tab routes to; the legacy `amountQuotePlugin` sits behind `pluginListBuyOld`):

- Parsing and maths are already variable-precision. The quote amount is a JSON
  number rendered back through `Number.toString()` and then handled by
  biggystring, which is arbitrary precision and accepts exponent notation.
- Nothing in the buy path stores or reconciles the amount at a fixed scale, and
  the one quote-vs-delivered comparison normalises both sides through the same
  number parse, so it assumes no decimal count.
- One place did hardcode a decimal count: `RampCreateScene` rendered the crypto
  amount field with `maxDecimals={6}`, which `FilledTextInput` applies as
  `toFixed(value, 0, 6)`, a truncation. Every MoonPay asset currently quotes at
  6 decimals or fewer, so the cap has never bitten; after September 1 it would
  silently drop 2 digits of BTC and 3 of ETH and SOL.

This derives the cap from the selected asset's own denomination instead, bounded
at 9 decimals. That gives BTC 8, ETH 9, SOL 9 and USDC 6, matching MoonPay's new
per-asset maximums. The bound matters for assets with more precision than a
quote can carry: when the user types a fiat amount the field divides by a float
exchange rate, whose rounding noise shows up past about 9 decimals, so rendering
ETH's full 18 would surface digits that are not real.

Verified on the iOS simulator with a before and after pair on the same input,
attached below. `verify-repo.sh` passes (eslint, jest, changelog).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e85b6b3c657271510a2fd0a582668e858fbe7cf3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->