### PR TITLE
Fix Android quick actions registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Android home screen long-press shortcuts no longer depend on a foreground activity during startup, and a shortcut registration failure no longer blocks the rest of the app.
+
 ## 4.51.0 (staging)
 
 - added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.

--- a/patches/expo-quick-actions+5.0.0.patch
+++ b/patches/expo-quick-actions+5.0.0.patch
@@ -11,6 +11,23 @@ index 4db980e..53bb319 100644
        }
      }
  
+diff --git a/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoQuickActionsModule.kt b/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoQuickActionsModule.kt
+index 66dc4a0..6bda3f8 100644
+--- a/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoQuickActionsModule.kt
++++ b/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoQuickActionsModule.kt
+@@ -3 +2,0 @@
+-import android.app.Activity
+@@ -126,3 +124,0 @@
+-  private val currentActivity: Activity?
+-    get() = appContext.currentActivity
+-
+@@ -229,0 +226,3 @@
++        val launchIntent = context.packageManager
++            .getLaunchIntentForPackage(context.packageName)
++            ?: throw IllegalStateException("Unable to find the app launch intent")
+@@ -232 +231 @@
+-            val intent = Intent(context, currentActivity!!::class.java)
++            val intent = Intent(launchIntent)
 diff --git a/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift b/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift
 index 252da49..12a29e4 100644
 --- a/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift

--- a/src/components/services/QuickActionsManager.tsx
+++ b/src/components/services/QuickActionsManager.tsx
@@ -7,6 +7,7 @@ import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { useHandler } from '../../hooks/useHandler'
 import { lstrings } from '../../locales/strings'
 import { config } from '../../theme/appConfig'
+import { trackError } from '../../util/tracking'
 import { showError } from './AirshipInstance'
 
 export const QuickActionsManager: React.FC = () => {
@@ -38,7 +39,7 @@ export const QuickActionsManager: React.FC = () => {
           }
         ])
       } catch (error: unknown) {
-        showError(error)
+        trackError(error, 'QuickActionsManager:setItems')
       }
     },
     [],


### PR DESCRIPTION
## Summary

- remove the unsafe Android `currentActivity!!` dependency by building shortcut intents from the package launch intent
- keep the dynamic, localized, app-configurable shortcuts introduced in #6001
- report any remaining registration failure without displaying a startup-blocking alert
- keep user-visible errors when a user taps a shortcut and its URL cannot open

## Why

[Sentry issue EDGE-REACT-GUI-4T7J](https://sentry.edge.app/organizations/edge/issues/158430/) has approximately 1,600 production events affecting 891 users:

```text
Call to function 'ExpoQuickActions.setItems' has been rejected.
→ Caused by: java.lang.NullPointerException
```

`currentActivity!!` is the old failure point, not the fix. `expo-quick-actions` 5.0.0 uses that Kotlin non-null assertion while constructing Android shortcut intents, so registration crashes when no Activity is available during JavaScript startup. The app caught that failure with `showError`, which displayed a large red alert even though quick actions are optional.

This patch uses the package launch intent, so shortcut registration does not require a foreground Activity. Unexpected registration failures are still reported to Sentry, but no longer interrupt startup.

## Controlled Android A/B proof

Device: Pixel 6 Pro `18311FDEE000AS`  
Android build: `CP1A.260405.005`

Pre-patch user-visible error:

<img width="600" alt="Pre-patch ExpoQuickActions startup error" src="https://github.com/user-attachments/assets/d7f08ba3-5d74-4044-bd85-6129e5fe13d1" />

For each run, the target APK was installed, the app was force-stopped, app data and logcat were cleared, and the app was sent Home as JavaScript initialized. Android logged `currentActivity isn't available` in both runs.

| | Pre-patch APK `26083104` | Patched APK `26083116` |
| --- | --- | --- |
| `ExpoQuickActions.setItems` rejection | 1 | 0 |
| Caused-by NPE | 1 | 0 |
| `contact_support` registered before reopen | No | Yes |
| `do_not_uninstall` registered before reopen | No | Yes |
| Red alert after reopen | Yes | No |

Pre-patch logcat:

```text
22:06:18.676 RNSentry: currentActivity isn't available.
22:06:18.938 ReactNativeJS: Showing error drop-down alert: Call to function 'ExpoQuickActions.setItems' has been rejected.
22:06:18.938 ReactNativeJS: → Caused by: java.lang.NullPointerException
```

Patched logcat, captured before returning the app to the foreground:

```text
22:09:32.174 RNSentry: currentActivity isn't available.
22:09:32.242 ReactNativeJS: Running "edge"
```

The patched log contained zero quick-actions rejection/NPE matches. Before reopening the app, `dumpsys shortcut` already contained both dynamic records with the same fresh timestamp:

```text
ShortcutInfo {id=contact_support, ... timestamp=1788239372428
ShortcutInfo {id=do_not_uninstall, ... timestamp=1788239372428
```

The patched lifecycle test was repeated at 50, 100, 150, and 200 ms. Every run logged that the Activity was unavailable, registered both shortcut IDs, and produced zero matching quick-actions errors.

## Behavior preserved from #6001

- titles and subtitles still come from `lstrings` / Crowdin
- URLs and availability remain app-configurable for white-label builds
- `setItems` still runs on launch, so wording changes and additional actions replace the previous definitions
- shortcuts remain dynamic rather than duplicated in native resources

## Verification

- controlled pre-patch versus patched device test above
- long-press menu contains both configured actions after the patched lifecycle test
- `npm run lint` — 0 errors (existing warnings only)
- `npx tsc --noEmit`
- `npm test` — 99 suites, 722 tests, 107 snapshots passed
- patch applied cleanly to the published `expo-quick-actions` 5.0.0 package

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Requirements

No intentional visual GUI changes. The quick-action menu remains dynamic and visible; the erroneous startup alert is removed because registration succeeds without a foreground Activity.
