### PR TITLE
Fix Paybis max sell quote amount and stuck confirm slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - changed: Standardize wallet list automation test IDs to use period separators.
 - fixed: USDC.e shown as USDC in the Optimism Tarot staking pools
 - fixed: Say "edit name" instead of "edit settings" on the create/split wallet scene when the listed wallets have no settings to edit
+- fixed: Paybis sell Max now quotes the wallet's full spendable amount.
+- fixed: A failed confirmation slide shows the error instead of a stuck spinner.
 
 ## 4.51.0 (staging)
 

--- a/src/components/scenes/SendScene2.tsx
+++ b/src/components/scenes/SendScene2.tsx
@@ -1290,9 +1290,22 @@ const SendComponent: React.FC<Props> = props => {
 
   const handleSliderComplete = useHandler(
     async (resetSlider: () => void): Promise<void> => {
-      if (edgeTransaction == null) return
+      // Every exit below has to re-arm the slider. SafeSlider holds its spinner
+      // and stays disabled until it is reset, so returning without one strands
+      // the user on a spinner that never clears.
+      if (edgeTransaction == null) {
+        resetSlider()
+        return
+      }
       if (pinSpendingLimitsEnabled && spendingLimitExceeded) {
-        const isAuthorized = await account.checkPin(pinValue ?? '')
+        let isAuthorized = false
+        try {
+          isAuthorized = await account.checkPin(pinValue ?? '')
+        } catch (error: unknown) {
+          resetSlider()
+          showError(error)
+          return
+        }
         if (!isAuthorized) {
           resetSlider()
           setPinValue('')
@@ -1308,6 +1321,7 @@ const SendComponent: React.FC<Props> = props => {
           'Error from before transaction route param hook: ',
           String(e)
         )
+        resetSlider()
         return
       }
 

--- a/src/components/themed/SafeSlider.tsx
+++ b/src/components/themed/SafeSlider.tsx
@@ -70,6 +70,11 @@ export const SafeSlider: React.FC<Props> = props => {
       wasReset = true
       resetSlider()
     })?.catch((err: unknown) => {
+      // Re-arm the slider before surfacing the error. `completed` drives both
+      // the spinner and `sliderDisabled`, so a rejection that never resets
+      // leaves the spinner up and the control permanently dead, with no way to
+      // retry the action.
+      resetSlider()
       showError(err)
     })
     // Only show spinner if reset wasn't called synchronously:

--- a/src/plugins/ramps/paybis/paybisRampPlugin.ts
+++ b/src/plugins/ramps/paybis/paybisRampPlugin.ts
@@ -1,4 +1,4 @@
-import { eq, lte, mul, round } from 'biggystring'
+import { eq, floor, lte, mul, round } from 'biggystring'
 import {
   asArray,
   asBoolean,
@@ -860,17 +860,18 @@ export const paybisRampPlugin: RampPluginFactory = (
           let amount
 
           if (isMaxAmount) {
-            // Use default max amounts
-            amount = amountType === 'fiat' ? '10000' : '10'
-
             if (maxAmountLimit != null) {
-              const maxCapNumber = parseFloat(maxAmountLimit)
-              const amountNumber = parseFloat(amount)
-              if (!Number.isNaN(maxCapNumber) && !Number.isNaN(amountNumber)) {
-                if (amountNumber > maxCapNumber) {
-                  amount = maxAmountLimit
-                }
-              }
+              // A sell max carries the user's actual maximum, so quote exactly
+              // that. Round DOWN: rounding up asks to sell more than the wallet
+              // can spend, which fails at the send step with the amount locked.
+              amount = floor(
+                maxAmountLimit,
+                amountType === 'fiat' ? FIAT_DECIMALS : CRYPTO_DECIMALS
+              )
+            } else {
+              // A buy max has no known ceiling, so probe with a large default
+              // and let the provider clamp it to its own limit.
+              amount = amountType === 'fiat' ? '10000' : '10'
             }
           } else {
             amount = exchangeAmount
@@ -896,16 +897,6 @@ export const paybisRampPlugin: RampPluginFactory = (
               amount = isMaxAmount ? amount : round(amount, CRYPTO_DECIMALS)
               directionChange = 'from'
             }
-          }
-
-          const bodyParams = {
-            currencyCodeFrom,
-            amount,
-            currencyCodeTo,
-            directionChange,
-            isReceivedAmount: directionChange === 'to',
-            paymentMethod: direction === 'buy' ? paymentMethod : undefined,
-            payoutMethod: direction === 'sell' ? paymentMethod : undefined
           }
 
           let promoCode: string | undefined
@@ -941,26 +932,47 @@ export const paybisRampPlugin: RampPluginFactory = (
             }
           }
 
-          const response = await paybisFetch({
-            method: 'POST',
-            url: state.apiUrl,
-            path: 'v2/public/quote',
-            apiKey: state.apiKey,
-            bodyParams,
-            promoCode
-          })
+          // Paybis reports its per-order ceiling only when a request exceeds it.
+          // A max request above that ceiling would otherwise be dropped, leaving
+          // Max with no quote at all, so re-quote once at the reported ceiling.
+          // Any other request surfaces the limit error unchanged.
+          const amountDecimals =
+            amountType === 'fiat' ? FIAT_DECIMALS : CRYPTO_DECIMALS
+          const requestedCurrencyCode =
+            directionChange === 'from' ? currencyCodeFrom : currencyCodeTo
+          let quoteAmount = amount
+          let quoteResult: ReturnType<typeof asQuote> | undefined
 
-          const {
-            id: quoteId,
-            paymentMethods,
-            paymentMethodErrors,
-            payoutMethods,
-            payoutMethodErrors
-          } = asQuote(response)
+          for (let attempt = 0; attempt < 2; attempt++) {
+            const bodyParams = {
+              currencyCodeFrom,
+              amount: quoteAmount,
+              currencyCodeTo,
+              directionChange,
+              isReceivedAmount: directionChange === 'to',
+              paymentMethod: direction === 'buy' ? paymentMethod : undefined,
+              payoutMethod: direction === 'sell' ? paymentMethod : undefined
+            }
 
-          const pmErrors = paymentMethodErrors ?? payoutMethodErrors
-          if (pmErrors != null) {
+            const response = await paybisFetch({
+              method: 'POST',
+              url: state.apiUrl,
+              path: 'v2/public/quote',
+              apiKey: state.apiKey,
+              bodyParams,
+              promoCode
+            })
+
+            const candidate = asQuote(response)
+            const pmErrors =
+              candidate.paymentMethodErrors ?? candidate.payoutMethodErrors
+            if (pmErrors == null) {
+              quoteResult = candidate
+              break
+            }
+
             let lastError
+            let ceilingAmount: string | undefined
             for (const e of pmErrors) {
               lastError = e
               // New error message observed from paybis API
@@ -982,40 +994,49 @@ export const paybisRampPlugin: RampPluginFactory = (
                 /^Minimum amount is (\d+(?:\.\d+)?) ([A-Z]+)/.exec(
                   e.error.message
                 )
-              if (maxMatch != null) {
+              const overLimit = maxMatch ?? maxMatchLegacy
+              const underLimit = minMatch ?? minMatchLegacy
+              if (overLimit != null) {
+                // The ceiling is the largest sellable amount, so a max request
+                // takes it and retries. Only when it is quoted in the same
+                // currency the amount was requested in.
+                if (
+                  isMaxAmount &&
+                  attempt === 0 &&
+                  overLimit[2] === requestedCurrencyCode
+                ) {
+                  ceilingAmount = floor(overLimit[1], amountDecimals)
+                  break
+                }
                 throw new FiatProviderError({
                   providerId: pluginId,
                   errorType: 'overLimit',
-                  errorAmount: Number(maxMatch[1]),
-                  displayCurrencyCode: maxMatch[2]
+                  errorAmount: Number(overLimit[1]),
+                  displayCurrencyCode: overLimit[2]
                 })
-              } else if (minMatch != null) {
+              } else if (underLimit != null) {
                 throw new FiatProviderError({
                   providerId: pluginId,
                   errorType: 'underLimit',
-                  errorAmount: Number(minMatch[1]),
-                  displayCurrencyCode: minMatch[2]
-                })
-              } else if (maxMatchLegacy != null) {
-                throw new FiatProviderError({
-                  providerId: pluginId,
-                  errorType: 'overLimit',
-                  errorAmount: Number(maxMatchLegacy[1]),
-                  displayCurrencyCode: maxMatchLegacy[2]
-                })
-              } else if (minMatchLegacy != null) {
-                throw new FiatProviderError({
-                  providerId: pluginId,
-                  errorType: 'underLimit',
-                  errorAmount: Number(minMatchLegacy[1]),
-                  displayCurrencyCode: minMatchLegacy[2]
+                  errorAmount: Number(underLimit[1]),
+                  displayCurrencyCode: underLimit[2]
                 })
               }
+            }
+
+            if (ceilingAmount != null) {
+              quoteAmount = ceilingAmount
+              continue
             }
             throw new Error(
               lastError?.error.message ?? 'Paybis Unknown paymentMethodError'
             )
           }
+
+          if (quoteResult == null) {
+            throw new Error('Paybis quote unavailable')
+          }
+          const { id: quoteId, paymentMethods, payoutMethods } = quoteResult
 
           let pmQuote
           if (direction === 'buy' && paymentMethods?.length === 1) {
@@ -1034,14 +1055,17 @@ export const paybisRampPlugin: RampPluginFactory = (
           let cryptoAmount: string
           let fiatAmount: string
 
+          // Compare against the amount actually sent: a max request that hit the
+          // provider ceiling was re-quoted at that ceiling, so the originally
+          // requested amount no longer matches what the quote answers.
           if (directionChange === 'from') {
             assert(
-              eq(amount, amountFrom.amount),
+              eq(quoteAmount, amountFrom.amount),
               'Quote not equal to requested from amount'
             )
           } else {
             assert(
-              eq(amount, amountTo.amount),
+              eq(quoteAmount, amountTo.amount),
               'Quote not equal to requested to amount'
             )
           }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Requirements

If you have made **any** visual changes to the GUI. Make sure you have:

- [x] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on small-screen device (iPod Touch)
- [ ] Tested on large-screen device (tablet)

### Description

[Asana task](https://app.asana.com/0/0/1218408624974487/f)

Support reported that a Paybis max sell leaves the user on a stuck spinner at the final
Slide to Confirm. The workaround was to abandon Max and hand-enter a lower amount. The quote
amount and the confirm slider each carry a defect, and both are fixed here.

**The sell-max quote was requested for a placeholder amount**

`isMaxAmount` is true for both amount-query shapes. A buy max sends `{ max: true }`, where
the app does not know the ceiling. A sell max sends `{ maxExchangeAmount: <computed max> }`,
which carries the real number. The sell path still started from a hardcoded 10 crypto units
(10000 fiat) and lowered it to the real max only when the placeholder was the larger of the
two, making the request `min(placeholder, realMax)`. Any sell max above 10 crypto units was
quoted at the placeholder instead of the balance.

Against Paybis's live API, a sell of 192 POL quotes 16.50 USD. The 10 POL the old code would
have sent quotes 0.00 USD.

The supplied max is now used directly, floored to the provider's decimals so it cannot exceed
the spendable balance and still satisfies the quote equality check. The placeholder applies
only to a buy max.

**A failed confirm left the slider spinning**

`SafeSlider` reported a rejected `onSlidingComplete` through `showError` but never reset the
control. `completed` drives both the spinner and `sliderDisabled`, so any rejection the
consumer did not swallow left the spinner up and the slider dead, with no way to retry.
`SendScene2.handleSliderComplete` supplied those rejections. Its exits before the resetting
`try/finally` were the null-transaction return, a throwing `checkPin`, and the
`beforeTransaction` failure.

A max sell reaches those paths more than any other amount. It is the largest value, which
makes it the most likely to exceed PIN spending limits, and that is the only path reaching
`checkPin`. It is also the most likely to flip `makeSpend` to an insufficient-funds error on a
re-run, which nulls the transaction under the slider.

The slider now resets in the rejection handler, and every early exit re-arms it.

### Testing

Driven in-app on the iOS simulator against the live Paybis API.

- Sell tab, region Texas/USA, USD, wallet "My Polygon 2" holding 192.57 POL. Tapping MAX
  produced a Paybis quote on Credit and Debit Card for 192.56909036 POL to 16.57 USD, the full
  max floored to 8 decimals. The old code would have requested 10 POL.
- The slider reset was checked under a temporary forced rejection, because a genuinely
  rejected confirm has no reliable natural trigger. The error surfaced and the slider returned
  to "Slide to Confirm" rather than spinning. That edit was reverted before committing.

`tsc --noEmit`, eslint and the jest suite pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Paybis quote/request logic and send confirmation error paths; behavior is more correct but affects ramp sell and slide-to-send flows users rely on for funds movement.
> 
> **Overview**
> Fixes two bugs that showed up together on **Paybis sell Max**: wrong quote amounts and a **Slide to Confirm** control that could spin forever after a failure.
> 
> **Paybis sell Max** now quotes the wallet’s real spendable max (floored to provider decimals) instead of a hardcoded probe amount. **Buy Max** still uses the large default and lets Paybis clamp. When a max sell hits Paybis’s per-order ceiling, the plugin **re-quotes once** at the reported limit instead of failing with no quote; quote equality checks use the amount actually sent.
> 
> **SafeSlider** resets before showing errors when `onSlidingComplete` rejects, and **SendScene2** re-arms the slider on every early exit (missing transaction, PIN check failure/error, `beforeTransaction` hook failure) so users can retry instead of staying on a disabled spinner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0491a8581bc56271c82bacbe3a207119b7cbeefd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="1" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6211/commits/398dff99ed90046ce3a21f1c08028619357f3151"><code>398dff9</code></a><br><sub>Reset confirm slider when the slide fails</sub><br><sub>🪓 <em>Forced by a temporary throw at the top of SendScene2.handleSliderComplete, reverted before commit. The marked frames prove the rendering, not the trigger.</em></sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-155707-agent-proof-1218408624974487-03-HACKED-slider-before-slide.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-155707-agent-proof-1218408624974487-03-HACKED-slider-before-slide.png" width="200"></a><br><sub>🪓 slider before slide</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-155707-agent-proof-1218408624974487-04-HACKED-slider-resets-on-failure.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-155707-agent-proof-1218408624974487-04-HACKED-slider-resets-on-failure.png" width="200"></a><br><sub>🪓 slider resets on failure</sub></td>
<td width="210"></td>
</tr>
<tr>
<td rowspan="2" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-react-gui/pull/6211/commits/0491a8581bc56271c82bacbe3a207119b7cbeefd"><code>0491a85</code></a><br><sub>Quote Paybis sell max at the wallet max</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-155707-agent-proof-1218408624974487-01-sell-scene-pol.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-155707-agent-proof-1218408624974487-01-sell-scene-pol.png" width="200"></a><br><sub>sell scene pol (before fix)</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-155707-agent-proof-1218408624974487-02-max-quote-full-amount.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-155707-agent-proof-1218408624974487-02-max-quote-full-amount.png" width="200"></a><br><sub>max quote full amount (before fix)</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-161129-agent-proof-1218408624974487-01-sell-scene-pol.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-161129-agent-proof-1218408624974487-01-sell-scene-pol.png" width="200"></a><br><sub>sell scene pol (after fix)</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-161129-agent-proof-1218408624974487-02-max-quote-full-amount.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-react-gui/pr-6211/20260911-161129-agent-proof-1218408624974487-02-max-quote-full-amount.png" width="200"></a><br><sub>max quote full amount (after fix)</sub></td>
<td width="210"></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->
