### PR TITLE
Fix password reminder after settings unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Password reminder no longer stops reappearing after unlocking Account Settings
+
 ## 4.51.0 (staging)
 
 - added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.

--- a/src/__tests__/reducers/passwordReminderReducer.test.ts
+++ b/src/__tests__/reducers/passwordReminderReducer.test.ts
@@ -4,9 +4,13 @@ import {
   initialState,
   MAX_NON_PASSWORD_DAYS_LIMIT,
   MAX_NON_PASSWORD_LOGINS_LIMIT,
+  NON_PASSWORD_DAYS_GROWTH_RATE,
+  NON_PASSWORD_LOGINS_GROWTH_RATE,
+  passwordReminder,
   type PasswordReminderReducerAction,
   untranslatedReducer as uut
 } from '../../reducers/PasswordReminderReducer'
+import type { Action } from '../../types/reduxTypes'
 import { daysBetween, MILLISECONDS_PER_DAY } from '../../util/utils'
 
 describe('PasswordReminder', () => {
@@ -261,6 +265,41 @@ describe('PasswordReminder', () => {
 
         expect(actual).toEqual(expected)
       })
+    })
+  })
+  describe('Account Settings unlock', () => {
+    // Unlocking Account Settings runs the password through `validatePassword`,
+    // which dispatches `PASSWORD_USED`, and then dispatches
+    // `UI/SETTINGS/SET_SETTINGS_LOCK` to record the unlocked state. Only the
+    // first of those may count as a password use: counting both squares the
+    // reminder thresholds and the reminder stops reappearing.
+    test('Counts one password use per unlock', () => {
+      const unlockActions: Action[] = [
+        { type: 'PASSWORD_USED' },
+        { type: 'UI/SETTINGS/SET_SETTINGS_LOCK', data: false }
+      ]
+
+      const actual = unlockActions.reduce(
+        (state, action) => passwordReminder(state, action),
+        initialState
+      )
+
+      expect(actual.passwordUseCount).toEqual(1)
+      expect(actual.nonPasswordLoginsLimit).toEqual(
+        NON_PASSWORD_LOGINS_GROWTH_RATE
+      )
+      expect(actual.nonPasswordDaysLimit).toEqual(NON_PASSWORD_DAYS_GROWTH_RATE)
+    })
+
+    test('Lock state changes alone are not password uses', () => {
+      const action: Action = {
+        type: 'UI/SETTINGS/SET_SETTINGS_LOCK',
+        data: false
+      }
+
+      const actual = passwordReminder(initialState, action)
+
+      expect(actual).toEqual(initialState)
     })
   })
 })

--- a/src/components/scenes/SettingsScene.tsx
+++ b/src/components/scenes/SettingsScene.tsx
@@ -204,11 +204,8 @@ export const SettingsScene: React.FC<Props> = props => {
         }
       )
       if (password == null) return true
+      // `showUnlockSettingsModal` already unlocked the settings.
       setValidatedPassword(password)
-      dispatch({
-        type: 'UI/SETTINGS/SET_SETTINGS_LOCK',
-        data: false
-      })
     }
     return false
   }

--- a/src/reducers/PasswordReminderReducer.ts
+++ b/src/reducers/PasswordReminderReducer.ts
@@ -237,15 +237,11 @@ function translateAction(action: Action): PasswordReminderReducerAction {
     }
   }
 
