### PR TITLE
Accept plugin IDs in wallet creation

### DIFF
--- a/docs/EDGE_CLI.md
+++ b/docs/EDGE_CLI.md
@@ -303,7 +303,7 @@ Session-scoped routes need a current session (`session.json`, `--session`, or
 
 | Command | Description | Endpoint |
 |---------|-------------|----------|
-| `wallet-create <type> [<name>]` | Create a currency wallet | `POST /v1/accounts/{sessionId}/wallets` |
+| `wallet-create <walletTypeOrPluginId> [<name>]` | Create a currency wallet | `POST /v1/accounts/{sessionId}/wallets` |
 | `wallet-list` | List wallets | `GET /v1/accounts/{sessionId}/wallets` |
 | `wallet-info <walletId>` | Show wallet details | `GET .../wallets/{walletId}` |
 | `wallet-rename <walletId> <name>` | Rename a wallet | `PATCH .../wallets/{walletId}` |
@@ -313,6 +313,9 @@ Session-scoped routes need a current session (`session.json`, `--session`, or
 | `plugin-list` | List currency configs for `wallet-create` | `GET /v1/currency-configs` |
 
 `{walletId}` accepts a full id or a unique prefix.
+
+`wallet-create` accepts either an Edge wallet type such as `wallet:bitcoin` or
+an enabled plugin ID returned by `plugin-list`, such as `bitcoin`.
 
 ### Keys
 

--- a/docs/EDGE_CLI_API.md
+++ b/docs/EDGE_CLI_API.md
@@ -1909,7 +1909,9 @@ Create one currency wallet.
 }
 ```
 
-`type` is accepted as an alias for `walletType`.
+`type` is accepted as an alias for `walletType`. Either field may contain an
+Edge wallet type such as `wallet:bitcoin` or an enabled plugin ID returned by
+`GET /v1/currency-configs`, such as `bitcoin`.
 
 **Success `201`:**
 
@@ -1924,12 +1926,12 @@ Create one currency wallet.
 
 **Errors:** `400 BAD_REQUEST`.
 
-**CLI:** `edge-cli wallet-create <walletType> [<name>]`
+**CLI:** `edge-cli wallet-create <walletTypeOrPluginId> [<name>]`
 
 ```bash
 curl --unix-socket "$SOCK" -X POST \
   -H 'Content-Type: application/json' \
-  -d '{"walletType":"wallet:bitcoin","name":"My BTC"}' \
+  -d '{"walletType":"bitcoin","name":"My BTC"}' \
   http://localhost/v1/accounts/$SESS/wallets
 ```
 

--- a/src/__tests__/cliResolve.test.ts
+++ b/src/__tests__/cliResolve.test.ts
@@ -1,0 +1,25 @@
+import { resolveWalletType } from '../cli/engine/resolve'
+
+describe('resolveWalletType', () => {
+  const account = {
+    currencyConfig: {
+      bitcoin: {
+        currencyInfo: {
+          walletType: 'wallet:bitcoin'
+        }
+      }
+    }
+  }
+
+  it('resolves a plugin id to its wallet type', () => {
+    expect(resolveWalletType(account, 'bitcoin')).toBe('wallet:bitcoin')
+  })
+
+  it('preserves an existing wallet type', () => {
+    expect(resolveWalletType(account, 'wallet:bitcoin')).toBe('wallet:bitcoin')
+  })
+
+  it('preserves unknown inputs for Edge Core to validate', () => {
+    expect(resolveWalletType(account, 'unknown-plugin')).toBe('unknown-plugin')
+  })
+})

--- a/src/cli/commands/wallet.ts
+++ b/src/cli/commands/wallet.ts
@@ -15,19 +15,19 @@ function walletPath(sessionId: string, walletId: string, suffix = ''): string {
 const walletCreateCmd = command(
   'wallet-create',
   {
-    usage: 'wallet-create <walletType> [<name>]',
-    help: 'Create a new currency wallet',
+    usage: 'wallet-create <walletTypeOrPluginId> [<name>]',
+    help: 'Create a currency wallet from a wallet type or plugin ID',
     needsSession: true
   },
   async (ctx, argv) => {
     if (argv.length < 1 || argv.length > 2)
       throw new UsageError(walletCreateCmd)
-    const [walletType, name] = argv
+    const [walletTypeOrPluginId, name] = argv
     const sessionId = requireSession(ctx)
     printJson(
       await ctx.client.post(
         `/v1/accounts/${encodeURIComponent(sessionId)}/wallets`,
-        { walletType, name }
+        { walletType: walletTypeOrPluginId, name }
       )
     )
   }

--- a/src/cli/engine/resolve.ts
+++ b/src/cli/engine/resolve.ts
@@ -2,6 +2,10 @@ import type { EdgeAccount, EdgeCurrencyWallet, EdgeTokenId } from 'edge-core-js'
 
 import { engineError } from './errors'
 
+interface WalletTypeAccount {
+  currencyConfig: Record<string, { currencyInfo: { walletType: string } }>
+}
+
 /**
  * Resolve a wallet id or unique prefix against account.currencyWallets.
  */
@@ -29,6 +33,20 @@ export function findWallet(
     )
   }
   return wallets[matches[0]]
+}
+
+/**
+ * Resolve an enabled currency plugin id to the wallet type Edge Core expects.
+ * Existing wallet type inputs pass through unchanged.
+ */
+export function resolveWalletType(
+  account: WalletTypeAccount,
+  walletTypeOrPluginId: string
+): string {
+  return (
+    account.currencyConfig[walletTypeOrPluginId]?.currencyInfo.walletType ??
+    walletTypeOrPluginId
+  )
 }
 
 /**

--- a/src/cli/engine/routes/wallets.ts
+++ b/src/cli/engine/routes/wallets.ts
@@ -2,7 +2,12 @@ import { div } from 'biggystring'
 import type { EdgeAccount, EdgeCurrencyWallet } from 'edge-core-js'
 
 import { engineError } from '../errors'
-import { findWallet, getMultiplier, parseTokenId } from '../resolve'
+import {
+  findWallet,
+  getMultiplier,
+  parseTokenId,
+  resolveWalletType
+} from '../resolve'
 import { requireBodyObject, type Router } from '../router'
 import {
   getAccount,
@@ -78,9 +83,9 @@ export function registerWalletsRoutes(router: Router): void {
   router.add('POST', '/v1/accounts/{sessionId}/wallets', async ctx => {
     const body = requireBodyObject(ctx.body)
     // Accept both the CLI field (`walletType`) and the REST doc field (`type`).
-    const walletType =
+    const walletTypeOrPluginId =
       optionalString(body, 'walletType') ?? optionalString(body, 'type')
-    if (walletType == null) {
+    if (walletTypeOrPluginId == null) {
       throw engineError(
         'BAD_REQUEST',
         'Missing required field "walletType" (or "type")',
@@ -89,7 +94,9 @@ export function registerWalletsRoutes(router: Router): void {
     }
     const name = optionalString(body, 'name')
     const fiatCurrencyCode = optionalString(body, 'fiatCurrencyCode')
-    const wallet = await getAccount(ctx).createCurrencyWallet(walletType, {
+    const account = getAccount(ctx)
+    const walletType = resolveWalletType(account, walletTypeOrPluginId)
+    const wallet = await account.createCurrencyWallet(walletType, {
       name,
       fiatCurrencyCode
     })


### PR DESCRIPTION
## Summary
- let wallet-create accept either an Edge wallet type or a plugin ID from plugin-list
- preserve existing wallet-type behavior and existing Edge Core validation for unknown inputs
- document both accepted forms

## Why
plugin-list advertises plugin IDs as the inputs available for wallet-create, but wallet-create currently forwards those IDs as wallet types and rejects them. This closes that discovery-to-action gap without adding another command.

## Tests
- npm test -- --runInBand src/__tests__/cliResolve.test.ts
- npm run test:cli:node-safe
- ESLint on touched TypeScript
- Prettier check on touched TypeScript
- git diff --check

Full tsc --noEmit remains blocked by the same pre-existing diagnostics on paul/cli; this branch adds no new diagnostics.