### PR TITLE
Make MAX and multi-recipient send exclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Hide the send scene's MAX button once a send has more than one recipient, and hide "Add another address" once MAX has been applied, so the two can no longer combine into an insufficient-funds transaction.
+
 ## 4.51.0 (staging)
 
 - added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.

--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -620,6 +620,11 @@ const SendComponent: React.FC<Props> = props => {
   const handleFlipInputModal =
     (index: number, spendTarget: EdgeSpendTarget) => (): void => {
       const { noChangeMiningFee } = getSpecialCurrencyInfo(pluginId)
+      // A max spend only has a defined meaning for a single recipient: it
+      // consumes the entire spendable balance. Once the send has more than one
+      // target there is nothing left over for the others, so the button is
+      // hidden rather than allowed to produce an insufficient-funds spend.
+      const isMultipleTargets = spendInfo.spendTargets.length > 1
       Airship.show<FlipInputModalResult>(bridge => (
         <FlipInputModal2
           ref={flipInputModalRef}
@@ -627,6 +632,7 @@ const SendComponent: React.FC<Props> = props => {
           startNativeAmount={spendTarget.nativeAmount}
           feeTokenId={null}
           forceField={fieldChanged}
+          hideMaxButton={isMultipleTargets}
           onAmountsChanged={handleAmountsChanged(spendTarget)}
           onMaxSet={() => {
             setMaxSpendSetter(index)
@@ -753,7 +759,11 @@ const SendComponent: React.FC<Props> = props => {
       hiddenFeaturesMap.address === true ||
       hiddenFeaturesMap.amount === true ||
       lockTilesMap.address === true ||
-      lockTilesMap.amount === true
+      lockTilesMap.amount === true ||
+      // The existing target already claims the whole spendable balance, so a
+      // second recipient could only ever be funded by shrinking it. Withhold
+      // the entry point instead of silently discarding the max amount.
+      maxSpendSetter >= 0
     ) {
       return null
     }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1209203315991847

MAX spends the entire spendable balance, which only has a coherent meaning for a
single recipient. Since the send scene gained 1-to-many support, MAX and
multi-send conflict in both orderings:

- Tap MAX on recipient 2 and nothing happens. The recalculation effect only ever
  honors `maxSpendSetter === 0`, so a max requested by any later target sets
  state that nothing consumes.
- Tap MAX on recipient 1, then add a second recipient with any amount, and the
  send fails with Insufficient Funds, because recipient 1 already claims the
  whole balance.

The operator's decision on the task (after twice rejecting a per-target
remainder calculation) is to make the two mutually exclusive. This does that in
both directions:

1. `handleFlipInputModal` passes `hideMaxButton` to `FlipInputModal2` once the
   send has more than one spend target. The prop already existed and is gated in
   `ExchangedFlipInput2` alongside `noMaxSpend`, so no new plumbing.
2. `renderAddAddress` withholds the "Add Another Address" row while a max spend
   is set. Clearing the max instead would silently discard an amount the user
   deliberately chose, so the entry point is withheld rather than the amount
   rewritten.

Single-recipient sends are unchanged, and currencies with `maxSpendTargets < 2`
never reach either branch.

### Testing

Driven on the iOS simulator against a funded Bitcoin Testnet wallet
(`maxSpendTargets` 32, same multi-send path as mainnet BTC):

- One recipient: MAX is present, and tapping it fills the amount as before.
- With MAX applied: "Add Another Address" is gone.
- Retyping the amount by hand on that same screen (which clears the max) brings
  the row back, so the two frames differ only in `maxSpendSetter`.
- Two recipients: the amount modal has no MAX button.
- A 2-recipient send still broadcasts to Transaction Success.

`tsc --noEmit`, jest (SendScene2 snapshots unchanged), and `verify-repo.sh` all pass.

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="2" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6178/commits/62ef3873f6ae82d5fa510a6b0eadde9d77f92da2"><code>62ef387</code></a><br><sub>Make MAX and multi-recipient send exclusive</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-01-max-present-single-recipient.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-01-max-present-single-recipient.png" width="200"></a><br><sub>max present single recipient</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-02-max-set-add-address-hidden.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-02-max-set-add-address-hidden.png" width="200"></a><br><sub>max set add address hidden</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-03-manual-amount-add-address-visible.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-03-manual-amount-add-address-visible.png" width="200"></a><br><sub>manual amount add address visible</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-04-max-hidden-second-recipient.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-04-max-hidden-second-recipient.png" width="200"></a><br><sub>max hidden second recipient</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-05-multisend-broadcast-success.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6178/20260827-193400-agent-proof-1209203315991847-05-multisend-broadcast-success.png" width="200"></a><br><sub>multisend broadcast success</sub></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Send-scene UI gating only; no changes to signing, broadcast, or balance calculation logic beyond preventing invalid user paths.
> 
> **Overview**
> Fixes a send-scene bug where **MAX** (whole balance) and **multiple recipients** could combine and produce insufficient-funds errors, or MAX on a non-first recipient doing nothing.
> 
> When there is more than one spend target, the amount modal now passes **`hideMaxButton`** to **`FlipInputModal2`**. While a max spend is active (`maxSpendSetter >= 0`), **"Add another address"** is withheld so the user is not pushed toward splitting a balance already claimed by MAX. Manual amount edits still clear max and restore the add-recipient row. Single-recipient sends and currencies with **`maxSpendTargets < 2`** are unchanged.
> 
> CHANGELOG documents the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626cc1368495f7779968fd9e99434a294cc90f32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->