### PR TITLE
Fix Choose Wallets to Add multi-word search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - fixed: An info card no longer disappears into an empty gap when the carousel's card list shrinks. A card's position comes entirely from an animated transform keyed on its index, and that transform is not re-applied when a surviving card shifts slots, so dropping a card left the ones after it parked a full card-width off-screen. The carousel now remounts a card whose slot changes. Reproduces wherever the list shrinks after mount - most visibly when a `noBalance` card is filtered out as balances finish loading.
 - fixed: Manage Tokens search now finds a token by its contract address, matching the Assets search.
 - fixed: Android quick-action shortcuts no longer throw a startup error when the app launches without ever coming to the foreground. Registration now waits for the app to be foregrounded, the native shortcut intent targets the launcher component instead of the current activity, and a registration failure is reported to Sentry instead of shown as a blocking alert.
+- fixed: Choose Wallets to Add search now finds a chain whose name is more than one word when that name is typed in full. "Robinhood Chain" returns the same result "Robinhood" does, instead of an empty list.
 
 ## 4.50.3 (2026-08-28)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -473,7 +473,6 @@ export default [
       'src/reducers/ExchangeInfoReducer.ts',
       'src/reducers/NetworkReducer.ts',
 
-      'src/selectors/getCreateWalletList.ts',
       'src/selectors/SettingsSelectors.ts',
       'src/state/createStateProvider.tsx',
       'src/state/SceneFooterState.tsx',

--- a/src/__tests__/walletSearch.test.ts
+++ b/src/__tests__/walletSearch.test.ts
@@ -268,6 +268,24 @@ describe('filterWalletCreateItemListBySearchText', () => {
       pluginId: 'bitcoin',
       walletType: 'wallet:bitcoin'
     }),
+    // Multi-word display name whose second word is absent from the pluginId:
+    makeTestCreateWalletItem({
+      key: 'create-robinhood',
+      currencyCode: 'ETH',
+      displayName: 'Robinhood Chain',
+      assetDisplayName: 'Ethereum',
+      pluginId: 'robinhood',
+      walletType: 'wallet:robinhood'
+    }),
+    // Multi-word display name whose second word IS in the pluginId:
+    makeTestCreateWalletItem({
+      key: 'create-bitcoincash',
+      currencyCode: 'BCH',
+      displayName: 'Bitcoin Cash',
+      assetDisplayName: 'Bitcoin Cash',
+      pluginId: 'bitcoincash',
+      walletType: 'wallet:bitcoincash'
+    }),
     makeTestCreateWalletItem({
       key: 'create-usdt',
       currencyCode: 'USDT',
@@ -293,7 +311,7 @@ describe('filterWalletCreateItemListBySearchText', () => {
   describe('empty search', () => {
     test('returns all items when search is empty', () => {
       const result = filterWalletCreateItemListBySearchText(testCreateList, '')
-      expect(result).toHaveLength(5)
+      expect(result).toHaveLength(7)
     })
 
     test('returns all items when search is only whitespace', () => {
@@ -301,7 +319,7 @@ describe('filterWalletCreateItemListBySearchText', () => {
         testCreateList,
         '   '
       )
-      expect(result).toHaveLength(5)
+      expect(result).toHaveLength(7)
     })
   })
 
@@ -322,18 +340,29 @@ describe('filterWalletCreateItemListBySearchText', () => {
         testCreateList,
         'bit'
       )
-      expect(result).toHaveLength(1)
-      expect(result[0].currencyCode).toBe('BTC')
+      const codes = result.map(r => r.currencyCode)
+      expect(codes).toEqual(['BTC', 'BCH'])
     })
 
-    test('does NOT match in middle (startsWith for currencyCode)', () => {
+    test('does NOT match in the middle of a word', () => {
+      const result = filterWalletCreateItemListBySearchText(
+        testCreateList,
+        'ether'
+      )
+      // "ether" is inside "Tether" but does not start any of its words
+      const codes = result.map(r => r.currencyCode)
+      expect(codes).not.toContain('USDT')
+    })
+
+    test('matches a later word of a display name by prefix', () => {
       const result = filterWalletCreateItemListBySearchText(
         testCreateList,
         'steth'
       )
-      // "steth" should not match "WSTETH" as currencyCode doesn't start with it
-      // nor "Wrapped stETH" as displayName doesn't start with it
-      expect(result).toHaveLength(0)
+      // "steth" is the second word of "Wrapped stETH", so it matches there,
+      // but it is still a prefix match rather than a substring of "WSTETH"
+      expect(result).toHaveLength(1)
+      expect(result[0].currencyCode).toBe('WSTETH')
     })
 
     test('matches assetDisplayName from beginning', () => {
@@ -341,8 +370,9 @@ describe('filterWalletCreateItemListBySearchText', () => {
         testCreateList,
         'ethereum'
       )
-      // Ethereum mainnet and Base both have assetDisplayName "Ethereum"
-      expect(result).toHaveLength(2)
+      // Ethereum mainnet, Base and Robinhood Chain all have the assetDisplayName
+      // "Ethereum"
+      expect(result).toHaveLength(3)
     })
   })
 
@@ -362,8 +392,9 @@ describe('filterWalletCreateItemListBySearchText', () => {
         testCreateList,
         'ethereum'
       )
-      // Should match Ethereum mainnet (pluginId and displayName), Base (assetDisplayName)
-      // But NOT tokens even though they have pluginId: 'ethereum'
+      // Should match Ethereum mainnet (pluginId and displayName), Base and
+      // Robinhood Chain (assetDisplayName), but NOT tokens even though they
+      // have pluginId: 'ethereum'
       expect(result.every(r => r.walletType != null)).toBe(true)
     })
   })
@@ -404,6 +435,52 @@ describe('filterWalletCreateItemListBySearchText', () => {
         'base   eth'
       )
       expect(result).toHaveLength(1)
+    })
+  })
+
+  describe('multi-word display names', () => {
+    test('matches the full name of a multi-word chain', () => {
+      const result = filterWalletCreateItemListBySearchText(
+        testCreateList,
+        'Robinhood Chain'
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0].pluginId).toBe('robinhood')
+    })
+
+    test('matches the first word of a multi-word chain', () => {
+      const result = filterWalletCreateItemListBySearchText(
+        testCreateList,
+        'Robinhood'
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0].pluginId).toBe('robinhood')
+    })
+
+    test('matches a multi-word chain typed without the space', () => {
+      const result = filterWalletCreateItemListBySearchText(
+        testCreateList,
+        'robinhoodchain'
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0].pluginId).toBe('robinhood')
+    })
+
+    test('still matches a multi-word chain named by its pluginId', () => {
+      const result = filterWalletCreateItemListBySearchText(
+        testCreateList,
+        'Bitcoin Cash'
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0].pluginId).toBe('bitcoincash')
+    })
+
+    test('returns nothing when the second word matches nothing', () => {
+      const result = filterWalletCreateItemListBySearchText(
+        testCreateList,
+        'Robinhood Bitcoin'
+      )
+      expect(result).toHaveLength(0)
     })
   })
 

