### PR TITLE
fix(maestro): persist GraalJS state via output

### DIFF
--- a/maestro/07-wallets/C000032-archive-and-restore-wallets.yaml
+++ b/maestro/07-wallets/C000032-archive-and-restore-wallets.yaml
@@ -22,38 +22,38 @@ tags:
 
 
 # Archive wallets
-- evalScript: ${var walletNames = ["My Bitcoin", "My Bitcoin Cash", "My Dash", "My Ether", "My Litecoin"]}
-- evalScript: ${var index = 0}
+- evalScript: ${output.walletNames = ["My Bitcoin", "My Bitcoin Cash", "My Dash", "My Ether", "My Litecoin"]}
+- evalScript: ${output.index = 0}
 - tapOn: Assets
 - repeat:
-    times: ${walletNames.length - 1}
+    times: ${output.walletNames.length - 1}
     commands:
-      - tapOn: ${walletNames[index]}
+      - tapOn: ${output.walletNames[output.index]}
       - tapOn: 
           id: gearIcon
       - tapOn: ".*Archive Wallet"
       # Modal
       - assertVisible: "Archive Wallet"
-      - assertVisible: ${"Are you sure you want to archive " + walletNames[index] + "?"}
+      - assertVisible: ${"Are you sure you want to archive " + output.walletNames[output.index] + "?"}
       - assertVisible: Cancel
       # Check if "My Ether" wallet
       - runFlow:
           when:
-            true: ${walletNames[index] == "My Ether"}
+            true: ${output.walletNames[output.index] == "My Ether"}
           commands: 
             - assertVisible: "Archiving this wallet will also archive any enabled tokens for this wallet."
           label: "Extra message for Ether wallets"
       # Archive
       - tapOn: Archive
-      - assertNotVisible: ${walletNames[index]}
+      - assertNotVisible: ${output.walletNames[output.index]}
       
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
     label: "Archive all wallets except last"
 
 # Unable to archive last wallet
 - runFlow:
     commands: 
-      - longPressOn: ${walletNames[index]}
+      - longPressOn: ${output.walletNames[output.index]}
       - tapOn: ".*Archive Wallet"
       - assertVisible: "Cannot Archive Wallet"
       - assertVisible: "At least one wallet required in this account."
@@ -80,13 +80,13 @@ tags:
 - assertVisible: "Restore Wallets"
 
 # Toggle on wallets to restore
-- evalScript: ${var walletCurrencyCodes = ["BTC", "BCH", "DASH", "ETH", "LTC"]}
-- evalScript: ${var index = 0}
+- evalScript: ${output.walletCurrencyCodes = ["BTC", "BCH", "DASH", "ETH", "LTC"]}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${walletCurrencyCodes.length - 1}
+    times: ${output.walletCurrencyCodes.length - 1}
     commands:
-      - tapOn: ${walletCurrencyCodes[index]}
-      - evalScript: ${index++}
+      - tapOn: ${output.walletCurrencyCodes[output.index]}
+      - evalScript: ${output.index++}
 - tapOn: Restore
 
 # Modal
@@ -97,14 +97,14 @@ tags:
 
 # Confirm restored and returned to assets screen
 - assertVisible: "Total Balance.*"
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${walletNames.length}
+    times: ${output.walletNames.length}
     commands:
       - scrollUntilVisible:
-          element: ${walletNames[index]}
+          element: ${output.walletNames[output.index]}
           direction: DOWN
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 # Ensure restore is not tappable when none left to restore
 - tapOn:

