### PR TITLE
Register Android quick actions without a foreground activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - fixed: Tapping Max on the Sell scene no longer briefly shows the entered fiat amount in the crypto field while the max is being calculated.
 - fixed: An info card no longer disappears into an empty gap when the carousel's card list shrinks. A card's position comes entirely from an animated transform keyed on its index, and that transform is not re-applied when a surviving card shifts slots, so dropping a card left the ones after it parked a full card-width off-screen. The carousel now remounts a card whose slot changes. Reproduces wherever the list shrinks after mount - most visibly when a `noBalance` card is filtered out as balances finish loading.
 - fixed: Manage Tokens search now finds a token by its contract address, matching the Assets search.
+- fixed: Android quick-action shortcuts no longer throw a startup error when the app launches without ever coming to the foreground. Registration now waits for the app to be foregrounded, the native shortcut intent targets the launcher component instead of the current activity, and a registration failure is reported to Sentry instead of shown as a blocking alert.
 
 ## 4.50.3 (2026-08-28)
 

--- a/patches/expo-quick-actions+5.0.0.patch
+++ b/patches/expo-quick-actions+5.0.0.patch
@@ -11,6 +11,39 @@ index 4db980e..53bb319 100644
        }
      }
  
+diff --git a/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoQuickActionsModule.kt b/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoQuickActionsModule.kt
+index 66dc4a0..4816c39 100644
+--- a/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoQuickActionsModule.kt
++++ b/node_modules/expo-quick-actions/android/src/main/java/expo/modules.quickactions/ExpoQuickActionsModule.kt
+@@ -1,6 +1,7 @@
+ package expo.modules.quickactions
+ 
+ import android.app.Activity
++import android.content.ComponentName
+ import android.content.Context
+ import android.content.Intent
+ import android.content.pm.ShortcutInfo
+@@ -228,8 +229,19 @@ class ExpoQuickActionsModule : Module() {
+     private fun setShortcuts(items: List<ActionObject>) {
+         val shortcutManager = context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
+ 
++        // Resolve the launcher activity from the package manager rather than from
++        // the current activity, which is null whenever no activity is resumed.
++        // Only the component is reused: the launch intent itself carries
++        // CATEGORY_LAUNCHER, a package and FLAG_ACTIVITY_NEW_TASK, none of which
++        // belong on a shortcut intent.
++        val launchComponent = context.packageManager
++                .getLaunchIntentForPackage(context.packageName)
++                ?.component
++                ?: currentActivity?.let { ComponentName(context, it::class.java) }
++                ?: throw IllegalStateException("No launcher activity found for ${context.packageName}")
++
+         val shortcuts = items.mapNotNull {
+-            val intent = Intent(context, currentActivity!!::class.java)
++            val intent = Intent().setComponent(launchComponent)
+             intent.action = UNIQ_ACTION_ID
+             intent.putExtra("shortcut_data", it.toBundle());
+             val builder = ShortcutInfo.Builder(context, it.id)
 diff --git a/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift b/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift
 index 252da49..12a29e4 100644
 --- a/node_modules/expo-quick-actions/ios/ExpoQuickActionsModule.swift

--- a/src/components/services/QuickActionsManager.tsx
+++ b/src/components/services/QuickActionsManager.tsx
@@ -1,19 +1,38 @@
 import * as QuickActions from 'expo-quick-actions'
 import { useQuickActionCallback } from 'expo-quick-actions/hooks'
-import type * as React from 'react'
-import { Linking, Platform } from 'react-native'
+import * as React from 'react'
+import { AppState, Linking, Platform } from 'react-native'
 
 import { useAsyncEffect } from '../../hooks/useAsyncEffect'
 import { useHandler } from '../../hooks/useHandler'
 import { lstrings } from '../../locales/strings'
 import { config } from '../../theme/appConfig'
+import { trackError } from '../../util/tracking'
 import { showError } from './AirshipInstance'
 
 export const QuickActionsManager: React.FC = () => {
+  // Android cannot register shortcuts until the app has a resumed activity, and
+  // the OS rate-limits shortcut updates made without one. This component mounts
+  // at the top of the app, which on Android can happen before the activity is
+  // published, so wait for the first foreground before registering:
+  const [isForeground, setIsForeground] = React.useState(
+    AppState.currentState === 'active'
+  )
+
+  React.useEffect(() => {
+    if (isForeground) return
+    const listener = AppState.addEventListener('change', state => {
+      if (state === 'active') setIsForeground(true)
+    })
+    return () => {
+      listener.remove()
+    }
+  }, [isForeground])
+
   useAsyncEffect(
     async () => {
       const { quickActions } = config
-      if (quickActions == null) return
+      if (quickActions == null || !isForeground) return
       try {
         await QuickActions.setItems([
           {
@@ -38,10 +57,12 @@ export const QuickActionsManager: React.FC = () => {
           }
         ])
       } catch (error: unknown) {
-        showError(error)
+        // Shortcuts are an optional convenience, so a registration failure
+        // must never block startup with an error modal:
+        trackError(error, 'QuickActionsManager')
       }
     },
-    [],
+    [isForeground],
     'QuickActionsManager'
   )
 


### PR DESCRIPTION
### Description

Android quick-action registration threw at startup, put a blocking red error alert in front of the user, and left the long-press shortcuts unregistered. Sentry groups [158430](https://sentry.edge.app/organizations/edge/issues/158430/) and [107357](https://sentry.edge.app/organizations/edge/issues/107357/) are the same runtime error split by minified culprit frame: roughly 4000 events across roughly 2255 users, both still firing.

expo-quick-actions 5.0.0 builds the shortcut intent with `Intent(context, currentActivity!!::class.java)`. `appContext.currentActivity` falls back to `ReactApplicationContext.currentActivity`, which React Native only sets in `ReactContext.onHostResume(activity)`. In `ReactInstanceManager.setupReactContext`, `attachRootViewToInstance` runs `AppRegistry.runApplication` before `moveReactContextToCurrentLifecycleState` is posted to the UI thread. JavaScript can therefore render and fire effects before the activity is published, and `QuickActionsManager` sits at the top of `App.tsx` with almost no JavaScript work in front of its `setItems` call. On 96 of 100 sampled events from 158430, `app.in_foreground` is false. The dominant path is an app that starts and never reaches a resumed activity.

Both halves of the failure are addressed:

- `QuickActionsManager` waits for the app to be foregrounded. It seeds from `AppState.currentState` and otherwise latches on the first `AppState` change to `active`. That removes the dominant failure path at the source and keeps the call out of Android's background rate limiting on `ShortcutManager`.
- `patches/expo-quick-actions+5.0.0.patch` resolves the launcher component once, above the items loop, via `packageManager.getLaunchIntentForPackage(context.packageName)?.component`, then builds a fresh `Intent` from that component. Only the component is reused. Copying the launch intent would drag in `CATEGORY_LAUNCHER`, `setPackage` and `FLAG_ACTIVITY_NEW_TASK`, none of which the original intent had. The registered intent targets the same component as before (`cmp=co.edgesecure.app/.MainActivity`).
- A registration failure goes to `trackError` instead of `showError`. An optional feature can no longer block startup with an alert.

Two constraints hold regardless of how the intent is built, and both are why the foreground gate carries most of the fix. `ShortcutManager.setDynamicShortcuts` is rate limited for an app with no foreground activity or service and returns false rather than throwing, and the Kotlin property setter discards that boolean. `ShortcutManager` also throws `IllegalStateException` while the user is locked, because shortcut data lives in credential encrypted storage.

Upstream still has `currentActivity!!` on main. An issue on EvanBacon/expo-quick-actions, so the patch-package diff can eventually be dropped, is tracked outside this PR.

Asana: https://app.asana.com/0/1215088146871429/1218112847508576

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

Verified on a physical Galaxy S9 (SM-G960U, Android 10) with a debug build. The startup timing race itself does not reproduce in a debug build, where JavaScript init takes about 11 seconds against a production window of about 1.9 seconds, so the null-activity precondition was forced directly for the A/B:

- Pre-fix native with `currentActivity` forced null: the red "Call to function 'ExpoQuickActions.setItems' has been rejected. Caused by: java.lang.NullPointerException" alert, and zero dynamic shortcuts in `dumpsys shortcut`.
- Fixed native under the same forced precondition: both `do_not_uninstall` and `contact_support` registered, same intent component, no alert.
- Clean build, normal launch: both shortcuts registered.
- Foreground gate: with the seed forced closed, nothing registers at mount. After one background and foreground cycle, both shortcuts register.
- Shortcut tapped from the launcher while the app sat on the login scene: the support article opened and the Edge task stayed at one activity record, so delivery went through `onNewIntent` without resetting the task stack.
- `verify-repo.sh` (eslint, jest, prepare) and `tsc --noEmit` pass.
