### PR TITLE
Add kraft, colby, string, parm, swiss cheese branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ def preTest(String stageName) {
 def buildProduction(String stageName) {
   stage("Build ${stageName}") {
     echo "Running on ${env.NODE_NAME}"
-    if (env.BRANCH_NAME in ['develop', 'staging', 'master', 'beta', 'test-cheddar', 'test-feta', 'test-gouda', 'test-halloumi', 'test-paneer', 'test', 'testMaestro', 'yolo']) {
+    if (env.BRANCH_NAME in ['develop', 'staging', 'master', 'beta', 'test-cheddar', 'test-feta', 'test-gouda', 'test-halloumi', 'test-paneer', 'test-kraft', 'test-colby', 'test-string', 'test-parm', 'test-swiss', 'test', 'testMaestro', 'yolo']) {
       if (stageName == 'ios' && params.IOS_BUILD) {
         sh 'npm run prepare.ios'
         sh "node -r sucrase/register ./scripts/deploy.ts edge ios ${BRANCH_NAME}"

--- a/scripts/gitVersionFile.ts
+++ b/scripts/gitVersionFile.ts
@@ -37,7 +37,12 @@ const specialBranches: Record<string, string> = {
   'test-feta': '-feta',
   'test-gouda': '-gouda',
   'test-halloumi': '-halloumi',
-  'test-paneer': '-paneer'
+  'test-paneer': '-paneer',
+  'test-kraft': '-kraft',
+  'test-colby': '-colby',
+  'test-string': '-string',
+  'test-parm': '-parm',
+  'test-swiss': '-swiss'
 }
 
 let _currentPath = __dirname


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Adds five cheese test branches: `test-kraft`, `test-colby`, `test-string`, `test-parm`, `test-swiss`.

- `Jenkinsfile`: the new branch names join the `buildProduction` allowlist so pushes to them run the deploy stage.
- `scripts/gitVersionFile.ts`: version suffixes `-kraft`, `-colby`, `-string`, `-parm`, `-swiss`, matching the existing cheeses.

Jenkins already discovers `test-*` branches, and the build-number repo creates its per-branch file on first build. Zealot schemes and channels for the five branches exist, and their channel keys are in jenkins-files `deploy-config.json`, so the deploy stage has somewhere to upload once this lands.
