### PR TITLE
Standardize wallet test ID separators

### DIFF
--- a/maestro/07-wallets/C000037-split-wallets.yaml
+++ b/maestro/07-wallets/C000037-split-wallets.yaml
@@ -45,7 +45,7 @@ tags:
 
 # Verify split option is available and tap it
 - tapOn:
-    id: walletListMenu_split
+    id: walletListMenu.split
 
 # Select Ethereum as target
 - assertVisible: Split Wallet

--- a/maestro/07-wallets/C000046-rename-wallet.yaml
+++ b/maestro/07-wallets/C000046-rename-wallet.yaml
@@ -21,7 +21,7 @@ tags:
 - tapOn: Assets
 - longPressOn: ${".*" + WALLET_NAME}
 - tapOn:
-    id: "walletListMenu_walletSettings"
+    id: walletListMenu.walletSettings
 # Wallet Settings modal
 - assertVisible: Wallet Settings
 - assertVisible:

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -353,7 +353,7 @@ export const WalletListMenuModal: React.FC<Props> = props => {
         return (
           <EdgeTouchableOpacity
             key={option.value}
-            testID={`walletListMenu_${option.value}`}
+            testID={`walletListMenu.${option.value}`}
             onPress={async () => {
               await optionAction(option.value)
             }}

--- a/src/components/themed/WalletListCurrencyRow.tsx
+++ b/src/components/themed/WalletListCurrencyRow.tsx
@@ -178,7 +178,7 @@ const WalletListCurrencyRowComponent: React.FC<Props> = props => {
     <View
       accessible
       accessibilityRole="button"
-      testID={`walletListRow_${walletName}_${displayCurrencyCode}`}
+      testID={`walletListRow.${walletName}.${displayCurrencyCode}`}
     >
       <EdgeCard
         icon={iconNode}


### PR DESCRIPTION
## Summary

- use periods consistently in composed wallet-list test IDs
- update the two Maestro consumers to match literal periods

## Impact

This only changes automation identifiers; wallet behavior, rendering, navigation, and accessibility labels remain unchanged. External automation using the old identifiers would need to migrate.

## Validation

- `npx eslint --concurrency=auto src/components/modals/WalletListMenuModal.tsx src/components/themed/WalletListCurrencyRow.tsx`
- `npx tsc`
- focused WalletListModal and CreateWalletSelectCryptoScene Jest tests
- Maestro syntax checks for C000037 and C000046
- exhaustive tracked-reference sweep for the old IDs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only identifier renames with no product logic changes; risk is limited to broken automation if callers miss the migration.
> 
> **Overview**
> **Wallet list automation IDs** now use **dot-separated** segments instead of underscores, aligned with other composed test IDs in the app.
> 
> `WalletListMenuModal` emits `walletListMenu.{option}` (e.g. `walletListMenu.split`, `walletListMenu.walletSettings`) instead of `walletListMenu_{option}`. `WalletListCurrencyRow` uses `walletListRow.{walletName}.{displayCurrencyCode}` instead of `walletListRow_{name}_{code}`.
> 
> Maestro flows **C000037** (split wallet) and **C000046** (rename wallet) were updated to tap the new menu IDs. App behavior, UI, and accessibility are unchanged; external E2E that still target the old IDs must be updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b258a8af1ba166509628f573a9a0c201f1985501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->