### PR TITLE
Persist QR scan warning past permission prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- fixed: Keep the QR scanner scam warning on screen until the user dismisses it, instead of letting the camera permission prompt replace it.
+
 ## 4.51.0 (staging)
 
 - added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -219,7 +219,7 @@ export default [
       'src/components/modals/RadioListModal.tsx',
       'src/components/modals/RawTextModal.tsx',
       'src/components/modals/ScamWarningModal.tsx',
-      'src/components/modals/ScanModal.tsx',
+
       'src/components/modals/StateProvinceListModal.tsx',
 
       'src/components/modals/TransferModal.tsx',

--- a/src/components/modals/ScanModal.tsx
+++ b/src/components/modals/ScanModal.tsx
@@ -38,6 +38,12 @@ import { ModalFooter } from '../themed/ModalParts'
 import { SceneHeaderUi4 } from '../themed/SceneHeaderUi4'
 import { EdgeModal } from './EdgeModal'
 
+/**
+ * How long the scam warning is on screen before the system camera permission
+ * prompt is requested on top of it.
+ */
+const PERMISSION_PROMPT_DELAY_MS = 750
+
 interface Props {
   bridge: AirshipBridge<string | undefined>
 
@@ -79,6 +85,13 @@ export const ScanModal: React.FC<Props> = props => {
   const cameraPermission = useSelector(state => state.permissions.camera)
   const [torchEnabled, setTorchEnabled] = React.useState(false)
   const [scanEnabled, setScanEnabled] = React.useState(false)
+  const [isPermissionResolved, setIsPermissionResolved] = React.useState(false)
+  const [isWarningAcknowledged, setIsWarningAcknowledged] =
+    React.useState(false)
+
+  const isCameraAllowed =
+    cameraPermission === RNPermissions.RESULTS.GRANTED ||
+    cameraPermission === RNPermissions.RESULTS.LIMITED
 
   const handleFlash = (): void => {
     triggerHaptic('impactLight')
@@ -88,10 +101,22 @@ export const ScanModal: React.FC<Props> = props => {
   // Mount effects
   React.useEffect(() => {
     setScanEnabled(true)
-    dispatch(checkAndRequestPermission('camera')).catch((error: unknown) => {
-      showError(error)
-    })
+
+    // Show the scam warning first and give it a beat to land, so the system
+    // permission prompt covers a modal the user has already seen and the
+    // warning is still there once the prompt is dismissed.
+    const timeoutId = setTimeout(() => {
+      dispatch(checkAndRequestPermission('camera'))
+        .catch((error: unknown) => {
+          showError(error)
+        })
+        .finally(() => {
+          setIsPermissionResolved(true)
+        })
+    }, PERMISSION_PROMPT_DELAY_MS)
+
     return () => {
+      clearTimeout(timeoutId)
       setScanEnabled(false)
     }
   }, [dispatch])
@@ -105,6 +130,11 @@ export const ScanModal: React.FC<Props> = props => {
   const handleSettings = async (): Promise<void> => {
     triggerHaptic('impactLight')
     await Linking.openSettings()
+  }
+
+  const handleAcknowledgeWarning = (): void => {
+    triggerHaptic('impactLight')
+    setIsWarningAcknowledged(true)
   }
 
   const handleTextInput = async (): Promise<void> => {
@@ -276,8 +306,18 @@ export const ScanModal: React.FC<Props> = props => {
     )
   }
 
-  return cameraPermission === RNPermissions.RESULTS.GRANTED ||
-    cameraPermission === RNPermissions.RESULTS.LIMITED ? (
+  // The scam warning gates the scanner: it stays up until the user dismisses
+  // it, whichever way the camera permission prompt was answered.
+  const primaryButton =
+    isPermissionResolved && !isCameraAllowed
+      ? { onPress: handleSettings, label: lstrings.open_settings }
+      : {
+          onPress: handleAcknowledgeWarning,
+          label: lstrings.string_got_it,
+          disabled: !isCameraAllowed
+        }
+
+  return isCameraAllowed && isWarningAcknowledged ? (
     <AirshipModal
       bridge={bridge}
       margin={[airshipMarginTop, 0, 0]}
@@ -293,7 +333,9 @@ export const ScanModal: React.FC<Props> = props => {
     </AirshipModal>
   ) : (
     <EdgeModal bridge={bridge} onCancel={handleClose}>
-      <Paragraph>{lstrings.scan_camera_permission_denied}</Paragraph>
+      {isPermissionResolved && !isCameraAllowed ? (
+        <Paragraph>{lstrings.scan_camera_permission_denied}</Paragraph>
+      ) : null}
       <AlertCardUi4
         title={lstrings.warning_scam_title}
         type="warning"
@@ -307,9 +349,7 @@ export const ScanModal: React.FC<Props> = props => {
         ]}
         footer={sprintf(lstrings.warning_scam_footer_s, config.supportEmail)}
       />
-      <ModalButtons
-        primary={{ onPress: handleSettings, label: lstrings.open_settings }}
-      />
+      <ModalButtons primary={primaryButton} />
     </EdgeModal>
   )
 }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1217260776591432

`ScanModal` chose between the scam warning and the camera scanner purely on the
camera permission status, and it fired the permission request the instant the
modal mounted. On a first camera use that produced the reported bug: the warning
rendered, the OS prompt landed on top of it before it could be read, and granting
the permission flipped the render branch, so the warning vanished as the scanner
opened. The warning was only readable when permission was denied, which is
backwards.

The scam warning is now the gate. It stays on screen until the user taps
"Got it!", whichever way the permission prompt was answered, and the permission
request is delayed a beat so the warning is painted before the system prompt
covers it.

- The camera branch renders on `isCameraAllowed && isWarningAcknowledged` instead
  of the permission status alone.
- The permission request runs 750ms after mount, on a timer cleared at unmount.
- Primary button: "Got it!" disabled while the permission is still resolving,
  "Got it!" once allowed, "Open Settings" (with the existing enable-camera
  guidance) when denied or blocked.

Covers all three entry points (Side Menu Scan QR, Send Scan, WalletConnect New
Connection); they all render this one component.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized QR scan UX change with no auth, payment, or data-handling impact; behavior is gated in a single modal component.
> 
> **Overview**
> **`ScanModal`** no longer switches straight to the camera when permission is granted. The financial scam **`AlertCardUi4`** stays visible until the user taps **Got it!**, and the live scanner only opens when **`isCameraAllowed && isWarningAcknowledged`**.
> 
> Camera permission is requested **750ms** after mount so the warning renders before the OS prompt. The footer uses **Got it!** (disabled until the permission flow finishes; enabled once camera access is allowed) or **Open Settings** with the existing denied copy when access is blocked. **`CHANGELOG`** documents the fix; **`eslint.config.mjs`** drops a legacy override entry for this modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c81aa663b67f3625682f7412329ae4550ae60ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->