### PR TITLE
Backport Maestro fixes to staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 - fixed: Wallet list rows now announce as a button to screen readers, instead of as an inert group that reads out but does not present itself as something to activate.
 - fixed: The buy/sell amount field no longer reads "Amount undefined" while the app is still working out which wallet to use.
 - fixed: Show the Monero Transaction Key of a send whose key never reached the transaction's saved metadata, by falling back to the key the wallet engine mirrors into `otherParams`. Covers sends made on 4.49.0 and later while the send path reported no key, on devices that still hold the original wallet cache.
+- changed: Add maestro test selectors (testIDs) to Manage Tokens rows.
+- changed: Add maestro test selectors (testIDs) to the Wallet Settings name input and Done button.
+- changed: Add a maestro test selector (testID) to the split-wallet confirmation button.
 - fixed: Force `NODE_ENV=test` in the Jest script so UI tests keep working when npm is invoked via Socket (Socket otherwise sets `NODE_ENV=development`, which makes react-native-gesture-handler treat Jest as a non-test env).
 - fixed: Bitwave CSV exports now use ISO 8601 UTC timestamps, leave the fee columns blank so Bitwave does not double-count fees, and copy the description into the second custom metadata column.
 - fixed: Bitwave account ids are no longer capitalized by the keyboard or padded with whitespace when entered, so exports import without hand-editing the account id.

--- a/maestro/01-accounts/C000000-change-password.yaml
+++ b/maestro/01-accounts/C000000-change-password.yaml
@@ -62,8 +62,9 @@ tags:
 - pressKey: Enter
 - assertVisible: Invalid username or password
 # Ensure new password works
+- tapOn:
+    id: "passwordFormField.clearIcon"
 - tapOn: Password
-- eraseText
 - inputText: ${SECOND_PASSWORD}
 - pressKey: Enter
 

--- a/maestro/01-accounts/C000001-switch-and-forget-account.yaml
+++ b/maestro/01-accounts/C000001-switch-and-forget-account.yaml
@@ -40,8 +40,9 @@ tags:
     id: "sideMenuButton"
 - tapOn: "Logout"
 - tapOn: "Exit PIN"
-- assertVisible: ${USERNAME}
-- tapOn: "Username"
+- assertVisible: ${USERNAME1}
+- tapOn:
+    id: "usernameFormField"
 - eraseText
 - inputText: ${USERNAME2}
 - pressKey: Enter
@@ -63,7 +64,8 @@ tags:
 - tapOn: "Logout"
 - tapOn: "Exit PIN"
 - assertVisible: ${USERNAME2}
-- tapOn: "Username"
+- tapOn:
+    id: "usernameFormField"
 - eraseText
 - inputText: ${USERNAME3}
 - pressKey: Enter
@@ -79,7 +81,7 @@ tags:
     id: "sideMenuButton"
 - tapOn:
     id: "downArrow"
-- assertVisible: ${USERNAME}
+- assertVisible: ${USERNAME1}
 - assertVisible: ${USERNAME2}
 - assertVisible: ${USERNAME3}
 
@@ -89,22 +91,22 @@ tags:
     index: 0
 - assertVisible: ${".*Forget Account.*"}
 - tapOn: "Cancel"
-- assertVisible: ${USERNAME}
+- assertVisible: ${USERNAME1}
 - assertVisible: ${USERNAME2}
 - assertVisible: ${USERNAME3}
 # Delete first account
 - tapOn:
     id: "sideMenuClose"
     index: 1
-- assertVisible: ${".*" + USERNAME + ".*"} # Username in confirmation modal
+- assertVisible: ${".*" + USERNAME1 + ".*"} # Username in confirmation modal
 - tapOn: "Forget"
-- assertNotVisible: ${USERNAME}
+- assertNotVisible: ${USERNAME1}
 - tapOn: ${USERNAME2}
 
 # View, forget, switch accounts from PIN login screen
 - assertVisible: ${USERNAME2}
 - tapOn: ${USERNAME2}
-- assertNotVisible: ${USERNAME}
+- assertNotVisible: ${USERNAME1}
 - assertVisible: ${USERNAME2}
 - assertVisible: ${USERNAME3}
 - tapOn:

--- a/maestro/03-login/C190284-2fa-01.yaml
+++ b/maestro/03-login/C190284-2fa-01.yaml
@@ -23,8 +23,8 @@ tags:
     visible: "Username and password are correct. This device cannot log in because\
     \ it does not have the right 2-factor code."
     timeout: 15000
-- assertVisible: "Enter Backup Code"
-- tapOn: "Enter Backup Code"
+- assertVisible: "Enter 2FA code"
+- tapOn: "Enter 2FA code"
 - inputText: ${MAESTRO_EDGE_2FA_BACKUP_CODE}
 - assertVisible: "Submit"
 
@@ -38,32 +38,6 @@ tags:
 
 # If the request notifications modal show with "Security is Our Priority"
 # Cancel it
-- tapOn:
-    text: "Cancel"
-    optional: true
-
-# If the 2FA warning shows up for another device, deny it
-- tapOn:
-    text: "Deny"
-    optional: true
-- tapOn:
-    text: "Deny All"
-    optional: true
-- tapOn:
-    text: "Deny"
-    optional: true
-- tapOn:
-    text: "Deny All"
-    optional: true
-- tapOn:
-    text: "SKIP"
-    optional: true
-- tapOn:
-    text: "SKIP"
-    optional: true
-
-# If the request notifications modal show with "Security is Our Priority"
-# Cancel it
 - extendedWaitUntil:
     visible: "Security is Our Priority"
     timeout: 20000
@@ -72,14 +46,46 @@ tags:
     text: "Cancel"
     optional: true
 
-# If the survey modal shows, dismiss it
+# Best effort: deny one request, deny all remaining requests, then deny one
+# final request.
 - extendedWaitUntil:
-    visible: "How Did You Discover Edge?"
+    visible: "A new device would like to log in to your account"
+    timeout: 30000
+    optional: true
+- tapOn:
+    id: "securityAlertDenyButton"
+    optional: true
+- extendedWaitUntil:
+    notVisible:
+      id: "securityAlertDenyButton.spinner"
     timeout: 20000
     optional: true
 - tapOn:
-    text: "Dismiss"
+    id: "securityAlertDenyAllButton"
     optional: true
+- extendedWaitUntil:
+    notVisible:
+      id: "securityAlertDenyAllButton.spinner"
+    timeout: 20000
+    optional: true
+- tapOn:
+    id: "securityAlertDenyButton"
+    optional: true
+- extendedWaitUntil:
+    notVisible:
+      id: "securityAlertDenyButton.spinner"
+    timeout: 20000
+    optional: true
+- tapOn:
+    text: "SKIP"
+    optional: true
+- tapOn:
+    text: "SKIP"
+    optional: true
+
+# Dismiss any remaining common modals and notifications.
+- runFlow:
+    file: ../common/dismiss-modals.yaml
 
 - assertVisible: "Assets"
 - tapOn: "Assets"