--- a/src/selectors/getCreateWalletList.ts
+++ b/src/selectors/getCreateWalletList.ts
@@ -106,15 +106,15 @@ export const getCreateWalletList = (
   const excludedAssetsMap = createAssetMap(excludeAssets)
   const allowedAssetsMap = createAssetMap(allowedAssets)
 
-  const isAllowed = (pluginId: string, tokenId: EdgeTokenId) =>
+  const isAllowed = (pluginId: string, tokenId: EdgeTokenId): boolean =>
     // if the wallet already exists, then it is not allowed
-    !existingWalletsMap.get(pluginId)?.has(tokenId) &&
+    existingWalletsMap.get(pluginId)?.has(tokenId) !== true &&
     // if allowedAssets is empty, then all assets are allowed
     (allowedAssetsMap.size === 0 ||
-      allowedAssetsMap.get(pluginId)?.has(tokenId)) &&
+      allowedAssetsMap.get(pluginId)?.has(tokenId) === true) &&
     // if excludedAssets is not empty, then the asset must not be in the excluded list
     (excludedAssetsMap.size === 0 ||
-      !excludedAssetsMap.get(pluginId)?.has(tokenId))
+      excludedAssetsMap.get(pluginId)?.has(tokenId) !== true)
 
   // Add top-level wallet types:
   const newWallets: MainWalletCreateItem[] = []
