### PR TITLE
Add blockscoutApiKey to the EVM env config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - added: Sign Message option in the wallet list menu for Bitcoin-family wallets, letting users prove self-hosted wallet ownership to exchanges by signing an exchange-provided message.
 - added: `edge://buy` and `edge://sell` deep links (and their `https://deep.edge.app` equivalents) that open the buy/sell flow, optionally pinning a provider and payment method to the top of the quote options for that visit.
 - added: Provider priority in the buy/sell options for affiliated accounts, configured through the info server promo card data.
+- added: `blockscoutApiKey` env config for EVM core plugins
 - changed: Adopt the iOS UIScene lifecycle, removing the deprecated app-delegate window and lifecycle APIs ahead of Xcode 27.
 - changed: Target Android 16 (API level 36), which Google Play requires for app updates submitted after Aug 30, 2026. Predictive back is opted out of for now, since React Native 0.79 cannot handle it, so the back button behaves exactly as it did before.
 - changed: Sign MoonPay buy/sell widget URLs and bind them to the customer's IP via the info server, for MoonPay's on-ramp IP-matching security upgrade.

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -39,6 +39,10 @@ const asEvmApiKeys = asObject({
   alethioApiKey: asOptional(asString, ''),
   amberdataApiKey: asOptional(asString, ''),
   blockchairApiKey: asOptional(asString, ''),
+  // Blockscout's hosted API at `api.blockscout.com` bills per key. It has no
+  // default, because the currency plugin drops that server when the option is
+  // absent and an empty string would read as a key that is merely broken.
+  blockscoutApiKey: asOptional(asEither(asString, asArray(asString))),
   drpcApiKey: asOptional(asString, ''),
   evmScanApiKey: asOptional(asArray(asString), () => []),
   gasStationApiKey: asOptional(asString, ''),


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

[EdgeApp/edge-currency-accountbased#1099](https://github.com/EdgeApp/edge-currency-accountbased/pull/1099) reads this option. Not a build dependency: `asEvmApiKeys` carries `.withRest`, so an `env.json` entry already reached the plugin before this change.

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

Asana: https://app.asana.com/0/1215088146871429/1218291556240193

Robinhood Chain's only source of internal transactions is Blockscout, and the instance the chain runs has dropped to 10 requests per window, so the currency plugin now reads them from Blockscout's hosted API at `api.blockscout.com` instead. That API bills per key, and the key is its own init option rather than a value inside `evmScanApiKey`, which holds a chain's Etherscan keys and picks one at random per request.

`asEvmApiKeys` carries `.withRest`, so an entry in `env.json` already reached the plugin, but nothing declared what the key was or what type it took. It has no default: the plugin drops the hosted server when the option is absent, and an empty string would read as a key that is merely broken.

No visual changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config schema and changelog only; optional key with no default preserves existing behavior when unset.
> 
> **Overview**
> Adds **`blockscoutApiKey`** to the **`asEvmApiKeys`** schema in `envConfig.ts` so `env.json` can supply Blockscout’s hosted API key(s) for EVM core plugins. The field accepts a single string or an array of strings, stays **optional with no default** (unlike other EVM keys that default to empty strings), so a missing value means the plugin skips Blockscout’s billed endpoint rather than treating `""` as a broken key.
> 
> Documents the change in the **4.51.0** CHANGELOG. No UI or runtime behavior changes in the GUI beyond typed env validation and forwarding keys the currency plugin already reads via `.withRest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2782d02796ad578f68a481a188cc82fc13f94c59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->