--- a/maestro/03-login/C999002-pin-login.yaml
+++ b/maestro/03-login/C999002-pin-login.yaml
@@ -22,10 +22,10 @@ tags:
 
 - tapOn: "Assets"
 - extendedWaitUntil:
-    visible: FIRO
+    visible: "FIRO.*"
     timeout: 15000
 # If too fast, app won't save state of being on "Assets" scene 
-- tapOn: FIRO
+- tapOn: "FIRO.*"
 
 - stopApp
 - launchApp
@@ -33,6 +33,7 @@ tags:
 - extendedWaitUntil:
     visible: ${MAESTRO_EDGE_UTXO_USERNAME}
     timeout: 15000
+- waitForAnimationToEnd
 
 - tapOn: ${MAESTRO_EDGE_UTXO_PIN_1}
 - tapOn: ${MAESTRO_EDGE_UTXO_PIN_2}
@@ -49,7 +50,7 @@ tags:
     optional: true
 
 - extendedWaitUntil:
-    visible: FIRO
+    visible: "FIRO.*"
     timeout: 15000
 
 - stopApp

--- a/maestro/07-wallets/C000018-master-private-key.yaml
+++ b/maestro/07-wallets/C000018-master-private-key.yaml
@@ -25,7 +25,7 @@ tags:
 
 # View master private key for new wallet
 - tapOn: Assets
-- longPressOn: My Bitcoin
+- longPressOn: ".*My Bitcoin"
 - tapOn: ".*Master Private Key"
 - tapOn: Enter your password
 - inputText: ${output.newAccountPassword}
@@ -47,10 +47,10 @@ tags:
 
 # Locate new wallet and check seed phrase
 - scrollUntilVisible:
-    element: ${WALLET_NAME}
+    element: ${".*" + WALLET_NAME}
     centerElement: true
     direction: DOWN
-- longPressOn: ${WALLET_NAME}
+- longPressOn: ${".*" + WALLET_NAME}
 - tapOn: ".*Master Private Key"
 
 # Password Modal

--- a/maestro/07-wallets/C000029a-migrate-wallets.yaml
+++ b/maestro/07-wallets/C000029a-migrate-wallets.yaml
@@ -17,7 +17,7 @@ env:
     IMPORT_SEED: ${MAESTRO_EDGE_MAX_IMPORT_SEED}
 tags:
 - android
-- C000029
+- C000029a
 ---
 - runFlow:
     file: ../common/launch-cleared.yaml

--- a/maestro/07-wallets/C000032-archive-and-restore-wallets.yaml
+++ b/maestro/07-wallets/C000032-archive-and-restore-wallets.yaml
@@ -22,38 +22,38 @@ tags:
 
 
 # Archive wallets
-- evalScript: ${var walletNames = ["My Bitcoin", "My Bitcoin Cash", "My Dash", "My Ether", "My Litecoin"]}
-- evalScript: ${var index = 0}
+- evalScript: ${output.walletNames = ["My Bitcoin", "My Bitcoin Cash", "My Dash", "My Ether", "My Litecoin"]}
+- evalScript: ${output.index = 0}
 - tapOn: Assets
 - repeat:
-    times: ${walletNames.length - 1}
+    times: ${output.walletNames.length - 1}
     commands:
-      - tapOn: ${walletNames[index]}
+      - tapOn: ${".*" + output.walletNames[output.index]}
       - tapOn: 
           id: gearIcon
       - tapOn: ".*Archive Wallet"
       # Modal
       - assertVisible: "Archive Wallet"
-      - assertVisible: ${"Are you sure you want to archive " + walletNames[index] + "?"}
+      - assertVisible: ${"Are you sure you want to archive " + output.walletNames[output.index] + "?"}
       - assertVisible: Cancel
       # Check if "My Ether" wallet
       - runFlow:
           when:
-            true: ${walletNames[index] == "My Ether"}
+            true: ${output.walletNames[output.index] == "My Ether"}
           commands: 
             - assertVisible: "Archiving this wallet will also archive any enabled tokens for this wallet."
           label: "Extra message for Ether wallets"
       # Archive
       - tapOn: Archive
-      - assertNotVisible: ${walletNames[index]}
+      - assertNotVisible: ${".*" + output.walletNames[output.index]}
       
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
     label: "Archive all wallets except last"
 
 # Unable to archive last wallet
 - runFlow:
     commands: 
-      - longPressOn: ${walletNames[index]}
+      - longPressOn: ${".*" + output.walletNames[output.index]}
       - tapOn: ".*Archive Wallet"
       - assertVisible: "Cannot Archive Wallet"
       - assertVisible: "At least one wallet required in this account."
@@ -80,13 +80,13 @@ tags:
 - assertVisible: "Restore Wallets"
 
 # Toggle on wallets to restore
-- evalScript: ${var walletCurrencyCodes = ["BTC", "BCH", "DASH", "ETH", "LTC"]}
-- evalScript: ${var index = 0}
+- evalScript: ${output.walletCurrencyCodes = ["BTC", "BCH", "DASH", "ETH", "LTC"]}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${walletCurrencyCodes.length - 1}
+    times: ${output.walletCurrencyCodes.length - 1}
     commands:
-      - tapOn: ${walletCurrencyCodes[index]}
-      - evalScript: ${index++}
+      - tapOn: ${output.walletCurrencyCodes[output.index]}
+      - evalScript: ${output.index++}
 - tapOn: Restore
 
 # Modal
@@ -97,14 +97,14 @@ tags:
 
 # Confirm restored and returned to assets screen
 - assertVisible: "Total Balance.*"
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${walletNames.length}
+    times: ${output.walletNames.length}
     commands:
       - scrollUntilVisible:
-          element: ${walletNames[index]}
+          element: ${".*" + output.walletNames[output.index]}
           direction: DOWN
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 # Ensure restore is not tappable when none left to restore
 - tapOn:

--- a/maestro/07-wallets/C000033-pause-wallets.yaml
+++ b/maestro/07-wallets/C000033-pause-wallets.yaml
@@ -29,14 +29,14 @@ tags:
     label: "Import BCH wallet"
 # Find new wallet
 - scrollUntilVisible:
-    element: ${WALLET_NAME}
+    element: ${".*" + WALLET_NAME}
     centerElement: true
     direction: "DOWN"
 # Ensure synced to show balance
 - extendedWaitUntil: 
     visible: ${BALANCE}
     timeout: 20000
-- longPressOn: ${WALLET_NAME}
+- longPressOn: ${".*" + WALLET_NAME}
 
 # Test pause wallet
 - tapOn:
@@ -47,12 +47,12 @@ tags:
       platform: iOS
     commands:
       - assertVisible: "This wallet will no longer synchronize with the blockchain and will not detect new transactions or balance changes"
-- assertVisible: "Wallet Paused"
+- assertVisible: ".*Wallet Paused"
 
 # Wait an arbitrary amount of time to ensure state is saved
 # TODO: Reduce wait period if possible
 - extendedWaitUntil:
