### PR TITLE
Standardize wallet test ID separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (develop)
 
+- changed: Standardize wallet list automation test IDs to use period separators.
+
 ## 4.51.0 (staging)
 
 - added: Robinhood Chain wallets

--- a/maestro/07-wallets/C000037-split-wallets.yaml
+++ b/maestro/07-wallets/C000037-split-wallets.yaml
@@ -45,7 +45,7 @@ tags:
 
 # Verify split option is available and tap it
 - tapOn:
-    id: walletListMenu_split
+    id: walletListMenu.split
 
 # Select Ethereum as target
 - assertVisible: Split Wallet

--- a/maestro/07-wallets/C000046-rename-wallet.yaml
+++ b/maestro/07-wallets/C000046-rename-wallet.yaml
@@ -21,7 +21,7 @@ tags:
 - tapOn: Assets
 - longPressOn: ${".*" + WALLET_NAME}
 - tapOn:
-    id: "walletListMenu_walletSettings"
+    id: walletListMenu.walletSettings
 # Wallet Settings modal
 - assertVisible: Wallet Settings
 - assertVisible:

--- a/src/components/modals/WalletListMenuModal.tsx
+++ b/src/components/modals/WalletListMenuModal.tsx
@@ -353,7 +353,7 @@ export const WalletListMenuModal: React.FC<Props> = props => {
         return (
           <EdgeTouchableOpacity
             key={option.value}
-            testID={`walletListMenu_${option.value}`}
+            testID={`walletListMenu.${option.value}`}
             onPress={async () => {
               await optionAction(option.value)
             }}

--- a/src/components/themed/WalletListCurrencyRow.tsx
+++ b/src/components/themed/WalletListCurrencyRow.tsx
@@ -178,7 +178,7 @@ const WalletListCurrencyRowComponent: React.FC<Props> = props => {
     <View
       accessible
       accessibilityRole="button"
-      testID={`walletListRow_${walletName}_${displayCurrencyCode}`}
+      testID={`walletListRow.${walletName}.${displayCurrencyCode}`}
     >
       <EdgeCard
         icon={iconNode}


### PR DESCRIPTION
### Description

Standardize composed wallet-list automation identifiers on period separators.

- `walletListMenu.{option}` replaces `walletListMenu_{option}`.
- `walletListRow.{walletName}.{displayCurrencyCode}` replaces the underscore-separated form.
- Maestro flows C000037 and C000046 now use the updated menu identifiers.

This only changes automation identifiers; wallet behavior, rendering, navigation, and accessibility labels remain unchanged.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

No visual GUI changes.

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Validation

- `npx eslint --concurrency=auto src/components/modals/WalletListMenuModal.tsx src/components/themed/WalletListCurrencyRow.tsx` (zero errors; one pre-existing warning)
- `npx tsc --noEmit`
- Focused WalletListModal and CreateWalletSelectCryptoScene Jest tests (3 passed; 2 snapshots)
- YAML parsing for C000037 and C000046
- Exact diff match against PR #6201 for the original four files

## Worked on by

- EdgeClaws
