### PR TITLE
Turn on the iOS 26 design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- changed: Turn on the iOS 26 design system by dropping the `UIDesignRequiresCompatibility` opt-out, so the app renders with Liquid Glass materials on iOS 26 instead of the legacy appearance.
+
 ## 4.51.0 (staging)
 
 - added: Push info-server attestation tokens into edge-core-js via `setAttestationToken` so the login server can skip CAPTCHA for attested devices, and allow `LOGIN_SERVER` / `INFO_SERVER` env overrides for local E2E stacks.

--- a/ios/edge/Info.plist
+++ b/ios/edge/Info.plist
@@ -198,7 +198,5 @@
 	<array>
 		<string>applinks:edge.app</string>
 	</array>
-	<key>UIDesignRequiresCompatibility</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1214464087258597

Deletes the `UIDesignRequiresCompatibility` opt-out from `ios/edge/Info.plist`, which
turns on the iOS 26 design system. This is the last item gating the move to Xcode 27:
that toolchain ignores the flag, so Liquid Glass switches on the moment a build box
picks it up. Doing it deliberately now, behind a test build, is how we find out what
it changes while Xcode 26 still honors the flag and we can put it back.

The scene lifecycle work this depends on landed in #6179.

### Testing

Driven on an iOS 26.5 simulator (iPhone 17 Pro), which is the only place Liquid Glass
renders. The account container was restored from a donor sim so the app came up logged
in.

With the flag gone:

- Cold launch reaches the wallet list with balances, the tab bar, the search field and
  the notification card all drawn normally.
- `https://deep.edge.app/buy` opens the Buy Crypto scene directly, with a live BTC
  quote. iOS delivered that universal link to the app with no "Open in Edge?" prompt,
  which also confirms the associated domains work.
- A system alert renders in the new material: translucent, with the content behind it
  dimmed.

Same build, flag restored in the installed bundle as an A/B baseline:

- The wallet list is visually identical. Edge draws its own surfaces in React Native,
  so the design-system switch does not reach them.
- The same system alert renders as a flat opaque panel, which is the old appearance.

So the only difference visible from the scenes reachable here is the system alert
material, and it is legible in both. The surfaces that need a human pass are the ones
that need taps to reach: the blur backgrounds (`BlurBackground`, `QrModal`,
`LoginScene`), native sheets presented by react-native-screens, and the keyboard
accessory on amount entry. That is what the `test-colby` build is for.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small plist change, but it alters native iOS chrome (alerts, sheets, blur-backed UI) on iOS 26 and needs visual QA on surfaces React Native does not fully control.
> 
> **Overview**
> Removes the **`UIDesignRequiresCompatibility`** opt-out from **`ios/edge/Info.plist`**, so Edge no longer forces the legacy iOS UI appearance on iOS 26 and **Liquid Glass** system materials apply instead (e.g. translucent system alerts rather than flat panels).
> 
> Documents the change in **CHANGELOG** under Unreleased. This is an intentional step ahead of **Xcode 27**, where the compatibility flag is expected to be ignored; it builds on the UIScene lifecycle work already in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4215dab44284bc76fe7cfb1ecd66d5c176899c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->