-    notVisible: "Wallet Paused"
+    notVisible: ".*Wallet Paused"
     timeout: 45000
     optional: true # Expected to fail
     label: "⏰ Waiting 45 seconds to ensure account state is saved"
@@ -71,10 +71,10 @@ tags:
 # Wait an arbitrary amount of time to ensure wallet is paused and does not sync to show balance
 - tapOn: Assets
 - scrollUntilVisible:
-    element: ${WALLET_NAME}
+    element: ".*Wallet Paused"
     centerElement: true
     direction: "DOWN"
-- assertVisible: "Wallet Paused"
+- assertVisible: ${".*" + WALLET_NAME + ".*Wallet Paused"}
 - extendedWaitUntil:
     visible: ${BALANCE}
     timeout: 10000
@@ -83,7 +83,7 @@ tags:
 - assertNotVisible: ${BALANCE}
 
 # Wallet should sync once you tap into it
-- tapOn: ${WALLET_NAME}
+- tapOn: ".*Wallet Paused"
 - extendedWaitUntil:
     visible: ${BALANCE}
     timeout: 15000
@@ -97,6 +97,6 @@ tags:
     optional: true # Disappears too quick for Android
 - tapOn:
     id: "chevronBack"
-- assertNotVisible: "Wallet Paused"
+- assertNotVisible: ".*Wallet Paused"
 
 - stopApp

--- a/maestro/07-wallets/C000034-detect-disable-tokens.yaml
+++ b/maestro/07-wallets/C000034-detect-disable-tokens.yaml
@@ -15,6 +15,7 @@ env:
     WALLET_NAME: "My Ether"
     ASSET_NAME: "Ethereum"
     TOKEN_NAME: "SHIB" # With balance
+    TOKEN_DISPLAY_NAME: "SHIBA INU"
 tags:
 - all
 - C000034
@@ -39,12 +40,21 @@ tags:
             ASSET_NAMES: ${ASSET_NAME}
             NO_COMPLETE: TRUE
           label: "Import ETH wallet with a token"
+      - extendedWaitUntil:
+          visible: ".*\uEB20"
+          timeout: 30000
       # Complete import
-      - tapOn: Next
+      - tapOn:
+          text: Next
+          waitToSettleTimeoutMs: 100
       # Ensure receive token detected notification and tap on it
+      # After trying several wait/tap patterns, this polling loop has been the
+      # most dependable: the notification disappears after about 5 seconds, so
+      # poll for up to 15 seconds while optional misses keep the loop moving.
+      - evalScript: ${output.deadline = Date.now() + 15000}
       - repeat:
           while:
-            visible: "Total Balance.*"
+            true: ${Date.now() < output.deadline}
           commands:
             - tapOn:
                 text: "Tokens Detected.*"
@@ -55,10 +65,9 @@ tags:
       - assertVisible: "Auto Detected Tokens"
       - assertVisible: "All Tokens"
       - tapOn:
-          text: ${TOKEN_NAME + ".*"}
-          index: 1
-      - tapOn: Done
-      - assertNotVisible: ${TOKEN_NAME}
+          id: ${"manageTokensRow." + TOKEN_NAME + "." + TOKEN_DISPLAY_NAME}
+      - tapOn: Save
+      - assertNotVisible: ${TOKEN_NAME + ".*"}
 
 # # Skip testing resync behavior until changed - expected NOT to rediscover tokens from a resync
 # - runFlow:
@@ -124,7 +133,7 @@ tags:
       - tapOn:
           id: "chevronBack"
       - scrollUntilVisible:
-          element: ${TOKEN_NAME}
+          element: ${TOKEN_NAME + ".*"}
           direction: DOWN
           centerElement: true
           timeout: 10000
@@ -133,11 +142,11 @@ tags:
 - runFlow:
     commands:
       # Hide token from "Disable Token" button in token wallet options menu
-      - longPressOn: ${TOKEN_NAME}
+      - longPressOn: ${TOKEN_NAME + ".*"}
       - tapOn: ".*Disable Token"
       # Modal
       - assertVisible: Disable Token
       - assertVisible: ${"Are you sure you want to disable token " + TOKEN_NAME + " in your " + WALLET_NAME + " wallet?"}
       - assertVisible: Cancel
       - tapOn: Archive
-      - assertNotVisible: ${TOKEN_NAME}
+      - assertNotVisible: ${TOKEN_NAME + ".*"}

--- a/maestro/07-wallets/C000035-get-raw-keys.yaml
+++ b/maestro/07-wallets/C000035-get-raw-keys.yaml
@@ -25,9 +25,25 @@ tags:
 - runFlow:
     file: ../common/dismiss-modals.yaml
 
+# Enable Developer Mode so Get Raw Keys is available
+- tapOn:
+    id: "sideMenuButton"
+- tapOn: "Settings"
+- scrollUntilVisible:
+    element: "Developer Mode"
+    direction: DOWN
+    visibilityPercentage: 100
+- tapOn: "Developer Mode"
+- scrollUntilVisible:
+    element: "Force Light Account Creation"
+    direction: DOWN
+    visibilityPercentage: 50
+- tapOn:
+    id: "chevronBack"
+
 # View master private key for new wallet
 - tapOn: Assets
-- longPressOn: My Bitcoin
+- longPressOn: ".*My Bitcoin"
 - tapOn: ".*Get Raw Keys"
 - tapOn: Enter your password
 - inputText: ${output.newAccountPassword}
@@ -53,10 +69,10 @@ tags:
 
 # Locate new wallet and check seed phrase
 - scrollUntilVisible:
-    element: ETH
+    element: "ETH.*"
     direction: DOWN
     centerElement: true
-- longPressOn: ETH
+- longPressOn: "ETH.*"
 - tapOn: ".*Get Raw Keys"
 
 # Password Modal

