### PR TITLE
Drop the false universal-link gap from the iOS 26 migration doc

### DIFF
--- a/src/docs/ios-26-scene-lifecycle-migration.md
+++ b/src/docs/ios-26-scene-lifecycle-migration.md
@@ -69,17 +69,9 @@ the scene callbacks that was removed before commit:
   (`launchOptions(from:)` rebuilding the `userActivityDictionary`, which the app
   answers with "Parsing link...") and the warm path (`scene(_:continue:)`, answered
   with "No wallets exist that support this link."). Those two are driven from a
-  synthesized `NSUserActivity` rather than a real link, for the reason below.
+  synthesized `NSUserActivity` rather than a real link, because the simulator
+  harness cannot deliver a real universal link.
 - The Release configuration compiles.
-
-### Universal links are not associated today
-
-`edge.app` serves a 404 HTML page at `/.well-known/apple-app-site-association`, and
-Apple's CDN has no entry for the domain. The app ships
-`com.apple.developer.associated-domains: applinks:edge.app`, but with no association
-file iOS never hands the app a browsing-web activity, so both universal-link paths
-are unreachable in production regardless of this change. That is worth fixing on its
-own, and until it is, the scene code above cannot be exercised by a real link.
 
 ## What is still owed before Xcode 27
 


### PR DESCRIPTION
### Technical Design Document

[ios-26-scene-lifecycle-migration.md](https://github.com/EdgeApp/edge-react-gui/blob/jon/ios26-doc-drop-universal-link-claim/src/docs/ios-26-scene-lifecycle-migration.md)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Doc-only. The iOS 26 migration doc claimed edge.app serves no apple-app-site-association and that the app ships `applinks:edge.app`, concluding universal links are dead app-wide. The entitlement has never listed the apex domain. It lists dl.edge.app, return.edge.app, and deep.edge.app, and all three serve a valid association file naming the app that Apple's CDN has picked up. This removes the section and rewords the test note that pointed at it.

Asana: https://app.asana.com/0/0/1214464087258597/f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, build, or configuration changes.
> 
> **Overview**
> **Doc-only correction** to `ios-26-scene-lifecycle-migration.md`: drops the **"Universal links are not associated today"** section that stated `edge.app` had no `apple-app-site-association`, Apple's CDN had no entry, and production universal-link paths were unreachable despite `applinks:edge.app`.
> 
> The verification bullet for universal-link testing is reworded so the synthesized `NSUserActivity` note explains the **simulator harness** limitation directly, instead of pointing at the removed section.
> 
> No app, entitlement, or lifecycle code changes—only aligning the migration write-up with how associated domains actually work (`dl` / `return` / `deep.edge.app` per the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21385679bf5167d1f888267a6f711ddb67d6b19c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->