### PR TITLE
Fix password recovery reminder triggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Show the password recovery reminder at every balance milestone, including for funds that arrived while the app was closed or before the exchange rates loaded.
+
 ## 4.51.0 (staging)
 
 - added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -126,7 +126,6 @@ export default [
       'src/actions/NotificationActions.ts',
       'src/actions/PaymentProtoActions.tsx',
       'src/actions/ReceiveDropdown.tsx',
-      'src/actions/RecoveryReminderActions.tsx',
 
       'src/actions/ScamWarningActions.tsx',
       'src/actions/ScanActions.tsx',
@@ -314,7 +313,7 @@ export default [
       'src/components/scenes/WcConnectScene.tsx',
       'src/components/scenes/WcDisconnectScene.tsx',
       'src/components/scenes/WebViewScene.tsx',
-      'src/components/services/AccountCallbackManager.tsx',
+
       'src/components/services/ActionQueueService.ts',
       'src/components/services/AirshipInstance.tsx',
       'src/components/services/AutoLogout.ts',

--- a/src/__tests__/actions/RecoveryReminderActions.test.ts
+++ b/src/__tests__/actions/RecoveryReminderActions.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import type { EdgeAccount, EdgeCurrencyWallet } from 'edge-core-js'
+
+import { checkPasswordRecovery } from '../../actions/RecoveryReminderActions'
+import type { PasswordReminderLevels } from '../../actions/SettingsActions'
+import type { RootState } from '../../reducers/RootReducer'
+import type { Action, Dispatch } from '../../types/reduxTypes'
+
+// Provide a virtual env.json so importing env.ts does not fail:
+jest.mock('../../../env.json', () => ({}), { virtual: true })
+
+const mockShowModal = jest.fn()
+const mockWriteReminders =
+  jest.fn<(account: EdgeAccount, levels: string[]) => void>()
+
+jest.mock('../../components/services/AirshipInstance', () => ({
+  Airship: {
+    show: async () => {
+      mockShowModal()
+      return 'cancel'
+    }
+  },
+  showError: () => {}
+}))
+jest.mock('../../components/modals/ButtonsModal', () => ({
+  ButtonsModal: () => null
+}))
+jest.mock('../../actions/SettingsActions', () => ({
+  writePasswordRecoveryReminders: async (
+    account: EdgeAccount,
+    levels: string[]
+  ) => {
+    mockWriteReminders(account, levels)
+  }
+}))
+
+type Navigation = Parameters<typeof checkPasswordRecovery>[0]
+const navigation = {
+  push: () => {}
+} as unknown as Navigation
+
+const noneShown: PasswordReminderLevels = {
+  '20': false,
+  '200': false,
+  '2000': false,
+  '20000': false,
+  '200000': false
+}
+
+/**
+ * A one-wallet account holding `btc` BTC, plus an optional balance of an
+ * unpriced token the rates server knows nothing about.
+ */
+const makeWallet = (btc: string, tokenBalance?: string): EdgeCurrencyWallet => {
+  const balanceMap = new Map<string | null, string>([[null, btc]])
+  if (tokenBalance != null) balanceMap.set('unknown-token', tokenBalance)
+
+  return {
+    id: 'wallet-1',
+    currencyInfo: {
+      pluginId: 'bitcoin',
+      currencyCode: 'BTC',
+      denominations: [{ name: 'BTC', multiplier: '100000000' }]
+    },
+    currencyConfig: {
+      allTokens: {
+        'unknown-token': {
+          currencyCode: 'UNKNOWN',
+          denominations: [{ name: 'UNKNOWN', multiplier: '100000000' }]
+        }
+      }
+    },
+    balanceMap
+  } as unknown as EdgeCurrencyWallet
+}
+
+/**
+ * A wallet on a chain the rates server never prices, e.g. a testnet coin.
+ */
+const makeUnpricedWallet = (balance: string): EdgeCurrencyWallet =>
+  ({
+    id: 'wallet-2',
+    currencyInfo: {
+      pluginId: 'bitcointestnet',
+      currencyCode: 'TESTBTC',
+      denominations: [{ name: 'TESTBTC', multiplier: '100000000' }]
+    },
+    currencyConfig: { allTokens: {} },
+    balanceMap: new Map([[null, balance]])
+  } as unknown as EdgeCurrencyWallet)
+
+interface StateOptions {
+  balance?: string
+  hasRate?: boolean
+  recoveryKey?: string
+  remindersShown?: Partial<PasswordReminderLevels>
+  tokenBalance?: string
+  unpricedBalance?: string
+  username?: string | null
+}
+
+const makeState = (opts: StateOptions = {}): RootState => {
+  const {
+    balance = '0',
+    hasRate = true,
+    recoveryKey,
+    remindersShown = {},
+    tokenBalance,
+    unpricedBalance,
+    username = 'test-user'
+  } = opts
+
+  const account = {
+    recoveryKey,
+    username,
+    currencyWallets: {
+      'wallet-1': makeWallet(balance, tokenBalance),
+      ...(unpricedBalance == null
+        ? {}
+        : { 'wallet-2': makeUnpricedWallet(unpricedBalance) })
+    }
+  } as unknown as EdgeAccount
+
+  return {
+    core: { account },
+    exchangeRates: {
+      crypto: hasRate
+        ? { bitcoin: { '': { 'iso:USD': { current: 100000 } } } }
+        : {},
+      fiat: {}
+    },
+    ui: {
+      settings: {
+        passwordRecoveryRemindersShown: { ...noneShown, ...remindersShown }
+      }
+    }
+  } as unknown as RootState
+}
+
+/**
+ * Run the thunk and report what it dispatched and wrote.
+ */
+const run = async (
+  state: RootState
+): Promise<{ levels: string[]; modalShown: boolean }> => {
+  const actions: Action[] = []
+  const dispatch = ((action: Action) => {
+    actions.push(action)
+    return action
+  }) as Dispatch
+
+  checkPasswordRecovery(navigation)(dispatch, () => state)
+  // Let the modal promise settle:
+  await Promise.resolve()
+
+  const levels = actions
+    .filter(
+      action => action.type === 'UPDATE_SHOW_PASSWORD_RECOVERY_REMINDER_MODAL'
+    )
+    .map(action => String((action as { data: string }).data))
+
+  return { levels, modalShown: mockShowModal.mock.calls.length > 0 }
+}
+
+describe('checkPasswordRecovery', () => {
+  beforeEach(() => {
+    mockShowModal.mockClear()
+    mockWriteReminders.mockClear()
+  })
+
+  it('does nothing below the lowest level', async () => {
+    // 0.0001 BTC at $100k = $10:
+    const { levels, modalShown } = await run(makeState({ balance: '10000' }))
+    expect(levels).toEqual([])
+    expect(modalShown).toBe(false)
+  })
+
+  it('shows the reminder once the balance crosses $20', async () => {
+    // 0.0005 BTC at $100k = $50:
+    const { levels, modalShown } = await run(makeState({ balance: '50000' }))
+    expect(levels).toEqual(['20'])
+    expect(modalShown).toBe(true)
+    expect(mockWriteReminders).toHaveBeenCalledWith(expect.anything(), ['20'])
+  })
+
+  it('marks every crossed level but shows one modal', async () => {
+    // 0.005 BTC at $100k = $500, which passes both $20 and $200:
+    const { levels, modalShown } = await run(makeState({ balance: '500000' }))
+    expect(levels).toEqual(['20', '200'])
+    expect(mockShowModal).toHaveBeenCalledTimes(1)
+    expect(modalShown).toBe(true)
+  })
+
+  it('skips levels that were already shown', async () => {
+    const { levels, modalShown } = await run(
+      makeState({ balance: '500000', remindersShown: { '20': true } })
+    )
+    expect(levels).toEqual(['200'])
+    expect(modalShown).toBe(true)
+  })
+
+  it('does nothing when every crossed level was shown', async () => {
+    const { levels, modalShown } = await run(
+      makeState({
+        balance: '500000',
+        remindersShown: { '20': true, '200': true }
+      })
+    )
+    expect(levels).toEqual([])
+    expect(modalShown).toBe(false)
+  })
+
+  it('waits when a funded wallet has no exchange rate yet', async () => {
+    const { levels, modalShown } = await run(
+      makeState({ balance: '500000', hasRate: false })
+    )
+    expect(levels).toEqual([])
+    expect(modalShown).toBe(false)
+  })
+
+  it('is not blocked by a token the rates server does not price', async () => {
+    // The token never gets a rate, so waiting on one would suppress the
+    // reminder forever. The native BTC rate is what gates the check:
+    const { levels, modalShown } = await run(
+      makeState({ balance: '500000', tokenBalance: '1000000' })
+    )
+    expect(levels).toEqual(['20', '200'])
+    expect(modalShown).toBe(true)
+  })
+
+  it('waits for a wallet whose rate has not loaded yet', async () => {
+    const { levels, modalShown } = await run(
+      makeState({ balance: '500000', unpricedBalance: '100000' })
+    )
+    expect(levels).toEqual([])
+    expect(modalShown).toBe(false)
+  })
+
+  it('stops waiting for a rate that is never coming', async () => {
+    // Five minutes on, a wallet with no rate is one the rates server does not
+    // price. Deferring past that would suppress the reminder forever:
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(Date.now() + 6 * 60 * 1000)
+    try {
+      const { levels, modalShown } = await run(
+        makeState({ balance: '500000', unpricedBalance: '100000' })
+      )
+      expect(levels).toEqual(['20', '200'])
+      expect(modalShown).toBe(true)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('skips accounts that already have recovery set up', async () => {
+    const { levels, modalShown } = await run(
+      makeState({ balance: '500000', recoveryKey: 'abcd' })
+    )
+    expect(levels).toEqual([])
+    expect(modalShown).toBe(false)
+  })
+
+  it('skips light accounts', async () => {
+    const { levels, modalShown } = await run(
+      makeState({ balance: '500000', username: null })
+    )
+    expect(levels).toEqual([])
+    expect(modalShown).toBe(false)
+  })
+})

--- a/src/__tests__/actions/RecoveryReminderActions.test.ts
+++ b/src/__tests__/actions/RecoveryReminderActions.test.ts
@@ -237,17 +237,40 @@ describe('checkPasswordRecovery', () => {
   })
 
   it('stops waiting for a rate that is never coming', async () => {
-    // Five minutes on, a wallet with no rate is one the rates server does not
-    // price. Deferring past that would suppress the reminder forever:
+    // Five minutes into the login session, a wallet with no rate is one the
+    // rates server does not price. Deferring past that would suppress the
+    // reminder forever. The window starts at this account's first check, so
+    // run once to open it, then let the clock run out:
+    const state = makeState({ balance: '500000', unpricedBalance: '100000' })
+    const opening = await run(state)
+    expect(opening.levels).toEqual([])
+
     const nowSpy = jest
       .spyOn(Date, 'now')
       .mockReturnValue(Date.now() + 6 * 60 * 1000)
     try {
-      const { levels, modalShown } = await run(
-        makeState({ balance: '500000', unpricedBalance: '100000' })
-      )
+      const { levels, modalShown } = await run(state)
       expect(levels).toEqual(['20', '200'])
       expect(modalShown).toBe(true)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('gives each account its own grace window', async () => {
+    // A second login later in the same session must not inherit an expired
+    // window from the first account:
+    const first = makeState({ balance: '500000', unpricedBalance: '100000' })
+    await run(first)
+
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(Date.now() + 6 * 60 * 1000)
+    try {
+      const second = makeState({ balance: '500000', unpricedBalance: '100000' })
+      const { levels, modalShown } = await run(second)
+      expect(levels).toEqual([])
+      expect(modalShown).toBe(false)
     } finally {
       nowSpy.mockRestore()
     }

--- a/src/actions/RecoveryReminderActions.tsx
+++ b/src/actions/RecoveryReminderActions.tsx
@@ -1,20 +1,34 @@
-import { lt } from 'biggystring'
+import { gte } from 'biggystring'
 import * as React from 'react'
 
 import { writePasswordRecoveryReminders } from '../actions/SettingsActions'
 import { ButtonsModal } from '../components/modals/ButtonsModal'
 import { Airship, showError } from '../components/services/AirshipInstance'
 import { lstrings } from '../locales/strings'
-import type { ThunkAction } from '../types/reduxTypes'
+import { getExchangeRate } from '../selectors/WalletSelectors'
+import type { RootState, ThunkAction } from '../types/reduxTypes'
 import type { NavigationBase } from '../types/routerTypes'
 import { isMaestro } from '../util/maestro'
-import { getTotalFiatAmountFromExchangeRates } from '../util/utils'
+import { getTotalFiatAmountFromExchangeRates, zeroString } from '../util/utils'
 
 const levels = ['20', '200', '2000', '20000', '200000'] as const
 
 /**
+ * How long to keep waiting for exchange rates before pricing the balance with
+ * whatever rates have arrived. Rates land within a refresh cycle or two of
+ * startup; anything still missing after this is an asset the rates server does
+ * not price, which will never arrive.
+ */
+const RATES_GRACE_MS = 5 * 60 * 1000
+const startupMs = Date.now()
+
+/**
  * Show a modal if the user's balance is over one of the limits &
  * they don't have recovery set up.
+ *
+ * This runs on each exchange-rate refresh as well as on incoming
+ * transactions, since funds can arrive while the app is closed and the rates
+ * needed to price them can land after the transaction does.
  */
 export function checkPasswordRecovery(
   navigation: NavigationBase
@@ -22,33 +36,81 @@ export function checkPasswordRecovery(
   return (dispatch, getState) => {
     const state = getState()
     const { account } = state.core
+    // Light accounts have no password to recover:
+    if (account.username == null) return
     if (account.recoveryKey != null) return
     if (isMaestro()) return
+
+    // An incomplete rate set undercounts the balance, which would credit the
+    // wrong milestone, so give the rates a chance to land. The wait is
+    // bounded: a wallet the rates server never prices (a testnet coin, an
+    // unlisted chain) has no rate coming, and must not suppress the reminder
+    // for the life of the account:
+    const ratesSettling = Date.now() - startupMs < RATES_GRACE_MS
+    if (ratesSettling && !hasRatesForFundedWallets(state)) return
 
     const totalDollars = getTotalFiatAmountFromExchangeRates(state, 'iso:USD')
     const { passwordRecoveryRemindersShown } = state.ui.settings
 
-    // Loop towards the highest non-shown level less than our balance:
-    for (const level of levels) {
-      if (passwordRecoveryRemindersShown[level]) continue
-      if (lt(totalDollars, level)) return
+    // Every level the balance has passed, whether or not it was passed just
+    // now. A balance that jumps straight to $500 has crossed both $20 and
+    // $200, and is owed one reminder, not two:
+    const crossedLevels = levels.filter(level => gte(totalDollars, level))
+    const newLevels = crossedLevels.filter(
+      level => !passwordRecoveryRemindersShown[level]
+    )
+    if (newLevels.length === 0) return
 
-      // Mark this level as shown:
+    // Mark them shown before showing the modal, so the next check doesn't
+    // stack a second one on top:
+    for (const level of newLevels) {
       dispatch({
         type: 'UPDATE_SHOW_PASSWORD_RECOVERY_REMINDER_MODAL',
         data: level
       })
-      writePasswordRecoveryReminders(account, level).catch((error: unknown) => {
-        showError(error)
-      })
-      showReminderModal(() => {
-        navigation.push('passwordRecovery')
-      }).catch((error: unknown) => {
-        showError(error)
-      })
-      return
     }
+    writePasswordRecoveryReminders(account, newLevels).catch(
+      (error: unknown) => {
+        showError(error)
+      }
+    )
+    showReminderModal(() => {
+      navigation.push('passwordRecovery')
+    }).catch((error: unknown) => {
+      showError(error)
+    })
   }
+}
+
+/**
+ * True when every funded wallet has a USD exchange rate for its native
+ * currency.
+ *
+ * `getExchangeRate` returns 0 for a rate it hasn't loaded, so a rate set that
+ * is still loading is indistinguishable from a small balance by total alone.
+ * Only the native currency is checked: a token the rates server doesn't know,
+ * or legitimately prices at 0, never gets a rate, so waiting on one would
+ * suppress the reminder for the life of the account.
+ */
+function hasRatesForFundedWallets(state: RootState): boolean {
+  const { exchangeRates } = state
+  const { currencyWallets } = state.core.account
+  for (const walletId of Object.keys(currencyWallets)) {
+    const wallet = currencyWallets[walletId]
+    const isFunded = [...wallet.balanceMap.values()].some(
+      nativeBalance => !zeroString(nativeBalance)
+    )
+    if (!isFunded) continue
+
+    const rate = getExchangeRate(
+      exchangeRates,
+      wallet.currencyInfo.pluginId,
+      null,
+      'iso:USD'
+    )
+    if (rate === 0) return false
+  }
+  return true
 }
 /**
  * Actually show the password reminder modal, calling `onSetUp` if the user

--- a/src/actions/RecoveryReminderActions.tsx
+++ b/src/actions/RecoveryReminderActions.tsx
@@ -1,4 +1,5 @@
 import { gte } from 'biggystring'
+import type { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
 
 import { writePasswordRecoveryReminders } from '../actions/SettingsActions'
@@ -16,11 +17,19 @@ const levels = ['20', '200', '2000', '20000', '200000'] as const
 /**
  * How long to keep waiting for exchange rates before pricing the balance with
  * whatever rates have arrived. Rates land within a refresh cycle or two of
- * startup; anything still missing after this is an asset the rates server does
+ * login; anything still missing after this is an asset the rates server does
  * not price, which will never arrive.
  */
 const RATES_GRACE_MS = 5 * 60 * 1000
-const startupMs = Date.now()
+
+/**
+ * When each account started waiting for its rates. The window belongs to the
+ * login session, not the process: a user can sit on the login screen past the
+ * grace window (a restore, a 2FA prompt), or log into a second account later
+ * in the same session. Keying on the account object gives a re-login a fresh
+ * window and lets the entry clean itself up.
+ */
+const graceStartMs = new WeakMap<EdgeAccount, number>()
 
 /**
  * Show a modal if the user's balance is over one of the limits &
@@ -41,16 +50,24 @@ export function checkPasswordRecovery(
     if (account.recoveryKey != null) return
     if (isMaestro()) return
 
+    const { passwordRecoveryRemindersShown } = state.ui.settings
+
+    // This runs on every rates refresh for the life of the session, so stop
+    // before the wallet walks below once there is no reminder left to show:
+    if (levels.every(level => passwordRecoveryRemindersShown[level])) return
+
     // An incomplete rate set undercounts the balance, which would credit the
     // wrong milestone, so give the rates a chance to land. The wait is
     // bounded: a wallet the rates server never prices (a testnet coin, an
     // unlisted chain) has no rate coming, and must not suppress the reminder
-    // for the life of the account:
-    const ratesSettling = Date.now() - startupMs < RATES_GRACE_MS
+    // for the rest of the session:
+    const now = Date.now()
+    const graceStart = graceStartMs.get(account) ?? now
+    graceStartMs.set(account, graceStart)
+    const ratesSettling = now - graceStart < RATES_GRACE_MS
     if (ratesSettling && !hasRatesForFundedWallets(state)) return
 
     const totalDollars = getTotalFiatAmountFromExchangeRates(state, 'iso:USD')
-    const { passwordRecoveryRemindersShown } = state.ui.settings
 
     // Every level the balance has passed, whether or not it was passed just
     // now. A balance that jumps straight to $500 has crossed both $20 and

--- a/src/actions/RecoveryReminderActions.tsx
+++ b/src/actions/RecoveryReminderActions.tsx
@@ -38,10 +38,12 @@ export function checkPasswordRecovery(
         type: 'UPDATE_SHOW_PASSWORD_RECOVERY_REMINDER_MODAL',
         data: level
       })
-      writePasswordRecoveryReminders(account, level).catch(error => {
+      writePasswordRecoveryReminders(account, level).catch((error: unknown) => {
         showError(error)
       })
-      showReminderModal(navigation).catch(error => {
+      showReminderModal(() => {
+        navigation.push('passwordRecovery')
+      }).catch((error: unknown) => {
         showError(error)
       })
       return
@@ -49,9 +51,10 @@ export function checkPasswordRecovery(
   }
 }
 /**
- * Actually show the password reminder modal.
+ * Actually show the password reminder modal, calling `onSetUp` if the user
+ * chooses to set recovery up now.
  */
-async function showReminderModal(navigation: NavigationBase) {
+async function showReminderModal(onSetUp: () => void): Promise<void> {
   const reply = await Airship.show<'ok' | 'cancel' | undefined>(bridge => (
     <ButtonsModal
       bridge={bridge}
@@ -63,5 +66,5 @@ async function showReminderModal(navigation: NavigationBase) {
       }}
     />
   ))
-  if (reply === 'ok') navigation.push('passwordRecovery')
+  if (reply === 'ok') onSetUp()
 }

--- a/src/actions/SettingsActions.tsx
+++ b/src/actions/SettingsActions.tsx
@@ -475,13 +475,15 @@ export const writeWalletsSort = async (
 
 export async function writePasswordRecoveryReminders(
   account: EdgeAccount,
-  level: PasswordReminderTime
+  levels: PasswordReminderTime[]
 ): Promise<void> {
   const settings = await readSyncedSettings(account)
   const passwordRecoveryRemindersShown = {
     ...settings.passwordRecoveryRemindersShown
   }
-  passwordRecoveryRemindersShown[level] = true
+  for (const level of levels) {
+    passwordRecoveryRemindersShown[level] = true
+  }
   const updatedSettings = { ...settings, passwordRecoveryRemindersShown }
   await writeSyncedSettings(account, updatedSettings)
 }

--- a/src/components/services/AccountCallbackManager.tsx
+++ b/src/components/services/AccountCallbackManager.tsx
@@ -194,9 +194,9 @@ export const AccountCallbackManager: React.FC<Props> = props => {
           }
         }
 
-        // Check if password recovery is set up:
-        const finalTxIndex = transactions.length - 1
-        if (!transactions[finalTxIndex].isSend) {
+        // Check if password recovery is set up. Any received transaction
+        // counts, not just the last one in the batch:
+        if (receivedTxs.length > 0) {
           dispatch(checkPasswordRecovery(navigation))
         }
       }),
@@ -267,9 +267,14 @@ export const AccountCallbackManager: React.FC<Props> = props => {
         datelog('Updating exchange rates')
         await dispatch(updateExchangeRates())
         await snooze(1000)
+
+        // Re-check now that the rates are fresh. Funds received while the app
+        // was closed never fire `newTransactions`, so this refresh cycle is
+        // the only thing that notices them:
+        dispatch(checkPasswordRecovery(navigation))
       }
     },
-    [dirty.rates],
+    [dirty.rates, navigation],
     'AccountCallbackManager:rates'
   )
 

--- a/src/components/services/AccountCallbackManager.tsx
+++ b/src/components/services/AccountCallbackManager.tsx
@@ -44,7 +44,7 @@ const notDirty: DirtyList = {
   walletList: false
 }
 
-export function AccountCallbackManager(props: Props) {
+export const AccountCallbackManager: React.FC<Props> = props => {
   const { account, navigation } = props
   const dispatch = useDispatch()
   const exchangeRates = useSelector(state => state.exchangeRates)
@@ -52,7 +52,7 @@ export function AccountCallbackManager(props: Props) {
   const numWallets = React.useRef(0)
 
   // Helper for marking wallets dirty:
-  function setRatesDirty() {
+  function setRatesDirty(): void {
     setDirty(dirty => ({
       ...dirty,
       rates: true
@@ -109,7 +109,7 @@ export function AccountCallbackManager(props: Props) {
             cacheEntries.forEach(cacheEntry => {
               const { currencyCode, metadata } = cacheEntry
               if (tx.currencyCode !== currencyCode) return
-              wallet.saveTx({ ...tx, metadata }).catch(err => {
+              wallet.saveTx({ ...tx, metadata }).catch((err: unknown) => {
                 console.warn(err)
               })
             })
@@ -127,9 +127,11 @@ export function AccountCallbackManager(props: Props) {
         // Check for incoming FIO requests:
         const receivedTxs = transactions.filter(tx => !tx.isSend)
         if (receivedTxs.length > 0)
-          dispatch(checkFioObtData(wallet, receivedTxs)).catch(err => {
-            console.warn(err)
-          })
+          dispatch(checkFioObtData(wallet, receivedTxs)).catch(
+            (err: unknown) => {
+              console.warn(err)
+            }
+          )
 
         // Review triggers: deposit & transaction count
         for (const tx of transactions) {
@@ -137,7 +139,7 @@ export function AccountCallbackManager(props: Props) {
             tx.savedAction?.actionType ?? tx.chainAction?.actionType
 
           if (!tx.isSend) {
-            dispatch(updateTransactionCount()).catch(err => {
+            dispatch(updateTransactionCount()).catch((err: unknown) => {
               console.warn(err)
             })
             const exchangeDenom = getExchangeDenom(
@@ -161,12 +163,12 @@ export function AccountCallbackManager(props: Props) {
               )
             )
             if (usdAmount > 0) {
-              dispatch(updateDepositAmount(usdAmount)).catch(err => {
+              dispatch(updateDepositAmount(usdAmount)).catch((err: unknown) => {
                 console.warn(err)
               })
             }
           } else if (actionType !== 'swap' && actionType !== 'fiat') {
-            dispatch(updateTransactionCount()).catch(err => {
+            dispatch(updateTransactionCount()).catch((err: unknown) => {
               console.warn(err)
             })
           }
@@ -181,11 +183,11 @@ export function AccountCallbackManager(props: Props) {
           if (account.username == null) {
             // Avoid showing modal for FIO wallets since the first transaction may be the handle creation
             if (wallet.currencyInfo.pluginId === 'fio') {
-              dispatch(refreshAllFioAddresses()).catch(err => {
+              dispatch(refreshAllFioAddresses()).catch((err: unknown) => {
                 console.warn(err)
               })
             } else {
-              showBackupModal({ navigation }).catch(error => {
+              showBackupModal({ navigation }).catch((error: unknown) => {
                 showDevError(error)
               })
             }
@@ -244,7 +246,7 @@ export function AccountCallbackManager(props: Props) {
       if (dirty.walletList) {
         // Update all wallets (hammer mode):
         datelog('Updating wallet list')
-        await dispatch(refreshConnectedWallets).catch(err => {
+        await dispatch(refreshConnectedWallets).catch((err: unknown) => {
           console.warn(err)
         })
         await snooze(1000)


### PR DESCRIPTION
### Description

The password-recovery reminder is meant to fire once per balance milestone ($20 / $200 / $2,000 / $20,000 / $200,000) for accounts with no recovery key. It rarely did, for these reasons:

1. **It only ran on `newTransactions`.** `checkPasswordRecovery` had exactly one dispatch site, inside the `wallet.on('newTransactions')` handler. It now also runs on each exchange-rate refresh, so funds that arrived while the app was closed are noticed.
2. **The rates could be missing.** `getExchangeRate` returns `0` for a rate it has not loaded, so a partly-loaded rate set undercounts the total and credits the wrong milestone. The thunk now defers while a funded wallet's NATIVE currency has no USD rate, and picks the check back up on a later pass. Only native currencies are checked, and the deferral is bounded to 5 minutes from the account's first check: a token the rates server does not price, or a chain it never prices (a funded `bitcointestnet` wallet is a real example on a test account), never gets a rate, so an unbounded wait on one would suppress the reminder for the life of the account. The window is keyed on the account object, not on process start, so it belongs to the login session: sitting on the login screen, or logging into a second account later in the same session, each get their own full window.
3. **Only the last transaction counted.** The guard was `!transactions[finalTxIndex].isSend`, so a batch whose last element was a send skipped the check even when the batch contained receives. It now uses the already-computed `receivedTxs`.

#### Trigger paths, before and after

Before, every path to the check was gated on something that was often false:

```mermaid
sequenceDiagram
    autonumber
    participant Chain
    participant Wallet
    participant ACM as AccountCallbackManager
    participant Check as checkPasswordRecovery

    Chain-->>Wallet: deposit lands while the app is closed
    Note over Wallet,ACM: no listener attached, so no event
    Wallet-->>ACM: app reopens, wallet syncs
    ACM--xCheck: never dispatched, the only call site was newTransactions

    Chain-->>Wallet: deposit while the app is running
    Wallet->>ACM: newTransactions([receive, send])
    ACM--xCheck: skipped, guard read transactions[last].isSend

    Chain-->>Wallet: deposit on a cold start
    Wallet->>ACM: newTransactions([receive])
    ACM->>Check: dispatch
    Note over Check: rates not loaded yet, so the total is 0<br/>lt(0, "20") returns early, and nothing re-runs it
```

After, the rate-refresh cycle gives the check a second, unconditional entry point, and the two broken guards are fixed:

```mermaid
sequenceDiagram
    autonumber
    participant Chain
    participant Wallet
    participant ACM as AccountCallbackManager
    participant Check as checkPasswordRecovery

    Chain-->>Wallet: deposit lands while the app is closed
    Wallet-->>ACM: app reopens, wallet syncs

    loop every rate refresh (30s)
        ACM->>Check: dispatch
        alt a funded wallet's native currency has no rate (first 5 min)
            Note over Check: defer to the next refresh
        else rates complete
            Check->>Check: mark every crossed level shown
            Check-->>ACM: show one reminder modal
        end
    end

    Chain-->>Wallet: deposit while the app is running
    Wallet->>ACM: newTransactions([receive, send])
    ACM->>Check: dispatch, guard is now receivedTxs.length > 0
```

The above also forces two supporting changes:

- The level loop marked only the *lowest* crossed level and returned, so an account that jumped straight to $500 earned two modals back to back. Now every crossed level is marked and a single modal is shown. `writePasswordRecoveryReminders` takes a level array so the marks are one read-modify-write, not a race.
- Light accounts (`account.username == null`) are skipped. They have no password to recover, and they already get the backup modal from the same handler.
- Because the check now runs on every 30-second rate refresh for the life of the session, it exits before both wallet walks once every level has already been shown.

Asana: https://app.asana.com/0/1215088146871429/1211152484915503

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing reminder timing depends on wallet sync, exchange rates, and new deferral logic; mistakes could miss or duplicate security nudges, though behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes **password recovery reminders** so they reliably appear at USD balance milestones ($20–$200k) for funded accounts without a recovery key.
> 
> **`checkPasswordRecovery`** now runs on **exchange-rate refreshes** as well as incoming receives, so deposits that landed while the app was closed are still evaluated once rates and wallets catch up. It **defers** pricing until wallets are loaded, synced, and funded wallets have native **USD rates**, with a **5-minute per-login grace** so unpriced chains/tokens do not block reminders forever. When balance crosses multiple thresholds at once, **all crossed levels are marked shown** and **one modal** is shown; light accounts are skipped. **`AccountCallbackManager`** triggers the check on any receive in a batch (not only the last tx) and after rate updates.
> 
> **`writePasswordRecoveryReminders`** accepts multiple levels in one write. Adds **unit tests** for milestone, deferral, and grace behavior; ESLint coverage tweaks for the touched action/service files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae68460dc5705b8d82db6bdbf0d4af4beb0b59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="2" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6177/commits/f23a34103c599b22f376977b875203e283e5eabb"><code>f23a341</code></a><br><sub>Fix password recovery reminder triggering</sub><br><sub>🪓 <em>commented out the newTransactions dispatch and forced passwordRecoveryRemindersShown to all-false, so the rate-refresh trigger was the only one that could fire; both edits reverted after capture.</em></sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260827-182850-agent-proof-1211152484915503-01-recovery-reminder-on-funded-account.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260827-182850-agent-proof-1211152484915503-01-recovery-reminder-on-funded-account.png" width="200"></a><br><sub>recovery reminder on funded account</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260827-182850-agent-proof-1211152484915503-02-HACKED-rate-refresh-trigger.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260827-182850-agent-proof-1211152484915503-02-HACKED-rate-refresh-trigger.png" width="200"></a><br><sub>🪓 rate refresh trigger</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260901-123057-agent-proof-1211152484915503-04-recovery-reminder-after-review-fix.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260901-123057-agent-proof-1211152484915503-04-recovery-reminder-after-review-fix.png" width="200"></a><br><sub>recovery reminder after review fix</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260901-123057-agent-proof-1211152484915503-05-HACKED-unpriced-funded-balances-diag.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260901-123057-agent-proof-1211152484915503-05-HACKED-unpriced-funded-balances-diag.png" width="200"></a><br><sub>🪓 unpriced funded balances diag</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260903-141643-agent-proof-1211152484915503-01-recovery-reminder-second-login-same-session.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6177/20260903-141643-agent-proof-1211152484915503-01-recovery-reminder-second-login-same-session.png" width="200"></a><br><sub>recovery reminder second login same session</sub></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->