### PR TITLE
Fix wallet row a11y role and token search testID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 - changed: Tron resource staking now describes its claim action as reclaiming your own TRX, instead of claiming a reward.
 - changed: Add maestro test selectors (testIDs) to the swap scene's from and to wallet pills.
 - changed: The balance card title now reads "Unhide Balance" while balances are hidden, and hiding balances shows a toast explaining how to bring them back.
+- changed: Deep links now wait only for the account state they actually use, so a link that just opens a scene, such as the buy/sell entry, follows immediately after login instead of waiting for every wallet to finish loading.
+- fixed: Wallet list rows now announce as a button to screen readers, instead of as an inert group that reads out but does not present itself as something to activate.
+- fixed: The buy/sell amount field no longer reads "Amount undefined" while the app is still working out which wallet to use.
+- fixed: Show the Monero Transaction Key of a send whose key never reached the transaction's saved metadata, by falling back to the key the wallet engine mirrors into `otherParams`. Covers sends made on 4.49.0 and later while the send path reported no key, on devices that still hold the original wallet cache.
 - fixed: Force `NODE_ENV=test` in the Jest script so UI tests keep working when npm is invoked via Socket (Socket otherwise sets `NODE_ENV=development`, which makes react-native-gesture-handler treat Jest as a non-test env).
 - fixed: Bitwave CSV exports now use ISO 8601 UTC timestamps, leave the fee columns blank so Bitwave does not double-count fees, and copy the description into the second custom metadata column.
 - fixed: Bitwave account ids are no longer capitalized by the keyboard or padded with whitespace when entered, so exports import without hand-editing the account id.

--- a/maestro/07-wallets/C000045-add-edit-tokens.yaml
+++ b/maestro/07-wallets/C000045-add-edit-tokens.yaml
@@ -60,7 +60,7 @@ tags:
 - tapOn: "Confirm & Finish"
 
 - tapOn:
-    id: "undefined.clearIcon"
+    id: "manageTokensSearch.clearIcon"
 
 - runFlow:
     label: "Add custom token"

--- a/src/components/themed/WalletListCurrencyRow.tsx
+++ b/src/components/themed/WalletListCurrencyRow.tsx
@@ -177,6 +177,7 @@ const WalletListCurrencyRowComponent: React.FC<Props> = props => {
   return (
     <View
       accessible
+      accessibilityRole="button"
       testID={`walletListRow_${walletName}_${displayCurrencyCode}`}
     >
       <EdgeCard
@@ -197,7 +198,6 @@ const WalletListCurrencyRowComponent: React.FC<Props> = props => {
           start: { x: 0, y: 0 },
           end: { x: 1, y: 0 }
         }}
-        testID={`walletListRow_${walletName}_${displayCurrencyCode}`}
       >
         <View style={styles.textContentContainer}>
           {firstRow}


### PR DESCRIPTION
### Description

Follow-up to #6170, which merged before its Cursor Bugbot findings could be gated. Two of them are real.

`FilledTextInput` derives its clear control's testID as `` `${testID}.clearIcon` ``, so the `testID="manageTokensSearch"` that #6170 added to the Manage Tokens search field renamed that control from the accidental `undefined.clearIcon` to `manageTokensSearch.clearIcon`. The C000045 Add/Edit Tokens maestro flow taps `undefined.clearIcon` on that exact scene to clear the search field, so it can no longer clear it. This updates that one selector. The flow's other `undefined.clearIcon` taps are unaffected: C000045's remaining two target the Add Custom Token modal's contract-address input, and the rename-modal and "Search Wallets" picker taps in the other flows use inputs that #6170 never touched.

The wallet list row's new wrapper `View` also carried the same testID as the `EdgeCard` inside it, and had no role. `EdgeCard` forces `accessible={false}` on its touchable, so only the wrapper's testID reaches XCUITest and the card's copy was dead weight. The wrapper now declares `accessibilityRole="button"`, so a screen reader announces the row as something to activate rather than as an inert group.

Asana: https://app.asana.com/0/1215088146871429/1217587221308437

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small a11y and E2E selector fixes on wallet list rows and one Maestro flow; no auth, payments, or send-path changes.
> 
> **Overview**
> Follow-up to Manage Tokens search **testID** work: the clear control is now `manageTokensSearch.clearIcon` instead of `undefined.clearIcon`, so the **C000045** Maestro flow can clear the search field again.
> 
> **Wallet list rows** expose `accessibilityRole="button"` on the outer wrapper (where the row **testID** lives), so VoiceOver/TalkBack treat the row as tappable. The duplicate **testID** on the inner `EdgeCard` is removed because the card touchable is not the accessible element tests and screen readers see.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b692c8df3c54f47199795b296bc3d57485897d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->