### PR TITLE
Add missing testIDs for maestro selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - changed: Use the UI4 warning card for the Reveal Raw Keys and Reveal Master Private Key password confirmation warnings.
 - changed: Tron resource staking now describes its claim action as reclaiming your own TRX, instead of claiming a reward.
 - changed: Deep links now wait only for the account state they actually use, so a link that just opens a scene, such as the buy/sell entry, follows immediately after login instead of waiting for every wallet to finish loading.
+- changed: Add maestro test selectors (testIDs) to the swap scene's from and to wallet pills.
 - fixed: The buy/sell amount field no longer reads "Amount undefined" while the app is still working out which wallet to use.
 - fixed: Show the Monero Transaction Key of a send whose key never reached the transaction's saved metadata, by falling back to the key the wallet engine mirrors into `otherParams`. Covers sends made on 4.49.0 and later while the send path reported no key, on devices that still hold the original wallet cache.
 - fixed: Force `NODE_ENV=test` in the Jest script so UI tests keep working when npm is invoked via Socket (Socket otherwise sets `NODE_ENV=development`, which makes react-native-gesture-handler treat Jest as a non-test env).

--- a/src/components/scenes/SwapCreateScene.tsx
+++ b/src/components/scenes/SwapCreateScene.tsx
@@ -560,6 +560,7 @@ export const SwapCreateScene: React.FC<Props> = props => {
                 ]}
                 tokenId={fromTokenId}
                 wallet={fromWallet}
+                walletPillTestID="swapFromWalletPill"
               />
             )}
           </EdgeAnim>
@@ -603,6 +604,7 @@ export const SwapCreateScene: React.FC<Props> = props => {
                 ]}
                 tokenId={toTokenId}
                 wallet={toWallet}
+                walletPillTestID="swapToWalletPill"
                 heading={lstrings.exchange_title_receiving}
               />
             )}

--- a/src/components/themed/SwapInput.tsx
+++ b/src/components/themed/SwapInput.tsx
@@ -61,6 +61,7 @@ export interface Props {
   onFocus?: () => void
   onNext?: () => void
   onSelectWallet: () => Promise<void>
+  walletPillTestID?: string
 }
 
 const forceFieldMap: { crypto: FieldNum; fiat: FieldNum } = {
@@ -80,6 +81,7 @@ const SwapInputComponent = React.forwardRef<SwapInputCardInputRef, Props>(
       tokenId,
       wallet,
       walletPlaceholderText,
+      walletPillTestID,
       // Events:
       onAmountChanged,
       onSelectWallet,
@@ -320,6 +322,7 @@ const SwapInputComponent = React.forwardRef<SwapInputCardInputRef, Props>(
           <PillButton
             label={walletPlaceholderText}
             onPress={onSelectWallet}
+            testID={walletPillTestID}
             icon={() => (
               <CryptoIcon
                 pluginId={wallet.currencyInfo.pluginId}


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1216079900947419

Test-infrastructure only. The diff adds two `testID` props and changes nothing else, so no rendering or behavior moves.

Driving the Exchange scene from a maestro flow had no way to reach the source and receiving wallet pills on `SwapCreateScene`: they are `PillButton`s that never received the `testID` the component already accepts, so a flow could only anchor on their accessibility text.

- `SwapInput` takes a `walletPillTestID` and forwards it to its `PillButton`.
- `SwapCreateScene` names the two pills `swapFromWalletPill` and `swapToWalletPill`.

The wallet picker rows are no longer part of this PR. `develop` has since added its own `walletListRow_<name>_<code>` selectors to `WalletListCurrencyRow`, which cover the same need, so the rebase dropped this branch's redundant (and differently named) row testID.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only props wired to existing `PillButton` `testID` support; no production logic or layout changes.
> 
> **Overview**
> **Maestro flows can now target the swap scene’s source and destination wallet selectors** without relying on accessibility labels.
> 
> `SwapInput` accepts an optional `walletPillTestID` and passes it to the header `PillButton` as `testID`. `SwapCreateScene` sets `swapFromWalletPill` and `swapToWalletPill` on the paying and receiving inputs. No user-visible UI or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996ae1513037ea27a95d837e48d2264292941d07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->