--- a/maestro/07-wallets/C000036-autodetect-all-networks.yaml
+++ b/maestro/07-wallets/C000036-autodetect-all-networks.yaml
@@ -23,7 +23,7 @@ tags:
 # All networks that support tokens (and import seed)
 # EVMs: Only Sonic and Pulsechain (others tested via regular asset sync)
 - evalScript: ${
-    var wallets = '[
+    output.wallets = '[
       "Coreum",
       "Osmosis",
       "Avalanche",
@@ -40,7 +40,7 @@ tags:
 - runFlow:
     file: ../common/import-wallets.yaml
     env:
-      ASSET_NAMES: ${wallets}
+      ASSET_NAMES: ${output.wallets}
     # label: "Import wallets"
 
 - runFlow:
@@ -54,7 +54,7 @@ tags:
 
 # Tokens matching the imported networks
 - evalScript: ${
-    var tokens = [
+    output.tokens = [
       "ATOM",
       "JOE",
       "PYTH",
@@ -94,17 +94,17 @@ tags:
 #     visible: ${".*New tokens were detected and enabled on " + WALLET_NAME + ".*"}
 #     timeout: 60000
 
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${tokens.length}
+    times: ${output.tokens.length}
     commands:
       - scrollUntilVisible:
-          element: ${tokens[index]}
+          element: ${output.tokens[output.index]}
           direction: UP
           timeout: 20000
           optional: true
       - scrollUntilVisible:
-          element: ${tokens[index]}
+          element: ${output.tokens[output.index]}
           direction: DOWN
           timeout: 90000
       - scrollUntilVisible:
@@ -114,7 +114,7 @@ tags:
           timeout: 10000
           optional: true
           label: "Scroll to bottom."
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 
 

--- a/maestro/07-wallets/C000037-split-wallets.yaml
+++ b/maestro/07-wallets/C000037-split-wallets.yaml
@@ -56,8 +56,8 @@ tags:
 - assertVisible: Split Wallet
 - assertVisible: This action creates wallets from pre-existing wallets.
 - assertVisible: Tap on wallet to edit name
-- evalScript: ${var newETHName = ".*My Ether \\(Split from My Base\\).*"}
-- assertVisible: ${newETHName}
+- evalScript: ${output.newETHName = ".*My Ether \\(Split from My Base\\).*"}
+- assertVisible: ${output.newETHName}
 
 # Rename modal
 - tapOn: 
@@ -109,7 +109,7 @@ tags:
 ## Verify new wallets and balances
 # ETH recovered
 - scrollUntilVisible:
-    element: ${newETHName}
+    element: ${output.newETHName}
     direction: DOWN
     centerElement: true
     timeout: 10000

--- a/maestro/07-wallets/C000043-private-view-key.yaml
+++ b/maestro/07-wallets/C000043-private-view-key.yaml
@@ -21,20 +21,20 @@ tags:
 # Monero/Zano (CryptoNote): 64-char hex
 # Zcash/Pirate (zk-SNARKs): longer alphanumeric strings
 - evalScript: ${
-    var walletFormats = {
+    output.walletFormats = {
       "Monero":"[a-fA-F0-9]{64}",
       "Pirate Chain":"[a-zA-Z0-9]{64,}",
       "Zcash":"[a-zA-Z0-9]{64,}",
       "Zano":"[a-fA-F0-9]{64}"
     }
     }
-- evalScript: ${var walletNames = Object.keys(walletFormats)}
+- evalScript: ${output.walletNames = Object.keys(output.walletFormats)}
 
 # Create account with wallets that support private view key
 - runFlow:
     file: ../common/create-account.yaml
     env:
-      NEW_WALLETS: ${JSON.stringify(walletNames)}
+      NEW_WALLETS: ${JSON.stringify(output.walletNames)}
     label: "Add wallets with private view key support"
 
 - runFlow:
@@ -43,17 +43,17 @@ tags:
 - tapOn: Assets
 
 # Loop over each wallet and test Private View Key
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${walletNames.length}
+    times: ${output.walletNames.length}
     commands:
       # Wallet nickname often excludes extra words (e.g. "Pirate Chain" -> "Pirate")
-      - evalScript: ${var nickName = "My " + walletNames[index].split(" ")[0]}
+      - evalScript: ${output.nickName = "My " + output.walletNames[output.index].split(" ")[0]}
       - scrollUntilVisible:
-          element: ${nickName}
+          element: ${output.nickName}
           direction: DOWN
           centerElement: true
-      - longPressOn: ${nickName}
+      - longPressOn: ${output.nickName}
       - assertVisible: ".*Private View Key"
       - tapOn: ".*Private View Key"
       # Private View Key Modal
@@ -63,9 +63,9 @@ tags:
       - assertVisible: "Copy"
       # Validate view key format for this network
       - assertVisible:
-          text: ${walletFormats[walletNames[index]]}
+          text: ${output.walletFormats[output.walletNames[output.index]]}
       - tapOn:
           id: "modal-close-button"
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 # - stopApp

--- a/maestro/07-wallets/C000044-create-all-wallet-types.yaml
+++ b/maestro/07-wallets/C000044-create-all-wallet-types.yaml
@@ -29,10 +29,10 @@ tags:
     file: ../common/no-errors.yaml
 
 # Validate that all wallets were created
-- evalScript: ${var index = 0}
-- evalScript: ${var walletNames = JSON.parse(output.assetNames)}
+- evalScript: ${output.index = 0}
+- evalScript: ${output.walletNames = JSON.parse(output.assetNames)}
 - repeat:
-    times: ${walletNames.length}
+    times: ${output.walletNames.length}
     commands:      
       # option 1
       # Preferred quicker method, but iOS wallet search is not currently reliable when maestro types too fast
@@ -45,9 +45,9 @@ tags:
       
       # Option 2
       # Wallet nickname often excludes extra words (e.g. "Pirate Chain" -> "My Pirate")
-      - evalScript: ${var nickName = "My " + walletNames[index].split(" ")[0] + ".*"}
+      - evalScript: ${output.nickName = "My " + output.walletNames[output.index].split(" ")[0] + ".*"}
       # Hack to address inconsistent wallet name for XRP
-      - evalScript: ${if (walletNames[index] === "XRPL") { nickName = "My XRP"}}
+      - evalScript: ${if (output.walletNames[output.index] === "XRPL") { output.nickName = "My XRP"}}
       - retry:
           maxRetries: 2
           commands:
@@ -57,9 +57,9 @@ tags:
                 speed: 150
                 timeout: 30000
             - scrollUntilVisible:
-                element: ${nickName}
+                element: ${output.nickName}
                 centerElement: true
                 timeout: 60000
                 speed: 5
 
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}

--- a/maestro/07-wallets/C000046-rename-wallet.yaml
+++ b/maestro/07-wallets/C000046-rename-wallet.yaml
@@ -31,10 +31,10 @@ tags:
 # Copy new name and save
 - copyTextFrom:
     id: "undefined.textInput"
-- evalScript: ${var newWalletName = maestro.copiedText}
+- evalScript: ${output.newWalletName = maestro.copiedText}
 - tapOn: Submit
 
-- assertVisible: ${newWalletName}
+- assertVisible: ${output.newWalletName}
 # Arbitrary wait to ensure wallet state is saved to sync server (~30 seconds)
 - extendedWaitUntil:
     visible: ${WALLET_NAME}
@@ -54,4 +54,4 @@ tags:
     file: ../common/dismiss-modals.yaml
 
 - tapOn: Assets
-- assertVisible: ${newWalletName}
+- assertVisible: ${output.newWalletName}

--- a/maestro/07-wallets/C000048-split-all-evm.yaml
+++ b/maestro/07-wallets/C000048-split-all-evm.yaml
@@ -39,7 +39,7 @@ tags:
 
 # Define expected EVM networks (ordered by appearance)
 - evalScript: |
-    ${var evmNetworks = [
+    ${output.evmNetworks = [
       "zkSync",
       "Optimism",
       "Ethereum Classic",
@@ -62,9 +62,9 @@ tags:
     ]}
 
 # Loop over each network and scroll until visible
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${evmNetworks.length}
+    times: ${output.evmNetworks.length}
     commands:
     #   # Once search can accomodate multiple words
     #   # Search is slower but more reliable
@@ -82,15 +82,15 @@ tags:
           maxRetries: 2
           commands:
             - scrollUntilVisible:
-                element: ${".*" + evmNetworks[index]}
+                element: ${".*" + output.evmNetworks[output.index]}
                 direction: DOWN
                 centerElement: true
                 speed: 1
                 timeout: 1000
                 optional: true
-            - tapOn: ${".*" + evmNetworks[index]}
+            - tapOn: ${".*" + output.evmNetworks[output.index]}
                 
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
     
 - tapOn: Next
 
@@ -108,4 +108,3 @@ tags:
 
 
 - stopApp
-

--- a/maestro/common/add-wallets.yaml
+++ b/maestro/common/add-wallets.yaml
@@ -8,8 +8,8 @@ appId: ${MAESTRO_APP_ID}
 env:
     ASSET_NAMES: ${ASSET_NAMES || ""}
 ---
-# Parse if an array/list- all passed env become strings with maestro's Rhino JS runtime
-- evalScript: ${if (ASSET_NAMES.startsWith('[')) ASSET_NAMES = JSON.parse(ASSET_NAMES); else ASSET_NAMES = [ASSET_NAMES]}
+# Parse if an array/list; all passed env values become strings
+- evalScript: '${output.ASSET_NAMES = ASSET_NAMES.startsWith("[") ? JSON.parse(ASSET_NAMES) : [ASSET_NAMES]}'
 
 - tapOn: Assets
 - tapOn:
@@ -17,17 +17,17 @@ env:
 - tapOn: Search Wallets
 
 # Loop over wallet names and add them
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${ASSET_NAMES.length}
+    times: ${output.ASSET_NAMES.length}
     commands:
       - tapOn:
           id: "undefined.clearIcon"
-      - inputText: ${ASSET_NAMES[index]}
+      - inputText: ${output.ASSET_NAMES[output.index]}
       - tapOn:
-          text: ${".*" + ASSET_NAMES[index]}
+          text: ${".*" + output.ASSET_NAMES[output.index]}
           index: 1 # First index is thesearch bar
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 - tapOn: Next
 

--- a/maestro/common/create-account.yaml
+++ b/maestro/common/create-account.yaml
@@ -131,30 +131,29 @@ env:
       true: ${NEW_WALLETS}
     commands:
       # Remove default wallets
-      - evalScript: ${var wallets = JSON.parse(NEW_WALLETS)}
-      - evalScript: ${var defaults = JSON.parse(DEFAULT_WALLETS)}
-      - evalScript: ${var filteredDefaults = defaults.filter(d => !wallets.includes(d))}
-      - evalScript: ${var filteredWallets = wallets.filter(w => !defaults.includes(w))}
-      - evalScript: ${var defIndex = 0}
+      - evalScript: ${output.wallets = JSON.parse(NEW_WALLETS)}
+      - evalScript: ${output.defaults = JSON.parse(DEFAULT_WALLETS)}
+      - evalScript: ${output.filteredDefaults = output.defaults.filter(d => !output.wallets.includes(d))}
+      - evalScript: ${output.filteredWallets = output.wallets.filter(w => !output.defaults.includes(w))}
+      - evalScript: ${output.defIndex = 0}
       - repeat:
-          times: ${filteredDefaults.length}
+          times: ${output.filteredDefaults.length}
           commands:
-            - tapOn: ${".*" + filteredDefaults[defIndex]}
-            - evalScript: ${defIndex++}
+            - tapOn: ${".*" + output.filteredDefaults[output.defIndex]}
+            - evalScript: ${output.defIndex++}
       # Add new wallets
-      - evalScript: ${var newIndex = 0}
+      - evalScript: ${output.newIndex = 0}
       - repeat:
-          times: ${filteredWallets.length}
+          times: ${output.filteredWallets.length}
           commands:
             - tapOn: Search Wallets
             - tapOn:
                 id: "undefined.clearIcon"
-            - inputText: ${filteredWallets[newIndex]}
+            - inputText: ${output.filteredWallets[output.newIndex]}
             - tapOn:
-                text: ${".*" + filteredWallets[newIndex]}
+                text: ${".*" + output.filteredWallets[output.newIndex]}
                 index: 1
-            - evalScript: ${newIndex++}
+            - evalScript: ${output.newIndex++}
 
 - tapOn:
     id: "nextButton"
-

--- a/maestro/common/import-wallets.yaml
+++ b/maestro/common/import-wallets.yaml
@@ -8,7 +8,7 @@ env:
     ZCASH_BDAY: ${ZCASH_BDAY || ""}
 ---
 # Parse env so we can accept a string or array input
-- evalScript: ${if (ASSET_NAMES.startsWith('[')) ASSET_NAMES = JSON.parse(ASSET_NAMES); else ASSET_NAMES = [ASSET_NAMES]}
+- evalScript: '${output.ASSET_NAMES = ASSET_NAMES.startsWith("[") ? JSON.parse(ASSET_NAMES) : [ASSET_NAMES]}'
 
 # Open add wallet screen
 - tapOn: Assets
@@ -17,21 +17,21 @@ env:
 - tapOn: Search Wallets
 
 # Loop over wallet names and import them
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${ASSET_NAMES.length}
+    times: ${output.ASSET_NAMES.length}
     commands:
-      - evalScript: ${var assetName = ASSET_NAMES[index]}
+      - evalScript: ${output.assetName = output.ASSET_NAMES[output.index]}
       - tapOn:
           id: "undefined.clearIcon"
-      - inputText: ${assetName}
+      - inputText: ${output.assetName}
       
       # Escape parentheses for regex matching - "Bitcoin (no Segwit)" breaks flow otherwise
-      - evalScript: ${assetName = assetName.replace(/\(/g, '\\(').replace(/\)/g, '\\)')}
+      - evalScript: ${output.assetName = output.assetName.replace(/\(/g, '\\(').replace(/\)/g, '\\)')}
       - tapOn:
-          text: ${".*" + assetName}
+          text: ${".*" + output.assetName}
           index: 1 # First index is thesearch bar
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 - tapOn: Next
 - tapOn: Import Wallets
@@ -64,7 +64,7 @@ env:
 
 # Add birthday height for Zcash and Pirate Chain
 # Index for targetting the correct "edit" icon 
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 # Pirate Chain on top if both are displayed
 - runFlow:
     when:
@@ -72,10 +72,10 @@ env:
     commands:
       - tapOn: 
           text: ""
-          index: ${index}
+          index: ${output.index}
       - inputText: ${PIRATE_BDAY}
       - tapOn: Submit
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 # Zcash birthday
 - runFlow:
     when:
@@ -83,10 +83,10 @@ env:
     commands:
       - tapOn: 
           text: ""
-          index: ${index}
+          index: ${output.index}
       - inputText: ${ZCASH_BDAY}
       - tapOn: Submit
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 
 # tap on next until it becomes tapable and works to see "assets" button


### PR DESCRIPTION
## Scope

Isolates the GraalJS compatibility repair from the existing Maestro-test fixes.

Cross-command JavaScript state now uses Maestro `output.*` instead of local `var` assignments, covering the shared account/wallet helpers and affected existing flows.

## Verification

- `git diff --check`
- No device run was launched for this commit split; existing test evidence remains attached to the individual test repairs.

Stack base for the clean Maestro-fixes review branch.