--- a/maestro/07-wallets/C000036-autodetect-all-networks.yaml
+++ b/maestro/07-wallets/C000036-autodetect-all-networks.yaml
@@ -23,8 +23,8 @@ tags:
 # All networks that support tokens (and import seed)
 # EVMs: Only Sonic and Pulsechain (others tested via regular asset sync)
 - evalScript: ${
-    var wallets = '[
-      "Coreum",
+    output.wallets = '[
+      "TX",
       "Osmosis",
       "Avalanche",
       "Solana",
@@ -40,7 +40,7 @@ tags:
 - runFlow:
     file: ../common/import-wallets.yaml
     env:
-      ASSET_NAMES: ${wallets}
+      ASSET_NAMES: ${output.wallets}
     # label: "Import wallets"
 
 - runFlow:
@@ -54,7 +54,7 @@ tags:
 
 # Tokens matching the imported networks
 - evalScript: ${
-    var tokens = [
+    output.tokens = [
       "ATOM",
       "JOE",
       "PYTH",
@@ -94,17 +94,17 @@ tags:
 #     visible: ${".*New tokens were detected and enabled on " + WALLET_NAME + ".*"}
 #     timeout: 60000
 
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${tokens.length}
+    times: ${output.tokens.length}
     commands:
       - scrollUntilVisible:
-          element: ${tokens[index]}
+          element: ${output.tokens[output.index] + ".*"}
           direction: UP
           timeout: 20000
           optional: true
       - scrollUntilVisible:
-          element: ${tokens[index]}
+          element: ${output.tokens[output.index] + ".*"}
           direction: DOWN
           timeout: 90000
       - scrollUntilVisible:
@@ -114,7 +114,7 @@ tags:
           timeout: 10000
           optional: true
           label: "Scroll to bottom."
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 
 

--- a/maestro/07-wallets/C000037-split-wallets.yaml
+++ b/maestro/07-wallets/C000037-split-wallets.yaml
@@ -36,49 +36,51 @@ tags:
 # Navigate to Base wallet
 - tapOn: Assets
 - scrollUntilVisible:
-    element: "My Base"
+    element: ".*My Base"
     direction: DOWN
     timeout: 10000
 
 # Open wallet options menu
-- longPressOn: "My Base"
+- longPressOn: ".*My Base"
 
 # Verify split option is available and tap it
-- tapOn: ".*Split Wallet"
+- tapOn:
+    id: walletListMenu_split
 
 # Select Ethereum as target
-- assertVisible: Create Wallet From Seed
+- assertVisible: Split Wallet
 - assertVisible: Search Wallets
-- tapOn: ".*Ethereum"
-- tapOn: Next
+- tapOn:
+    id: "createWalletRow.create-wallet:ethereum-ethereum"
+- tapOn:
+    id: nextButton
 
 # Next scene
 - assertVisible: Split Wallet
-- assertVisible: This action creates wallets from pre-existing wallets.
-- assertVisible: Tap on wallet to edit name
-- evalScript: ${var newETHName = ".*My Ether \\(Split from My Base\\).*"}
-- assertVisible: ${newETHName}
+- assertVisible: EVM-compatible networks share the.*existing address.
+- assertVisible: Tap on wallet to edit settings
+- evalScript: ${output.newETHName = ".*My Ether \\(Split from My Base\\).*"}
+- assertVisible: ${output.newETHName}
 
 # Rename modal
 - tapOn: 
     text: ${"ETH.*"}
     index: 0
 - tapOn:
-    id: "undefined.clearIcon"
+    id: "walletSettingsNameInput.clearIcon"
 - inputRandomText
 ## Unable to target text input field to test changing name
 # - copyTextFrom:
 #     id: "undefined.textInput"
 # - evalScript: ${var newETHName = maestro.copiedText}
-# - tapOn: Submit
-- assertVisible: Submit
+# - tapOn: Done
+- assertVisible: Done
 - tapOn:
     id: "modal-close-button"
 
 # Button shares name with scene title
-- tapOn: 
-    text: Split Wallet
-    index: 1
+- tapOn:
+    id: splitWalletConfirmButton
 
 
 
@@ -98,7 +100,7 @@ tags:
 
 # - assertVisible: Split Wallet
 # - assertVisible: This action creates wallets from pre-existing wallets.
-# - assertVisible: Tap on wallet to edit name
+# - assertVisible: Tap on wallet to edit settings
 # - evalScript: ${var newBTCName = ".*My Bitcoin \\(Split from My Litecoin\\).*"}
 # - assertVisible: ${newBTCName}
 # - tapOn: 
@@ -109,7 +111,7 @@ tags:
 ## Verify new wallets and balances
 # ETH recovered
 - scrollUntilVisible:
-    element: ${newETHName}
+    element: ${output.newETHName}
     direction: DOWN
     centerElement: true
     timeout: 10000

--- a/maestro/07-wallets/C000043-private-view-key.yaml
+++ b/maestro/07-wallets/C000043-private-view-key.yaml
@@ -21,20 +21,20 @@ tags:
 # Monero/Zano (CryptoNote): 64-char hex
 # Zcash/Pirate (zk-SNARKs): longer alphanumeric strings
 - evalScript: ${
-    var walletFormats = {
+    output.walletFormats = {
       "Monero":"[a-fA-F0-9]{64}",
       "Pirate Chain":"[a-zA-Z0-9]{64,}",
       "Zcash":"[a-zA-Z0-9]{64,}",
       "Zano":"[a-fA-F0-9]{64}"
     }
     }
-- evalScript: ${var walletNames = Object.keys(walletFormats)}
+- evalScript: ${output.walletNames = Object.keys(output.walletFormats)}
 
 # Create account with wallets that support private view key
 - runFlow:
     file: ../common/create-account.yaml
     env:
-      NEW_WALLETS: ${JSON.stringify(walletNames)}
+      NEW_WALLETS: ${JSON.stringify(output.walletNames)}
     label: "Add wallets with private view key support"
 
 - runFlow:
@@ -43,17 +43,17 @@ tags:
 - tapOn: Assets
 
 # Loop over each wallet and test Private View Key
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${walletNames.length}
+    times: ${output.walletNames.length}
     commands:
       # Wallet nickname often excludes extra words (e.g. "Pirate Chain" -> "Pirate")
-      - evalScript: ${var nickName = "My " + walletNames[index].split(" ")[0]}
+      - evalScript: ${output.nickName = ".*My " + output.walletNames[output.index].split(" ")[0]}
       - scrollUntilVisible:
-          element: ${nickName}
+          element: ${output.nickName}
           direction: DOWN
           centerElement: true
-      - longPressOn: ${nickName}
+      - longPressOn: ${output.nickName}
       - assertVisible: ".*Private View Key"
       - tapOn: ".*Private View Key"
       # Private View Key Modal
@@ -63,9 +63,9 @@ tags:
       - assertVisible: "Copy"
       # Validate view key format for this network
       - assertVisible:
-          text: ${walletFormats[walletNames[index]]}
+          text: ${output.walletFormats[output.walletNames[output.index]]}
       - tapOn:
           id: "modal-close-button"
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 # - stopApp

--- a/maestro/07-wallets/C000044-create-all-wallet-types.yaml
+++ b/maestro/07-wallets/C000044-create-all-wallet-types.yaml
@@ -29,10 +29,10 @@ tags:
     file: ../common/no-errors.yaml
 
 # Validate that all wallets were created
-- evalScript: ${var index = 0}
-- evalScript: ${var walletNames = JSON.parse(output.assetNames)}
+- evalScript: ${output.index = 0}
+- evalScript: ${output.walletNames = JSON.parse(output.assetNames)}
 - repeat:
-    times: ${walletNames.length}
+    times: ${output.walletNames.length}
     commands:      
       # option 1
       # Preferred quicker method, but iOS wallet search is not currently reliable when maestro types too fast
@@ -45,9 +45,9 @@ tags:
       
       # Option 2
       # Wallet nickname often excludes extra words (e.g. "Pirate Chain" -> "My Pirate")
-      - evalScript: ${var nickName = "My " + walletNames[index].split(" ")[0] + ".*"}
+      - evalScript: ${output.nickName = ".*My " + output.walletNames[output.index].split(" ")[0] + ".*"}
       # Hack to address inconsistent wallet name for XRP
-      - evalScript: ${if (walletNames[index] === "XRPL") { nickName = "My XRP"}}
+      - evalScript: ${if (output.walletNames[output.index] === "XRPL") { output.nickName = ".*My XRP"}}
       - retry:
           maxRetries: 2
           commands:
@@ -57,9 +57,9 @@ tags:
                 speed: 150
                 timeout: 30000
             - scrollUntilVisible:
-                element: ${nickName}
+                element: ${output.nickName}
                 centerElement: true
                 timeout: 60000
                 speed: 5
 
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}

--- a/maestro/07-wallets/C000045-add-edit-tokens.yaml
+++ b/maestro/07-wallets/C000045-add-edit-tokens.yaml
@@ -38,10 +38,10 @@ tags:
 # Navigate to scene
 - tapOn: Assets
 - scrollUntilVisible:
-    element: ETH
+    element: "ETH.*"
     direction: DOWN
     centerElement: true
-- longPressOn: ETH
+- longPressOn: "ETH.*"
 - tapOn: ".*Add / Edit Tokens"
 
 # Test search
@@ -50,9 +50,8 @@ tags:
 - pressKey: Enter
 
 # First time token warning modal
-- tapOn: 
-    text: "1INCH.*"
-    index: 2
+- tapOn:
+    id: manageTokensRow.1INCH.1inch
 - assertVisible: "ETH Needed to Send Tokens"
 - tapOn: "ETH is required to pay the mining fees when sending tokens. The associated ETH wallet must contain a sufficient.*"
 - tapOn: "Please confirm your understanding below:"
@@ -117,19 +116,17 @@ tags:
                 timeout: 15000
       # Save token
       - tapOn: Save
-      - assertVisible: ".*MOG.*"
-      
-    
+
 # Confirm
-- tapOn: Done
+- tapOn: Save
 
 # Ensure tokens are visible
 - scrollUntilVisible:
-    element: 1INCH
+    element: "1INCH.*"
     direction: DOWN
     timeout: 10000
 - scrollUntilVisible:
-    element: Mog
+    element: "MOG.*"
     direction: DOWN
     centerElement: true
     timeout: 10000
@@ -158,11 +155,11 @@ tags:
 
 - tapOn: Assets
 - scrollUntilVisible: 
-    element: "Mog"
+    element: "MOG.*"
     direction: DOWN
     centerElement: true
     timeout: 10000
-- tapOn: Mog
+- tapOn: "MOG.*"
 
 - extendedWaitUntil:
     visible: ".*348,083.*"

--- a/maestro/07-wallets/C000046-rename-wallet.yaml
+++ b/maestro/07-wallets/C000046-rename-wallet.yaml
@@ -19,22 +19,24 @@ tags:
     file: ../common/dismiss-modals.yaml
 
 - tapOn: Assets
-- longPressOn: ${WALLET_NAME}
-- tapOn: ".*Rename"
-# Modal
-- assertVisible: Rename Wallet
+- longPressOn: ${".*" + WALLET_NAME}
+- tapOn:
+    id: "walletListMenu_walletSettings"
+# Wallet Settings modal
+- assertVisible: Wallet Settings
 - assertVisible:
     id: "modal-close-button"
 - tapOn:
-    id: "undefined.clearIcon"
+    id: "walletSettingsNameInput.clearIcon"
 - inputRandomText
 # Copy new name and save
 - copyTextFrom:
-    id: "undefined.textInput"
-- evalScript: ${var newWalletName = maestro.copiedText}
-- tapOn: Submit
+    id: "walletSettingsNameInput.textInput"
+- evalScript: ${output.newWalletName = maestro.copiedText}
+- tapOn:
+    id: "walletSettingsDoneButton"
 
-- assertVisible: ${newWalletName}
+- assertVisible: ${".*" + output.newWalletName}
 # Arbitrary wait to ensure wallet state is saved to sync server (~30 seconds)
 - extendedWaitUntil:
     visible: ${WALLET_NAME}
@@ -54,4 +56,4 @@ tags:
     file: ../common/dismiss-modals.yaml
 
 - tapOn: Assets
-- assertVisible: ${newWalletName}
+- assertVisible: ${".*" + output.newWalletName}

--- a/maestro/07-wallets/C000047-view-xpub.yaml
+++ b/maestro/07-wallets/C000047-view-xpub.yaml
@@ -25,7 +25,7 @@ tags:
 
 # View xpub for new Dash wallet (created by default)
 - tapOn: Assets
-- longPressOn: My Dash
+- longPressOn: ".*My Dash"
 - tapOn: ".*View XPub Address"
 - assertVisible: "View XPub Address"
 # Dash xpub starts with "drkp" followed by base58 characters (111 chars total)
@@ -46,9 +46,9 @@ tags:
 
 # View xpub for imported Dogecoin wallet
 - scrollUntilVisible:
-    element: "My Doge"
+    element: ".*My Doge"
     direction: DOWN
-- longPressOn: "My Doge"
+- longPressOn: ".*My Doge"
 - tapOn: ".*View XPub Address"
 - assertVisible: "View XPub Address"
 # Dogecoin xpub starts with "dgub" followed by base58 characters (111 chars total)
@@ -61,4 +61,3 @@ tags:
 - assertVisible: Assets
 
 - stopApp
-

--- a/maestro/07-wallets/C000048-split-all-evm.yaml
+++ b/maestro/07-wallets/C000048-split-all-evm.yaml
@@ -23,23 +23,23 @@ tags:
 # Navigate to Ethereum wallet
 - tapOn: Assets
 - scrollUntilVisible:
-    element: "My Ether"
+    element: ".*My Ether"
     direction: DOWN
     timeout: 10000
 
 # Open wallet options menu
-- longPressOn: "My Ether"
+- longPressOn: ".*My Ether"
 
 # Verify split option is available and tap it
 - tapOn: ".*Split Wallet"
 
 # Verify split wallet scene
-- assertVisible: Create Wallet From Seed
+- assertVisible: Split Wallet
 - assertVisible: Search Wallets
 
 # Define expected EVM networks (ordered by appearance)
 - evalScript: |
-    ${var evmNetworks = [
+    ${output.evmNetworks = [
       "zkSync",
       "Optimism",
       "Ethereum Classic",
@@ -49,10 +49,10 @@ tags:
       "Avalanche",
       "BNB Smart Chain",
       "BOB",
+      "Robinhood Chain",
       "Abstract",
       "Arbitrum One",
       "Base",
-      "Botanix Bitcoin",
       "Celo",
       "EthereumPoW",
       "Filecoin FEVM",
@@ -62,9 +62,9 @@ tags:
     ]}
 
 # Loop over each network and scroll until visible
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${evmNetworks.length}
+    times: ${output.evmNetworks.length}
     commands:
     #   # Once search can accomodate multiple words
     #   # Search is slower but more reliable
@@ -82,15 +82,15 @@ tags:
           maxRetries: 2
           commands:
             - scrollUntilVisible:
-                element: ${".*" + evmNetworks[index]}
+                element: ${".*" + output.evmNetworks[output.index]}
                 direction: DOWN
                 centerElement: true
                 speed: 1
                 timeout: 1000
                 optional: true
-            - tapOn: ${".*" + evmNetworks[index]}
+            - tapOn: ${".*" + output.evmNetworks[output.index]}
                 
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
     
 - tapOn: Next
 
@@ -108,4 +108,3 @@ tags:
 
 
 - stopApp
-

--- a/maestro/10-assets/C184035-utxo-01.yaml
+++ b/maestro/10-assets/C184035-utxo-01.yaml
@@ -26,49 +26,49 @@ tags:
 - tapOn: "Assets"
 
 - extendedWaitUntil:
-    visible: FIRO
+    visible: "FIRO.*"
     timeout: 15000
-- tapOn: FIRO
+- tapOn: "FIRO.*"
 - extendedWaitUntil:
     visible: 0.369074 FIRO
     timeout: 50000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: DGB
+    element: "DGB.*"
     direction: DOWN
-- tapOn: DGB
+- tapOn: "DGB.*"
 - extendedWaitUntil:
     visible: 18.79649375 DGB
     timeout: 15000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: DOGE
+    element: "DOGE.*"
     direction: DOWN
-- tapOn: DOGE
+- tapOn: "DOGE.*"
 - extendedWaitUntil:
     visible: 25.81052584 DOGE
     timeout: 15000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: RVN
+    element: "RVN.*"
     direction: DOWN
     centerElement: true
     timeout: 50000
-- tapOn: RVN
+- tapOn: "RVN.*"
 - extendedWaitUntil:
     visible: 22.85548 RVN
     timeout: 15000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: BCH
+    element: "BCH.*"
     direction: DOWN
     centerElement: true
     timeout: 50000
-- tapOn: BCH
+- tapOn: "BCH.*"
 - extendedWaitUntil:
     visible: 0.00588867 BCH
     timeout: 15000
@@ -76,99 +76,77 @@ tags:
 
 
 - scrollUntilVisible:
-    element: DASH
+    element: "DASH.*"
     direction: DOWN
     centerElement: true
     timeout: 50000
-- tapOn: DASH
+- tapOn: "DASH.*"
 - extendedWaitUntil:
     visible: 0.03081175 DASH
     timeout: 15000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: QTUM
+    element: "QTUM.*"
     direction: DOWN
     centerElement: true
     timeout: 50000
-- tapOn: QTUM
+- tapOn: "QTUM.*"
 - extendedWaitUntil:
     visible: 0.17765112 QTUM
     timeout: 15000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: BTG
+    element: "BTG.*"
     direction: DOWN
     centerElement: true
     timeout: 50000
-- tapOn: BTG
+- tapOn: "BTG.*"
 - extendedWaitUntil:
     visible: 0 BTG
     timeout: 15000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: LTC
+    element: "LTC.*"
     direction: DOWN
     centerElement: true
     timeout: 50000
-- tapOn: LTC
+- tapOn: "LTC.*"
 - extendedWaitUntil:
     visible: 0.00921812 LTC
     timeout: 15000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: BTC
+    element: "BTC.*"
     direction: DOWN
     centerElement: true
     timeout: 50000
-- tapOn: BTC
+- tapOn: "BTC.*"
 - extendedWaitUntil:
     visible: 0.00013643 BTC
     timeout: 15000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: VTC
+    element: "VTC.*"
     direction: DOWN
     centerElement: true
     timeout: 50000
-- tapOn: VTC
+- tapOn: "VTC.*"
 - extendedWaitUntil:
     visible: 0.1430639 VTC
     timeout: 15000
 - tapOn: Assets
 
 - scrollUntilVisible:
-    element: GRS
+    element: "PIVX.*"
     direction: DOWN
     centerElement: true
     timeout: 50000
-- tapOn: GRS
-- extendedWaitUntil:
-    visible: 1.43161025 GRS
-    timeout: 15000
-- tapOn: Assets
-
-- scrollUntilVisible:
-    element: UFO
-    direction: DOWN
-    centerElement: true
-    timeout: 50000
-- tapOn: UFO
-- extendedWaitUntil:
-    visible: "1,337 UFO"
-    timeout: 15000
-- tapOn: Assets
-
-- scrollUntilVisible:
-    element: PIVX
-    direction: DOWN
-    centerElement: true
-    timeout: 50000
-- tapOn: PIVX
+- tapOn: "PIVX.*"
 - extendedWaitUntil:
     visible: 0.611 PIVX
     timeout: 15000

--- a/maestro/10-assets/C209290-xmr-01.yaml
+++ b/maestro/10-assets/C209290-xmr-01.yaml
@@ -25,9 +25,9 @@ tags:
 - tapOn: Assets
 
 - extendedWaitUntil:
-    visible: XMR
+    visible: "XMR.*"
     timeout: 15000
-- tapOn: XMR
+- tapOn: "XMR.*"
 - extendedWaitUntil:
     visible: 0.0112 XMR
     timeout: 15000

--- a/maestro/10-assets/C999000-tx-details.yaml
+++ b/maestro/10-assets/C999000-tx-details.yaml
@@ -22,9 +22,9 @@ tags:
 
 - tapOn: "Assets"
 - extendedWaitUntil:
-    visible: My Bitcoin
+    visible: ".*My Bitcoin"
     timeout: 15000
-- tapOn: My Bitcoin
+- tapOn: ".*My Bitcoin"
 - extendedWaitUntil:
     visible: 0.00003462 BTC
     timeout: 15000
@@ -68,4 +68,3 @@ tags:
 - assertVisible: "Bitcoin Network"
 
 - stopApp
-

--- a/maestro/10-assets/C999004-no-crash-max-xrp-dex.yaml
+++ b/maestro/10-assets/C999004-no-crash-max-xrp-dex.yaml
@@ -24,21 +24,19 @@ tags:
     visible: "Wallets"
     timeout: 15000
 - extendedWaitUntil:
-    visible: "My XRP"
+    visible: ".*My XRP"
     timeout: 15000
 - assertVisible:
     text: "Exchange"
 - tapOn: "Exchange"
 - tapOn: "Select Source Wallet"
 - tapOn:
-    text: "XRP"
+    text: "XRP(?: .*)?"
 - tapOn: "Select Receiving Wallet"
-- tapOn: "Ripple USD"
+- tapOn: "Ripple USD.*"
 - tapOn: "MAX"
 - extendedWaitUntil:
-    visible: "Exchange"
+    visible: "Tap to Change Provider"
     timeout: 15000
-- assertVisible:
-    text: "Tap to Change Provider"
 
 - stopApp

--- a/maestro/13-settings/C999003-help-logged-in.yaml
+++ b/maestro/13-settings/C999003-help-logged-in.yaml
@@ -32,12 +32,11 @@ tags:
 - assertVisible: "Thanks for using Edge!"
 - assertVisible: "Knowledge Base"
 - assertVisible: "Live Chat"
-- assertVisible: "Submit a Support Ticket"
 - assertVisible: "Call for Assistance"
 - assertVisible: "Visit Official Site"
 - tapOn: "Knowledge Base"
 - extendedWaitUntil:
-    visible: "Edge Help Center home page"
+    visible: ".*Troubleshooting for Edge related issues.*"
     timeout: 15000
 - assertVisible:
     id: "chevronBack"
@@ -48,18 +47,13 @@ tags:
 - tapOn: "Live Chat"
 # Ensure it opens to correct page AND chat is open
 - assertVisible: ".*support\\.edge\\.app.*" 
-- assertVisible: "Options menu"
+- assertVisible: ".*Need Help\\? Reach Out via Our Chat Bubble!.*"
+# Call button opens in phone app
 - launchApp:
     stopApp: false
 - extendedWaitUntil:
-    visible: "Submit a Support Ticket"
+    visible: "Call for Assistance"
     timeout: 15000
-- tapOn: "Submit a Support Ticket"
-- assertVisible: "Submit a Request"
-- tapOn:
-    id: "chevronBack"
-# Call button opens in phone app
-- tapOn: "Help"
 - tapOn: "Call for Assistance"
 # Optional for iOS simulator (unable to open phone app)
 - extendedWaitUntil:
@@ -78,4 +72,3 @@ tags:
     id: "chevronBack"
 
 - stopApp
-

--- a/maestro/99-misc/C999001-receive.yaml
+++ b/maestro/99-misc/C999001-receive.yaml
@@ -21,9 +21,9 @@ tags:
 
 - tapOn: Assets
 - extendedWaitUntil:
-    visible: DGB
+    visible: "DGB.*"
     timeout: 15000
-- tapOn: DGB
+- tapOn: "DGB.*"
 - extendedWaitUntil:
     visible: 18.79649375 DGB
     timeout: 15000

--- a/maestro/common/add-wallets.yaml
+++ b/maestro/common/add-wallets.yaml
@@ -8,8 +8,8 @@ appId: ${MAESTRO_APP_ID}
 env:
     ASSET_NAMES: ${ASSET_NAMES || ""}
 ---
-# Parse if an array/list- all passed env become strings with maestro's Rhino JS runtime
-- evalScript: ${if (ASSET_NAMES.startsWith('[')) ASSET_NAMES = JSON.parse(ASSET_NAMES); else ASSET_NAMES = [ASSET_NAMES]}
+# Parse if an array/list; all passed env values become strings
+- evalScript: ${if (ASSET_NAMES.startsWith('[')) output.ASSET_NAMES = JSON.parse(ASSET_NAMES); else output.ASSET_NAMES = [ASSET_NAMES]}
 
 - tapOn: Assets
 - tapOn:
@@ -17,17 +17,17 @@ env:
 - tapOn: Search Wallets
 
 # Loop over wallet names and add them
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${ASSET_NAMES.length}
+    times: ${output.ASSET_NAMES.length}
     commands:
       - tapOn:
           id: "undefined.clearIcon"
-      - inputText: ${ASSET_NAMES[index]}
+      - inputText: ${output.ASSET_NAMES[output.index]}
       - tapOn:
-          text: ${".*" + ASSET_NAMES[index]}
+          text: ${".*" + output.ASSET_NAMES[output.index]}
           index: 1 # First index is thesearch bar
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 - tapOn: Next
 

--- a/maestro/common/create-account.yaml
+++ b/maestro/common/create-account.yaml
@@ -131,30 +131,29 @@ env:
       true: ${NEW_WALLETS}
     commands:
       # Remove default wallets
-      - evalScript: ${var wallets = JSON.parse(NEW_WALLETS)}
-      - evalScript: ${var defaults = JSON.parse(DEFAULT_WALLETS)}
-      - evalScript: ${var filteredDefaults = defaults.filter(d => !wallets.includes(d))}
-      - evalScript: ${var filteredWallets = wallets.filter(w => !defaults.includes(w))}
-      - evalScript: ${var defIndex = 0}
+      - evalScript: ${output.wallets = JSON.parse(NEW_WALLETS)}
+      - evalScript: ${output.defaults = JSON.parse(DEFAULT_WALLETS)}
+      - evalScript: ${output.filteredDefaults = output.defaults.filter(d => !output.wallets.includes(d))}
+      - evalScript: ${output.filteredWallets = output.wallets.filter(w => !output.defaults.includes(w))}
+      - evalScript: ${output.defIndex = 0}
       - repeat:
-          times: ${filteredDefaults.length}
+          times: ${output.filteredDefaults.length}
           commands:
-            - tapOn: ${".*" + filteredDefaults[defIndex]}
-            - evalScript: ${defIndex++}
+            - tapOn: ${".*" + output.filteredDefaults[output.defIndex]}
+            - evalScript: ${output.defIndex++}
       # Add new wallets
-      - evalScript: ${var newIndex = 0}
+      - evalScript: ${output.newIndex = 0}
       - repeat:
-          times: ${filteredWallets.length}
+          times: ${output.filteredWallets.length}
           commands:
             - tapOn: Search Wallets
             - tapOn:
                 id: "undefined.clearIcon"
-            - inputText: ${filteredWallets[newIndex]}
+            - inputText: ${output.filteredWallets[output.newIndex]}
             - tapOn:
-                text: ${".*" + filteredWallets[newIndex]}
+                text: ${".*" + output.filteredWallets[output.newIndex]}
                 index: 1
-            - evalScript: ${newIndex++}
+            - evalScript: ${output.newIndex++}
 
 - tapOn:
     id: "nextButton"
-

--- a/maestro/common/import-wallets.yaml
+++ b/maestro/common/import-wallets.yaml
@@ -8,7 +8,7 @@ env:
     ZCASH_BDAY: ${ZCASH_BDAY || ""}
 ---
 # Parse env so we can accept a string or array input
-- evalScript: ${if (ASSET_NAMES.startsWith('[')) ASSET_NAMES = JSON.parse(ASSET_NAMES); else ASSET_NAMES = [ASSET_NAMES]}
+- evalScript: ${if (ASSET_NAMES.startsWith('[')) output.ASSET_NAMES = JSON.parse(ASSET_NAMES); else output.ASSET_NAMES = [ASSET_NAMES]}
 
 # Open add wallet screen
 - tapOn: Assets
@@ -17,21 +17,21 @@ env:
 - tapOn: Search Wallets
 
 # Loop over wallet names and import them
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 - repeat:
-    times: ${ASSET_NAMES.length}
+    times: ${output.ASSET_NAMES.length}
     commands:
-      - evalScript: ${var assetName = ASSET_NAMES[index]}
+      - evalScript: ${output.assetName = output.ASSET_NAMES[output.index]}
       - tapOn:
           id: "undefined.clearIcon"
-      - inputText: ${assetName}
+      - inputText: ${output.assetName}
       
       # Escape parentheses for regex matching - "Bitcoin (no Segwit)" breaks flow otherwise
-      - evalScript: ${assetName = assetName.replace(/\(/g, '\\(').replace(/\)/g, '\\)')}
+      - evalScript: ${output.assetName = output.assetName.replace(/\(/g, '\\(').replace(/\)/g, '\\)')}
       - tapOn:
-          text: ${".*" + assetName}
-          index: 1 # First index is thesearch bar
-      - evalScript: ${index++}
+          text: ${".*" + output.assetName}
+          index: 1 # First index is the search bar
+      - evalScript: ${output.index++}
 
 - tapOn: Next
 - tapOn: Import Wallets
@@ -47,11 +47,15 @@ env:
         - hideKeyboard
         - tapOn: "Enter your.*"
 # Drop keyboard - iOS
+# Do not press Enter/Return: seed field is multiline, returnKeyType=none,
+# blurOnSubmit=false. Tapping the field label also fails to dismiss. Tap the
+# non-interactive instruction paragraph (Maestro iOS keyboard workaround).
 - runFlow:
     when:
       platform: iOS
     commands:
-        - tapOn: "Private Key or Private Seed"
+        - tapOn:
+            text: "^Enter your private seed, private key, or active key to verify and restore the associated wallet$"
 
 - tapOn: Next
 
@@ -64,7 +68,7 @@ env:
 
 # Add birthday height for Zcash and Pirate Chain
 # Index for targetting the correct "edit" icon 
-- evalScript: ${var index = 0}
+- evalScript: ${output.index = 0}
 # Pirate Chain on top if both are displayed
 - runFlow:
     when:
@@ -72,10 +76,10 @@ env:
     commands:
       - tapOn: 
           text: ""
-          index: ${index}
+          index: ${output.index}
       - inputText: ${PIRATE_BDAY}
       - tapOn: Submit
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 # Zcash birthday
 - runFlow:
     when:
@@ -83,19 +87,27 @@ env:
     commands:
       - tapOn: 
           text: ""
-          index: ${index}
+          index: ${output.index}
       - inputText: ${ZCASH_BDAY}
       - tapOn: Submit
-      - evalScript: ${index++}
+      - evalScript: ${output.index++}
 
 
-# tap on next until it becomes tapable and works to see "assets" button
-# skip if NO_COMPLETE is true (for autodetect tokens flow test)
-- repeat:
-    while:
-      visible: Next
+# Complete the import unless the caller intentionally stops early
+# to test the auto-detected-token notification.
+- runFlow:
+    when:
       true: ${!NO_COMPLETE}
     commands:
-      - tapOn: 
-          text: Next
-          optional: true
+      # Bound retries so a stuck Next button cannot hang the suite.
+      - repeat:
+          times: 10
+          while:
+            visible: Next
+          commands:
+            - tapOn:
+                text: Next
+                optional: true
+
+      # A bounded repeat can exhaust successfully, so verify completion.
+      - assertNotVisible: Next

--- a/src/components/modals/WalletSettingsModal.tsx
+++ b/src/components/modals/WalletSettingsModal.tsx
@@ -157,6 +157,7 @@ export const WalletSettingsModal: React.FC<Props> = props => {
       scroll
     >
       <ModalFilledTextInput
+        testID="walletSettingsNameInput"
         autoCorrect={false}
         autoFocus={false}
         value={name}
@@ -208,6 +209,7 @@ export const WalletSettingsModal: React.FC<Props> = props => {
       <ModalButtons
         primary={{
           label: lstrings.string_done_cap,
+          testID: 'walletSettingsDoneButton',
           onPress: handleSubmit,
           disabled: isSubmitting,
           spinner: isSubmitting

--- a/src/components/scenes/CreateWalletEditNameScene.tsx
+++ b/src/components/scenes/CreateWalletEditNameScene.tsx
@@ -441,7 +441,8 @@ const CreateWalletEditNameComponent: React.FC<Props> = props => {
           <ButtonsView
             primary={{
               label: lstrings.fragment_wallets_split_wallet,
-              onPress: handleSplit
+              onPress: handleSplit,
+              testID: 'splitWalletConfirmButton'
             }}
           />
         ) : (

--- a/src/components/themed/ManageTokensRow.tsx
+++ b/src/components/themed/ManageTokensRow.tsx
@@ -83,7 +83,11 @@ export const ManageTokensRowComponent: React.FC<Props> = props => {
   })
 
   return (
-    <Pressable style={styles.row} onPress={handleToggle}>
+    <Pressable
+      style={styles.row}
+      testID={`manageTokensRow.${token.currencyCode}.${token.displayName}`}
+      onPress={handleToggle}
+    >
       <CryptoIcon
         marginRem={[0, 0.5, 0, 0]} // We don't need left margins because there's no border. This component effectively is the left "border"
         sizeRem={2}


### PR DESCRIPTION
Backport #6172 to `staging` to repair Maestro account, wallet, and asset flows and their accessibility selectors, including Robinhood Chain split coverage.

Cherry-picked merge commit `9b59394caeb290152a9a0fcb45c6977d504d9ee9` with parent 1. The resulting patch matches the original PR exactly and applied without conflicts. Staging already includes Robinhood Chain support.

Validation: patch identity and whitespace checks passed; C000048 Maestro syntax passed. The original changes were Maestro-tested before merging into develop; the staging suite has not been rerun.

### CHANGELOG

- [x] Yes — original entries included
- [ ] No

### Dependencies

None.

### Requirements

No visual GUI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production impact is limited to non-functional testID attributes; remaining changes are Maestro scripts and changelog notes.
> 
> **Overview**
> Backports Maestro stability work from develop: **CHANGELOG** notes new **testIDs** on Manage Tokens rows, Wallet Settings name/Done, and the split-wallet confirm button, matching small **React Native** hooks in `WalletSettingsModal`, `CreateWalletEditNameScene`, and `ManageTokensRow`.
> 
> The bulk of the diff updates **Maestro YAML** flows—accounts, login (2FA, PIN, password clear), wallets, assets, settings, and shared helpers—to use the `output.*` script pattern, regex wallet row labels (e.g. `".*My Bitcoin"`), and **id**-based taps where text was flaky (`usernameFormField`, security-alert deny buttons, `manageTokensRow.*`, split/create-wallet rows). Flows also track UI copy changes (Wallet Settings vs Rename, Save vs Done, 2FA wording), import-keyboard workarounds on iOS, bounded **Next** retries in `import-wallets.yaml`, and trimmed or retargeted asset checks (e.g. UTXO suite, help/live chat assertions). **C000048** refreshs the expected EVM split list (adds Robinhood Chain, drops Botanix Bitcoin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa81723e7e53e968145cbfbe87f1c8eab28a4f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->