@@ -125,7 +125,7 @@ export const getCreateWalletList = (
     // Prevent plugins that are "watch only" from being allowed to create new wallets
     if (isKeysOnlyPlugin(pluginId)) continue
     // Prevent currencies that needs activation from being created from a modal
-    if (filterActivation && requiresActivation(pluginId)) continue
+    if (filterActivation === true && requiresActivation(pluginId)) continue
 
     const currencyConfig = account.currencyConfig[pluginId]
     const { assetDisplayName, currencyCode, displayName, walletType } =
@@ -287,7 +287,7 @@ export const filterWalletCreateItemListBySearchText = (
   return out
 }
 
-function requiresActivation(pluginId: string) {
+function requiresActivation(pluginId: string): boolean {
   const { isAccountActivationRequired = false } =
     SPECIAL_CURRENCY_INFO[pluginId] ?? {}
   return isAccountActivationRequired

--- a/src/selectors/getCreateWalletList.ts
+++ b/src/selectors/getCreateWalletList.ts
@@ -220,6 +220,19 @@ export const getCreateWalletList = (
 }
 
 /**
+ * Breaks a display name into the forms a search term may match by prefix: each
+ * of its whitespace-separated words, plus, for a multi-word name, the whole
+ * name with its whitespace squashed out. The words let a later word of a name
+ * match on its own ("chain" finds "Robinhood Chain"), while the squashed form
+ * keeps a spaceless query ("bitcoincash") working.
+ */
+const getSearchableNameParts = (name: string): string[] => {
+  const words = name.split(/\s+/).filter(word => word !== '')
+  const parts = words.length > 1 ? [...words, words.join('')] : words
+  return parts.map(part => normalizeForSearch(part))
+}
+
+/**
  * Filters a wallet create item list using a search string.
  * Supports multi-word search where each word must match at least one field.
  */
@@ -246,38 +259,40 @@ export const filterWalletCreateItemListBySearchText = (
       walletType
     } = item
 
+    // Normalize each field once per item, rather than once per search term:
+    const isMainnetItem = walletType != null
+    const normalizedCurrencyCode = normalizeForSearch(currencyCode)
+    const normalizedPluginId = normalizeForSearch(pluginId)
+    const displayNameParts = getSearchableNameParts(displayName)
+    const assetDisplayNameParts =
+      assetDisplayName == null ? [] : getSearchableNameParts(assetDisplayName)
+    const normalizedLocations = Object.values(networkLocation)
+      .filter((value): value is string => typeof value === 'string')
+      .map(value => normalizeForSearch(value))
+
     // Check if all search terms match at least one field (AND logic)
     const allTermsMatch = searchTerms.every(term => {
       // Asset identification fields use startsWith to avoid partial matches
       // (e.g., "eth" matches "Ethereum" but not "Tether")
       if (
-        normalizeForSearch(currencyCode).startsWith(term) ||
-        normalizeForSearch(displayName).startsWith(term)
+        normalizedCurrencyCode.startsWith(term) ||
+        displayNameParts.some(part => part.startsWith(term))
       ) {
         return true
       }
       // Search assetDisplayName for mainnet create items (also uses startsWith)
       if (
-        walletType != null &&
-        assetDisplayName != null &&
-        normalizeForSearch(assetDisplayName).startsWith(term)
+        isMainnetItem &&
+        assetDisplayNameParts.some(part => part.startsWith(term))
       ) {
         return true
       }
       // Search pluginId for mainnet create items (uses includes for discovery)
-      if (walletType != null && normalizeForSearch(pluginId).includes(term)) {
+      if (isMainnetItem && normalizedPluginId.includes(term)) {
         return true
       }
       // Search networkLocation values ie. contractAddress (uses includes)
-      for (const value of Object.values(networkLocation)) {
-        if (
-          typeof value === 'string' &&
-          normalizeForSearch(value).includes(term)
-        ) {
-          return true
-        }
-      }
-      return false
+      return normalizedLocations.some(location => location.includes(term))
     })
 
     if (allTermsMatch) {


### PR DESCRIPTION
### Description

Asana: https://app.asana.com/0/1215088146871429/1218294332796824

`filterWalletCreateItemListBySearchText` splits the query on whitespace and requires every term to match some field, but it compares `displayName` / `assetDisplayName` with `startsWith` after `normalizeForSearch` has squashed their whitespace away. "Robinhood Chain" becomes the single token `robinhoodchain`, so the term `chain` can only match as a prefix of that squashed name (it is not) or as a substring of the pluginId (`robinhood` does not contain `chain`), and the list comes back empty. "Bitcoin Cash" and "Ethereum Classic" survive only because their pluginIds contain the second word.

Each term now also matches the individual whitespace-separated words of `displayName` and `assetDisplayName`, any word by prefix. The squashed whole-name form is kept alongside the words, so a query typed without the space ("robinhoodchain") still matches. `currencyCode`, `pluginId` and `networkLocation` matching are unchanged, and the prefix rule still keeps "eth" off Tether.

Each item's fields are now normalized once per item instead of once per search term.

The existing `steth` test asserted an empty result on the reasoning that neither `WSTETH` nor `Wrapped stETH` starts with it. Under per-word matching, `steth` is a prefix of that name's second word and legitimately matches, so that case is rewritten to keep its real intent (no mid-word substring matching, `ether` must not match Tether) and the word-prefix hit gets its own test.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized search-filter logic with expanded unit tests; no changes to wallet creation, auth, or transactions.
> 
> **Overview**
> **Choose Wallets to Add** search no longer returns an empty list when users type a full multi-word chain name (e.g. **Robinhood Chain**). Previously each query term was checked with `startsWith` against a whitespace-squashed `displayName`, so the second word could not match unless it appeared in `pluginId`.
> 
> Matching now uses **per-word prefixes** on `displayName` and `assetDisplayName` (via new `getSearchableNameParts`), while still keeping the squashed whole name so spaceless queries like `robinhoodchain` work. **currencyCode**, **pluginId**, and contract-address behavior is unchanged; mid-word substring matches (e.g. `ether` on Tether) stay excluded.
> 
> Search fields are normalized **once per list item** instead of per term. Tests cover multi-word chains, updated expectations (including legitimate `steth` → Wrapped stETH), plus a CHANGELOG entry and a small eslint config tweak for `getCreateWalletList.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25271dc01342a96524ba6017d421a48a5d25b855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->