### PR TITLE
Match wallet edit prompt to what the tap does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - changed: Standardize wallet list automation test IDs to use period separators.
 - fixed: USDC.e shown as USDC in the Optimism Tarot staking pools
+- fixed: Say "edit name" instead of "edit settings" on the create/split wallet scene when the listed wallets have no settings to edit
 
 ## 4.51.0 (staging)
 

--- a/maestro/07-wallets/C000037-split-wallets.yaml
+++ b/maestro/07-wallets/C000037-split-wallets.yaml
@@ -58,7 +58,7 @@ tags:
 # Next scene
 - assertVisible: Split Wallet
 - assertVisible: EVM-compatible networks share the.*existing address.
-- assertVisible: Tap on wallet to edit settings
+- assertVisible: Tap on wallet to edit name
 - evalScript: ${output.newETHName = ".*My Ether \\(Split from My Base\\).*"}
 - assertVisible: ${output.newETHName}
 
@@ -100,7 +100,7 @@ tags:
 
 # - assertVisible: Split Wallet
 # - assertVisible: This action creates wallets from pre-existing wallets.
-# - assertVisible: Tap on wallet to edit settings
+# - assertVisible: Tap on wallet to edit name
 # - evalScript: ${var newBTCName = ".*My Bitcoin \\(Split from My Litecoin\\).*"}
 # - assertVisible: ${newBTCName}
 # - tapOn: 

--- a/src/__tests__/scenes/__snapshots__/CreateWalletEditNameScene.test.tsx.snap
+++ b/src/__tests__/scenes/__snapshots__/CreateWalletEditNameScene.test.tsx.snap
@@ -312,7 +312,7 @@ exports[`CreateWalletEditNameComponent should render with loading props 1`] = `
         ]
       }
     >
-      Tap on wallet to edit settings
+      Tap on wallet to edit name
     </Text>
     <RCTScrollView
       automaticallyAdjustContentInsets={false}

--- a/src/components/scenes/CreateWalletEditNameScene.tsx
+++ b/src/components/scenes/CreateWalletEditNameScene.tsx
@@ -115,6 +115,21 @@ const CreateWalletEditNameComponent: React.FC<Props> = props => {
     )
   )
 
+  // Tapping a row opens the wallet settings modal, which only shows a name
+  // field unless the asset declares its own settings (Monero's backend picker).
+  // Promise settings in the instructions only when a listed wallet has some,
+  // otherwise the tap does nothing but rename. Splits never qualify, since no
+  // splittable asset declares wallet settings.
+  const hasWalletSettings = React.useMemo(
+    () =>
+      createWalletList.some(item => {
+        if (item.walletType == null) return false
+        const settings = SPECIAL_CURRENCY_INFO[item.pluginId]?.walletSettings
+        return settings != null && settings.length > 0
+      }),
+    [createWalletList]
+  )
+
   const handleEditWalletName = useHandler(
     async (key: string, currentName: string, pluginId: string) => {
       const result = await Airship.show<WalletSettingsResult | undefined>(
@@ -427,7 +442,9 @@ const CreateWalletEditNameComponent: React.FC<Props> = props => {
           </Paragraph>
         )}
         <EdgeText style={styles.instructionalText} numberOfLines={1}>
-          {lstrings.fragment_create_wallet_edit_settings_instructions}
+          {hasWalletSettings
+            ? lstrings.fragment_create_wallet_edit_settings_instructions
+            : lstrings.fragment_create_wallet_instructions}
         </EdgeText>
         <FlatList
           automaticallyAdjustContentInsets={false}


### PR DESCRIPTION
### Description

The Split Wallet confirmation scene told users "Tap on wallet to edit settings", but in that flow the tap opens a modal with nothing except a Wallet Name field. The copy was generalized when Monero gained an LWS backend picker, and Monero wallets cannot be split, so the split flow never had settings to offer.

`CreateWalletEditNameScene` serves both the create-wallet and split-wallet flows, so the instruction line now follows what the listed wallets actually expose: it uses the settings wording only when some listed wallet declares `walletSettings` in `SPECIAL_CURRENCY_INFO` (Monero is the only one), and otherwise falls back to the existing `fragment_create_wallet_instructions` string, "Tap on wallet to edit name". No new locale key, so the translations already shipped for that string are kept.

Asana: https://app.asana.com/0/1215088146871429/1217847844643601

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and conditional string selection only; no auth, payments, or wallet-creation logic changes.
> 
> **Overview**
> The create/split wallet confirmation scene no longer always tells users to **"Tap on wallet to edit settings"**. **`CreateWalletEditNameScene`** now picks the instruction line based on whether any wallet in the list exposes **`walletSettings`** in **`SPECIAL_CURRENCY_INFO`** (Monero’s server picker is the only case today). Split and most create flows only open a rename modal, so they use the existing **`fragment_create_wallet_instructions`** copy (**"Tap on wallet to edit name"**); multi-asset create flows that include Monero still show the settings wording.
> 
> Maestro split-wallet coverage and the scene snapshot were updated to match. CHANGELOG notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 690048b4d9e1b09aeed625f4b3388a37fc748091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->