+  // `validatePassword` dispatches this for every successful password entry,
+  // including the Account Settings unlock. It is the only signal counted here:
+  // each password entry must raise `passwordUseCount` exactly once, because the
+  // reminder thresholds grow as `GROWTH_RATE ** passwordUseCount`.
   if (action.type === 'PASSWORD_USED') {
-    return {
-      type: 'PASSWORD_USED',
-      data: {
-        lastPasswordUseDate: Date.now()
-      }
-    }
-  }
-  if (action.type === 'UI/SETTINGS/SET_SETTINGS_LOCK' && !action.data) {
     return {
       type: 'PASSWORD_USED',
       data: {


### PR DESCRIPTION
### Description

The password reminder ("Security Check: Tap to verify password") stopped
reappearing after a user visited Account Settings, which is what QA hit while
following the Change Username repro in
https://app.asana.com/0/1215088146871429/1213821580712784.

One password entry at the unlock modal reached the reducer as two or three
separate password uses:

```mermaid
sequenceDiagram
    autonumber
    actor User
    participant Scene as SettingsScene
    participant Settings as SettingsActions
    participant Acct as AccountActions
    participant Reducer as PasswordReminderReducer

    User->>Scene: tap "Change Username" while locked
    Scene->>Settings: showUnlockSettingsModal()
    Settings->>Acct: validatePassword()
    Acct->>Acct: account.checkPassword(pw) succeeds
    Acct->>Reducer: PASSWORD_USED
    Note over Reducer: passwordUseCount 0 to 1<br/>(correct, kept)
    Settings->>Reducer: SET_SETTINGS_LOCK false
    Note over Reducer: translateAction mapped this<br/>to PASSWORD_USED: 1 to 2<br/>(removed by this PR)
    Scene->>Reducer: SET_SETTINGS_LOCK false again
    Note over Reducer: third PASSWORD_USED: 2 to 3<br/>(dispatch removed by this PR)
```

Step 5 is the correct count. Step 6 double-counts it, and step 7 both counts it
a third time and re-dispatches an unlock that step 6 already performed. Every
path that unlocks Account Settings goes through `validatePassword`, so the
`SET_SETTINGS_LOCK` translation added no coverage the canonical dispatch lacked.

The reminder thresholds are `4 ** passwordUseCount`, so one visit to Account
Settings moved the next reminder far out of reach:

| One unlock, entered from | passwordUseCount | Logins until the next reminder |
| --- | --- | --- |
| the lock row, before | 2 | 16 |
| the Change Username row, before | 3 | 64 |
| either row, after this PR | 1 | 4 |

The username change itself was incidental. Account Settings is the trigger, and
the same escalation applied to Change Password, Change PIN, 2FA, Recovery and
Delete Account, which all go through `hasLock`.

The fix makes one password entry count exactly once. The backoff design is
unchanged. Adds a regression test covering the unlock dispatch sequence.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="1" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6176/commits/4da97774f21e2198b9fc15ed40794208fe435661"><code>4da9777</code></a><br><sub>Fix password reminder after settings unlock</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6176/20260827-182422-agent-proof-1213821580712784-01-reminder-shows-after-pin-login.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6176/20260827-182422-agent-proof-1213821580712784-01-reminder-shows-after-pin-login.png" width="200"></a><br><sub>reminder shows after pin login</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6176/20260827-182422-agent-proof-1213821580712784-02-username-changed.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6176/20260827-182422-agent-proof-1213821580712784-02-username-changed.png" width="200"></a><br><sub>username changed</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6176/20260827-182422-agent-proof-1213821580712784-03-reminder-returns-after-username-change.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6176/20260827-182422-agent-proof-1213821580712784-03-reminder-returns-after-username-change.png" width="200"></a><br><sub>reminder returns after username change</sub></td>
</tr>
</table>
<!-- agent-test-evidence:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows password-reminder accounting without changing password validation or lock behavior; reduces incorrect backoff rather than altering auth flows.
> 
> **Overview**
> Fixes the **Security Check** password reminder stopping for a long time after visiting Account Settings. Unlocking settings was inflating `passwordUseCount` because the same successful password was counted more than once, and reminder backoff uses **`GROWTH_RATE ** passwordUseCount`**.
> 
> **PasswordReminderReducer** no longer treats `UI/SETTINGS/SET_SETTINGS_LOCK` (unlock) as a second `PASSWORD_USED`; only the dispatch from **`validatePassword`** counts. **SettingsScene** `hasLock` stops re-dispatching unlock after the modal already unlocked, avoiding a third bump.
> 
> Regression tests cover the unlock action sequence (one use per unlock; lock toggles alone do not count). CHANGELOG notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb099cb9f890ac01c2de803be532db3eafd4fbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->