### PR TITLE
Explain an empty Manage Tokens search result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- added: A "no tokens match your search" message on the Manage Tokens search. An address for a token the wallet's list does not carry used to render an empty scene, which is indistinguishable from a search that is not working.
+
 ## 4.51.0 (staging)
 
 - added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.

--- a/src/components/scenes/ManageTokensScene.tsx
+++ b/src/components/scenes/ManageTokensScene.tsx
@@ -190,6 +190,18 @@ const ManageTokensSceneComponent: React.FC<Props> = props => {
     }
   }, [autoDetectedTokenIds, filteredTokenIds])
 
+  // A search that matches nothing otherwise renders a bare scene, which reads
+  // exactly like a broken search. Say which one it is:
+  const emptyComponent = React.useMemo(
+    () =>
+      searchValue === '' ? null : (
+        <EdgeText style={styles.emptyText} numberOfLines={3}>
+          {lstrings.managetokens_search_no_result}
+        </EdgeText>
+      ),
+    [searchValue, styles.emptyText]
+  )
+
   const handleItemLayout = useRowLayout()
 
   // Goes to the add token scene:
@@ -354,6 +366,7 @@ const ManageTokensSceneComponent: React.FC<Props> = props => {
           data={filteredTokenIds}
           extraData={extraData}
           keyExtractor={keyExtractor}
+          ListEmptyComponent={emptyComponent}
           renderItem={renderRow}
           style={styles.list}
         />
@@ -396,6 +409,13 @@ const keyExtractor = (tokenId: string): string => tokenId
 
 const getStyles = cacheStyles((theme: Theme) => ({
   buttonsContainer: { marginTop: theme.rem(1), marginBottom: theme.rem(1) },
+  emptyText: {
+    color: theme.secondaryText,
+    fontSize: theme.rem(0.85),
+    marginHorizontal: theme.rem(1),
+    marginTop: theme.rem(1),
+    textAlign: 'center'
+  },
   list: {
     marginHorizontal: theme.rem(0.5)
   },

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -199,6 +199,8 @@ const strings = {
   managetokens_detected_tokens_header: 'Auto Detected Tokens',
   managetokens_all_tokens_header: 'All Tokens',
   managetokens_top_instructions: 'Select tokens to display in wallet:',
+  managetokens_search_no_result:
+    'No tokens match your search. Use "Add Custom" to add a token by its contract address.',
   accept_button_text: 'Accept',
   addtoken_contract_address_input_text: 'Contract Address',
   addtoken_currency_code_input_text: 'Token Code',

--- a/src/locales/strings/enUS.json
+++ b/src/locales/strings/enUS.json
@@ -116,6 +116,7 @@
   "managetokens_detected_tokens_header": "Auto Detected Tokens",
   "managetokens_all_tokens_header": "All Tokens",
   "managetokens_top_instructions": "Select tokens to display in wallet:",
+  "managetokens_search_no_result": "No tokens match your search. Use \"Add Custom\" to add a token by its contract address.",
   "accept_button_text": "Accept",
   "addtoken_contract_address_input_text": "Contract Address",
   "addtoken_currency_code_input_text": "Token Code",


### PR DESCRIPTION
### Description

Manage Tokens now says when a search matches nothing.

Searching Manage Tokens for a contract address the wallet's token list does not carry rendered a bare scene: no rows, no message, and the "Add Custom" button hidden behind the keyboard. That frame is pixel-identical to a search that is not matching at all, so nobody can tell "this token is not in the list" from "the search is broken".

That ambiguity is what this PR's task is about. QA filed [1217587221308437](https://app.asana.com/0/1215088146871429/1217587221308437) against the Manage Tokens contract-address search, that search was fixed in [EdgeApp/edge-react-gui#6170](https://github.com/EdgeApp/edge-react-gui/pull/6170), and a later QA pass attached another blank-scene screenshot. This run reproduced the QA steps on current `develop` and the search works: the full MOG contract address `0xaaeE1A9723aaDB7afA2810263653A34bA2C21C7a` returns the Mog row, and so does UNI's `0x1f9840a85d5af5bf1d1762f925bdaddc4201f984`. What the blank frame cannot show is which of the two causes produced it.

MOG makes the gap easy to hit. It is not a built-in token: it is absent from `edge-currency-accountbased`'s compiled Ethereum list and from the info-server token payload, so it only exists in an account after someone adds it through "Add Custom". On an account that never did, an address search for it correctly returns nothing, and says nothing.

The fix renders a centered message in the list's empty slot while a search is active. A search that matches nothing now says so, and points at the control that adds the token.

Asana: https://app.asana.com/0/1215088146871429/1218117826000799

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)
