### PR TITLE
Split wallet search name words on punctuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 - fixed: An info card no longer disappears into an empty gap when the carousel's card list shrinks. A card's position comes entirely from an animated transform keyed on its index, and that transform is not re-applied when a surviving card shifts slots, so dropping a card left the ones after it parked a full card-width off-screen. The carousel now remounts a card whose slot changes. Reproduces wherever the list shrinks after mount - most visibly when a `noBalance` card is filtered out as balances finish loading.
 - fixed: Manage Tokens search now finds a token by its contract address, matching the Assets search.
 - fixed: Android quick-action shortcuts no longer throw a startup error when the app launches without ever coming to the foreground. Registration now waits for the app to be foregrounded, the native shortcut intent targets the launcher component instead of the current activity, and a registration failure is reported to Sentry instead of shown as a blocking alert.
-- fixed: Choose Wallets to Add search now finds a chain whose name is more than one word when that name is typed in full. "Robinhood Chain" returns the same result "Robinhood" does, instead of an empty list.
+- fixed: Choose Wallets to Add search now matches multi-word chain names and words inside parentheses
 
 ## 4.50.3 (2026-08-28)
 

--- a/src/__tests__/walletSearch.test.ts
+++ b/src/__tests__/walletSearch.test.ts
@@ -484,6 +484,60 @@ describe('filterWalletCreateItemListBySearchText', () => {
     })
   })
 
+  describe('punctuation in display names', () => {
+    const segwitCreateList = [
+      makeTestCreateWalletItem({
+        key: 'create-wallet:bitcoin-bip49-bitcoin',
+        currencyCode: 'BTC',
+        displayName: 'Bitcoin (Segwit)',
+        assetDisplayName: 'Bitcoin',
+        pluginId: 'bitcoin',
+        walletType: 'wallet:bitcoin'
+      }),
+      makeTestCreateWalletItem({
+        key: 'create-wallet:bitcoin-bip44-bitcoin',
+        currencyCode: 'BTC',
+        displayName: 'Bitcoin (no Segwit)',
+        assetDisplayName: 'Bitcoin',
+        pluginId: 'bitcoin',
+        walletType: 'wallet:bitcoin'
+      })
+    ]
+
+    test('matches a word wrapped in parentheses', () => {
+      const result = filterWalletCreateItemListBySearchText(
+        segwitCreateList,
+        'segwit'
+      )
+      expect(result.map(r => r.displayName)).toEqual([
+        'Bitcoin (Segwit)',
+        'Bitcoin (no Segwit)'
+      ])
+    })
+
+    test('matches a word that follows an opening parenthesis', () => {
+      const result = filterWalletCreateItemListBySearchText(
+        segwitCreateList,
+        'bitcoin no'
+      )
+      expect(result.map(r => r.displayName)).toEqual(['Bitcoin (no Segwit)'])
+    })
+
+    test('matches each visible label typed exactly', () => {
+      const segwit = filterWalletCreateItemListBySearchText(
+        segwitCreateList,
+        'Bitcoin (Segwit)'
+      )
+      expect(segwit.map(r => r.displayName)).toEqual(['Bitcoin (Segwit)'])
+
+      const noSegwit = filterWalletCreateItemListBySearchText(
+        segwitCreateList,
+        'Bitcoin (no Segwit)'
+      )
+      expect(noSegwit.map(r => r.displayName)).toEqual(['Bitcoin (no Segwit)'])
+    })
+  })
+
   describe('case insensitivity', () => {
     test('matches regardless of case', () => {
       const resultLower = filterWalletCreateItemListBySearchText(

--- a/src/selectors/getCreateWalletList.ts
+++ b/src/selectors/getCreateWalletList.ts
@@ -220,16 +220,20 @@ export const getCreateWalletList = (
 }
 
 /**
- * Breaks a display name into the forms a search term may match by prefix: each
- * of its whitespace-separated words, plus, for a multi-word name, the whole
- * name with its whitespace squashed out. The words let a later word of a name
- * match on its own ("chain" finds "Robinhood Chain"), while the squashed form
- * keeps a spaceless query ("bitcoincash") working.
+ * Breaks a display name into the forms a search term may match by prefix: the
+ * whole name with its whitespace squashed out, plus each of its words in two
+ * forms. Words split on whitespace keep their punctuation, so a query that
+ * copies the visible label ("Bitcoin (Segwit)") still matches. Words split on
+ * any run of characters that are not letters or numbers drop it, so a bare
+ * "segwit" matches the word inside the parentheses. The words let a later word
+ * of a name match on its own ("chain" finds "Robinhood Chain"), while the
+ * whole-name form keeps a spaceless query ("bitcoincash") working.
  */
 const getSearchableNameParts = (name: string): string[] => {
-  const words = name.split(/\s+/).filter(word => word !== '')
-  const parts = words.length > 1 ? [...words, words.join('')] : words
-  return parts.map(part => normalizeForSearch(part))
+  const words = [...name.split(/\s+/), ...name.split(/[^\p{L}\p{N}]+/u)]
+    .map(word => normalizeForSearch(word))
+    .filter(word => word !== '')
+  return [...new Set([normalizeForSearch(name), ...words])]
 }
 
 /**


### PR DESCRIPTION
### Description

Asana: https://app.asana.com/0/1215088146871429/1218294332796824

Follow-up to #6205, addressing Cursor Bugbot's finding on it ("Punctuation skews later-word matches"), which posted after the PR had merged.

`getSearchableNameParts` split display names on whitespace only, so parentheses stayed attached to words. The create list adds `(Segwit)` and `(no Segwit)` suffixes for Bitcoin, Litecoin and DigiByte, so a `segwit` query matched the no-Segwit rows (word `segwit)`) and missed the Segwit rows (word `(segwit)`).

Each name word is now kept in two forms: split on whitespace (punctuation kept, so the exact visible label "Bitcoin (Segwit)" matches) and split on any run of characters that are not letters or numbers (`/[^\p{L}\p{N}]+/u`, so a bare "segwit" matches the word inside the parentheses). The whole-name form keeps its punctuation, so a query such as "crypto.com" still matches by prefix, and the parts are deduplicated. Currency code, pluginId and network location matching are unchanged.

The CHANGELOG line #6205 added under 4.51.0 (staging) now covers both outcomes, since 4.51.0 has not shipped.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to wallet-create list search tokenization with new unit tests; no auth, payments, or transaction flows affected.
> 
> **Overview**
> **Choose Wallets to Add** search now treats display names like `Bitcoin (Segwit)` correctly when users type words inside parentheses or paste the full label.
> 
> `getSearchableNameParts` builds searchable tokens from the full normalized name plus words from **whitespace splits** (punctuation kept) and **Unicode letter/number splits** (so `segwit` matches inside `(Segwit)` without false hits on `(segwit)`-attached tokens). Results are deduplicated. Tests cover Segwit/no-Segwit Bitcoin rows; the 4.51.0 changelog entry is merged into one line for multi-word names and parenthetical words.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fe1c1847d3c77d1bc1deb0685e97b1f1b4f417b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->